### PR TITLE
Redesigned Settings Dropdown with New Local Mode Header and Improved Layout

### DIFF
--- a/apps/desktop/src/components/left-sidebar/top-area/settings-button.tsx
+++ b/apps/desktop/src/components/left-sidebar/top-area/settings-button.tsx
@@ -9,8 +9,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@hypr/ui/components/ui/dropdown-menu";
 
@@ -33,25 +31,38 @@ export function SettingsButton() {
         </Button>
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent align="start">
-        <DropdownMenuLabel className="flex items-center gap-2 bg-neutral-600 rounded text-white">
-          <CpuIcon className="size-4" /> <Trans>Local mode</Trans>
-        </DropdownMenuLabel>
-        <DropdownMenuSeparator />
+      <DropdownMenuContent align="start" className="w-52 p-0">
+        <div className="px-2 py-3 bg-gradient-to-r from-gray-800 to-gray-900 rounded-t-md relative overflow-hidden">
+          <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZGVmcz48cGF0dGVybiBpZD0iZ3JpZCIgd2lkdGg9IjIwIiBoZWlnaHQ9IjIwIiBwYXR0ZXJuVW5pdHM9InVzZXJTcGFjZU9uVXNlIj48cGF0aCBkPSJNIDIwIDAgTCAwIDAgTCAwIDIwIiBmaWxsPSJub25lIiBzdHJva2U9InJnYmEoMjU1LDI1NSwyNTUsMC4xNSkiIHN0cm9rZS13aWR0aD0iMS41Ii8+PC9wYXR0ZXJuPjwvZGVmcz48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSJ1cmwoI2dyaWQpIi8+PC9zdmc+')] opacity-70">
+          </div>
+          <div className="flex items-center gap-3 text-white relative z-10">
+            <CpuIcon className="size-8 animate-pulse" />
+            <div>
+              <div className="font-medium">
+                <Trans>Local mode</Trans>
+              </div>
+              <div className="text-xs text-white/80 mt-0.5">
+                Privacy-focused AI
+              </div>
+            </div>
+          </div>
+        </div>
 
-        <DropdownMenuItem
-          onClick={handleClickSettings}
-          className="cursor-pointer"
-        >
-          <Trans>Settings</Trans>
-          <Shortcut macDisplay="⌘," windowsDisplay="Ctrl+," />
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={handleClickProfile}
-          className="cursor-pointer"
-        >
-          <Trans>My Profile</Trans>
-        </DropdownMenuItem>
+        <div className="p-1">
+          <DropdownMenuItem
+            onClick={handleClickSettings}
+            className="cursor-pointer"
+          >
+            <Trans>Settings</Trans>
+            <Shortcut macDisplay="⌘," windowsDisplay="Ctrl+," />
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={handleClickProfile}
+            className="cursor-pointer"
+          >
+            <Trans>My Profile</Trans>
+          </DropdownMenuItem>
+        </div>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/desktop/src/locales/en/messages.po
+++ b/apps/desktop/src/locales/en/messages.po
@@ -333,7 +333,6 @@ msgid "Built-in Templates"
 msgstr "Built-in Templates"
 
 #: src/components/settings/components/settings-header.tsx:26
-#: src/components/settings/components/main-sidebar.tsx:30
 msgid "Calendar"
 msgstr "Calendar"
 
@@ -413,7 +412,7 @@ msgstr "Connecting..."
 msgid "Contacts Access"
 msgstr "Contacts Access"
 
-#: src/routes/app.human.$id.tsx:381
+#: src/routes/app.human.$id.tsx:493
 #: src/components/editor-area/note-header/chips/participants-chip/participants-list.tsx:378
 msgid "Create"
 msgstr "Create"
@@ -501,7 +500,7 @@ msgid "Exclude these apps from auto detection"
 msgstr "Exclude these apps from auto detection"
 
 #: src/components/settings/components/settings-header.tsx:32
-#: src/components/settings/components/main-sidebar.tsx:38
+#: src/components/settings/components/main-sidebar.tsx:40
 msgid "Extensions"
 msgstr "Extensions"
 
@@ -538,7 +537,7 @@ msgid "Full name"
 msgstr "Full name"
 
 #: src/components/settings/components/settings-header.tsx:20
-#: src/components/settings/components/main-sidebar.tsx:28
+#: src/components/settings/components/main-sidebar.tsx:29
 msgid "General"
 msgstr "General"
 
@@ -635,7 +634,7 @@ msgstr "Local AI"
 #~ msgid "Local Language Model"
 #~ msgstr "Local Language Model"
 
-#: src/components/left-sidebar/top-area/settings-button.tsx:38
+#: src/components/left-sidebar/top-area/settings-button.tsx:42
 msgid "Local mode"
 msgstr "Local mode"
 
@@ -684,7 +683,7 @@ msgstr "Monthly"
 msgid "Much better AI performance"
 msgstr "Much better AI performance"
 
-#: src/components/left-sidebar/top-area/settings-button.tsx:53
+#: src/components/left-sidebar/top-area/settings-button.tsx:63
 msgid "My Profile"
 msgstr "My Profile"
 
@@ -912,7 +911,7 @@ msgstr "Select Calendars"
 msgid "Send invite"
 msgstr "Send invite"
 
-#: src/components/left-sidebar/top-area/settings-button.tsx:46
+#: src/components/left-sidebar/top-area/settings-button.tsx:56
 msgid "Settings"
 msgstr "Settings"
 
@@ -932,7 +931,7 @@ msgstr "Show notifications whenever a microphone is being used"
 msgid "Single sign-on for all users"
 msgstr "Single sign-on for all users"
 
-#: src/components/settings/components/main-sidebar.tsx:34
+#: src/components/settings/components/main-sidebar.tsx:36
 msgid "Sound"
 msgstr "Sound"
 

--- a/apps/desktop/src/locales/ko/messages.po
+++ b/apps/desktop/src/locales/ko/messages.po
@@ -333,7 +333,6 @@ msgid "Built-in Templates"
 msgstr ""
 
 #: src/components/settings/components/settings-header.tsx:26
-#: src/components/settings/components/main-sidebar.tsx:30
 msgid "Calendar"
 msgstr ""
 
@@ -413,7 +412,7 @@ msgstr ""
 msgid "Contacts Access"
 msgstr "<<<<<<< HEAD"
 
-#: src/routes/app.human.$id.tsx:381
+#: src/routes/app.human.$id.tsx:493
 #: src/components/editor-area/note-header/chips/participants-chip/participants-list.tsx:378
 msgid "Create"
 msgstr ""
@@ -501,7 +500,7 @@ msgid "Exclude these apps from auto detection"
 msgstr ""
 
 #: src/components/settings/components/settings-header.tsx:32
-#: src/components/settings/components/main-sidebar.tsx:38
+#: src/components/settings/components/main-sidebar.tsx:40
 msgid "Extensions"
 msgstr ""
 
@@ -538,7 +537,7 @@ msgid "Full name"
 msgstr ""
 
 #: src/components/settings/components/settings-header.tsx:20
-#: src/components/settings/components/main-sidebar.tsx:28
+#: src/components/settings/components/main-sidebar.tsx:29
 msgid "General"
 msgstr ""
 
@@ -635,7 +634,7 @@ msgstr ""
 #~ msgid "Local Language Model"
 #~ msgstr ""
 
-#: src/components/left-sidebar/top-area/settings-button.tsx:38
+#: src/components/left-sidebar/top-area/settings-button.tsx:42
 msgid "Local mode"
 msgstr ""
 
@@ -684,7 +683,7 @@ msgstr ""
 msgid "Much better AI performance"
 msgstr ""
 
-#: src/components/left-sidebar/top-area/settings-button.tsx:53
+#: src/components/left-sidebar/top-area/settings-button.tsx:63
 msgid "My Profile"
 msgstr ""
 
@@ -912,7 +911,7 @@ msgstr ""
 msgid "Send invite"
 msgstr ""
 
-#: src/components/left-sidebar/top-area/settings-button.tsx:46
+#: src/components/left-sidebar/top-area/settings-button.tsx:56
 msgid "Settings"
 msgstr ""
 
@@ -932,7 +931,7 @@ msgstr ""
 msgid "Single sign-on for all users"
 msgstr ""
 
-#: src/components/settings/components/main-sidebar.tsx:34
+#: src/components/settings/components/main-sidebar.tsx:36
 msgid "Sound"
 msgstr ""
 


### PR DESCRIPTION
- Enhance the design and layout of the settings button dropdown menu
- Introduce a new header section with a gradient background, CPU icon, and "Local mode" label
- Adjust the overall width of the dropdown menu to 52 pixels
- Add a subtle background pattern to the header section
- Adjust the spacing and alignment of the settings and profile menu items
- Remove the "DropdownMenuLabel" and "DropdownMenuSeparator" components