### PR TITLE
feat(events-list): Add context menu and navigation options

### DIFF
--- a/apps/desktop/src/components/left-sidebar/events-list.tsx
+++ b/apps/desktop/src/components/left-sidebar/events-list.tsx
@@ -1,6 +1,7 @@
 import { Trans } from "@lingui/react/macro";
-import { useNavigate } from "@tanstack/react-router";
+import { LinkProps, useNavigate } from "@tanstack/react-router";
 import { clsx } from "clsx";
+import { format } from "date-fns";
 import { AppWindowMacIcon, ArrowUpRight, CalendarDaysIcon } from "lucide-react";
 
 import { type Event, type Session } from "@hypr/plugin-db";
@@ -79,9 +80,13 @@ function EventItem({
 
   const handleOpenCalendar = () => {
     const date = new Date(event.start_date);
-    const formattedDate = date.toISOString().split("T")[0]; // Format as YYYY-MM-DD
 
-    const url = `/app/calendar?date=${formattedDate}`;
+    const params = {
+      to: "/app/calendar",
+      search: { date: format(date, "yyyy-MM-dd") },
+    } as const satisfies LinkProps;
+
+    const url = `${params.to}?date=${params.search.date}`;
     safeNavigate({ type: "calendar" }, url);
   };
 

--- a/apps/desktop/src/components/left-sidebar/events-list.tsx
+++ b/apps/desktop/src/components/left-sidebar/events-list.tsx
@@ -1,10 +1,19 @@
 import { Trans } from "@lingui/react/macro";
 import { useNavigate } from "@tanstack/react-router";
 import { clsx } from "clsx";
+import { AppWindowMacIcon, ArrowUpRight, CalendarDaysIcon } from "lucide-react";
 
 import { type Event, type Session } from "@hypr/plugin-db";
+import { commands as windowsCommands } from "@hypr/plugin-windows";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@hypr/ui/components/ui/context-menu";
 import { useSession } from "@hypr/utils/contexts";
 import { formatUpcomingTime } from "@hypr/utils/datetime";
+import { safeNavigate } from "@hypr/utils/navigation";
 
 type EventWithSession = Event & { session: Session | null };
 
@@ -13,7 +22,10 @@ interface EventsListProps {
   activeSessionId?: string;
 }
 
-export default function EventsList({ events, activeSessionId }: EventsListProps) {
+export default function EventsList({
+  events,
+  activeSessionId,
+}: EventsListProps) {
   if (!events || events.length === 0) {
     return null;
   }
@@ -27,15 +39,25 @@ export default function EventsList({ events, activeSessionId }: EventsListProps)
       <div>
         {events
           .sort((a, b) => a.start_date.localeCompare(b.start_date))
-          .map((event) => <EventItem key={event.id} event={event} activeSessionId={activeSessionId} />)}
+          .map((event) => (
+            <EventItem
+              key={event.id}
+              event={event}
+              activeSessionId={activeSessionId}
+            />
+          ))}
       </div>
     </section>
   );
 }
 
-function EventItem(
-  { event, activeSessionId }: { event: EventWithSession; activeSessionId?: string },
-) {
+function EventItem({
+  event,
+  activeSessionId,
+}: {
+  event: EventWithSession;
+  activeSessionId?: string;
+}) {
   const navigate = useNavigate();
 
   const handleClick = () => {
@@ -49,23 +71,69 @@ function EventItem(
     }
   };
 
-  const isActive = activeSessionId && event.session?.id && (activeSessionId === event.session.id);
+  const handleOpenWindow = () => {
+    if (event.session) {
+      windowsCommands.windowShow({ type: "note", value: event.session.id });
+    }
+  };
+
+  const handleOpenCalendar = () => {
+    const date = new Date(event.start_date);
+    const formattedDate = date.toISOString().split("T")[0]; // Format as YYYY-MM-DD
+
+    const url = `/app/calendar?date=${formattedDate}`;
+    safeNavigate({ type: "calendar" }, url);
+  };
+
+  const isActive = activeSessionId
+    && event.session?.id
+    && activeSessionId === event.session.id;
 
   return (
-    <button
-      onClick={handleClick}
-      className={clsx([
-        "w-full text-left group flex items-start gap-3 py-2 rounded-lg px-2",
-        isActive ? "bg-neutral-200" : "hover:bg-neutral-100",
-      ])}
-    >
-      <div className="flex flex-col items-start gap-1">
-        <EventItemTitle event={event} />
-        <div className="flex items-center gap-2 text-xs text-neutral-500 line-clamp-1">
-          <span>{formatUpcomingTime(new Date(event.start_date))}</span>
-        </div>
-      </div>
-    </button>
+    <ContextMenu>
+      <ContextMenuTrigger>
+        <button
+          onClick={handleClick}
+          className={clsx([
+            "w-full text-left group flex items-start gap-3 py-2 rounded-lg px-2",
+            isActive ? "bg-neutral-200" : "hover:bg-neutral-100",
+          ])}
+        >
+          <div className="flex flex-col items-start gap-1">
+            <EventItemTitle event={event} />
+            <div className="flex items-center gap-2 text-xs text-neutral-500 line-clamp-1">
+              <span>{formatUpcomingTime(new Date(event.start_date))}</span>
+            </div>
+          </div>
+        </button>
+      </ContextMenuTrigger>
+
+      <ContextMenuContent>
+        {event.session && (
+          <ContextMenuItem
+            className="cursor-pointer flex items-center justify-between"
+            onClick={handleOpenWindow}
+          >
+            <div className="flex items-center gap-2">
+              <AppWindowMacIcon size={16} />
+              <Trans>New window</Trans>
+            </div>
+            <ArrowUpRight size={16} className="ml-1 text-zinc-500" />
+          </ContextMenuItem>
+        )}
+
+        <ContextMenuItem
+          className="cursor-pointer flex items-center justify-between"
+          onClick={handleOpenCalendar}
+        >
+          <div className="flex items-center gap-2">
+            <CalendarDaysIcon size={16} />
+            <Trans>View in calendar</Trans>
+          </div>
+          <ArrowUpRight size={16} className="ml-1 text-zinc-500" />
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 

--- a/apps/desktop/src/locales/en/messages.po
+++ b/apps/desktop/src/locales/en/messages.po
@@ -701,6 +701,7 @@ msgid "New note"
 msgstr "New note"
 
 #: src/components/left-sidebar/notes-list.tsx:287
+#: src/components/left-sidebar/events-list.tsx:124
 msgid "New window"
 msgstr "New window"
 
@@ -1066,7 +1067,7 @@ msgstr "Untitled"
 msgid "Untitled Template"
 msgstr "Untitled Template"
 
-#: src/components/left-sidebar/events-list.tsx:24
+#: src/components/left-sidebar/events-list.tsx:37
 msgid "Upcoming"
 msgstr "Upcoming"
 
@@ -1098,6 +1099,7 @@ msgstr "username"
 msgid "View calendar"
 msgstr "View calendar"
 
+#: src/components/left-sidebar/events-list.tsx:136
 #: src/components/editor-area/note-header/chips/event-chip.tsx:43
 msgid "View in calendar"
 msgstr "View in calendar"

--- a/apps/desktop/src/locales/ko/messages.po
+++ b/apps/desktop/src/locales/ko/messages.po
@@ -701,6 +701,7 @@ msgid "New note"
 msgstr ""
 
 #: src/components/left-sidebar/notes-list.tsx:287
+#: src/components/left-sidebar/events-list.tsx:124
 msgid "New window"
 msgstr ""
 
@@ -1066,7 +1067,7 @@ msgstr ""
 msgid "Untitled Template"
 msgstr ""
 
-#: src/components/left-sidebar/events-list.tsx:24
+#: src/components/left-sidebar/events-list.tsx:37
 msgid "Upcoming"
 msgstr ""
 
@@ -1098,6 +1099,7 @@ msgstr ""
 msgid "View calendar"
 msgstr ""
 
+#: src/components/left-sidebar/events-list.tsx:136
 #: src/components/editor-area/note-header/chips/event-chip.tsx:43
 msgid "View in calendar"
 msgstr ""


### PR DESCRIPTION
This commit adds a context menu to the event items in the events list, providing
users with additional options to interact with the events. The main changes
include:

1. Implement a context menu using the `ContextMenu` component from the `@hypr/ui`
   library.
2. Add two context menu items:
   - "New window": Opens the associated session in a new window.
   - "View in calendar": Navigates to the calendar view with the event's date
     pre-selected.
3. Refactor the `EventItem` component to handle the context menu and the new
   navigation options.
4. Improve the formatting and readability of the code.