### PR TITLE
Add Onboarding Video Support and Refactor Note Editor Onboarding Logic

### DIFF
--- a/apps/desktop/src/components/editor-area/index.tsx
+++ b/apps/desktop/src/components/editor-area/index.tsx
@@ -21,9 +21,17 @@ import { NoteHeader } from "./note-header";
 export default function EditorArea({
   editable,
   sessionId,
+  onboardingSupport,
 }: {
   editable: boolean;
   sessionId: string;
+  onboardingSupport?: {
+    isOnboardingSession: boolean;
+    videoId: string;
+    ongoingSessionStatus: string;
+    playOnboardingVideo: () => void;
+    stopOnboardingVideo: () => void;
+  } | null;
 }) {
   const { ongoingSessionStatus } = useOngoingSession((s) => ({
     ongoingSessionStatus: s.status,
@@ -103,6 +111,7 @@ export default function EditorArea({
         editable={editable}
         onNavigateToEditor={safelyFocusEditor}
         hashtags={hashtags}
+        onboardingSupport={onboardingSupport}
       />
 
       <div

--- a/apps/desktop/src/components/editor-area/note-header/index.tsx
+++ b/apps/desktop/src/components/editor-area/note-header/index.tsx
@@ -60,6 +60,7 @@ export function NoteHeader({
           {onboardingSupport
             ? (
               <OnboardingVideoButton
+                sessionId={sessionId}
                 ongoingSessionStatus={onboardingSupport.ongoingSessionStatus}
                 playVideo={onboardingSupport.playOnboardingVideo}
                 stopVideo={onboardingSupport.stopOnboardingVideo}

--- a/apps/desktop/src/components/editor-area/note-header/index.tsx
+++ b/apps/desktop/src/components/editor-area/note-header/index.tsx
@@ -5,6 +5,7 @@ import { getCurrentWebviewWindowLabel } from "@hypr/plugin-windows";
 import { useSession } from "@hypr/utils/contexts";
 import Chips from "./chips";
 import ListenButton from "./listen-button";
+import OnboardingVideoButton from "./onboarding-video-button";
 import TitleInput from "./title-input";
 
 interface NoteHeaderProps {
@@ -12,9 +13,22 @@ interface NoteHeaderProps {
   editable?: boolean;
   sessionId: string;
   hashtags?: string[];
+  onboardingSupport?: {
+    isOnboardingSession: boolean;
+    videoId: string;
+    ongoingSessionStatus: string;
+    playOnboardingVideo: () => void;
+    stopOnboardingVideo: () => void;
+  } | null;
 }
 
-export function NoteHeader({ onNavigateToEditor, editable, sessionId, hashtags = [] }: NoteHeaderProps) {
+export function NoteHeader({
+  onNavigateToEditor,
+  editable,
+  sessionId,
+  hashtags = [],
+  onboardingSupport,
+}: NoteHeaderProps) {
   const sessionStore = useSession(sessionId, (s) => ({
     session: s.session,
     updateTitle: s.updateTitle,
@@ -41,7 +55,20 @@ export function NoteHeader({ onNavigateToEditor, editable, sessionId, hashtags =
         <Chips sessionId={sessionId} hashtags={hashtags} />
       </div>
 
-      {isInNoteMain && <ListenButton sessionId={sessionId} />}
+      {isInNoteMain && (
+        <>
+          {onboardingSupport
+            ? (
+              <OnboardingVideoButton
+                ongoingSessionStatus={onboardingSupport.ongoingSessionStatus}
+                playVideo={onboardingSupport.playOnboardingVideo}
+                stopVideo={onboardingSupport.stopOnboardingVideo}
+                isEnhanced={!!sessionStore.session.enhanced_memo_html}
+              />
+            )
+            : <ListenButton sessionId={sessionId} />}
+        </>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/components/editor-area/note-header/listen-button.tsx
+++ b/apps/desktop/src/components/editor-area/note-header/listen-button.tsx
@@ -16,14 +16,9 @@ import { toast } from "@hypr/ui/components/ui/toast";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@hypr/ui/components/ui/tooltip";
 import { useOngoingSession, useSession } from "@hypr/utils/contexts";
 
-interface ListenButtonProps {
+export default function ListenButton({ sessionId }: {
   sessionId: string;
-}
-
-export default function ListenButton({ sessionId }: ListenButtonProps) {
-  const [open, setOpen] = useState(false);
-  const [isHovered, setIsHovered] = useState(false);
-
+}) {
   const modelDownloaded = useQuery({
     queryKey: ["check-stt-model-downloaded"],
     refetchInterval: 1000,
@@ -56,35 +51,6 @@ export default function ListenButton({ sessionId }: ListenButtonProps) {
   );
   const meetingEnded = isEnhancePending || nonEmptySession;
 
-  const { data: isMicMuted, refetch: refetchMicMuted } = useQuery({
-    queryKey: ["mic-muted"],
-    queryFn: () => listenerCommands.getMicMuted(),
-  });
-
-  const { data: isSpeakerMuted, refetch: refetchSpeakerMuted } = useQuery({
-    queryKey: ["speaker-muted"],
-    queryFn: () => listenerCommands.getSpeakerMuted(),
-  });
-
-  useEffect(() => {
-    refetchMicMuted();
-    refetchSpeakerMuted();
-  }, [ongoingSessionStatus, refetchMicMuted, refetchSpeakerMuted]);
-
-  const toggleMicMuted = useMutation({
-    mutationFn: () => listenerCommands.setMicMuted(!isMicMuted),
-    onSuccess: () => {
-      refetchMicMuted();
-    },
-  });
-
-  const toggleSpeakerMuted = useMutation({
-    mutationFn: () => listenerCommands.setSpeakerMuted(!isSpeakerMuted),
-    onSuccess: () => {
-      refetchSpeakerMuted();
-    },
-  });
-
   useEffect(() => {
     if (ongoingSessionStatus === "running_active" && prevOngoingSessionStatus === "inactive") {
       toast({
@@ -105,16 +71,6 @@ export default function ListenButton({ sessionId }: ListenButtonProps) {
 
   const handleResumeSession = () => {
     ongoingSessionStore.resume();
-  };
-
-  const handlePauseSession = () => {
-    ongoingSessionStore.pause();
-    setOpen(false);
-  };
-
-  const handleStopSession = () => {
-    ongoingSessionStore.stop();
-    setOpen(false);
   };
 
   if (ongoingSessionStore.loading) {
@@ -146,44 +102,17 @@ export default function ListenButton({ sessionId }: ListenButtonProps) {
   if (ongoingSessionStatus === "inactive") {
     if (!meetingEnded) {
       return (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              disabled={!modelDownloaded.data}
-              onClick={handleStartSession}
-              className={clsx([
-                "w-9 h-9 rounded-full border-2 transition-all hover:scale-95  cursor-pointer outline-none p-0 flex items-center justify-center",
-                !modelDownloaded.data ? "bg-neutral-200 border-neutral-400" : "bg-red-500 border-neutral-400",
-              ])}
-              style={{
-                boxShadow: "0 0 0 2px rgba(255, 255, 255, 0.8) inset",
-              }}
-            >
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" align="end">
-            <p>
-              <Trans>Start recording</Trans>
-            </p>
-          </TooltipContent>
-        </Tooltip>
+        <WhenInactiveAndMeetingNotEnded
+          disabled={!modelDownloaded.data}
+          onClick={handleStartSession}
+        />
       );
     } else {
       return (
-        <button
+        <WhenInactiveAndMeetingEnded
           disabled={!modelDownloaded.data || isEnhancePending}
           onClick={handleStartSession}
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
-          className={clsx(
-            "w-16 h-9 rounded-full transition-all hover:scale-95 cursor-pointer outline-none p-0 flex items-center justify-center text-xs font-medium",
-            "bg-neutral-200 border-2 border-neutral-400 text-neutral-600 opacity-30",
-            !isEnhancePending && "hover:opacity-100 hover:bg-red-100 hover:text-red-600 hover:border-red-400",
-          )}
-          style={{ boxShadow: "0 0 0 2px rgba(255, 255, 255, 0.8) inset" }}
-        >
-          <Trans>{isHovered ? "Resume" : "Ended"}</Trans>
-        </button>
+        />
       );
     }
   }
@@ -193,69 +122,168 @@ export default function ListenButton({ sessionId }: ListenButtonProps) {
       return null;
     }
 
-    return (
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <button
-            onClick={handleStartSession}
-            className={clsx([
-              open && "hover:scale-95",
-              "w-14 h-9 rounded-full bg-red-100 border-2 transition-all border-red-400 cursor-pointer outline-none p-0 flex items-center justify-center",
-            ])}
-            style={{
-              boxShadow: "0 0 0 2px rgba(255, 255, 255, 0.8) inset",
-            }}
-          >
-            <SoundIndicator color="#ef4444" size="long" />
-          </button>
-        </PopoverTrigger>
-
-        <PopoverContent className="w-60" align="end">
-          <div className="flex w-full justify-between mb-4">
-            <AudioControlButton
-              isMuted={isMicMuted}
-              onToggle={() => toggleMicMuted.mutate()}
-              type="mic"
-            />
-            <AudioControlButton
-              isMuted={isSpeakerMuted}
-              onToggle={() => toggleSpeakerMuted.mutate()}
-              type="speaker"
-            />
-          </div>
-
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              onClick={handlePauseSession}
-              className="w-full"
-            >
-              <PauseIcon size={16} />
-              <Trans>Pause</Trans>
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleStopSession}
-              className="w-full"
-            >
-              <StopCircleIcon size={16} />
-              <Trans>Stop</Trans>
-            </Button>
-          </div>
-        </PopoverContent>
-      </Popover>
-    );
+    return <WhenActive sessionId={sessionId} />;
   }
 }
 
+function WhenInactiveAndMeetingNotEnded({ disabled, onClick }: { disabled: boolean; onClick: () => void }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          disabled={disabled}
+          onClick={onClick}
+          className={clsx([
+            "w-9 h-9 rounded-full border-2 transition-all hover:scale-95  cursor-pointer outline-none p-0 flex items-center justify-center",
+            disabled ? "bg-neutral-200 border-neutral-400" : "bg-red-500 border-neutral-400",
+          ])}
+          style={{
+            boxShadow: "0 0 0 2px rgba(255, 255, 255, 0.8) inset",
+          }}
+        >
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" align="end">
+        <p>
+          <Trans>Start recording</Trans>
+        </p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function WhenInactiveAndMeetingEnded({ disabled, onClick }: { disabled: boolean; onClick: () => void }) {
+  const [isHovered, setIsHovered] = useState(false);
+  return (
+    <button
+      disabled={disabled}
+      onClick={onClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      className={clsx(
+        "w-16 h-9 rounded-full transition-all hover:scale-95 cursor-pointer outline-none p-0 flex items-center justify-center text-xs font-medium",
+        "bg-neutral-200 border-2 border-neutral-400 text-neutral-600 opacity-30",
+        !disabled && "hover:opacity-100 hover:bg-red-100 hover:text-red-600 hover:border-red-400",
+      )}
+      style={{ boxShadow: "0 0 0 2px rgba(255, 255, 255, 0.8) inset" }}
+    >
+      <Trans>{isHovered ? "Resume" : "Ended"}</Trans>
+    </button>
+  );
+}
+
+export function WhenActive({ sessionId }: { sessionId: string }) {
+  const [open, setOpen] = useState(false);
+
+  const { data: isMicMuted, refetch: refetchMicMuted } = useQuery({
+    queryKey: ["mic-muted"],
+    queryFn: () => listenerCommands.getMicMuted(),
+  });
+
+  const { data: isSpeakerMuted, refetch: refetchSpeakerMuted } = useQuery({
+    queryKey: ["speaker-muted"],
+    queryFn: () => listenerCommands.getSpeakerMuted(),
+  });
+
+  const toggleMicMuted = useMutation({
+    mutationFn: () => listenerCommands.setMicMuted(!isMicMuted),
+    onSuccess: () => {
+      refetchMicMuted();
+    },
+  });
+
+  const toggleSpeakerMuted = useMutation({
+    mutationFn: () => listenerCommands.setSpeakerMuted(!isSpeakerMuted),
+    onSuccess: () => {
+      refetchSpeakerMuted();
+    },
+  });
+
+  const ongoingSessionStatus = useOngoingSession((s) => s.status);
+  const ongoingSessionStore = useOngoingSession((s) => ({
+    start: s.start,
+    pause: s.pause,
+    stop: s.stop,
+  }));
+
+  const handleStartSession = () => {
+    if (ongoingSessionStatus === "inactive") {
+      ongoingSessionStore.start(sessionId);
+    }
+  };
+
+  const handlePauseSession = () => {
+    ongoingSessionStore.pause();
+    setOpen(false);
+  };
+
+  const handleStopSession = () => {
+    ongoingSessionStore.stop();
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          onClick={handleStartSession}
+          className={clsx([
+            open && "hover:scale-95",
+            "w-14 h-9 rounded-full bg-red-100 border-2 transition-all border-red-400 cursor-pointer outline-none p-0 flex items-center justify-center",
+          ])}
+          style={{
+            boxShadow: "0 0 0 2px rgba(255, 255, 255, 0.8) inset",
+          }}
+        >
+          <SoundIndicator color="#ef4444" size="long" />
+        </button>
+      </PopoverTrigger>
+
+      <PopoverContent className="w-60" align="end">
+        <div className="flex w-full justify-between mb-4">
+          <AudioControlButton
+            isMuted={isMicMuted}
+            onClick={() => toggleMicMuted.mutate()}
+            type="mic"
+          />
+          <AudioControlButton
+            isMuted={isSpeakerMuted}
+            onClick={() => toggleSpeakerMuted.mutate()}
+            type="speaker"
+          />
+        </div>
+
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={handlePauseSession}
+            className="w-full"
+          >
+            <PauseIcon size={16} />
+            <Trans>Pause</Trans>
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleStopSession}
+            className="w-full"
+          >
+            <StopCircleIcon size={16} />
+            <Trans>Stop</Trans>
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 function AudioControlButton({
-  isMuted,
-  onToggle,
   type,
+  isMuted,
+  onClick,
 }: {
-  isMuted?: boolean;
-  onToggle: () => void;
   type: "mic" | "speaker";
+  isMuted?: boolean;
+  onClick: () => void;
 }) {
   const Icon = type === "mic"
     ? isMuted
@@ -266,7 +294,7 @@ function AudioControlButton({
     : Volume2Icon;
 
   return (
-    <Button variant="ghost" size="icon" onClick={onToggle} className="w-full">
+    <Button variant="ghost" size="icon" onClick={onClick} className="w-full">
       <Icon className={isMuted ? "text-neutral-500" : ""} size={20} />
       <SoundIndicator input={type} size="long" />
     </Button>

--- a/apps/desktop/src/components/editor-area/note-header/onboarding-video-button.tsx
+++ b/apps/desktop/src/components/editor-area/note-header/onboarding-video-button.tsx
@@ -1,0 +1,223 @@
+import { Trans } from "@lingui/react/macro";
+import { MicIcon, MicOffIcon, PlayIcon, StopCircleIcon, Volume2Icon, VolumeOffIcon } from "lucide-react";
+import { type AnimationProps, motion, type MotionProps } from "motion/react";
+import { useEffect, useState } from "react";
+
+import SoundIndicator from "@/components/sound-indicator";
+import { commands as listenerCommands } from "@hypr/plugin-listener";
+import { Button } from "@hypr/ui/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@hypr/ui/components/ui/popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@hypr/ui/components/ui/tooltip";
+import { cn } from "@hypr/ui/lib/utils";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+interface OnboardingVideoButtonProps {
+  ongoingSessionStatus: string;
+  playVideo: () => void;
+  stopVideo: () => void;
+  isEnhanced?: boolean;
+}
+
+interface ShinyButtonProps extends Omit<React.HTMLAttributes<HTMLElement>, keyof MotionProps>, MotionProps {
+  children: React.ReactNode;
+  className?: string;
+  onClick?: () => void;
+}
+
+const animationProps = {
+  initial: { "--x": "100%" },
+  animate: { "--x": "-100%" },
+  whileTap: { scale: 0.95 },
+  transition: {
+    repeat: Infinity,
+    repeatType: "loop",
+    repeatDelay: 1,
+    duration: 1.5,
+  },
+} as AnimationProps;
+
+function ShinyButton({ children, className, onClick, ...props }: ShinyButtonProps) {
+  return (
+    <motion.button
+      className={cn(
+        "relative transition-all hover:scale-95 cursor-pointer outline-none flex items-center justify-center p-0",
+        className,
+      )}
+      onClick={onClick}
+      {...animationProps}
+      {...props}
+    >
+      <span
+        className="relative flex items-center justify-center w-full h-full"
+        style={{
+          maskImage:
+            "linear-gradient(-75deg,rgba(255,255,255,1) calc(var(--x) + 20%),transparent calc(var(--x) + 30%),rgba(255,255,255,1) calc(var(--x) + 100%))",
+        }}
+      >
+        {children}
+      </span>
+      <span
+        style={{
+          mask: "linear-gradient(rgb(0,0,0), rgb(0,0,0)) content-box exclude,linear-gradient(rgb(0,0,0), rgb(0,0,0))",
+          WebkitMask:
+            "linear-gradient(rgb(0,0,0), rgb(0,0,0)) content-box exclude,linear-gradient(rgb(0,0,0), rgb(0,0,0))",
+          backgroundImage:
+            "linear-gradient(-75deg,rgba(255,255,255,0.1) calc(var(--x)+20%),rgba(255,255,255,0.5) calc(var(--x)+25%),rgba(255,255,255,0.1) calc(var(--x)+100%))",
+        }}
+        className="absolute inset-0 z-10 block rounded-[inherit] p-px"
+      >
+      </span>
+    </motion.button>
+  );
+}
+
+export default function OnboardingVideoButton({
+  ongoingSessionStatus,
+  playVideo,
+  stopVideo,
+  isEnhanced = false,
+}: OnboardingVideoButtonProps) {
+  const [open, setOpen] = useState(false);
+
+  const { data: isMicMuted, refetch: refetchMicMuted } = useQuery({
+    queryKey: ["mic-muted"],
+    queryFn: () => listenerCommands.getMicMuted(),
+  });
+
+  const { data: isSpeakerMuted, refetch: refetchSpeakerMuted } = useQuery({
+    queryKey: ["speaker-muted"],
+    queryFn: () => listenerCommands.getSpeakerMuted(),
+  });
+
+  useEffect(() => {
+    refetchMicMuted();
+    refetchSpeakerMuted();
+  }, [ongoingSessionStatus, refetchMicMuted, refetchSpeakerMuted]);
+
+  const toggleMicMuted = useMutation({
+    mutationFn: () => listenerCommands.setMicMuted(!isMicMuted),
+    onSuccess: () => {
+      refetchMicMuted();
+    },
+  });
+
+  const toggleSpeakerMuted = useMutation({
+    mutationFn: () => listenerCommands.setSpeakerMuted(!isSpeakerMuted),
+    onSuccess: () => {
+      refetchSpeakerMuted();
+    },
+  });
+
+  if (ongoingSessionStatus === "inactive" && !isEnhanced) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <ShinyButton
+            onClick={playVideo}
+            className={cn([
+              "w-24 h-9 rounded-full border-2 transition-all cursor-pointer outline-none p-0 flex items-center justify-center gap-1",
+              "bg-neutral-800 border-neutral-700 text-white text-xs font-medium",
+            ])}
+            style={{
+              boxShadow: "0 0 0 2px rgba(255, 255, 255, 0.8) inset",
+            }}
+          >
+            <PlayIcon size={14} />
+            <Trans>Play video</Trans>
+          </ShinyButton>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" align="end">
+          <p>
+            <Trans>Start onboarding video</Trans>
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  if (ongoingSessionStatus === "running_active") {
+    return (
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            className={cn([
+              open && "hover:scale-95",
+              "w-14 h-9 rounded-full bg-red-100 border-2 transition-all border-red-400 cursor-pointer outline-none p-0 flex items-center justify-center",
+            ])}
+            style={{
+              boxShadow: "0 0 0 2px rgba(255, 255, 255, 0.8) inset",
+            }}
+          >
+            <SoundIndicator color="#ef4444" size="long" />
+          </button>
+        </PopoverTrigger>
+
+        <PopoverContent className="w-60" align="end">
+          <div className="flex w-full justify-between mb-4">
+            <AudioControlButton
+              isMuted={isMicMuted}
+              onToggle={() => toggleMicMuted.mutate()}
+              type="mic"
+            />
+            <AudioControlButton
+              isMuted={isSpeakerMuted}
+              onToggle={() => toggleSpeakerMuted.mutate()}
+              type="speaker"
+            />
+          </div>
+
+          <div className="flex gap-2">
+            <Button
+              variant="destructive"
+              onClick={stopVideo}
+              className="w-full"
+            >
+              <StopCircleIcon size={16} />
+              <Trans>Stop</Trans>
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+    );
+  }
+
+  return (
+    <button
+      onClick={playVideo}
+      className={cn(
+        "w-28 h-9 rounded-full transition-all hover:scale-95 cursor-pointer outline-none p-0 flex items-center justify-center gap-1 text-xs font-medium",
+        "bg-neutral-200 border-2 border-neutral-400 text-neutral-600",
+        "hover:bg-neutral-300 hover:text-neutral-800 hover:border-neutral-500",
+      )}
+      style={{ boxShadow: "0 0 0 2px rgba(255, 255, 255, 0.8) inset" }}
+    >
+      <PlayIcon size={14} />
+      <Trans>Play again</Trans>
+    </button>
+  );
+}
+
+function AudioControlButton({
+  isMuted,
+  onToggle,
+  type,
+}: {
+  isMuted?: boolean;
+  onToggle: () => void;
+  type: "mic" | "speaker";
+}) {
+  const Icon = type === "mic"
+    ? isMuted
+      ? MicOffIcon
+      : MicIcon
+    : isMuted
+    ? VolumeOffIcon
+    : Volume2Icon;
+
+  return (
+    <Button variant="ghost" size="icon" onClick={onToggle} className="w-full">
+      <Icon className={isMuted ? "text-neutral-500" : ""} size={20} />
+      <SoundIndicator input={type} size="long" />
+    </Button>
+  );
+}

--- a/apps/desktop/src/components/editor-area/note-header/onboarding-video-button.tsx
+++ b/apps/desktop/src/components/editor-area/note-header/onboarding-video-button.tsx
@@ -1,21 +1,71 @@
 import { Trans } from "@lingui/react/macro";
-import { MicIcon, MicOffIcon, PlayIcon, StopCircleIcon, Volume2Icon, VolumeOffIcon } from "lucide-react";
+import { PlayIcon } from "lucide-react";
 import { type AnimationProps, motion, type MotionProps } from "motion/react";
-import { useEffect, useState } from "react";
 
-import SoundIndicator from "@/components/sound-indicator";
-import { commands as listenerCommands } from "@hypr/plugin-listener";
-import { Button } from "@hypr/ui/components/ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "@hypr/ui/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@hypr/ui/components/ui/tooltip";
 import { cn } from "@hypr/ui/lib/utils";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { WhenActive } from "./listen-button";
 
 interface OnboardingVideoButtonProps {
+  sessionId: string;
   ongoingSessionStatus: string;
   playVideo: () => void;
   stopVideo: () => void;
   isEnhanced?: boolean;
+}
+
+export default function OnboardingVideoButton({
+  sessionId,
+  ongoingSessionStatus,
+  playVideo,
+  stopVideo,
+  isEnhanced = false,
+}: OnboardingVideoButtonProps) {
+  if (ongoingSessionStatus === "inactive" && !isEnhanced) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <ShinyButton
+            onClick={playVideo}
+            className={cn([
+              "w-24 h-9 rounded-full border-2 transition-all cursor-pointer outline-none p-0 flex items-center justify-center gap-1",
+              "bg-neutral-800 border-neutral-700 text-white text-xs font-medium",
+            ])}
+            style={{
+              boxShadow: "0 0 0 2px rgba(255, 255, 255, 0.8) inset",
+            }}
+          >
+            <PlayIcon size={14} />
+            <Trans>Play video</Trans>
+          </ShinyButton>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" align="end">
+          <p>
+            <Trans>Start onboarding video</Trans>
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  if (ongoingSessionStatus === "running_active") {
+    return <WhenActive sessionId={sessionId} />;
+  }
+
+  return (
+    <button
+      onClick={playVideo}
+      className={cn(
+        "w-28 h-9 rounded-full transition-all hover:scale-95 cursor-pointer outline-none p-0 flex items-center justify-center gap-1 text-xs font-medium",
+        "bg-neutral-200 border-2 border-neutral-400 text-neutral-600",
+        "hover:bg-neutral-300 hover:text-neutral-800 hover:border-neutral-500",
+      )}
+      style={{ boxShadow: "0 0 0 2px rgba(255, 255, 255, 0.8) inset" }}
+    >
+      <PlayIcon size={14} />
+      <Trans>Play again</Trans>
+    </button>
+  );
 }
 
 interface ShinyButtonProps extends Omit<React.HTMLAttributes<HTMLElement>, keyof MotionProps>, MotionProps {
@@ -68,156 +118,5 @@ function ShinyButton({ children, className, onClick, ...props }: ShinyButtonProp
       >
       </span>
     </motion.button>
-  );
-}
-
-export default function OnboardingVideoButton({
-  ongoingSessionStatus,
-  playVideo,
-  stopVideo,
-  isEnhanced = false,
-}: OnboardingVideoButtonProps) {
-  const [open, setOpen] = useState(false);
-
-  const { data: isMicMuted, refetch: refetchMicMuted } = useQuery({
-    queryKey: ["mic-muted"],
-    queryFn: () => listenerCommands.getMicMuted(),
-  });
-
-  const { data: isSpeakerMuted, refetch: refetchSpeakerMuted } = useQuery({
-    queryKey: ["speaker-muted"],
-    queryFn: () => listenerCommands.getSpeakerMuted(),
-  });
-
-  useEffect(() => {
-    refetchMicMuted();
-    refetchSpeakerMuted();
-  }, [ongoingSessionStatus, refetchMicMuted, refetchSpeakerMuted]);
-
-  const toggleMicMuted = useMutation({
-    mutationFn: () => listenerCommands.setMicMuted(!isMicMuted),
-    onSuccess: () => {
-      refetchMicMuted();
-    },
-  });
-
-  const toggleSpeakerMuted = useMutation({
-    mutationFn: () => listenerCommands.setSpeakerMuted(!isSpeakerMuted),
-    onSuccess: () => {
-      refetchSpeakerMuted();
-    },
-  });
-
-  if (ongoingSessionStatus === "inactive" && !isEnhanced) {
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <ShinyButton
-            onClick={playVideo}
-            className={cn([
-              "w-24 h-9 rounded-full border-2 transition-all cursor-pointer outline-none p-0 flex items-center justify-center gap-1",
-              "bg-neutral-800 border-neutral-700 text-white text-xs font-medium",
-            ])}
-            style={{
-              boxShadow: "0 0 0 2px rgba(255, 255, 255, 0.8) inset",
-            }}
-          >
-            <PlayIcon size={14} />
-            <Trans>Play video</Trans>
-          </ShinyButton>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" align="end">
-          <p>
-            <Trans>Start onboarding video</Trans>
-          </p>
-        </TooltipContent>
-      </Tooltip>
-    );
-  }
-
-  if (ongoingSessionStatus === "running_active") {
-    return (
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <button
-            className={cn([
-              open && "hover:scale-95",
-              "w-14 h-9 rounded-full bg-red-100 border-2 transition-all border-red-400 cursor-pointer outline-none p-0 flex items-center justify-center",
-            ])}
-            style={{
-              boxShadow: "0 0 0 2px rgba(255, 255, 255, 0.8) inset",
-            }}
-          >
-            <SoundIndicator color="#ef4444" size="long" />
-          </button>
-        </PopoverTrigger>
-
-        <PopoverContent className="w-60" align="end">
-          <div className="flex w-full justify-between mb-4">
-            <AudioControlButton
-              isMuted={isMicMuted}
-              onToggle={() => toggleMicMuted.mutate()}
-              type="mic"
-            />
-            <AudioControlButton
-              isMuted={isSpeakerMuted}
-              onToggle={() => toggleSpeakerMuted.mutate()}
-              type="speaker"
-            />
-          </div>
-
-          <div className="flex gap-2">
-            <Button
-              variant="destructive"
-              onClick={stopVideo}
-              className="w-full"
-            >
-              <StopCircleIcon size={16} />
-              <Trans>Stop</Trans>
-            </Button>
-          </div>
-        </PopoverContent>
-      </Popover>
-    );
-  }
-
-  return (
-    <button
-      onClick={playVideo}
-      className={cn(
-        "w-28 h-9 rounded-full transition-all hover:scale-95 cursor-pointer outline-none p-0 flex items-center justify-center gap-1 text-xs font-medium",
-        "bg-neutral-200 border-2 border-neutral-400 text-neutral-600",
-        "hover:bg-neutral-300 hover:text-neutral-800 hover:border-neutral-500",
-      )}
-      style={{ boxShadow: "0 0 0 2px rgba(255, 255, 255, 0.8) inset" }}
-    >
-      <PlayIcon size={14} />
-      <Trans>Play again</Trans>
-    </button>
-  );
-}
-
-function AudioControlButton({
-  isMuted,
-  onToggle,
-  type,
-}: {
-  isMuted?: boolean;
-  onToggle: () => void;
-  type: "mic" | "speaker";
-}) {
-  const Icon = type === "mic"
-    ? isMuted
-      ? MicOffIcon
-      : MicIcon
-    : isMuted
-    ? VolumeOffIcon
-    : Volume2Icon;
-
-  return (
-    <Button variant="ghost" size="icon" onClick={onToggle} className="w-full">
-      <Icon className={isMuted ? "text-neutral-500" : ""} size={20} />
-      <SoundIndicator input={type} size="long" />
-    </Button>
   );
 }

--- a/apps/desktop/src/locales/en/messages.po
+++ b/apps/desktop/src/locales/en/messages.po
@@ -218,7 +218,7 @@ msgstr "{weeks} weeks later"
 #. placeholder {0}: type === "google-calendar" ? "Google Calendar" : "Outlook Calendar"
 #. placeholder {0}: isHovered ? "Resume" : "Ended"
 #: src/components/settings/components/calendar/cloud-calendar-integration-details.tsx:36
-#: src/components/editor-area/note-header/listen-button.tsx:185
+#: src/components/editor-area/note-header/listen-button.tsx:191
 msgid "{0}"
 msgstr "{0}"
 
@@ -788,7 +788,7 @@ msgstr "or"
 msgid "Owner"
 msgstr "Owner"
 
-#: src/components/editor-area/note-header/listen-button.tsx:234
+#: src/components/editor-area/note-header/listen-button.tsx:239
 msgid "Pause"
 msgstr "Pause"
 
@@ -803,6 +803,14 @@ msgstr "people"
 #: src/components/settings/components/main-sidebar.tsx:39
 #~ msgid "Permissions"
 #~ msgstr "Permissions"
+
+#: src/components/editor-area/note-header/onboarding-video-button.tsx:195
+msgid "Play again"
+msgstr "Play again"
+
+#: src/components/editor-area/note-header/onboarding-video-button.tsx:126
+msgid "Play video"
+msgstr "Play video"
 
 #: src/components/settings/views/billing.tsx:33
 msgid "Pro"
@@ -849,7 +857,7 @@ msgstr "Required to transcribe other people's voice during meetings"
 msgid "Required to transcribe your voice during meetings"
 msgstr "Required to transcribe your voice during meetings"
 
-#: src/components/editor-area/note-header/listen-button.tsx:141
+#: src/components/editor-area/note-header/listen-button.tsx:144
 msgid "Resume"
 msgstr "Resume"
 
@@ -955,7 +963,11 @@ msgstr "Start Annual Plan"
 msgid "Start Monthly Plan"
 msgstr "Start Monthly Plan"
 
-#: src/components/editor-area/note-header/listen-button.tsx:166
+#: src/components/editor-area/note-header/onboarding-video-button.tsx:131
+msgid "Start onboarding video"
+msgstr "Start onboarding video"
+
+#: src/components/editor-area/note-header/listen-button.tsx:171
 msgid "Start recording"
 msgstr "Start recording"
 
@@ -965,7 +977,8 @@ msgstr "Start recording"
 msgid "Start Server"
 msgstr "Start Server"
 
-#: src/components/editor-area/note-header/listen-button.tsx:242
+#: src/components/editor-area/note-header/onboarding-video-button.tsx:176
+#: src/components/editor-area/note-header/listen-button.tsx:247
 msgid "Stop"
 msgstr "Stop"
 

--- a/apps/desktop/src/locales/ko/messages.po
+++ b/apps/desktop/src/locales/ko/messages.po
@@ -218,7 +218,7 @@ msgstr ""
 #. placeholder {0}: type === "google-calendar" ? "Google Calendar" : "Outlook Calendar"
 #. placeholder {0}: isHovered ? "Resume" : "Ended"
 #: src/components/settings/components/calendar/cloud-calendar-integration-details.tsx:36
-#: src/components/editor-area/note-header/listen-button.tsx:185
+#: src/components/editor-area/note-header/listen-button.tsx:191
 msgid "{0}"
 msgstr ""
 
@@ -788,7 +788,7 @@ msgstr ""
 msgid "Owner"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:234
+#: src/components/editor-area/note-header/listen-button.tsx:239
 msgid "Pause"
 msgstr ""
 
@@ -803,6 +803,14 @@ msgstr ""
 #: src/components/settings/components/main-sidebar.tsx:39
 #~ msgid "Permissions"
 #~ msgstr ""
+
+#: src/components/editor-area/note-header/onboarding-video-button.tsx:195
+msgid "Play again"
+msgstr ""
+
+#: src/components/editor-area/note-header/onboarding-video-button.tsx:126
+msgid "Play video"
+msgstr ""
 
 #: src/components/settings/views/billing.tsx:33
 msgid "Pro"
@@ -849,7 +857,7 @@ msgstr ""
 msgid "Required to transcribe your voice during meetings"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:141
+#: src/components/editor-area/note-header/listen-button.tsx:144
 msgid "Resume"
 msgstr ""
 
@@ -955,7 +963,11 @@ msgstr ""
 msgid "Start Monthly Plan"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:166
+#: src/components/editor-area/note-header/onboarding-video-button.tsx:131
+msgid "Start onboarding video"
+msgstr ""
+
+#: src/components/editor-area/note-header/listen-button.tsx:171
 msgid "Start recording"
 msgstr ""
 
@@ -965,7 +977,8 @@ msgstr ""
 msgid "Start Server"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:242
+#: src/components/editor-area/note-header/onboarding-video-button.tsx:176
+#: src/components/editor-area/note-header/listen-button.tsx:247
 msgid "Stop"
 msgstr ""
 

--- a/apps/desktop/src/routes/video.tsx
+++ b/apps/desktop/src/routes/video.tsx
@@ -3,7 +3,7 @@ import type { MuxPlayerElementEventMap } from "@mux/mux-player";
 import MuxPlayer from "@mux/mux-player-react/lazy";
 import { createFileRoute } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { z } from "zod";
 
 import { commands as windowsCommands, events as windowsEvents } from "@hypr/plugin-windows";
@@ -24,22 +24,23 @@ export const Route = createFileRoute("/video")({
 function Component() {
   const { id } = Route.useLoaderData();
   const player = useRef<MuxPlayerElement>(null);
+  const [didExpandRightPanel, setDidExpandRightPanel] = useState(false);
 
   const styles = {
     "--bottom-controls": "none",
-    "aspectRatio": "16 / 9",
+    aspectRatio: "16 / 9",
   } as React.CSSProperties;
 
   const handleEnded = () => {
-    windowsEvents.mainWindowState.emit({
-      left_sidebar_expanded: true,
-      right_panel_expanded: false,
-    }).then(() => {
-      windowsCommands.windowDestroy({ type: "video", value: id });
-    });
+    windowsEvents.mainWindowState
+      .emit({
+        left_sidebar_expanded: true,
+        right_panel_expanded: false,
+      })
+      .then(() => {
+        windowsCommands.windowDestroy({ type: "video", value: id });
+      });
   };
-
-  const [didExpandRightPanel, setDidExpandRightPanel] = useState(false);
 
   const handleTimeUpdate = (e: MuxPlayerElementEventMap["timeupdate"]) => {
     if (e.timeStamp > 67500 && !didExpandRightPanel) {
@@ -51,16 +52,27 @@ function Component() {
     }
   };
 
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (player.current) {
+        player.current.play();
+      }
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, []);
+
   return (
-    <div
-      data-tauri-drag-region
-      className="w-full h-full relative"
-    >
-      <div className="absolute top-0 left-0 w-full h-11 bg-transparent z-50" data-tauri-drag-region></div>
+    <div data-tauri-drag-region className="w-full h-full relative">
+      <div
+        className="absolute top-0 left-0 w-full h-11 bg-transparent z-50"
+        data-tauri-drag-region
+      >
+      </div>
       <MuxPlayer
         ref={player}
         playbackId={id}
-        autoPlay={true}
+        autoPlay={false}
         style={styles}
         loading="viewport"
         onEnded={handleEnded}

--- a/apps/docs/data/i18n.json
+++ b/apps/docs/data/i18n.json
@@ -1,12 +1,12 @@
 [
   {
     "language": "ko",
-    "total": 259,
-    "missing": 250
+    "total": 262,
+    "missing": 253
   },
   {
     "language": "en (source)",
-    "total": 259,
+    "total": 262,
     "missing": 0
   }
 ]


### PR DESCRIPTION
- Add onboarding support to the note editor page
- Introduce an `onboardingSupport` object to handle the onboarding session
- Pass the `onboardingSupport` object to the `EditorArea` component
- Refactor the `Component` function to handle the onboarding session logic
- Remove the `OnboardingSupport` component
- Add onboarding video support to the note header component
- Conditionally render the `OnboardingVideoButton` component
- Implement the `OnboardingVideoButton` component with play/stop and mute/unmute controls
- Add an enhanced mode for the `OnboardingVideoButton` component
- Apply a shiny animation effect to the onboarding video button
- Add auto-play functionality and expand the right panel when the video ends
- Update translations for the note header components, including new strings for the onboarding video button