### PR TITLE
feat(note-header): Improve listen button styles

### DIFF
--- a/apps/desktop/src/components/editor-area/note-header/listen-button.tsx
+++ b/apps/desktop/src/components/editor-area/note-header/listen-button.tsx
@@ -181,10 +181,11 @@ export default function ListenButton({ sessionId }: ListenButtonProps) {
           onMouseEnter={() => setIsHovered(true)}
           onMouseLeave={() => setIsHovered(false)}
           className={cn(
-            "w-16 h-9 rounded-full transition-all hover:scale-95 cursor-pointer outline-none p-0 flex items-center justify-center text-xs font-medium",
+            "w-16 h-9 rounded-full transition-all outline-none p-0 flex items-center justify-center text-xs font-medium",
             "bg-neutral-200 border-2 border-neutral-400 text-neutral-600 opacity-30",
             !isEnhancePending
-              && "hover:opacity-100 hover:bg-red-100 hover:text-red-600 hover:border-red-400",
+              ? "hover:opacity-100 hover:bg-red-100 hover:text-red-600 hover:border-red-400"
+              : "hover:scale-95",
           )}
           style={{ boxShadow: "0 0 0 2px rgba(255, 255, 255, 0.8) inset" }}
         >


### PR DESCRIPTION
Enhances the styles of the listen button in the note header
component. The button now has a consistent appearance
regardless of the hover state, and the hover effect is
applied only when the enhancement is not pending.