### PR TITLE
Add Pending State Indicator for Sidebar Items and Update Localization Strings

### DIFF
--- a/apps/desktop/src/components/left-sidebar/events-list.tsx
+++ b/apps/desktop/src/components/left-sidebar/events-list.tsx
@@ -4,6 +4,7 @@ import { clsx } from "clsx";
 import { format } from "date-fns";
 import { AppWindowMacIcon, ArrowUpRight, CalendarDaysIcon } from "lucide-react";
 
+import { useEnhancePendingState } from "@/hooks/enhance-pending";
 import { type Event, type Session } from "@hypr/plugin-db";
 import { commands as windowsCommands } from "@hypr/plugin-windows";
 import {
@@ -12,6 +13,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from "@hypr/ui/components/ui/context-menu";
+import { SplashLoader } from "@hypr/ui/components/ui/splash";
 import { useSession } from "@hypr/utils/contexts";
 import { formatUpcomingTime } from "@hypr/utils/datetime";
 import { safeNavigate } from "@hypr/utils/navigation";
@@ -94,6 +96,10 @@ function EventItem({
     && event.session?.id
     && activeSessionId === event.session.id;
 
+  const sessionId = event.session?.id || "";
+  const isEnhancePending = useEnhancePendingState(sessionId);
+  const shouldShowPending = !!event.session?.id && isEnhancePending;
+
   return (
     <ContextMenu>
       <ContextMenuTrigger>
@@ -104,11 +110,16 @@ function EventItem({
             isActive ? "bg-neutral-200" : "hover:bg-neutral-100",
           ])}
         >
-          <div className="flex flex-col items-start gap-1">
-            <EventItemTitle event={event} />
-            <div className="flex items-center gap-2 text-xs text-neutral-500 line-clamp-1">
-              <span>{formatUpcomingTime(new Date(event.start_date))}</span>
+          <div className="flex items-center gap-1 w-full">
+            <div className="flex-1 flex flex-col items-start gap-1 truncate">
+              <EventItemTitle event={event} />
+
+              <div className="flex items-center gap-2 text-xs text-neutral-500 line-clamp-1">
+                <span>{formatUpcomingTime(new Date(event.start_date))}</span>
+              </div>
             </div>
+
+            {shouldShowPending && <SplashLoader size={20} strokeWidth={2} />}
           </div>
         </button>
       </ContextMenuTrigger>

--- a/apps/desktop/src/components/left-sidebar/notes-list.tsx
+++ b/apps/desktop/src/components/left-sidebar/notes-list.tsx
@@ -8,6 +8,7 @@ import { motion } from "motion/react";
 import { useCallback, useEffect, useRef } from "react";
 
 import { useHypr } from "@/contexts";
+import { useEnhancePendingState } from "@/hooks/enhance-pending";
 import { commands as dbCommands, type Event, type Session } from "@hypr/plugin-db";
 import { commands as windowsCommands } from "@hypr/plugin-windows";
 import {
@@ -17,6 +18,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@hypr/ui/components/ui/context-menu";
+import { SplashLoader } from "@hypr/ui/components/ui/splash";
 import { cn } from "@hypr/ui/lib/utils";
 import { useSession, useSessions } from "@hypr/utils/contexts";
 import { format, formatRelative, formatTimeAgo, isToday } from "@hypr/utils/datetime";
@@ -180,6 +182,8 @@ function NoteItem({
     created_at: s.session.created_at,
   }));
 
+  const isEnhancePending = useEnhancePendingState(currentSessionId);
+
   const currentSessionEvent = useQuery({
     queryKey: ["event", currentSessionId],
     queryFn: () => dbCommands.sessionGetEvent(currentSessionId),
@@ -263,16 +267,20 @@ function NoteItem({
             isActive ? "bg-neutral-200" : "hover:bg-neutral-100",
           )}
         >
-          <div className="flex flex-col items-start gap-1 max-w-[180px] truncate">
-            <div className="flex items-center justify-between gap-1">
-              <div className="font-medium text-sm">
-                {currentSession.title || "Untitled"}
+          <div className="flex items-center gap-1 w-full">
+            <div className="flex-1 flex flex-col items-start gap-1 truncate">
+              <div className="flex items-center justify-between gap-1">
+                <div className="font-medium text-sm">
+                  {currentSession.title || "Untitled"}
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3 text-xs text-neutral-500">
+                <span className="font-medium">{formattedSessionDate}</span>
               </div>
             </div>
 
-            <div className="flex items-center gap-3 text-xs text-neutral-500">
-              <span className="font-medium">{formattedSessionDate}</span>
-            </div>
+            {isEnhancePending && <SplashLoader size={20} strokeWidth={2} />}
           </div>
         </button>
       </ContextMenuTrigger>

--- a/apps/desktop/src/locales/en/messages.po
+++ b/apps/desktop/src/locales/en/messages.po
@@ -300,7 +300,7 @@ msgid "Apple"
 msgstr "Apple"
 
 #: src/components/toolbar/buttons/delete-note-button.tsx:37
-#: src/components/left-sidebar/notes-list.tsx:247
+#: src/components/left-sidebar/notes-list.tsx:251
 msgid "Are you sure you want to delete this note?"
 msgstr "Are you sure you want to delete this note?"
 
@@ -435,7 +435,7 @@ msgstr "Current Plan"
 
 #: src/components/settings/views/template.tsx:86
 #: src/components/settings/views/team.tsx:165
-#: src/components/left-sidebar/notes-list.tsx:310
+#: src/components/left-sidebar/notes-list.tsx:318
 msgid "Delete"
 msgstr "Delete"
 
@@ -700,8 +700,8 @@ msgstr "Needs download"
 msgid "New note"
 msgstr "New note"
 
-#: src/components/left-sidebar/notes-list.tsx:287
-#: src/components/left-sidebar/events-list.tsx:124
+#: src/components/left-sidebar/notes-list.tsx:295
+#: src/components/left-sidebar/events-list.tsx:135
 msgid "New window"
 msgstr "New window"
 
@@ -1067,7 +1067,7 @@ msgstr "Untitled"
 msgid "Untitled Template"
 msgstr "Untitled Template"
 
-#: src/components/left-sidebar/events-list.tsx:37
+#: src/components/left-sidebar/events-list.tsx:39
 msgid "Upcoming"
 msgstr "Upcoming"
 
@@ -1095,11 +1095,11 @@ msgstr "username"
 #~ msgid "Verify that your local language model is working correctly"
 #~ msgstr "Verify that your local language model is working correctly"
 
-#: src/components/left-sidebar/notes-list.tsx:298
+#: src/components/left-sidebar/notes-list.tsx:306
 msgid "View calendar"
 msgstr "View calendar"
 
-#: src/components/left-sidebar/events-list.tsx:136
+#: src/components/left-sidebar/events-list.tsx:147
 #: src/components/editor-area/note-header/chips/event-chip.tsx:43
 msgid "View in calendar"
 msgstr "View in calendar"

--- a/apps/desktop/src/locales/ko/messages.po
+++ b/apps/desktop/src/locales/ko/messages.po
@@ -300,7 +300,7 @@ msgid "Apple"
 msgstr ""
 
 #: src/components/toolbar/buttons/delete-note-button.tsx:37
-#: src/components/left-sidebar/notes-list.tsx:247
+#: src/components/left-sidebar/notes-list.tsx:251
 msgid "Are you sure you want to delete this note?"
 msgstr ""
 
@@ -435,7 +435,7 @@ msgstr ""
 
 #: src/components/settings/views/template.tsx:86
 #: src/components/settings/views/team.tsx:165
-#: src/components/left-sidebar/notes-list.tsx:310
+#: src/components/left-sidebar/notes-list.tsx:318
 msgid "Delete"
 msgstr ""
 
@@ -700,8 +700,8 @@ msgstr ""
 msgid "New note"
 msgstr ""
 
-#: src/components/left-sidebar/notes-list.tsx:287
-#: src/components/left-sidebar/events-list.tsx:124
+#: src/components/left-sidebar/notes-list.tsx:295
+#: src/components/left-sidebar/events-list.tsx:135
 msgid "New window"
 msgstr ""
 
@@ -1067,7 +1067,7 @@ msgstr ""
 msgid "Untitled Template"
 msgstr ""
 
-#: src/components/left-sidebar/events-list.tsx:37
+#: src/components/left-sidebar/events-list.tsx:39
 msgid "Upcoming"
 msgstr ""
 
@@ -1095,11 +1095,11 @@ msgstr ""
 #~ msgid "Verify that your local language model is working correctly"
 #~ msgstr ""
 
-#: src/components/left-sidebar/notes-list.tsx:298
+#: src/components/left-sidebar/notes-list.tsx:306
 msgid "View calendar"
 msgstr ""
 
-#: src/components/left-sidebar/events-list.tsx:136
+#: src/components/left-sidebar/events-list.tsx:147
 #: src/components/editor-area/note-header/chips/event-chip.tsx:43
 msgid "View in calendar"
 msgstr ""


### PR DESCRIPTION
- Implement a pending state indicator (splash loader) for event and note items in the left sidebar
- Update localization strings for note deletion confirmation and "New window" button