### PR TITLE
Improve Transcript Hook Logic and Session Handling with Updated Listen Button Texts

### DIFF
--- a/apps/desktop/src/locales/en/messages.po
+++ b/apps/desktop/src/locales/en/messages.po
@@ -218,7 +218,7 @@ msgstr "{weeks} weeks later"
 #. placeholder {0}: type === "google-calendar" ? "Google Calendar" : "Outlook Calendar"
 #. placeholder {0}: isHovered ? "Resume" : "Ended"
 #: src/components/settings/components/calendar/cloud-calendar-integration-details.tsx:36
-#: src/components/editor-area/note-header/listen-button.tsx:185
+#: src/components/editor-area/note-header/listen-button.tsx:168
 msgid "{0}"
 msgstr "{0}"
 
@@ -789,7 +789,7 @@ msgstr "or"
 msgid "Owner"
 msgstr "Owner"
 
-#: src/components/editor-area/note-header/listen-button.tsx:234
+#: src/components/editor-area/note-header/listen-button.tsx:251
 msgid "Pause"
 msgstr "Pause"
 
@@ -850,7 +850,7 @@ msgstr "Required to transcribe other people's voice during meetings"
 msgid "Required to transcribe your voice during meetings"
 msgstr "Required to transcribe your voice during meetings"
 
-#: src/components/editor-area/note-header/listen-button.tsx:141
+#: src/components/editor-area/note-header/listen-button.tsx:93
 msgid "Resume"
 msgstr "Resume"
 
@@ -956,7 +956,7 @@ msgstr "Start Annual Plan"
 msgid "Start Monthly Plan"
 msgstr "Start Monthly Plan"
 
-#: src/components/editor-area/note-header/listen-button.tsx:166
+#: src/components/editor-area/note-header/listen-button.tsx:141
 msgid "Start recording"
 msgstr "Start recording"
 
@@ -966,7 +966,7 @@ msgstr "Start recording"
 msgid "Start Server"
 msgstr "Start Server"
 
-#: src/components/editor-area/note-header/listen-button.tsx:242
+#: src/components/editor-area/note-header/listen-button.tsx:259
 msgid "Stop"
 msgstr "Stop"
 

--- a/apps/desktop/src/locales/ko/messages.po
+++ b/apps/desktop/src/locales/ko/messages.po
@@ -218,7 +218,7 @@ msgstr ""
 #. placeholder {0}: type === "google-calendar" ? "Google Calendar" : "Outlook Calendar"
 #. placeholder {0}: isHovered ? "Resume" : "Ended"
 #: src/components/settings/components/calendar/cloud-calendar-integration-details.tsx:36
-#: src/components/editor-area/note-header/listen-button.tsx:185
+#: src/components/editor-area/note-header/listen-button.tsx:168
 msgid "{0}"
 msgstr ""
 
@@ -789,7 +789,7 @@ msgstr ""
 msgid "Owner"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:234
+#: src/components/editor-area/note-header/listen-button.tsx:251
 msgid "Pause"
 msgstr ""
 
@@ -850,7 +850,7 @@ msgstr ""
 msgid "Required to transcribe your voice during meetings"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:141
+#: src/components/editor-area/note-header/listen-button.tsx:93
 msgid "Resume"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgstr ""
 msgid "Start Monthly Plan"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:166
+#: src/components/editor-area/note-header/listen-button.tsx:141
 msgid "Start recording"
 msgstr ""
 
@@ -966,7 +966,7 @@ msgstr ""
 msgid "Start Server"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:242
+#: src/components/editor-area/note-header/listen-button.tsx:259
 msgid "Stop"
 msgstr ""
 

--- a/extensions/transcript/src/components/transcript.tsx
+++ b/extensions/transcript/src/components/transcript.tsx
@@ -1,15 +1,20 @@
-import { EarIcon } from "lucide-react";
+import { EarIcon, Loader2Icon } from "lucide-react";
 import { forwardRef, useEffect, useRef } from "react";
 
+import { useSessions } from "@hypr/utils/contexts";
 import { useTranscript } from "../hooks/useTranscript";
 
 interface TranscriptProps {
-  sessionId: string;
+  sessionId?: string;
 }
 
 const Transcript = forwardRef<HTMLDivElement, TranscriptProps>(
   ({ sessionId }, ref) => {
-    const { timeline, isLive } = useTranscript(sessionId);
+    // Get current session ID if none is provided
+    const currentSessionId = useSessions((s) => s.currentSessionId);
+    const effectiveSessionId = sessionId || currentSessionId;
+
+    const { timeline, isLive, isLoading } = useTranscript(effectiveSessionId);
     const localRef = useRef<HTMLDivElement>(null);
     const transcriptRef = ref || localRef;
 
@@ -35,17 +40,28 @@ const Transcript = forwardRef<HTMLDivElement, TranscriptProps>(
         ref={transcriptRef}
         className="flex-1 scrollbar-none px-4 flex flex-col gap-2 overflow-y-auto text-sm py-4"
       >
-        {items.map((item, index) => (
-          <div key={index}>
-            <p>{item.text}</p>
-          </div>
-        ))}
+        {isLoading
+          ? (
+            <div className="flex items-center gap-2 justify-center py-2 text-neutral-400">
+              <Loader2Icon size={14} className="animate-spin" /> Loading transcript...
+            </div>
+          )
+          : (
+            <>
+              {items.length > 0
+                && items.map((item, index) => (
+                  <div key={index}>
+                    <p>{item.text}</p>
+                  </div>
+                ))}
 
-        {isLive && (
-          <div className="flex items-center gap-2 justify-center py-2 text-neutral-400">
-            <EarIcon size={14} /> Listening... (there might be a delay)
-          </div>
-        )}
+              {isLive && (
+                <div className="flex items-center gap-2 justify-center py-2 text-neutral-400">
+                  <EarIcon size={14} /> Listening... (there might be a delay)
+                </div>
+              )}
+            </>
+          )}
       </div>
     );
   },


### PR DESCRIPTION
- Add support for using the current session ID if none is provided in the `TranscriptProps`
- Improve the handling of the ongoing session state in the `useTranscript` hook
  - Separate the ongoing session status and session ID into a single state object
  - Only show the "LIVE" indicator if the current session is the one being recorded
  - Add a loading state to the hook to indicate when the timeline data is being fetched
  - Unsubscribe from live updates when the current session is not the ongoing session
- Update the text strings used in the listen button component across the English and Korean locales