### PR TITLE
feat(transcript): enhance empty state message

### DIFF
--- a/extensions/transcript/src/hooks/useTranscriptWidget.ts
+++ b/extensions/transcript/src/hooks/useTranscriptWidget.ts
@@ -1,12 +1,14 @@
+import { useSession } from "@hypr/utils/contexts";
 import { useTranscript } from "./useTranscript";
 
 export function useTranscriptWidget(sessionId: string | null) {
-  const { timeline, isLive, selectedLanguage, handleLanguageChange } = useTranscript(sessionId);
+  const { timeline, isLive, selectedLanguage, handleLanguageChange, isLoading } = useTranscript(sessionId);
+  const isEnhanced = sessionId ? useSession(sessionId, (s) => !!s.session.enhanced_memo_html) : false;
 
-  // Determine the widget state
   const hasTranscript = timeline?.items && timeline.items.length > 0;
   const isSessionActive = sessionId && (hasTranscript || isLive);
-  const showEmptyMessage = sessionId && !hasTranscript && !isLive;
+
+  const showEmptyMessage = sessionId && !hasTranscript && !isLive && !isLoading;
 
   return {
     timeline,
@@ -16,5 +18,7 @@ export function useTranscriptWidget(sessionId: string | null) {
     hasTranscript,
     isSessionActive,
     showEmptyMessage,
+    isEnhanced,
+    isLoading,
   };
 }

--- a/extensions/transcript/src/widgets/default/2x2.tsx
+++ b/extensions/transcript/src/widgets/default/2x2.tsx
@@ -11,7 +11,7 @@ import { useTranscriptWidget } from "../../hooks/useTranscriptWidget";
 
 const Transcript2x2: WidgetTwoByTwo = ({ onMaximize, queryClient }) => {
   const sessionId = useSessions((s) => s.currentSessionId);
-  const { showEmptyMessage } = useTranscriptWidget(sessionId);
+  const { showEmptyMessage, isEnhanced } = useTranscriptWidget(sessionId);
 
   const handleOpenTranscriptSettings = () => {
     const extensionId = "@hypr/extension-transcript";
@@ -70,7 +70,9 @@ const Transcript2x2: WidgetTwoByTwo = ({ onMaximize, queryClient }) => {
       {sessionId && showEmptyMessage && (
         <div className="absolute inset-0 backdrop-blur-sm bg-white/50 flex items-center justify-center z-10 rounded-2xl">
           <div className="text-neutral-500 font-medium">
-            Meeting is not active
+            {isEnhanced
+              ? "No transcript available"
+              : "Meeting is not active"}
           </div>
         </div>
       )}

--- a/extensions/transcript/src/widgets/default/full.tsx
+++ b/extensions/transcript/src/widgets/default/full.tsx
@@ -11,7 +11,7 @@ import { useTranscriptWidget } from "../../hooks/useTranscriptWidget";
 
 const TranscriptFull: WidgetFullSize = ({ onMinimize }) => {
   const sessionId = useSessions((s) => s.currentSessionId);
-  const { showEmptyMessage } = useTranscriptWidget(sessionId);
+  const { showEmptyMessage, isEnhanced } = useTranscriptWidget(sessionId);
 
   const handleOpenTranscriptSettings = () => {
     const extensionId = "@hypr/extension-transcript";
@@ -64,7 +64,9 @@ const TranscriptFull: WidgetFullSize = ({ onMinimize }) => {
       {sessionId && showEmptyMessage && (
         <div className="absolute inset-0 backdrop-blur-sm bg-white/50 flex items-center justify-center z-10 rounded-2xl">
           <div className="text-neutral-500 font-medium">
-            Meeting is not active
+            {isEnhanced
+              ? "No transcript available"
+              : "Meeting is not active"}
           </div>
         </div>
       )}


### PR DESCRIPTION
- Add a new `isEnhanced` flag to the `useTranscriptWidget` hook to check if the current session has an enhanced memo HTML.
- Update the empty state message to display "No transcript available" if the session is enhanced, and "Meeting is not active" if the session is not enhanced.
- Add the `isLoading` flag to the `useTranscriptWidget` hook to prevent the empty state message from being displayed while the transcript is still loading.