### PR TITLE
feat(desktop): Adjust DMG window size

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
         "background": "assets/dmg-background-stable.png",
         "windowSize": {
           "width": 660,
-          "height": 438
+          "height": 400
         },
         "appPosition": {
           "x": 177,


### PR DESCRIPTION
Reduce the window height from 438 to 400 pixels to provide a more compact and user-friendly interface for the desktop application. This change ensures the application window fits better on various screen sizes and improves the overall user experience.