### PR TITLE
Introduce DefaultToolbar Component and Integrate with Plans Route

### DIFF
--- a/apps/desktop/src/components/toolbar/bars/default-toolbar.tsx
+++ b/apps/desktop/src/components/toolbar/bars/default-toolbar.tsx
@@ -1,8 +1,10 @@
-export function TransparentToolbar() {
+export function DefaultToolbar({ title }: { title?: string }) {
   return (
     <header
       data-tauri-drag-region
       className="flex w-full items-center justify-center h-11 p-1 px-2 border-b border-transparent bg-transparent"
-    />
+    >
+      {title && <h3 className="text-lg font-semibold">{title}</h3>}
+    </header>
   );
 }

--- a/apps/desktop/src/components/toolbar/bars/index.tsx
+++ b/apps/desktop/src/components/toolbar/bars/index.tsx
@@ -1,8 +1,8 @@
 export * from "./calendar-toolbar";
+export * from "./default-toolbar";
 export * from "./entity-toolbar";
 export * from "./main-toolbar";
 export * from "./note-toolbar";
-export * from "./transparent-toolbar";
 
 import { useEditMode } from "@/contexts";
 import { getCurrentWebviewWindowLabel } from "@hypr/plugin-windows";

--- a/apps/desktop/src/components/toolbar/index.tsx
+++ b/apps/desktop/src/components/toolbar/index.tsx
@@ -2,7 +2,7 @@ import { useMatch } from "@tanstack/react-router";
 
 import { useEditMode } from "@/contexts/edit-mode-context";
 import { getCurrentWebviewWindowLabel } from "@hypr/plugin-windows";
-import { CalendarToolbar, EntityToolbar, MainToolbar, NoteToolbar, TransparentToolbar } from "./bars";
+import { CalendarToolbar, DefaultToolbar, EntityToolbar, MainToolbar, NoteToolbar } from "./bars";
 
 export default function Toolbar() {
   const noteMatch = useMatch({ from: "/app/note/$id", shouldThrow: false });
@@ -25,7 +25,7 @@ export default function Toolbar() {
   }
 
   if (isPlans) {
-    return <TransparentToolbar />;
+    return <DefaultToolbar title="Plans" />;
   }
 
   if (!isMain) {


### PR DESCRIPTION
- Added a new `DefaultToolbar` component that can be used in place of the `TransparentToolbar` component
- The `DefaultToolbar` component includes an optional `title` prop to display a title within the toolbar
- Updated the `Toolbar` component to use the `DefaultToolbar` component when the current route matches the "Plans" route