### PR TITLE
Add source parameter to pro waitlist link

### DIFF
--- a/apps/desktop/src/routes/app.plans.tsx
+++ b/apps/desktop/src/routes/app.plans.tsx
@@ -160,7 +160,7 @@ function PricingCard({
           )
           : (
             <a
-              href="https://hyprnote.com/pro-waitlist"
+              href="https://hyprnote.com/pro-waitlist?source=APP"
               target="_blank"
               rel="noopener noreferrer"
               className={cn(


### PR DESCRIPTION
Added a `source=APP` parameter to the pro waitlist link to track where the user came from
