### PR TITLE
fix(build): fix broken builds on macOS due to hardcoded windows var

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,11 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-Ctarget-feature=+crt-static"]
+# Windows-specific environment variables
+env.CFLAGS = "/MT"
+env.CXXFLAGS = "/MT"
 
-[env]
-CFLAGS = "/MT"
-CXXFLAGS = "/MT"
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]
+# Windows-specific environment variables
+env.CFLAGS = "/MT"
+env.CXXFLAGS = "/MT"


### PR DESCRIPTION
- fix: macOS builds, these are currently broken due a hardcoded requirement for a MS Windows compiler flag (`/MT`)