### PR TITLE
Add app version to settings menu

### DIFF
--- a/apps/desktop/src/components/left-sidebar/top-area/settings-button.tsx
+++ b/apps/desktop/src/components/left-sidebar/top-area/settings-button.tsx
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui/react/macro";
+import { getVersion } from "@tauri-apps/api/app";
 import { CogIcon, CpuIcon } from "lucide-react";
 import { useState } from "react";
 
@@ -13,10 +14,21 @@ import {
   DropdownMenuTrigger,
 } from "@hypr/ui/components/ui/dropdown-menu";
 import { cn } from "@hypr/ui/lib/utils";
+import { useQuery } from "@tanstack/react-query";
 
 export function SettingsButton() {
   const [open, setOpen] = useState(false);
   const { userId } = useHypr();
+
+  const { data: version, error } = useQuery({
+    queryKey: ["appVersion"],
+    queryFn: getVersion,
+  });
+
+  // Handle potential error during version fetching
+  if (error) {
+    console.error("Failed to fetch app version:", error);
+  }
 
   const handleClickSettings = () => {
     setOpen(false);
@@ -77,6 +89,9 @@ export function SettingsButton() {
             className="cursor-pointer"
           >
             <Trans>My Profile</Trans>
+          </DropdownMenuItem>
+          <DropdownMenuItem disabled className="text-xs text-muted-foreground focus:bg-transparent">
+            {version ? `Version ${version}` : "Loading version..."}
           </DropdownMenuItem>
         </div>
       </DropdownMenuContent>

--- a/apps/desktop/src/components/left-sidebar/top-area/settings-button.tsx
+++ b/apps/desktop/src/components/left-sidebar/top-area/settings-button.tsx
@@ -1,5 +1,5 @@
 import { Trans } from "@lingui/react/macro";
-import { getVersion } from "@tauri-apps/api/app";
+import { getName, getVersion } from "@tauri-apps/api/app";
 import { CogIcon, CpuIcon } from "lucide-react";
 import { useState } from "react";
 
@@ -20,15 +20,13 @@ export function SettingsButton() {
   const [open, setOpen] = useState(false);
   const { userId } = useHypr();
 
-  const { data: version, error } = useQuery({
+  const versionQuery = useQuery({
     queryKey: ["appVersion"],
-    queryFn: getVersion,
+    queryFn: async () => {
+      const [version, name] = await Promise.all([getVersion(), getName()]);
+      return `${name} ${version}`;
+    },
   });
-
-  // Handle potential error during version fetching
-  if (error) {
-    console.error("Failed to fetch app version:", error);
-  }
 
   const handleClickSettings = () => {
     setOpen(false);
@@ -90,8 +88,8 @@ export function SettingsButton() {
           >
             <Trans>My Profile</Trans>
           </DropdownMenuItem>
-          <DropdownMenuItem disabled className="text-xs text-muted-foreground focus:bg-transparent">
-            {version ? `Version ${version}` : "Loading version..."}
+          <DropdownMenuItem disabled className="text-xs text-muted-foreground">
+            {versionQuery.data ?? "..."}
           </DropdownMenuItem>
         </div>
       </DropdownMenuContent>

--- a/apps/desktop/src/locales/en/messages.po
+++ b/apps/desktop/src/locales/en/messages.po
@@ -636,7 +636,7 @@ msgstr "Loading..."
 #~ msgid "Local Language Model"
 #~ msgstr "Local Language Model"
 
-#: src/components/left-sidebar/top-area/settings-button.tsx:58
+#: src/components/left-sidebar/top-area/settings-button.tsx:68
 msgid "Local mode"
 msgstr "Local mode"
 
@@ -685,7 +685,7 @@ msgstr "Monthly"
 msgid "Much better AI performance"
 msgstr "Much better AI performance"
 
-#: src/components/left-sidebar/top-area/settings-button.tsx:79
+#: src/components/left-sidebar/top-area/settings-button.tsx:89
 msgid "My Profile"
 msgstr "My Profile"
 
@@ -923,7 +923,7 @@ msgstr "Select Calendars"
 msgid "Send invite"
 msgstr "Send invite"
 
-#: src/components/left-sidebar/top-area/settings-button.tsx:72
+#: src/components/left-sidebar/top-area/settings-button.tsx:82
 msgid "Settings"
 msgstr "Settings"
 

--- a/apps/desktop/src/locales/ko/messages.po
+++ b/apps/desktop/src/locales/ko/messages.po
@@ -636,7 +636,7 @@ msgstr ""
 #~ msgid "Local Language Model"
 #~ msgstr ""
 
-#: src/components/left-sidebar/top-area/settings-button.tsx:58
+#: src/components/left-sidebar/top-area/settings-button.tsx:68
 msgid "Local mode"
 msgstr ""
 
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Much better AI performance"
 msgstr ""
 
-#: src/components/left-sidebar/top-area/settings-button.tsx:79
+#: src/components/left-sidebar/top-area/settings-button.tsx:89
 msgid "My Profile"
 msgstr ""
 
@@ -923,7 +923,7 @@ msgstr ""
 msgid "Send invite"
 msgstr ""
 
-#: src/components/left-sidebar/top-area/settings-button.tsx:72
+#: src/components/left-sidebar/top-area/settings-button.tsx:82
 msgid "Settings"
 msgstr ""
 


### PR DESCRIPTION
- Added the app version to the settings menu
- The version is fetched using the `getVersion` function from the `@tauri-apps/api/app` module
- The version is displayed in a disabled dropdown menu item
- This change provides users with easy access to the current version of the application, which can be useful for troubleshooting or checking for updates