### PR TITLE
Add queryClient to useTwentyNotes hook

### DIFF
--- a/extensions/twenty/src/widgets/default/2x2.tsx
+++ b/extensions/twenty/src/widgets/default/2x2.tsx
@@ -1,5 +1,6 @@
 import { WidgetHeader, type WidgetTwoByTwo, WidgetTwoByTwoWrapper } from "@hypr/ui/components/ui/widgets";
 import { useSessions } from "@hypr/utils/contexts";
+import { type QueryClient } from "@tanstack/react-query";
 
 import { safeNavigate } from "@hypr/utils/navigation";
 import { CreateNoteButton } from "../components/create-note-button";
@@ -36,12 +37,20 @@ const Twenty2x2: WidgetTwoByTwo = ({ queryClient }) => {
         />
       </div>
 
-      <WidgetBody sessionId={sessionId} />
+      {queryClient
+        ? <WidgetBody sessionId={sessionId} queryClient={queryClient} />
+        : (
+          <div className="flex items-center justify-center h-full p-4">
+            <div className="text-center text-red-500">
+              <p>Widget Configuration Error</p>
+            </div>
+          </div>
+        )}
     </WidgetTwoByTwoWrapper>
   );
 };
 
-function WidgetBody({ sessionId }: { sessionId: string | null }) {
+function WidgetBody({ sessionId, queryClient }: { sessionId: string | null; queryClient: QueryClient }) {
   if (!sessionId) {
     return (
       <div className="flex items-center justify-center h-full p-4">
@@ -68,7 +77,7 @@ function WidgetBody({ sessionId }: { sessionId: string | null }) {
     handleRemovePerson,
     handleCreateNote,
     setShowSearchResults,
-  } = useTwentyNotes(sessionId);
+  } = useTwentyNotes(sessionId, queryClient);
 
   return (
     <div className="overflow-y-auto flex-1 p-4 pt-0 gap-2 flex flex-col">

--- a/extensions/twenty/src/widgets/hooks/useTwentyNotes.ts
+++ b/extensions/twenty/src/widgets/hooks/useTwentyNotes.ts
@@ -1,11 +1,11 @@
 import { useOngoingSession, useSession } from "@hypr/utils/contexts";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { type QueryClient, useMutation, useQuery } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 
 import { commands as dbCommands } from "@hypr/plugin-db";
 import { ops as twenty, type Person } from "../../client";
 
-export const useTwentyNotes = (sessionId: string) => {
+export const useTwentyNotes = (sessionId: string, queryClient: QueryClient) => {
   const searchRef = useRef<HTMLDivElement>(null);
 
   const [searchQuery, setSearchQuery] = useState("");
@@ -25,7 +25,7 @@ export const useTwentyNotes = (sessionId: string) => {
     queryKey: ["people", searchQuery],
     queryFn: () => twenty.findManyPeople(searchQuery),
     staleTime: 5000,
-  });
+  }, queryClient);
 
   const createNoteMutation = useMutation({
     mutationFn: async () => {
@@ -49,7 +49,7 @@ export const useTwentyNotes = (sessionId: string) => {
     onSuccess: () => {
       setSelectedPeople([]);
     },
-  });
+  }, queryClient);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {


### PR DESCRIPTION
- Passes the `queryClient` as a parameter to the `useTwentyNotes` hook
- Updates the `useMutation` and `useQuery` calls in the `useTwentyNotes` hook to use the provided `queryClient`
- Adds a fallback UI in the `2x2.tsx` file to display an error message when the `queryClient` is not provided

These changes ensure that the `useTwentyNotes` hook can properly interact with the React Query cache, improving the overall performance and reliability of the Twenty widget.