### PR TITLE
Add Error Variant to SessionEvent Enum for Handling Setup Failures and Broadcast to Frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13246,6 +13246,7 @@ dependencies = [
  "data",
  "db-core",
  "db-user",
+ "futures",
  "futures-util",
  "hound",
  "listener-interface",

--- a/plugins/listener/Cargo.toml
+++ b/plugins/listener/Cargo.toml
@@ -46,6 +46,7 @@ tauri-specta = { workspace = true, features = ["derive", "typescript"] }
 thiserror = { workspace = true }
 url = { workspace = true }
 
+futures = "0.3"
 futures-util = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 

--- a/plugins/listener/js/bindings.gen.ts
+++ b/plugins/listener/js/bindings.gen.ts
@@ -78,8 +78,9 @@ statusEvent: "plugin:listener:status-event"
 
 /** user-defined types **/
 
-export type SessionEvent = ({ type: "started" } & SessionEventStarted) | { type: "stopped" } | { type: "paused" } | { type: "resumed" } | { type: "silence" } | ({ type: "timelineView" } & SessionEventTimelineView) | ({ type: "audioAmplitude" } & SessionEventAudioAmplitude)
+export type SessionEvent = ({ type: "started" } & SessionEventStarted) | { type: "stopped" } | { type: "paused" } | { type: "resumed" } | { type: "silence" } | ({ type: "timelineView" } & SessionEventTimelineView) | ({ type: "audioAmplitude" } & SessionEventAudioAmplitude) | ({ type: "error" } & SessionEventError)
 export type SessionEventAudioAmplitude = { mic: number; speaker: number }
+export type SessionEventError = { message: string }
 export type SessionEventStarted = { seconds: number }
 export type SessionEventTimelineView = { timeline: TimelineView }
 export type StatusEvent = "inactive" | "running_active" | "running_paused"

--- a/plugins/listener/src/events.rs
+++ b/plugins/listener/src/events.rs
@@ -15,6 +15,8 @@ pub enum SessionEvent {
     TimelineView(SessionEventTimelineView),
     #[serde(rename = "audioAmplitude")]
     AudioAmplitude(SessionEventAudioAmplitude),
+    #[serde(rename = "error")]
+    Error(SessionEventError),
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, specta::Type)]
@@ -31,6 +33,11 @@ pub struct SessionEventTimelineView {
 pub struct SessionEventAudioAmplitude {
     pub mic: u16,
     pub speaker: u16,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, specta::Type)]
+pub struct SessionEventError {
+    pub message: String,
 }
 
 impl From<(&[f32], &[f32])> for SessionEventAudioAmplitude {


### PR DESCRIPTION
- Added a new `Error` variant to the `SessionEvent` enum to handle session setup failures
- Defined a `SessionEventError` struct to encapsulate the error message
- Regenerated TypeScript bindings to include the new event type for frontend consumption
- Implemented broadcasting of `SessionEvent::Error` when session setup fails during the `inactive` to `active` state transition