### PR TITLE
Updated Setup -> Requirements section. Added dependency on cmake

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,8 @@
 curl https://sh.rustup.rs -sSf | sh
 # libomp is required for llama-cpp
 brew install libomp
+# cmake is required for whisper-rs
+brew install cmake
 # cidre uses this for audio capture and types
 xcode-select --install
 # Installing the tools


### PR DESCRIPTION
Executing `pnpm install && turbo -F @hypr/desktop tauri:dev` ran into issues on my M1 Mac machine. This was caused by `whisper-rs`. I found that the solution is to install `cmake`. 

Added `brew install cmake` to the `Setup` -> `Requirements` section of `CONTRIBUTING.md`

See issue [failed to run custom build command for `whisper-rs-sys v0.12.1 (https://github.com/tazz4843/whisper-rs(...)](#297) for more information