### PR TITLE
Remove window positioning

### DIFF
--- a/apps/desktop/src/components/settings/views/extension.tsx
+++ b/apps/desktop/src/components/settings/views/extension.tsx
@@ -32,7 +32,6 @@ export default function Extensions({
 
   useEffect(() => {
     windowsCommands.windowResizeDefault({ type: "main" }).then(() => {
-      windowsCommands.windowPosition({ type: "main" }, "right-half");
       windowsEvents.mainWindowState.emit({
         left_sidebar_expanded: false,
         right_panel_expanded: true,

--- a/apps/desktop/src/routes/app.note.$id.tsx
+++ b/apps/desktop/src/routes/app.note.$id.tsx
@@ -144,8 +144,6 @@ function OnboardingSupport({ session }: { session: Session }) {
 
     if (ongoingSessionStatus === "running_active") {
       windowsCommands.windowShow({ type: "video", value: video }).then(() => {
-        windowsCommands.windowPosition({ type: "video", value: video }, "left-half");
-        windowsCommands.windowPosition({ type: "main" }, "right-half");
         windowsCommands.windowResizeDefault({ type: "video", value: video });
         windowsCommands.windowResizeDefault({ type: "main" });
       });


### PR DESCRIPTION
- Optimized the window layout for the video and main views in the desktop application
- Removed the explicit positioning of the video and main windows, allowing the default window resizing to handle the layout automatically
- Ensured the main window is resized to its default size after the video window is shown