### PR TITLE
Center windows on screen

### DIFF
--- a/plugins/windows/src/ext.rs
+++ b/plugins/windows/src/ext.rs
@@ -266,12 +266,7 @@ impl HyprWindow {
                     window.set_size(default_size)?;
                     window.set_min_size(Some(min_size))?;
 
-                    {
-                        let mut cursor = app.cursor_position().unwrap();
-                        cursor.x -= 160.0;
-                        cursor.y -= 30.0;
-                        window.set_position(cursor)?;
-                    }
+                    window.center()?;
                 }
                 Self::Human(_) => {
                     window.hide()?;
@@ -283,12 +278,7 @@ impl HyprWindow {
                     window.set_size(default_size)?;
                     window.set_min_size(Some(min_size))?;
 
-                    {
-                        let mut cursor = app.cursor_position().unwrap();
-                        cursor.x -= 160.0;
-                        cursor.y -= 30.0;
-                        window.set_position(cursor)?;
-                    }
+                    window.center()?;
                 }
                 Self::Organization(_) => {
                     window.hide()?;
@@ -300,12 +290,7 @@ impl HyprWindow {
                     window.set_size(default_size)?;
                     window.set_min_size(Some(min_size))?;
 
-                    {
-                        let mut cursor = app.cursor_position().unwrap();
-                        cursor.x -= 160.0;
-                        cursor.y -= 30.0;
-                        window.set_position(cursor)?;
-                    }
+                    window.center()?;
                 }
                 Self::Calendar => {
                     window.hide()?;
@@ -317,12 +302,7 @@ impl HyprWindow {
                     window.set_size(default_size)?;
                     window.set_min_size(Some(min_size))?;
 
-                    {
-                        let mut cursor = app.cursor_position().unwrap();
-                        cursor.x -= 640.0;
-                        cursor.y -= 30.0;
-                        window.set_position(cursor)?;
-                    }
+                    window.center()?;
                 }
                 Self::Settings => {
                     window.hide()?;
@@ -334,12 +314,7 @@ impl HyprWindow {
                     window.set_size(default_size)?;
                     window.set_min_size(Some(min_size))?;
 
-                    {
-                        let mut cursor = app.cursor_position().unwrap();
-                        cursor.x -= 800.0;
-                        cursor.y -= 30.0;
-                        window.set_position(cursor)?;
-                    }
+                    window.center()?;
                 }
                 Self::Video(_) => {
                     window.hide()?;


### PR DESCRIPTION
- Center windows on the screen instead of positioning them relative to the cursor
- Provide a more consistent user experience and ensure that the windows are always visible and accessible
- Update the `HyprWindow` implementation in `plugins/windows/src/ext.rs` to use the `window.center()` method instead of manually calculating the position based on the cursor coordinates