### PR TITLE
Disable chat shortcut if feature flag is disabled

### DIFF
--- a/apps/desktop/src/contexts/right-panel.tsx
+++ b/apps/desktop/src/contexts/right-panel.tsx
@@ -1,3 +1,5 @@
+import { commands as flagsCommands } from "@hypr/plugin-flags";
+import { useQuery } from "@tanstack/react-query";
 import { createContext, useCallback, useContext, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
@@ -88,6 +90,11 @@ export function RightPanelProvider({
     [isExpanded, currentView],
   );
 
+  const { data: chatPanelEnabled = false } = useQuery({
+    queryKey: ["flags", "ChatRightPanel"],
+    queryFn: () => flagsCommands.isEnabled("ChatRightPanel"),
+  });
+
   useHotkeys(
     "mod+r",
     (event) => {
@@ -140,6 +147,7 @@ export function RightPanelProvider({
     {
       enableOnFormTags: true,
       enableOnContentEditable: true,
+      ignoreEventWhen: () => !chatPanelEnabled,
     },
   );
 


### PR DESCRIPTION
- Added a new flag to check if the chat panel is enabled
- The flag is used to conditionally enable the hotkey for toggling the right panel
- This ensures the hotkey is only active when the chat panel is enabled, improving the user experience