### PR TITLE
Prevent left sidebar from opening up after closing Settings view

### DIFF
--- a/apps/desktop/src/components/settings/views/extension.tsx
+++ b/apps/desktop/src/components/settings/views/extension.tsx
@@ -33,17 +33,10 @@ export default function Extensions({
   useEffect(() => {
     windowsCommands.windowResizeDefault({ type: "main" }).then(() => {
       windowsEvents.mainWindowState.emit({
-        left_sidebar_expanded: false,
+        left_sidebar_expanded: null,
         right_panel_expanded: true,
       });
     });
-
-    return () => {
-      windowsEvents.mainWindowState.emit({
-        left_sidebar_expanded: true,
-        right_panel_expanded: false,
-      });
-    };
   }, []);
 
   useEffect(() => {

--- a/apps/desktop/src/locales/en/messages.po
+++ b/apps/desktop/src/locales/en/messages.po
@@ -627,7 +627,7 @@ msgstr "LinkedIn username"
 msgid "Live summary of the meeting"
 msgstr "Live summary of the meeting"
 
-#: src/components/settings/views/extension.tsx:125
+#: src/components/settings/views/extension.tsx:118
 msgid "Loading extension details..."
 msgstr "Loading extension details..."
 

--- a/apps/desktop/src/locales/ko/messages.po
+++ b/apps/desktop/src/locales/ko/messages.po
@@ -627,7 +627,7 @@ msgstr ""
 msgid "Live summary of the meeting"
 msgstr ""
 
-#: src/components/settings/views/extension.tsx:125
+#: src/components/settings/views/extension.tsx:118
 msgid "Loading extension details..."
 msgstr ""
 

--- a/apps/desktop/src/routes/video.tsx
+++ b/apps/desktop/src/routes/video.tsx
@@ -54,12 +54,7 @@ function Component() {
   } as React.CSSProperties;
 
   const handleEnded = () => {
-    windowsEvents.mainWindowState.emit({
-      left_sidebar_expanded: true,
-      right_panel_expanded: false,
-    }).then(() => {
-      windowsCommands.windowDestroy({ type: "video", value: id });
-    });
+    windowsCommands.windowDestroy({ type: "video", value: id });
   };
 
   const [didExpandRightPanel, setDidExpandRightPanel] = useState(false);
@@ -68,7 +63,7 @@ function Component() {
     if (e.timeStamp > 67500 && !didExpandRightPanel) {
       setDidExpandRightPanel(true);
       windowsEvents.mainWindowState.emit({
-        left_sidebar_expanded: false,
+        left_sidebar_expanded: null,
         right_panel_expanded: true,
       });
     }

--- a/plugins/windows/src/events.rs
+++ b/plugins/windows/src/events.rs
@@ -27,16 +27,6 @@ pub fn on_window_event<R: tauri::Runtime>(window: &tauri::Window<R>, event: &tau
                         guard.windows.remove(&w);
                     }
 
-                    {
-                        if w.label() == HyprWindow::Settings.label() {
-                            let event = MainWindowState {
-                                left_sidebar_expanded: Some(true),
-                                right_panel_expanded: Some(false),
-                            };
-                            let _ = event.emit(app);
-                        }
-                    }
-
                     let event = WindowDestroyed { window: w };
                     let _ = event.emit(app);
                 }


### PR DESCRIPTION
- Simplified video player handling by removing unnecessary logic to expand the left sidebar and collapse the right panel when the video ends
- Updated the logic to expand the right panel when the video reaches a certain timestamp
- Adjusted the main window state when the extension view is loaded, collapsing the left sidebar by default and expanding the right panel