### PR TITLE
feat: Add dark mode toggle in Settings

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -3,11 +3,28 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+    <meta name="color-scheme" content="light dark">
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
     <title>Hyprnote</title>
+    <script>
+      // Initialize theme from localStorage and prepare for synchronization
+      document.addEventListener('DOMContentLoaded', function() {
+        // Get theme from localStorage
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme === 'dark' || savedTheme === 'light') {
+          // Apply theme
+          document.documentElement.classList.remove('dark', 'light');
+          document.documentElement.classList.add(savedTheme);
+        } else {
+          // Default to dark if no theme is saved
+          document.documentElement.classList.add('dark');
+          localStorage.setItem('theme', 'dark');
+        }
+      });
+    </script>
   </head>
   <body spellcheck="false">
     <div id="root"></div>

--- a/apps/desktop/src/components/editor-area/floating-button.tsx
+++ b/apps/desktop/src/components/editor-area/floating-button.tsx
@@ -57,16 +57,16 @@ export function FloatingButton({
     "rounded-l-xl border-l border-y",
     "border-border px-4 py-2.5 transition-all ease-in-out",
     showRaw
-      ? "bg-primary text-primary-foreground border-black hover:bg-neutral-800"
-      : "bg-background text-neutral-400 hover:bg-neutral-100",
+      ? "bg-primary text-primary-foreground border-black hover:bg-neutral-800 dark:border-zinc-700"
+      : "bg-background text-neutral-400 hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-zinc-800 dark:border-zinc-700",
   );
 
   const enhanceButtonClasses = cn(
     "rounded-r-xl border-r border-y",
     "border border-border px-4 py-2.5 transition-all ease-in-out",
     showRaw
-      ? "bg-background text-neutral-400 hover:bg-neutral-100"
-      : "bg-primary text-primary-foreground border-black hover:bg-neutral-800",
+      ? "bg-background text-neutral-400 hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-zinc-800 dark:border-zinc-700"
+      : "bg-primary text-primary-foreground border-black hover:bg-neutral-800 dark:border-zinc-700",
   );
 
   const showRefresh = !showRaw && isHovered && showRefreshIcon;

--- a/apps/desktop/src/components/editor-area/note-header/listen-button.tsx
+++ b/apps/desktop/src/components/editor-area/note-header/listen-button.tsx
@@ -208,7 +208,7 @@ function WhenInactiveAndMeetingNotEnded({ disabled, onClick }: { disabled: boole
           disabled={disabled}
           className={cn([
             "w-9 h-9 rounded-full border-2 transition-all hover:scale-95 cursor-pointer outline-none p-0 flex items-center justify-center",
-            disabled ? "bg-neutral-200 border-neutral-400" : "bg-red-500 border-neutral-400",
+            disabled ? "bg-neutral-200 dark:bg-zinc-700 border-neutral-400 dark:border-zinc-600" : "bg-red-500 border-neutral-400 dark:border-red-600",
             "shadow-[inset_0_0_0_2px_rgba(255,255,255,0.8)]",
           ])}
         >
@@ -217,7 +217,7 @@ function WhenInactiveAndMeetingNotEnded({ disabled, onClick }: { disabled: boole
       <PopoverContent className="w-80" align="end">
         <div className="flex flex-col gap-3">
           <div className="flex flex-col gap-2">
-            <div className="text-sm font-medium text-neutral-700">
+            <div className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
               <Trans>Custom instruction</Trans>
             </div>
             <Textarea
@@ -226,7 +226,7 @@ function WhenInactiveAndMeetingNotEnded({ disabled, onClick }: { disabled: boole
               placeholder="ex) Hyprnote, JDCE, Fastrepl, John, Yujong"
               className="min-h-[80px] resize-none border-neutral-300 text-sm focus-visible:ring-0 focus-visible:ring-offset-0"
             />
-            <p className="text-xs text-neutral-400">
+            <p className="text-xs text-neutral-400 dark:text-neutral-500">
               <Trans>
                 Provide descriptions about the meeting. Company specific terms, acronyms, jargons... any thing!
               </Trans>
@@ -265,10 +265,10 @@ function WhenInactiveAndMeetingEnded({ disabled, onClick }: { disabled: boolean;
       onMouseLeave={() => setIsHovered(false)}
       className={cn(
         "w-16 h-9 rounded-full transition-all outline-none p-0 flex items-center justify-center text-xs font-medium",
-        "bg-neutral-200 border-2 border-neutral-400 text-neutral-600",
+        "bg-neutral-200 dark:bg-zinc-700 border-2 border-neutral-400 dark:border-zinc-600 text-neutral-600 dark:text-neutral-300",
         "shadow-[0_0_0_2px_rgba(255,255,255,0.8)_inset]",
         !disabled
-          ? "hover:opacity-100 hover:bg-red-100 hover:text-red-600 hover:border-red-400 hover:scale-95 cursor-pointer"
+          ? "hover:opacity-100 hover:bg-red-100 hover:text-red-600 hover:border-red-400 dark:hover:bg-red-900 dark:hover:text-red-400 dark:hover:border-red-700 hover:scale-95 cursor-pointer"
           : "opacity-10 cursor-progress",
       )}
     >
@@ -303,10 +303,10 @@ function WhenInactiveAndMeetingEndedOnboarding({ disabled, onClick }: { disabled
       onClick={onClick}
       className={cn(
         "w-28 h-9 rounded-full outline-none p-0 flex items-center justify-center gap-1 text-xs font-medium",
-        "bg-neutral-200 border-2 border-neutral-400 text-neutral-600",
+        "bg-neutral-200 dark:bg-zinc-700 border-2 border-neutral-400 dark:border-zinc-600 text-neutral-600 dark:text-neutral-300",
         "shadow-[0_0_0_2px_rgba(255,255,255,0.8)_inset]",
         !disabled
-          ? "hover:bg-neutral-300 hover:text-neutral-800 hover:border-neutral-500 transition-all hover:scale-95 cursor-pointer"
+          ? "hover:bg-neutral-300 hover:text-neutral-800 hover:border-neutral-500 dark:hover:bg-zinc-600 dark:hover:text-neutral-200 dark:hover:border-zinc-500 transition-all hover:scale-95 cursor-pointer"
           : "opacity-10 cursor-progress",
       )}
     >
@@ -366,7 +366,7 @@ export function WhenActive() {
         <button
           className={cn([
             open && "hover:scale-95",
-            "w-14 h-9 rounded-full bg-red-100 border-2 transition-all border-red-400 cursor-pointer outline-none p-0 flex items-center justify-center",
+            "w-14 h-9 rounded-full bg-red-100 dark:bg-red-900 border-2 transition-all border-red-400 dark:border-red-700 cursor-pointer outline-none p-0 flex items-center justify-center",
             "shadow-[0_0_0_2px_rgba(255,255,255,0.8)_inset]",
           ])}
         >

--- a/apps/desktop/src/components/editor-area/note-header/title-input.tsx
+++ b/apps/desktop/src/components/editor-area/note-header/title-input.tsx
@@ -31,7 +31,7 @@ export default function TitleInput({
       onChange={onChange}
       value={value}
       placeholder={t`Untitled`}
-      className="w-full border-none bg-transparent text-2xl font-bold focus:outline-none placeholder:text-neutral-400"
+      className="w-full border-none bg-transparent text-2xl font-bold focus:outline-none placeholder:text-neutral-400 dark:placeholder:text-zinc-500"
       onKeyDown={handleKeyDown}
     />
   );

--- a/apps/desktop/src/components/human-profile/upcoming-events.tsx
+++ b/apps/desktop/src/components/human-profile/upcoming-events.tsx
@@ -45,25 +45,25 @@ export function UpcomingEvents({ human }: { human: Human }) {
             {upcomingEvents.map((event) => (
               <Card
                 key={event.id}
-                className="hover:bg-gray-50 transition-colors cursor-pointer border border-gray-200 shadow-sm rounded-lg overflow-hidden"
+                className="hover:bg-gray-50 dark:hover:bg-zinc-800 transition-colors cursor-pointer border border-gray-200 dark:border-zinc-800 shadow-sm dark:shadow-zinc-900/20 rounded-lg overflow-hidden"
               >
                 <CardContent className="p-4">
                   <div className="flex items-start justify-between">
                     <div className="flex-1">
-                      <h3 className="font-medium text-zinc-900">{event.name}</h3>
-                      <p className="text-sm text-zinc-500 mt-1 flex items-center gap-1">
+                      <h3 className="font-medium text-zinc-900 dark:text-zinc-100">{event.name}</h3>
+                      <p className="text-sm text-zinc-500 dark:text-zinc-400 mt-1 flex items-center gap-1">
                         <Clock className="h-3.5 w-3.5 inline" />
                         {format(new Date(event.start_date), "MMMM do, yyyy")} •{" "}
                         {format(new Date(event.start_date), "h:mm a")} - {format(new Date(event.end_date), "h:mm a")}
                       </p>
-                      {event.note && <p className="mt-2 text-sm text-zinc-600">{event.note}</p>}
+                      {event.note && <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">{event.note}</p>}
                     </div>
                     {event.google_event_url && (
                       <a
                         href={event.google_event_url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-zinc-400 hover:text-zinc-600 transition-colors ml-2"
+                        className="text-zinc-400 hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300 transition-colors ml-2"
                         onClick={(e) => e.stopPropagation()}
                       >
                         <ExternalLink className="h-4 w-4" />

--- a/apps/desktop/src/components/left-sidebar/events-list.tsx
+++ b/apps/desktop/src/components/left-sidebar/events-list.tsx
@@ -34,8 +34,8 @@ export default function EventsList({
   }
 
   return (
-    <section className="border-b mb-4 border-border">
-      <h2 className="font-bold text-neutral-600 mb-1">
+    <section className="border-b mb-4 border-border dark:border-zinc-700">
+      <h2 className="font-bold text-neutral-600 dark:text-neutral-400 mb-1">
         <Trans>Upcoming</Trans>
       </h2>
 
@@ -107,14 +107,16 @@ function EventItem({
           onClick={handleClick}
           className={clsx([
             "w-full text-left group flex items-start gap-3 py-2 rounded-lg px-2",
-            isActive ? "bg-neutral-200" : "hover:bg-neutral-100",
+            isActive 
+              ? "bg-neutral-200 dark:bg-zinc-800" 
+              : "hover:bg-neutral-100 dark:hover:bg-zinc-800/70",
           ])}
         >
           <div className="flex items-center gap-1 w-full">
             <div className="flex-1 flex flex-col items-start gap-1 truncate">
               <EventItemTitle event={event} />
 
-              <div className="flex items-center gap-2 text-xs text-neutral-500 line-clamp-1">
+              <div className="flex items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400 line-clamp-1">
                 <span>{formatUpcomingTime(new Date(event.start_date))}</span>
               </div>
             </div>

--- a/apps/desktop/src/components/left-sidebar/index.tsx
+++ b/apps/desktop/src/components/left-sidebar/index.tsx
@@ -75,7 +75,7 @@ export default function LeftSidebar() {
       initial={{ width: isExpanded ? 240 : 0, opacity: isExpanded ? 1 : 0 }}
       animate={{ width: isExpanded ? 240 : 0, opacity: isExpanded ? 1 : 0 }}
       transition={{ duration: 0.1 }}
-      className="h-full flex flex-col overflow-hidden border-r bg-neutral-50"
+      className="h-full flex flex-col overflow-hidden border-r border-border dark:border-zinc-800 bg-neutral-50 dark:bg-zinc-900"
     >
       <TopArea />
 

--- a/apps/desktop/src/components/left-sidebar/notes-list.tsx
+++ b/apps/desktop/src/components/left-sidebar/notes-list.tsx
@@ -133,7 +133,7 @@ export default function NotesList({ ongoingSessionId, filter }: NotesListProps) 
 
             return (
               <section key={`${key}-${pageIndex}`}>
-                <h2 className="font-bold text-neutral-600 mb-1">
+                <h2 className="font-bold text-neutral-600 dark:text-neutral-400 mb-1">
                   {key}
                 </h2>
 
@@ -269,7 +269,9 @@ function NoteItem({
           disabled={isActive}
           className={cn(
             "group flex items-start gap-3 py-2 w-full text-left transition-all rounded-lg px-2",
-            isActive ? "bg-neutral-200" : "hover:bg-neutral-100",
+            isActive 
+              ? "bg-neutral-200 dark:bg-zinc-800" 
+              : "hover:bg-neutral-100 dark:hover:bg-zinc-800/70",
           )}
         >
           <div className="flex items-center gap-1 w-full">
@@ -280,7 +282,7 @@ function NoteItem({
                 </div>
               </div>
 
-              <div className="flex items-center gap-3 text-xs text-neutral-500">
+              <div className="flex items-center gap-3 text-xs text-neutral-500 dark:text-neutral-400">
                 <span className="font-medium">{formattedSessionDate}</span>
               </div>
             </div>

--- a/apps/desktop/src/components/left-sidebar/search-list.tsx
+++ b/apps/desktop/src/components/left-sidebar/search-list.tsx
@@ -35,8 +35,8 @@ export default function SearchList({ matches }: { matches: SearchMatch[] }) {
     <div className="h-full space-y-4 px-3 pb-4">
       {sessionMatches.length > 0 && (
         <section>
-          <h2 className="font-bold text-neutral-600 mb-1 flex items-center gap-1">
-            <FileTextIcon className="h-4 w-4 text-neutral-500" />
+          <h2 className="font-bold text-neutral-600 dark:text-neutral-400 mb-1 flex items-center gap-1">
+            <FileTextIcon className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
             Notes
           </h2>
           <div>
@@ -49,8 +49,8 @@ export default function SearchList({ matches }: { matches: SearchMatch[] }) {
 
       {eventMatches.length > 0 && (
         <section>
-          <h2 className="font-bold text-neutral-600 mb-1 flex items-center gap-1">
-            <CalendarIcon className="h-4 w-4 text-neutral-500" />
+          <h2 className="font-bold text-neutral-600 dark:text-neutral-400 mb-1 flex items-center gap-1">
+            <CalendarIcon className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
             Events
           </h2>
           <div>
@@ -63,8 +63,8 @@ export default function SearchList({ matches }: { matches: SearchMatch[] }) {
 
       {humanMatches.length > 0 && (
         <section>
-          <h2 className="font-bold text-neutral-600 mb-1 flex items-center gap-1">
-            <UserIcon className="h-4 w-4 text-neutral-500" />
+          <h2 className="font-bold text-neutral-600 dark:text-neutral-400 mb-1 flex items-center gap-1">
+            <UserIcon className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
             People
           </h2>
           <div>
@@ -77,8 +77,8 @@ export default function SearchList({ matches }: { matches: SearchMatch[] }) {
 
       {organizationMatches.length > 0 && (
         <section>
-          <h2 className="font-bold text-neutral-600 mb-1 flex items-center gap-1">
-            <BuildingIcon className="h-4 w-4 text-neutral-500" />
+          <h2 className="font-bold text-neutral-600 dark:text-neutral-400 mb-1 flex items-center gap-1">
+            <BuildingIcon className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
             Organizations
           </h2>
           <div>
@@ -110,12 +110,12 @@ export function SessionMatch({ match: { item: session } }: { match: SearchMatch 
       onClick={handleClick}
       className={cn([
         "w-full text-left group flex items-start py-2 rounded-lg px-2",
-        isActive ? "bg-neutral-200" : "hover:bg-neutral-100",
+        isActive ? "bg-neutral-200 dark:bg-zinc-800" : "hover:bg-neutral-100 dark:hover:bg-zinc-800/70",
       ])}
     >
       <div className="flex flex-col items-start gap-1">
         <div className="font-medium text-sm line-clamp-1">{session.title || "Untitled Note"}</div>
-        <div className="flex items-center gap-2 text-xs text-neutral-500 line-clamp-1">
+        <div className="flex items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400 line-clamp-1">
           {new Date(session.created_at).toLocaleDateString()}
         </div>
       </div>
@@ -134,11 +134,11 @@ function EventMatch({ match }: { match: SearchMatch & { type: "event" } }) {
   return (
     <button
       onClick={handleClick}
-      className="w-full text-left group flex items-start py-2 hover:bg-neutral-100 rounded-lg px-2"
+      className="w-full text-left group flex items-start py-2 hover:bg-neutral-100 dark:hover:bg-zinc-800/70 rounded-lg px-2"
     >
       <div className="flex flex-col items-start gap-1">
         <div className="font-medium text-sm line-clamp-1">{event.name}</div>
-        <div className="flex items-center gap-2 text-xs text-neutral-500 line-clamp-1">
+        <div className="flex items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400 line-clamp-1">
           {formatRemainingTime(new Date(event.start_date))}
         </div>
       </div>
@@ -182,16 +182,16 @@ function HumanMatch({ match: { item } }: { match: SearchMatch & { type: "human" 
           disabled={isActive}
           className={cn([
             "w-full text-left group flex items-start py-2 rounded-lg px-2",
-            isActive ? "bg-neutral-200" : "hover:bg-neutral-100",
+            isActive ? "bg-neutral-200 dark:bg-zinc-800" : "hover:bg-neutral-100 dark:hover:bg-zinc-800/70",
             isOpen && "bg-neutral-100",
           ])}
         >
           <div className="flex flex-col items-start gap-1">
             <div className="font-medium text-sm line-clamp-1 flex items-center justify-between w-full">
               <span>{human.data?.full_name || "Unnamed Person"}</span>
-              <span className="text-neutral-500 text-xs font-normal ml-auto">{human.data?.job_title}</span>
+              <span className="text-neutral-500 dark:text-neutral-400 text-xs font-normal ml-auto">{human.data?.job_title}</span>
             </div>
-            <div className="flex items-center gap-2 text-xs text-neutral-500 line-clamp-1">
+            <div className="flex items-center gap-2 text-xs text-neutral-500 dark:text-neutral-400 line-clamp-1">
               {human.data?.email}
             </div>
           </div>
@@ -249,13 +249,13 @@ function OrganizationMatch(
           disabled={isActive}
           className={cn([
             "w-full text-left group flex items-start py-2 rounded-lg px-2",
-            isActive ? "bg-neutral-200" : "hover:bg-neutral-100",
+            isActive ? "bg-neutral-200 dark:bg-zinc-800" : "hover:bg-neutral-100 dark:hover:bg-zinc-800/70",
             isOpen && "bg-neutral-100",
           ])}
         >
           <div className="flex flex-col items-start gap-1 w-full overflow-hidden">
             <div className="font-medium text-sm line-clamp-1 w-full">{org.data?.name}</div>
-            <div className="text-xs text-neutral-500 truncate w-full overflow-hidden text-ellipsis whitespace-nowrap">
+            <div className="text-xs text-neutral-500 dark:text-neutral-400 truncate w-full overflow-hidden text-ellipsis whitespace-nowrap">
               {org.data?.description}
             </div>
           </div>

--- a/apps/desktop/src/components/login-modal.tsx
+++ b/apps/desktop/src/components/login-modal.tsx
@@ -92,7 +92,7 @@ export function LoginModal({ isOpen, onClose }: LoginModalProps) {
                 animation="slideUp"
                 by="word"
                 once
-                className="mb-20 text-center text-2xl font-medium text-neutral-600"
+                className="mb-20 text-center text-2xl font-medium text-neutral-600 dark:text-neutral-400"
               >
                 {t`AI notepad for meetings`}
               </TextAnimate>

--- a/apps/desktop/src/components/right-panel/components/chat/chat-input.tsx
+++ b/apps/desktop/src/components/right-panel/components/chat/chat-input.tsx
@@ -98,21 +98,21 @@ export function ChatInput(
   const entityTitle = getEntityTitle();
 
   return (
-    <div className="border border-b-0 border-input mx-4 rounded-t-lg overflow-clip flex flex-col bg-white">
+    <div className="border border-b-0 border-input dark:border-zinc-700 mx-4 rounded-t-lg overflow-clip flex flex-col bg-white dark:bg-zinc-800">
       <textarea
         ref={chatInputRef}
         value={inputValue}
         onChange={onChange}
         onKeyDown={onKeyDown}
         placeholder="Type a message..."
-        className="w-full resize-none overflow-hidden px-3 py-2 pr-10 text-sm placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 min-h-[40px] max-h-[120px]"
+        className="w-full resize-none overflow-hidden px-3 py-2 pr-10 text-sm placeholder:text-muted-foreground dark:placeholder:text-zinc-500 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 min-h-[40px] max-h-[120px]"
         rows={1}
       />
       <div className="flex items-center justify-between pb-2 px-3">
         {entityId
           ? (
             <Badge
-              className="mr-2 bg-white text-black border border-border inline-flex items-center gap-1 hover:bg-neutral-100 cursor-pointer"
+              className="mr-2 bg-white text-black dark:bg-zinc-800 dark:text-white border border-border dark:border-zinc-700 inline-flex items-center gap-1 hover:bg-neutral-100 dark:hover:bg-zinc-700 cursor-pointer"
               onClick={onNoteBadgeClick}
             >
               {getBadgeIcon()} {entityTitle}

--- a/apps/desktop/src/components/right-panel/components/widget-renderer/configure-widgets-button.tsx
+++ b/apps/desktop/src/components/right-panel/components/widget-renderer/configure-widgets-button.tsx
@@ -31,7 +31,7 @@ export function ConfigureWidgetsButton({
       onClick={handleClickConfigureWidgets}
       variant="outline"
       size="sm"
-      className="rounded-full hover:scale-95 active:scale-90 transition-transform"
+      className="rounded-full hover:scale-95 active:scale-90 transition-transform dark:border-border dark:text-foreground dark:hover:bg-accent dark:hover:text-accent-foreground"
     >
       {children}
     </Button>

--- a/apps/desktop/src/components/right-panel/components/widget-renderer/index.tsx
+++ b/apps/desktop/src/components/right-panel/components/widget-renderer/index.tsx
@@ -153,7 +153,7 @@ export default function WidgetRenderer({
                 duration: 0.25,
                 ease: "easeInOut",
               }}
-              className="absolute inset-0 z-10 flex items-center justify-center"
+              className="absolute inset-0 z-10 flex items-center justify-center bg-background dark:bg-background"
             >
               <SuspenseWidget
                 widgetConfig={getFullWidgetConfig(fullWidgetConfig)}
@@ -172,6 +172,7 @@ export default function WidgetRenderer({
                 duration: 0.25,
                 ease: "easeInOut",
               }}
+              className="text-foreground dark:text-foreground"
             >
               <GridLayout
                 layout={layout}

--- a/apps/desktop/src/components/right-panel/index.tsx
+++ b/apps/desktop/src/components/right-panel/index.tsx
@@ -13,7 +13,7 @@ export default function RightPanel() {
       initial={false}
       animate={{ width: show ? 380 : 0 }}
       transition={{ duration: 0.14 }}
-      className="h-full border-l bg-neutral-50 overflow-hidden"
+      className="h-full border-l bg-neutral-50 dark:bg-zinc-900 dark:border-zinc-800 overflow-hidden"
     >
       {(currentView === "widget") ? <WidgetsView /> : <ChatView />}
     </motion.div>

--- a/apps/desktop/src/components/search-bar.tsx
+++ b/apps/desktop/src/components/search-bar.tsx
@@ -32,15 +32,16 @@ export function SearchBar() {
     <div
       className={clsx([
         "w-60 flex items-center gap-2 h-[34px]",
-        "text-neutral-500 hover:text-neutral-600",
-        "border border-border rounded-md px-2 py-2 bg-transparent",
-        "hover:bg-white",
-        isFocused && "bg-white",
+        "text-neutral-500 hover:text-neutral-600 dark:text-neutral-400 dark:hover:text-neutral-300",
+        "border rounded-md px-2 py-2 bg-transparent",
+        "border-border dark:border-zinc-700",
+        "hover:bg-white dark:hover:bg-zinc-800",
+        isFocused && "bg-white dark:bg-zinc-800",
         "transition-colors duration-200",
       ])}
       onClick={() => focusSearch()}
     >
-      <SearchIcon className="h-4 w-4 text-neutral-500" />
+      <SearchIcon className="h-4 w-4 text-neutral-500 dark:text-neutral-400" />
       <input
         ref={searchInputRef}
         type="text"
@@ -49,13 +50,13 @@ export function SearchBar() {
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
         placeholder={t`Search...`}
-        className="flex-1 bg-transparent outline-none text-xs"
+        className="flex-1 bg-transparent outline-none text-xs dark:text-white dark:placeholder-neutral-400"
       />
       {searchQuery
         ? (
           <XIcon
             onClick={() => clearSearch()}
-            className="h-4 w-4 text-neutral-400 hover:text-neutral-600"
+            className="h-4 w-4 text-neutral-400 hover:text-neutral-600 dark:text-neutral-400 dark:hover:text-neutral-300"
           />
         )
         : <Shortcut macDisplay="⌘K" windowsDisplay="Ctrl+K" />}

--- a/apps/desktop/src/components/settings/components/extensions-sidebar.tsx
+++ b/apps/desktop/src/components/settings/components/extensions-sidebar.tsx
@@ -24,11 +24,11 @@ export function ExtensionsSidebar({
     <>
       <div className="p-2">
         <div className="relative flex items-center">
-          <SearchIcon className="absolute left-2 h-4 w-4 text-neutral-400" />
+          <SearchIcon className="absolute left-2 h-4 w-4 text-neutral-400 dark:text-neutral-500" />
           <input
             type="text"
             placeholder="Search extensions..."
-            className="w-full rounded-md border border-neutral-200 bg-white py-1 pl-8 pr-2 text-sm placeholder:text-neutral-400 focus:outline-none focus:ring-1 focus:ring-neutral-400"
+            className="w-full rounded-md border border-neutral-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 dark:text-neutral-200 py-1 pl-8 pr-2 text-sm placeholder:text-neutral-400 dark:placeholder:text-neutral-500 focus:outline-none focus:ring-1 focus:ring-neutral-400 dark:focus:ring-neutral-600"
             value={searchQuery}
             onChange={onSearchChange}
           />
@@ -41,8 +41,8 @@ export function ExtensionsSidebar({
             <button
               key={extension.id}
               className={cn(
-                "flex w-full items-center gap-2 rounded-lg p-2 text-sm text-neutral-600 hover:bg-neutral-100",
-                selectedExtension === extension.id && "bg-neutral-100 font-medium",
+                "flex w-full items-center gap-2 rounded-lg p-2 text-sm text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-zinc-800",
+                selectedExtension === extension.id && "bg-neutral-100 dark:bg-zinc-800 font-medium",
               )}
               onClick={() => onExtensionSelect(extension.id as ExtensionName)}
               disabled={!extension.implemented}
@@ -51,7 +51,7 @@ export function ExtensionsSidebar({
               <div className="flex flex-1 items-center justify-between">
                 <span>{extension.title}</span>
                 {!extension.implemented && (
-                  <span className="text-xs text-neutral-400">
+                  <span className="text-xs text-neutral-400 dark:text-neutral-500">
                     <Trans>Coming Soon</Trans>
                   </span>
                 )}

--- a/apps/desktop/src/components/settings/components/main-sidebar.tsx
+++ b/apps/desktop/src/components/settings/components/main-sidebar.tsx
@@ -18,8 +18,8 @@ export function MainSidebar({ current, onTabClick }: MainSidebarProps) {
             <button
               key={tab.name}
               className={cn(
-                "flex w-full items-center gap-2 rounded-lg p-2 text-sm text-neutral-600 hover:bg-neutral-100",
-                current === tab.name && "bg-neutral-100 font-medium",
+                "flex w-full items-center gap-2 rounded-lg p-2 text-sm text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-zinc-800",
+                current === tab.name && "bg-neutral-100 dark:bg-zinc-800 font-medium",
               )}
               onClick={() => onTabClick(tab.name)}
             >

--- a/apps/desktop/src/components/settings/components/settings-header.tsx
+++ b/apps/desktop/src/components/settings/components/settings-header.tsx
@@ -40,7 +40,7 @@ export function SettingsHeader({ current, onCreateTemplate }: SettingsHeaderProp
   };
 
   return (
-    <header data-tauri-drag-region className="h-11 w-full flex items-center justify-between border-b px-2">
+    <header data-tauri-drag-region className="h-11 w-full flex items-center justify-between border-b dark:border-zinc-800 px-2">
       <div className="w-40" data-tauri-drag-region></div>
 
       <h1 className="text-md font-semibold capitalize" data-tauri-drag-region>

--- a/apps/desktop/src/components/settings/components/templates-sidebar.tsx
+++ b/apps/desktop/src/components/settings/components/templates-sidebar.tsx
@@ -27,11 +27,11 @@ export function TemplatesSidebar({
     <>
       <div className="p-2">
         <div className="relative flex items-center">
-          <SearchIcon className="absolute left-2 h-4 w-4 text-neutral-400" />
+          <SearchIcon className="absolute left-2 h-4 w-4 text-neutral-400 dark:text-neutral-500" />
           <input
             type="text"
             placeholder={t`Search templates...`}
-            className="w-full rounded-md border border-neutral-200 bg-white py-1 pl-8 pr-2 text-sm placeholder:text-neutral-400 focus:outline-none focus:ring-1 focus:ring-neutral-400"
+            className="w-full rounded-md border border-neutral-200 dark:border-zinc-700 bg-white dark:bg-zinc-800 dark:text-neutral-200 py-1 pl-8 pr-2 text-sm placeholder:text-neutral-400 dark:placeholder:text-neutral-500 focus:outline-none focus:ring-1 focus:ring-neutral-400 dark:focus:ring-neutral-600"
             value={searchQuery}
             onChange={onSearchChange}
           />
@@ -41,7 +41,7 @@ export function TemplatesSidebar({
         <div className="space-y-4 p-2">
           {customTemplates.length > 0 && (
             <div>
-              <h3 className="mb-1 px-2 text-xs font-medium uppercase text-neutral-500">
+              <h3 className="mb-1 px-2 text-xs font-medium uppercase text-neutral-500 dark:text-neutral-400">
                 <Trans>Your Templates</Trans>
               </h3>
               <div className="space-y-1">
@@ -49,8 +49,8 @@ export function TemplatesSidebar({
                   <button
                     key={template.id}
                     className={cn(
-                      "flex w-full items-center gap-2 rounded-lg p-2 text-sm text-neutral-600 hover:bg-neutral-100",
-                      selectedTemplate === template.id && "bg-neutral-100 font-medium",
+                      "flex w-full items-center gap-2 rounded-lg p-2 text-sm text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-zinc-800",
+                      selectedTemplate === template.id && "bg-neutral-100 dark:bg-zinc-800 font-medium",
                     )}
                     onClick={() => onTemplateSelect(template.id)}
                   >
@@ -64,7 +64,7 @@ export function TemplatesSidebar({
 
           {builtinTemplates.length > 0 && (
             <div>
-              <h3 className="mb-1 px-2 text-xs font-medium uppercase text-neutral-500">
+              <h3 className="mb-1 px-2 text-xs font-medium uppercase text-neutral-500 dark:text-neutral-400">
                 <Trans>Built-in Templates</Trans>
               </h3>
               <div className="space-y-1">
@@ -72,8 +72,8 @@ export function TemplatesSidebar({
                   <button
                     key={template.id}
                     className={cn(
-                      "flex w-full items-center gap-2 rounded-lg p-2 text-sm text-neutral-600 hover:bg-neutral-100",
-                      selectedTemplate === template.id && "bg-neutral-100 font-medium",
+                      "flex w-full items-center gap-2 rounded-lg p-2 text-sm text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-zinc-800",
+                      selectedTemplate === template.id && "bg-neutral-100 dark:bg-zinc-800 font-medium",
                     )}
                     onClick={() => onTemplateSelect(template.id)}
                   >

--- a/apps/desktop/src/components/settings/views/ai.tsx
+++ b/apps/desktop/src/components/settings/views/ai.tsx
@@ -160,8 +160,8 @@ export default function LocalAI() {
   return (
     <div className="space-y-6">
       <Accordion type="single" collapsible className="space-y-2">
-        <AccordionItem value="stt" className="border rounded-md overflow-hidden">
-          <AccordionTrigger className="px-4 py-3 hover:bg-neutral-50">
+        <AccordionItem value="stt" className="border dark:border-zinc-700 rounded-md overflow-hidden">
+          <AccordionTrigger className="px-4 py-3 hover:bg-neutral-50 dark:hover:bg-zinc-800">
             <div className="flex items-center gap-2">
               <MicIcon size={18} className="text-neutral-500" />
               <span className="font-medium">
@@ -179,7 +179,7 @@ export default function LocalAI() {
                   className="space-y-3"
                 >
                   {supportedSTTModels.data?.map(({ model, isDownloaded }) => (
-                    <div key={model} className="flex items-center justify-between rounded-md p-2 hover:bg-neutral-50">
+                    <div key={model} className="flex items-center justify-between rounded-md p-2 hover:bg-neutral-50 dark:hover:bg-zinc-800">
                       <div className="flex items-center space-x-3">
                         <RadioGroupItem value={model} id={`model-${model}`} disabled={!isDownloaded} />
                         <Label htmlFor={`model-${model}`} className="flex items-center cursor-pointer font-medium">
@@ -230,8 +230,8 @@ export default function LocalAI() {
           </AccordionContent>
         </AccordionItem>
 
-        <AccordionItem value="llm" className="border rounded-md overflow-hidden">
-          <AccordionTrigger className="px-4 py-3 hover:bg-neutral-50">
+        <AccordionItem value="llm" className="border dark:border-zinc-700 rounded-md overflow-hidden">
+          <AccordionTrigger className="px-4 py-3 hover:bg-neutral-50 dark:hover:bg-zinc-800">
             <div className="flex items-center gap-2">
               <BrainIcon size={18} className="text-neutral-500" />
               <span className="font-medium">
@@ -249,14 +249,14 @@ export default function LocalAI() {
                   }}
                   className="space-y-4"
                 >
-                  <div className="flex items-center space-x-3 rounded-md p-2 hover:bg-neutral-50">
+                  <div className="flex items-center space-x-3 rounded-md p-2 hover:bg-neutral-50 dark:hover:bg-zinc-800">
                     <RadioGroupItem value="llama-3.2-3b-q4" id="model-llama-3-2" />
                     <Label htmlFor="model-llama-3-2" className="flex items-center cursor-pointer font-medium">
                       <span>llama-3.2-3b-q4</span>
                     </Label>
                   </div>
 
-                  <div className="rounded-md border border-neutral-200 p-3">
+                  <div className="rounded-md border border-neutral-200 dark:border-zinc-700 p-3">
                     <div className="flex items-center space-x-3 mb-3">
                       <RadioGroupItem value="custom" id="model-custom" />
                       <Label htmlFor="model-custom" className="flex items-center cursor-pointer font-medium">

--- a/apps/desktop/src/components/settings/views/billing.tsx
+++ b/apps/desktop/src/components/settings/views/billing.tsx
@@ -96,11 +96,11 @@ export default function Billing({ currentPlan, trialDaysLeft }: BillingProps) {
 
   return (
     <div className="relative h-full">
-      <div className="absolute inset-0 backdrop-blur-sm bg-white/50 z-10 flex flex-col items-center justify-center">
-        <div className="text-4xl font-bold text-neutral-900 mb-4">
+      <div className="absolute inset-0 backdrop-blur-sm bg-white/50 dark:bg-zinc-900/50 z-10 flex flex-col items-center justify-center">
+        <div className="text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
           <Trans>Coming Soon</Trans>
         </div>
-        <p className="text-neutral-700 max-w-md text-center">
+        <p className="text-neutral-700 dark:text-neutral-300 max-w-md text-center">
           <Trans>
             Billing features are currently under development and will be available in a future update.
           </Trans>

--- a/apps/desktop/src/components/settings/views/extension.tsx
+++ b/apps/desktop/src/components/settings/views/extension.tsx
@@ -133,8 +133,8 @@ export default function Extensions({
 
   return (
     <div className="flex flex-col gap-4">
-      <div className={hasMultipleGroups ? "border-b pb-4 border-border" : ""}>
-        <h3 className="text-2xl font-semibold text-neutral-700 mb-2">
+      <div className={hasMultipleGroups ? "border-b pb-4 border-border dark:border-zinc-700" : ""}>
+        <h3 className="text-2xl font-semibold text-neutral-700 dark:text-neutral-300 mb-2">
           {selectedExtension.title}
         </h3>
 

--- a/apps/desktop/src/components/settings/views/team.tsx
+++ b/apps/desktop/src/components/settings/views/team.tsx
@@ -64,11 +64,11 @@ export default function TeamComponent() {
 
   return (
     <div className="relative h-full">
-      <div className="absolute inset-0 backdrop-blur-sm bg-white/50 z-10 flex flex-col items-center justify-center">
-        <div className="text-4xl font-bold text-neutral-900 mb-4">
+      <div className="absolute inset-0 backdrop-blur-sm bg-white/50 dark:bg-zinc-900/50 z-10 flex flex-col items-center justify-center">
+        <div className="text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
           <Trans>Coming Soon</Trans>
         </div>
-        <p className="text-neutral-700 max-w-md text-center">
+        <p className="text-neutral-700 dark:text-neutral-300 max-w-md text-center">
           <Trans>
             Team management features are currently under development and will be available in a future update.
           </Trans>

--- a/apps/desktop/src/components/share-and-permission/publish.tsx
+++ b/apps/desktop/src/components/share-and-permission/publish.tsx
@@ -14,7 +14,7 @@ export const Publish = () => {
         <h3 className="text-lg font-medium mb-1">
           <Trans>Publish your note</Trans>
         </h3>
-        <p className="text-sm text-neutral-600">
+        <p className="text-sm text-neutral-600 dark:text-neutral-400">
           <Trans>Anyone with the link can view this page</Trans>
         </p>
       </div>

--- a/apps/desktop/src/components/toolbar/bars/main-toolbar.tsx
+++ b/apps/desktop/src/components/toolbar/bars/main-toolbar.tsx
@@ -36,7 +36,7 @@ export function MainToolbar() {
       className={cn([
         "flex w-full items-center justify-between min-h-11 py-1 px-2 border-b",
         isMain
-          ? "border-border bg-neutral-50"
+          ? "border-border bg-neutral-50 dark:bg-zinc-900 dark:border-zinc-700"
           : "border-transparent bg-transparent",
         !isExpanded && "pl-[72px]",
       ])}

--- a/apps/desktop/src/components/toolbar/buttons/chat-panel-button.tsx
+++ b/apps/desktop/src/components/toolbar/buttons/chat-panel-button.tsx
@@ -36,7 +36,7 @@ function ChatPanelButtonBase() {
           variant="ghost"
           size="icon"
           onClick={handleClick}
-          className={cn("hover:bg-neutral-200 text-xs size-7 p-0", isActive && "bg-neutral-200")}
+          className={cn("hover:bg-neutral-200 dark:hover:bg-zinc-800 text-xs size-7 p-0", isActive && "bg-neutral-200 dark:bg-zinc-800")}
         >
           <div className="relative w-6 aspect-square flex items-center justify-center">
             <img

--- a/apps/desktop/src/components/toolbar/buttons/delete-note-button.tsx
+++ b/apps/desktop/src/components/toolbar/buttons/delete-note-button.tsx
@@ -52,7 +52,7 @@ function DeleteNoteButtonInNote() {
       disabled={!hasContent}
       variant="ghost"
       size="icon"
-      className="hover:bg-neutral-200"
+      className="hover:bg-neutral-200 dark:hover:bg-zinc-800 text-neutral-700 dark:text-neutral-300"
       aria-label="Delete Note"
       onClick={handleDelete}
     >

--- a/apps/desktop/src/components/toolbar/buttons/left-sidebar-button.tsx
+++ b/apps/desktop/src/components/toolbar/buttons/left-sidebar-button.tsx
@@ -23,7 +23,7 @@ export function LeftSidebarButton({ type }: { type: "toolbar" | "sidebar" }) {
             variant="ghost"
             size="icon"
             onClick={togglePanel}
-            className="hover:bg-neutral-200"
+            className="hover:bg-neutral-200 dark:hover:bg-zinc-800 text-neutral-700 dark:text-neutral-300"
           >
             <ToggleIcon className="size-4" />
           </Button>

--- a/apps/desktop/src/components/toolbar/buttons/new-note-button.tsx
+++ b/apps/desktop/src/components/toolbar/buttons/new-note-button.tsx
@@ -35,7 +35,7 @@ function ActualButton({ disabled }: { disabled: boolean }) {
           disabled={disabled}
           variant="ghost"
           size="icon"
-          className="hover:bg-neutral-200"
+          className="hover:bg-neutral-200 dark:hover:bg-zinc-800 text-neutral-700 dark:text-neutral-300"
           onClick={createNewNote}
           aria-label="New Note"
         >

--- a/apps/desktop/src/components/toolbar/buttons/new-window-button.tsx
+++ b/apps/desktop/src/components/toolbar/buttons/new-window-button.tsx
@@ -25,7 +25,7 @@ export function NewWindowButton() {
           variant="ghost"
           size="icon"
           onClick={handleClick}
-          className="hover:bg-neutral-200"
+          className="hover:bg-neutral-200 dark:hover:bg-zinc-800 text-neutral-700 dark:text-neutral-300"
           aria-label="Open in new window"
         >
           <ArrowUpRight size={16} />

--- a/apps/desktop/src/components/toolbar/buttons/share-button.tsx
+++ b/apps/desktop/src/components/toolbar/buttons/share-button.tsx
@@ -30,7 +30,7 @@ export function ShareButton() {
         <Button
           variant="ghost"
           size="icon"
-          className="hover:bg-neutral-200"
+          className="hover:bg-neutral-200 dark:hover:bg-zinc-800 text-neutral-700 dark:text-neutral-300"
           aria-label="Share"
         >
           <Share2Icon className="size-4" />

--- a/apps/desktop/src/components/toolbar/buttons/widget-panel-button.tsx
+++ b/apps/desktop/src/components/toolbar/buttons/widget-panel-button.tsx
@@ -24,8 +24,8 @@ export function WidgetPanelButton() {
           size="icon"
           onClick={handleClick}
           className={cn(
-            "hover:bg-neutral-300 text-xs",
-            isActive && "bg-neutral-200",
+            "hover:bg-neutral-300 dark:hover:bg-zinc-800 text-xs",
+            isActive && "bg-neutral-200 dark:bg-zinc-800",
           )}
         >
           {!isExpanded ? <PanelRightOpen className="size-4" /> : <PanelRightClose className="size-4" />}

--- a/apps/desktop/src/components/workspace-calendar/index.tsx
+++ b/apps/desktop/src/components/workspace-calendar/index.tsx
@@ -120,7 +120,7 @@ export default function WorkspaceCalendar({
   return (
     <div
       ref={calendarRef}
-      className="grid grid-cols-7 divide-x divide-neutral-200 h-full grid-rows-6 gap-0"
+      className="grid grid-cols-7 divide-x divide-neutral-200 dark:divide-zinc-800 h-full grid-rows-6 gap-0"
     >
       {calendarDays.map((day, i) => {
         const dayItems = getItemsForDay(day);
@@ -163,8 +163,8 @@ export default function WorkspaceCalendar({
             style={{ height: cellHeight > 0 ? `${cellHeight}px` : "auto" }}
             className={cn(
               "relative flex flex-col",
-              !isLastWeek && "border-b border-neutral-200",
-              isWeekend ? "bg-neutral-50" : "bg-white",
+              !isLastWeek && "border-b border-neutral-200 dark:border-zinc-800",
+              isWeekend ? "bg-neutral-50 dark:bg-zinc-900" : "bg-white dark:bg-zinc-950",
             )}
           >
             <div className="flex items-center justify-end px-1 text-sm h-8">
@@ -178,10 +178,10 @@ export default function WorkspaceCalendar({
                   <span
                     className={cn(
                       !isCurrentMonth
-                        ? "text-neutral-400"
+                        ? "text-neutral-400 dark:text-zinc-600"
                         : isWeekend
-                        ? "text-neutral-500"
-                        : "text-neutral-700",
+                        ? "text-neutral-500 dark:text-zinc-400"
+                        : "text-neutral-700 dark:text-zinc-300",
                     )}
                   >
                     {monthName}
@@ -199,10 +199,10 @@ export default function WorkspaceCalendar({
                       isHighlighted
                         ? "text-white font-medium"
                         : !isCurrentMonth
-                        ? "text-neutral-400"
+                        ? "text-neutral-400 dark:text-zinc-600"
                         : isWeekend
-                        ? "text-neutral-500"
-                        : "text-neutral-700",
+                        ? "text-neutral-500 dark:text-zinc-400"
+                        : "text-neutral-700 dark:text-zinc-300",
                     )}
                   >
                     {dayNumber}
@@ -229,15 +229,15 @@ export default function WorkspaceCalendar({
                   {hiddenCount > 0 && (
                     <Popover>
                       <PopoverTrigger asChild>
-                        <div className="text-xs text-neutral-600 rounded py-0.5 cursor-pointer hover:bg-neutral-200 mx-1 h-5">
+                        <div className="text-xs text-neutral-600 dark:text-zinc-400 rounded py-0.5 cursor-pointer hover:bg-neutral-200 dark:hover:bg-zinc-800 mx-1 h-5">
                           {`+${hiddenCount} more`}
                         </div>
                       </PopoverTrigger>
                       <PopoverContent
-                        className="w-80 p-4 max-h-52 space-y-1 overflow-y-auto bg-white border-neutral-200 m-2 shadow-lg outline-none focus:outline-none focus:ring-0"
+                        className="w-80 p-4 max-h-52 space-y-1 overflow-y-auto bg-white dark:bg-zinc-900 border-neutral-200 dark:border-zinc-800 m-2 shadow-lg dark:shadow-zinc-900/50 outline-none focus:outline-none focus:ring-0"
                         align="start"
                       >
-                        <div className="text-lg font-semibold text-neutral-800">
+                        <div className="text-lg font-semibold text-neutral-800 dark:text-zinc-200">
                           {format(day, "MMMM d, yyyy")}
                         </div>
 
@@ -254,7 +254,7 @@ export default function WorkspaceCalendar({
                           .map((item) => (
                             <div
                               key={item.id}
-                              className="text-sm hover:bg-neutral-100 rounded cursor-pointer transition-colors"
+                              className="text-sm hover:bg-neutral-100 dark:hover:bg-zinc-800 rounded cursor-pointer transition-colors"
                             >
                               {"calendar_event_id" in item
                                 ? <NoteCard session={item as Session} showTime />

--- a/apps/desktop/src/components/workspace-calendar/note-card.tsx
+++ b/apps/desktop/src/components/workspace-calendar/note-card.tsx
@@ -80,26 +80,26 @@ export function NoteCard({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <div className="flex items-start space-x-1 px-0.5 py-0.5 cursor-pointer rounded hover:bg-neutral-200 transition-colors h-5">
-          <div className="w-1 h-3 mt-0.5 rounded-full flex-shrink-0 bg-neutral-600"></div>
+        <div className="flex items-start space-x-1 px-0.5 py-0.5 cursor-pointer rounded hover:bg-neutral-200 dark:hover:bg-zinc-700 transition-colors h-5">
+          <div className="w-1 h-3 mt-0.5 rounded-full flex-shrink-0 bg-neutral-600 dark:bg-neutral-400"></div>
 
-          <div className="flex-1 text-xs text-neutral-800 truncate">
+          <div className="flex-1 text-xs text-neutral-800 dark:text-neutral-200 truncate">
             {session.title || "Untitled"}
           </div>
 
           {showTime && (
-            <div className="text-xs text-neutral-500">
+            <div className="text-xs text-neutral-500 dark:text-neutral-400">
               {format(getStartDate(), "h:mm a")} - {format(getEndDate(), "h:mm a")}
             </div>
           )}
         </div>
       </PopoverTrigger>
-      <PopoverContent className="w-72 p-4 bg-white border-neutral-200 m-2 shadow-lg outline-none focus:outline-none focus:ring-0">
-        <div className="font-semibold text-lg mb-2 text-neutral-800">
+      <PopoverContent className="w-72 p-4 bg-white dark:bg-zinc-800 border-neutral-200 dark:border-zinc-700 m-2 shadow-lg outline-none focus:outline-none focus:ring-0">
+        <div className="font-semibold text-lg mb-2 text-neutral-800 dark:text-neutral-200">
           {session.title || "Untitled"}
         </div>
 
-        <p className="text-sm mb-2 text-neutral-600">
+        <p className="text-sm mb-2 text-neutral-600 dark:text-neutral-400">
           {format(getStartDate(), "MMM d, h:mm a")}
           {" - "}
           {format(getStartDate(), "yyyy-MM-dd")
@@ -109,7 +109,7 @@ export function NoteCard({
         </p>
 
         {participantsPreview && participantsPreview.length > 0 && (
-          <div className="text-xs text-neutral-600 mb-4 truncate">
+          <div className="text-xs text-neutral-600 dark:text-neutral-400 mb-4 truncate">
             {participantsPreview.join(", ")}
           </div>
         )}

--- a/apps/desktop/src/contexts/theme-provider.tsx
+++ b/apps/desktop/src/contexts/theme-provider.tsx
@@ -1,11 +1,9 @@
-// https://ui.shadcn.com/docs/dark-mode/vite
-
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, ReactNode, useContext, useEffect, useState } from "react";
 
 type Theme = "dark" | "light" | "system";
 
 type ThemeProviderProps = {
-  children: React.ReactNode;
+  children: ReactNode;
   defaultTheme?: Theme;
   storageKey?: string;
 };
@@ -29,44 +27,31 @@ export function ThemeProvider({
   ...props
 }: ThemeProviderProps) {
   const [theme, setTheme] = useState<Theme>(
-    () => defaultTheme
+    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
   );
 
   useEffect(() => {
     const root = window.document.documentElement;
-    const darkModeMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-
-    const updateSystemTheme = (e: MediaQueryListEvent | MediaQueryList) => {
-      if (theme === "system") {
-        root.classList.remove("light", "dark");
-        const systemTheme = e.matches ? "dark" : "light";
-        root.classList.add(systemTheme);
-      }
-    };
-
-    const onThemeChange = () => {
-      root.classList.remove("light", "dark");
-
-      if (theme === "system") {
-        const systemTheme = darkModeMediaQuery.matches ? "dark" : "light";
-        root.classList.add(systemTheme);
-        return;
-      }
-
-      root.classList.add(theme);
-    };
-
-    onThemeChange();
     
-    // Listen for system preference changes
-    darkModeMediaQuery.addEventListener("change", updateSystemTheme);
+    root.classList.remove("light", "dark");
     
-    return () => darkModeMediaQuery.removeEventListener("change", updateSystemTheme);
+    if (theme === "system") {
+      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
+        .matches
+        ? "dark"
+        : "light";
+      
+      root.classList.add(systemTheme);
+      return;
+    }
+    
+    root.classList.add(theme);
   }, [theme]);
 
   const value = {
     theme,
     setTheme: (theme: Theme) => {
+      localStorage.setItem(storageKey, theme);
       setTheme(theme);
     },
   };
@@ -81,7 +66,7 @@ export function ThemeProvider({
 export const useTheme = () => {
   const context = useContext(ThemeProviderContext);
 
-  if (!context) {
+  if (context === undefined) {
     throw new Error("useTheme must be used within a ThemeProvider");
   }
 

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -3,10 +3,21 @@ import "./styles/globals.css";
 
 import { i18n } from "@lingui/core";
 import { I18nProvider } from "@lingui/react";
-import { QueryClient, QueryClientProvider, useQuery, useQueryClient } from "@tanstack/react-query";
-import { CatchBoundary, createRouter, ErrorComponent, RouterProvider } from "@tanstack/react-router";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  CatchBoundary,
+  createRouter,
+  ErrorComponent,
+  RouterProvider,
+} from "@tanstack/react-router";
 import { useEffect } from "react";
 import ReactDOM from "react-dom/client";
+import { setTheme } from "@tauri-apps/api/app";
 
 import type { Context } from "@/types";
 import { commands } from "@/types";
@@ -19,7 +30,10 @@ import { broadcastQueryClient } from "./utils";
 import { messages as enMessages } from "./locales/en/messages";
 import { messages as koMessages } from "./locales/ko/messages";
 
-import { createOngoingSessionStore, createSessionsStore } from "@hypr/utils/stores";
+import {
+  createOngoingSessionStore,
+  createSessionsStore,
+} from "@hypr/utils/stores";
 import { routeTree } from "./routeTree.gen";
 
 import * as Sentry from "@sentry/react";
@@ -96,7 +110,12 @@ function App() {
     return null;
   }
 
-  return <RouterProvider router={router} context={{ ...context, userId: userId.data }} />;
+  return (
+    <RouterProvider
+      router={router}
+      context={{ ...context, userId: userId.data }}
+    />
+  );
 }
 
 if (!rootElement.innerHTML) {
@@ -104,20 +123,18 @@ if (!rootElement.innerHTML) {
   root.render(
     <CatchBoundary getResetKey={() => "error"} errorComponent={ErrorComponent}>
       <TooltipProvider delayDuration={700} skipDelayDuration={300}>
-        <ThemeProvider defaultTheme="light">
-          <QueryClientProvider client={queryClient}>
-            <I18nProvider i18n={i18n}>
-              <App />
-              <Toaster
-                position="bottom-left"
-                expand={process.env.NODE_ENV === "development"}
-                offset={16}
-                duration={Infinity}
-                swipeDirections={[]}
-              />
-            </I18nProvider>
-          </QueryClientProvider>
-        </ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider i18n={i18n}>
+            <App />
+            <Toaster
+              position="bottom-left"
+              expand={process.env.NODE_ENV === "development"}
+              offset={16}
+              duration={Infinity}
+              swipeDirections={[]}
+            />
+          </I18nProvider>
+        </QueryClientProvider>
       </TooltipProvider>
     </CatchBoundary>,
   );

--- a/apps/desktop/src/routes/app.note.$id.tsx
+++ b/apps/desktop/src/routes/app.note.$id.tsx
@@ -86,7 +86,7 @@ function Component() {
   return (
     <div className="flex h-full overflow-hidden">
       <div className="flex-1">
-        <main className="flex h-full overflow-hidden bg-white">
+        <main className="flex h-full overflow-hidden bg-white dark:bg-zinc-900">
           <div className="h-full flex-1 pt-6">
             <OnboardingSupport session={session} />
             <EditorArea editable={getCurrentWebviewWindowLabel() === "main"} sessionId={sessionId} />

--- a/apps/desktop/src/routes/app.settings.tsx
+++ b/apps/desktop/src/routes/app.settings.tsx
@@ -85,7 +85,7 @@ function Component() {
     <div className="relative flex h-screen w-screen overflow-hidden">
       <div className="flex h-full w-full flex-col overflow-hidden bg-background">
         <div className="flex h-full">
-          <div className="w-60 border-r">
+          <div className="w-60 border-r dark:border-zinc-800">
             <div
               data-tauri-drag-region
               className="flex items-center h-11 justify-end px-2"
@@ -94,7 +94,7 @@ function Component() {
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="hover:bg-neutral-200 text-neutral-600 hover:text-neutral-600"
+                  className="hover:bg-neutral-200 dark:hover:bg-zinc-800 text-neutral-600 dark:text-neutral-300 hover:text-neutral-600 dark:hover:text-neutral-300"
                   onClick={() => handleClickTab("general")}
                 >
                   <ArrowLeft className="h-4 w-4" />

--- a/apps/desktop/src/routes/app.tsx
+++ b/apps/desktop/src/routes/app.tsx
@@ -51,7 +51,7 @@ function Component() {
                   <NewNoteProvider>
                     <SearchProvider>
                       <EditModeProvider>
-                        <div className="relative flex h-screen w-screen overflow-hidden">
+                        <div className="relative flex h-screen w-screen overflow-hidden bg-white dark:bg-zinc-900 dark:text-white">
                           <LeftSidebar />
                           <div className="flex-1 flex h-screen w-screen flex-col overflow-hidden">
                             <Toolbar />

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -4,21 +4,80 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Add support for system theme media queries */
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color-scheme: light;
+  }
+}
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 0 0% 3.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 0 0% 3.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 3.9%;
+    --primary: 0 0% 9%;
+    --primary-foreground: 0 0% 98%;
+    --secondary: 0 0% 96.1%;
+    --secondary-foreground: 0 0% 9%;
+    --muted: 0 0% 96.1%;
+    --muted-foreground: 0 0% 45.1%;
+    --accent: 0 0% 96.1%;
+    --accent-foreground: 0 0% 9%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 89.8%;
+    --input: 0 0% 89.8%;
+    --ring: 0 0% 3.9%;
+  }
+
+  .dark {
+    --background: 0 0% 3.9%;
+    --foreground: 0 0% 98%;
+    --card: 0 0% 3.9%;
+    --card-foreground: 0 0% 98%;
+    --popover: 0 0% 3.9%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 0 0% 9%;
+    --secondary: 0 0% 14.9%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 0 0% 14.9%;
+    --muted-foreground: 0 0% 63.9%;
+    --accent: 0 0% 14.9%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 40%; /* Lighter border in dark mode */
+    --input: 0 0% 14.9%;
+    --ring: 0 0% 83.1%;
+  }
+}
+
 /* https://www.joshwcomeau.com/css/custom-css-reset/ */
 
 *,
 *::before,
 *::after {
-  box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 * {
-  margin: 0;
+    margin: 0;
 }
 
 body {
-  line-height: 1.5;
-  -webkit-font-smoothing: antialiased;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
 }
 
 img,
@@ -26,15 +85,15 @@ picture,
 video,
 canvas,
 svg {
-  display: block;
-  max-width: 100%;
+    display: block;
+    max-width: 100%;
 }
 
 input,
 button,
 textarea,
 select {
-  font: inherit;
+    font: inherit;
 }
 
 p,
@@ -44,72 +103,173 @@ h3,
 h4,
 h5,
 h6 {
-  overflow-wrap: break-word;
+    overflow-wrap: break-word;
 }
 
 p {
-  text-wrap: pretty;
+    text-wrap: pretty;
 }
+
 h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
-  text-wrap: balance;
+    text-wrap: balance;
 }
 
 #root,
 #__next {
-  isolation: isolate;
+    isolation: isolate;
 }
 
 /* https://github.com/gitbutlerapp/gitbutler/blob/master/apps/desktop/src/styles/styles.css */
 
 html,
 body {
-  height: 100vh;
-  width: 100vw;
-  overflow-y: hidden;
+    height: 100vh;
+    width: 100vw;
+    overflow-y: hidden;
 
-  user-select: none;
-  overscroll-behavior: none;
+    user-select: none;
+    overscroll-behavior: none;
 }
 
 ::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+    width: 8px;
+    height: 8px;
 }
 
 ::-webkit-scrollbar-track {
-  background: transparent;
+    background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #e5e5e5;
-  border-radius: 4px;
+    background: #e5e5e5;
+    border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #d5d5d5;
+    background: #d5d5d5;
+}
+
+/* Dark theme scrollbar and component styles */
+.dark ::-webkit-scrollbar-thumb {
+    background: #3f3f46;
+    border-radius: 4px;
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+    background: #52525b;
+}
+
+.dark ::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+/* Fix Radix UI popover content wrapper in dark mode */
+.dark [data-radix-popper-content-wrapper] {
+    --border-color: rgb(63 63 70); 
+    --bg-color: rgb(24 24 27); 
+}
+
+.dark [data-radix-popper-content-wrapper] > div {
+    border-color: var(--border-color) !important;
+    background-color: var(--bg-color) !important;
+}
+
+.dark [data-radix-popper-content-wrapper] [role="tooltip"],
+.dark [data-radix-popper-content-wrapper] [role="dialog"],
+.dark [data-radix-popper-content-wrapper] [role="listbox"] {
+    border-color: var(--border-color) !important;
+    background-color: var(--bg-color) !important;
+    color: rgb(212 212 216) !important; 
+}
+
+/* Ensure form components have proper dark mode styling */
+.dark select,
+.dark option,
+.dark [role="combobox"],
+.dark [role="option"] {
+    background-color: var(--bg-color);
+    color: rgb(212 212 216); 
+}
+
+/* Fix for Select component in dark mode */
+.dark [data-radix-select-content] {
+    background-color: var(--bg-color) !important;
+    border-color: var(--border-color) !important;
+}
+
+/* Fix for buttons in dark mode */
+.dark button {
+    border-color: rgba(255, 255, 255, 0.2) !important; /* Lighter border */
+}
+
+/* Specifically fix Edit Widgets button in dark mode */
+.dark button.rounded-full {
+    color: white !important;
+    border-color: rgba(255, 255, 255, 0.3) !important;
+    background-color: rgba(39, 39, 42, 0.8) !important;
+}
+
+/* Fix for transcript widget in dark mode */
+.dark [style*="background: white"] {
+    background-color: #27272a !important; /* zinc-800 */
+}
+
+.dark .bg-white\/50 {
+    background-color: rgba(39, 39, 42, 0.5) !important; /* zinc-800 with opacity */
+}
+
+.dark .text-neutral-900 {
+    color: white !important;
+}
+
+/* Fix for widget borders in dark mode */
+.dark [style*="border-width: 1px"] {
+    border-color: rgba(255, 255, 255, 0.2) !important;
+}
+
+/* Fix for borders in Settings > Lab */
+.dark .rounded-lg.border {
+    border-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Fix for toast notifications in dark mode */
+.dark .group.overflow-clip {
+    border-color: rgba(255, 255, 255, 0.2);
+}
+
+/* More specific fix for model download notification */
+.dark [id="model-download-needed"] {
+    border-color: rgba(255, 255, 255, 0.2) !important;
+}
+
+.dark div[role="status"] {
+    border-color: rgba(255, 255, 255, 0.2) !important;
 }
 
 @layer utilities {
-  .scrollbar-none {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-  }
-  .scrollbar-none::-webkit-scrollbar {
-    display: none;
-  }
+    .scrollbar-none {
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+    }
+
+    .scrollbar-none::-webkit-scrollbar {
+        display: none;
+    }
 }
 
 @layer base {
-  * {
-    @apply select-none;
-  }
+    * {
+        @apply select-none;
+    }
 
-  input, textarea, [contenteditable="true"] {
-    @apply select-text;
-  }
+    input,
+    textarea,
+    [contenteditable="true"] {
+        @apply select-text;
+    }
 }

--- a/apps/desktop/src/utils/index.ts
+++ b/apps/desktop/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from "./dialog";
 export * from "./parse";
 export * from "./shell";
 export * from "./store";
+export * from "./theme";

--- a/apps/desktop/src/utils/theme.ts
+++ b/apps/desktop/src/utils/theme.ts
@@ -1,0 +1,63 @@
+import { emit, listen } from "@tauri-apps/api/event";
+import { setTheme as setTauriTheme } from "@tauri-apps/api/app";
+import { getCurrentWebviewWindowLabel } from "@hypr/plugin-windows";
+
+export type Theme = "dark" | "light";
+const THEME_EVENT = "theme-changed";
+const THEME_STORAGE_KEY = "theme";
+
+// Apply theme to the DOM
+export function applyTheme(theme: Theme) {
+  // Update document classes
+  document.documentElement.classList.remove("dark", "light");
+  document.documentElement.classList.add(theme);
+  
+  // Update Tauri native theme
+  try {
+    setTauriTheme(theme).catch(err => {
+      console.error("Failed to set Tauri theme:", err);
+    });
+  } catch (e) {
+    console.error("Failed to call Tauri setTheme:", e);
+  }
+  
+  // Store in localStorage for persistence
+  localStorage.setItem(THEME_STORAGE_KEY, theme);
+}
+
+// Set theme and broadcast to other windows
+export async function setTheme(theme: Theme) {
+  // Apply theme locally
+  applyTheme(theme);
+  
+  // Broadcast to other windows
+  try {
+    const currentWindow = getCurrentWebviewWindowLabel();
+    await emit(THEME_EVENT, { theme, source: currentWindow });
+  } catch (e) {
+    console.error("Failed to broadcast theme change:", e);
+  }
+}
+
+// Get the current theme from localStorage
+export function getTheme(): Theme {
+  const savedTheme = localStorage.getItem(THEME_STORAGE_KEY) as Theme | null;
+  return savedTheme || "dark"; // Default to dark
+}
+
+// Listen for theme changes from other windows
+export function listenForThemeChanges() {
+  const currentWindow = getCurrentWebviewWindowLabel();
+  
+  listen<{ theme: Theme, source: string }>(THEME_EVENT, (event) => {
+    // Skip if the event was sent by this window
+    if (event.payload.source === currentWindow) {
+      return;
+    }
+    
+    // Apply theme without broadcasting again
+    applyTheme(event.payload.theme);
+  }).catch(err => {
+    console.error("Failed to set up theme listener:", err);
+  });
+}

--- a/apps/desktop/tailwind.config.ts
+++ b/apps/desktop/tailwind.config.ts
@@ -7,6 +7,8 @@ import ExtensionTranscript from "@hypr/extension-transcript/tailwind.config";
 import ExtensionTwenty from "@hypr/extension-twenty/tailwind.config";
 
 const config = {
+  // Use class strategy for dark mode
+  darkMode: ["class"],
   content: [
     ...ExtensionSummary.content,
     ...ExtensionTranscript.content,

--- a/extensions/transcript/src/widgets/default/base.tsx
+++ b/extensions/transcript/src/widgets/default/base.tsx
@@ -73,14 +73,14 @@ export const TranscriptBase: React.FC<TranscriptBaseProps> = ({
       {sessionId && <Transcript sessionId={sessionId} />}
 
       {!sessionId && (
-        <div className="absolute inset-0 backdrop-blur-sm bg-white/50 flex items-center justify-center">
-          <div className="text-neutral-500 font-medium">Session not found</div>
+        <div className="absolute inset-0 backdrop-blur-sm bg-white/50 dark:bg-zinc-900/50 flex items-center justify-center">
+          <div className="text-neutral-500 dark:text-neutral-400 font-medium">Session not found</div>
         </div>
       )}
 
       {sessionId && showEmptyMessage && (
-        <div className="absolute inset-0 backdrop-blur-sm bg-white/50 flex items-center justify-center rounded-2xl">
-          <div className="text-neutral-500 font-medium">
+        <div className="absolute inset-0 backdrop-blur-sm bg-white/50 dark:bg-zinc-900/50 flex items-center justify-center rounded-2xl">
+          <div className="text-neutral-500 dark:text-neutral-400 font-medium">
             {isEnhanced
               ? "No transcript available"
               : "Meeting is not active"}

--- a/extensions/twenty/src/widgets/components/participants-list.tsx
+++ b/extensions/twenty/src/widgets/components/participants-list.tsx
@@ -13,10 +13,10 @@ export const ParticipantsList = ({
   isMeetingActive,
 }: ParticipantsListProps) => {
   return (
-    <div className="flex-1 flex flex-col overflow-y-auto border border-border rounded-md scrollbar-none">
+    <div className="flex-1 flex flex-col overflow-y-auto border border-border dark:border-zinc-700 rounded-md scrollbar-none">
       {selectedPeople.length > 0
         ? (
-          <ul className="divide-y divide-border">
+          <ul className="divide-y divide-border dark:divide-zinc-700">
             {selectedPeople.map((person) => (
               <ParticipantItem
                 key={person.id}
@@ -28,7 +28,7 @@ export const ParticipantsList = ({
           </ul>
         )
         : (
-          <div className="flex items-center justify-center h-full text-sm text-neutral-500 p-4">
+          <div className="flex items-center justify-center h-full text-sm text-neutral-500 dark:text-neutral-400 p-4">
             No participants selected
           </div>
         )}
@@ -47,7 +47,7 @@ const ParticipantItem = ({ person, handleRemovePerson, isMeetingActive }: Partic
   const email = person.emails.primaryEmail;
 
   return (
-    <li className="flex items-center justify-between p-2 hover:bg-neutral-50">
+    <li className="flex items-center justify-between p-2 hover:bg-neutral-50 dark:hover:bg-zinc-800">
       <div className="flex items-center gap-2">
         <div className="flex-shrink-0 size-10 flex items-center justify-center rounded-full overflow-hidden">
           {person.avatarUrl
@@ -65,13 +65,13 @@ const ParticipantItem = ({ person, handleRemovePerson, isMeetingActive }: Partic
             )}
         </div>
         <div>
-          <p className="text-sm font-medium">{fullName}</p>
-          <p className="text-xs text-neutral-500">{email}</p>
+          <p className="text-sm font-medium dark:text-neutral-200">{fullName}</p>
+          <p className="text-xs text-neutral-500 dark:text-neutral-400">{email}</p>
         </div>
       </div>
       <button
         onClick={() => handleRemovePerson(person.id)}
-        className="text-neutral-500 hover:text-neutral-700 p-1"
+        className="text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-300 p-1"
         disabled={isMeetingActive}
       >
         <XIcon size={16} />

--- a/extensions/twenty/src/widgets/components/search-input.tsx
+++ b/extensions/twenty/src/widgets/components/search-input.tsx
@@ -54,12 +54,12 @@ export const SearchInput = ({
 
       {showSearchResults && (
         <div className="relative">
-          <div className="absolute z-10 w-full mt-1 bg-white rounded-md border border-border overflow-hidden">
+          <div className="absolute z-10 w-full mt-1 bg-white dark:bg-zinc-900 rounded-md border border-border dark:border-zinc-700 overflow-hidden">
             {isLoading
               ? (
                 <div className="flex items-center justify-center p-4">
-                  <Loader className="size-4 text-neutral-500 animate-spin mr-2" />
-                  <span className="text-sm text-neutral-500">Loading...</span>
+                  <Loader className="size-4 text-neutral-500 dark:text-neutral-400 animate-spin mr-2" />
+                  <span className="text-sm text-neutral-500 dark:text-neutral-400">Loading...</span>
                 </div>
               )
               : filteredResults.length > 0
@@ -75,7 +75,7 @@ export const SearchInput = ({
                 </div>
               )
               : (
-                <div className="px-3 py-2 text-sm text-neutral-500">
+                <div className="px-3 py-2 text-sm text-neutral-500 dark:text-neutral-400">
                   {searchResults.length > 0 && filteredResults.length === 0
                     ? "All matching people are already selected"
                     : "No results found"}
@@ -100,7 +100,7 @@ const SearchResultItem = ({ person, handleSelectPerson }: SearchResultItemProps)
   return (
     <button
       type="button"
-      className="flex items-center px-3 py-2 text-sm text-left hover:bg-neutral-100 transition-colors w-full"
+      className="flex items-center px-3 py-2 text-sm text-left hover:bg-neutral-100 dark:hover:bg-zinc-800 transition-colors w-full"
       onClick={() => handleSelectPerson(person)}
     >
       <div className="flex-shrink-0 size-8 flex items-center justify-center mr-2 rounded-full overflow-hidden">
@@ -119,10 +119,10 @@ const SearchResultItem = ({ person, handleSelectPerson }: SearchResultItemProps)
           )}
       </div>
       <div className="flex flex-col">
-        <span className="font-medium text-neutral-900 truncate">
+        <span className="font-medium text-neutral-900 dark:text-neutral-200 truncate">
           {fullName}
         </span>
-        <span className="text-xs text-neutral-500 truncate">
+        <span className="text-xs text-neutral-500 dark:text-neutral-400 truncate">
           {email}
         </span>
       </div>

--- a/packages/tiptap/src/styles/base.css
+++ b/packages/tiptap/src/styles/base.css
@@ -7,6 +7,8 @@
   caret-color: #374151;
   padding-left: 2rem;
   padding-right: 2rem;
+  color: inherit;
+  background-color: transparent;
 
   :first-child {
     margin-top: 0;
@@ -21,4 +23,8 @@
   p {
     margin-bottom: 0.25rem;
   }
+}
+
+:root.dark .tiptap {
+  caret-color: #e5e7eb;
 }

--- a/packages/tiptap/src/styles/tiptap.css
+++ b/packages/tiptap/src/styles/tiptap.css
@@ -29,3 +29,9 @@
   pointer-events: none;
   height: 0;
 }
+
+/* Dark mode styles */
+:root.dark .ProseMirror .is-editor-empty:first-child::before,
+:root.dark .ProseMirror .is-empty::before {
+  color: #64646e;
+}

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -17,13 +17,13 @@ const styles = {
 
   variants: {
     default:
-      "bg-primary text-primary-foreground hover:bg-primary/90 active:bg-primary/80 focus:ring-2 focus:ring-primary/20",
+      "bg-primary text-primary-foreground hover:bg-primary/90 active:bg-primary/80 focus:ring-2 focus:ring-primary/20 dark:bg-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-600 dark:active:bg-zinc-600/80",
     destructive:
-      "bg-destructive text-destructive-foreground hover:bg-destructive/90 active:bg-destructive/80 focus:ring-2 focus:ring-destructive/20",
+      "bg-destructive text-destructive-foreground hover:bg-destructive/90 active:bg-destructive/80 focus:ring-2 focus:ring-destructive/20 dark:bg-red-700 dark:hover:bg-red-600",
     outline:
-      "border border-input bg-background hover:bg-accent hover:text-accent-foreground active:bg-accent/80 focus:ring-2 focus:ring-accent/20",
+      "border border-input bg-background hover:bg-accent hover:text-accent-foreground active:bg-accent/80 focus:ring-2 focus:ring-accent/20 dark:border-zinc-700 dark:bg-zinc-900 dark:hover:bg-zinc-800 dark:text-zinc-300",
     ghost:
-      "text-foreground hover:bg-accent hover:text-accent-foreground active:bg-accent/80 focus:ring-2 focus:ring-accent/20",
+      "text-foreground hover:bg-accent hover:text-accent-foreground active:bg-accent/80 focus:ring-2 focus:ring-accent/20 dark:text-zinc-300 dark:hover:bg-zinc-800 dark:hover:text-zinc-200 dark:active:bg-zinc-800/80",
   },
 
   sizes: {

--- a/packages/ui/src/components/ui/modal.tsx
+++ b/packages/ui/src/components/ui/modal.tsx
@@ -71,7 +71,7 @@ export function Modal({
         aria-modal="true"
         className={cn(
           "fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2",
-          "overflow-clip rounded-lg bg-background shadow-lg",
+          "overflow-clip rounded-lg bg-background shadow-lg dark:shadow-zinc-900/50",
           sizeClasses[size],
           className,
         )}

--- a/packages/ui/src/components/ui/switch.tsx
+++ b/packages/ui/src/components/ui/switch.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "../../lib/utils";
 
 const switchVariants = cva(
-  "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+  "peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-zinc-700",
   {
     variants: {
       size: {
@@ -13,15 +13,20 @@ const switchVariants = cva(
         default: "h-6 w-11",
         lg: "h-7 w-14",
       },
+      color: {
+        default: "data-[state=checked]:bg-primary",
+        gray: "data-[state=checked]:bg-neutral-700 dark:data-[state=checked]:bg-neutral-500",
+      },
     },
     defaultVariants: {
       size: "default",
+      color: "default",
     },
   },
 );
 
 const thumbVariants = cva(
-  "pointer-events-none block rounded-full bg-background shadow-lg ring-0 transition-transform",
+  "pointer-events-none block rounded-full bg-background dark:bg-zinc-300 shadow-lg ring-0 transition-transform",
   {
     variants: {
       size: {
@@ -43,9 +48,9 @@ interface SwitchProps
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
   SwitchProps
->(({ className, size, ...props }, ref) => (
+>(({ className, size, color, ...props }, ref) => (
   <SwitchPrimitives.Root
-    className={cn(switchVariants({ size, className }))}
+    className={cn(switchVariants({ size, color, className }))}
     {...props}
     ref={ref}
   >

--- a/packages/ui/src/components/ui/toast.tsx
+++ b/packages/ui/src/components/ui/toast.tsx
@@ -29,7 +29,7 @@ export function CustomToast(props: CustomToastProps) {
       {dismissible && (
         <button
           onClick={() => sonnerToast.dismiss(id)}
-          className="cursor-pointer absolute top-2 right-2 p-1 rounded-full opacity-0 group-hover:opacity-100 hover:bg-neutral-100 transition-opacity"
+          className="cursor-pointer absolute top-2 right-2 p-1 rounded-full opacity-0 group-hover:opacity-100 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-opacity"
           aria-label="Dismiss"
         >
           <X size={16} />
@@ -38,7 +38,7 @@ export function CustomToast(props: CustomToastProps) {
 
       <div className="font-medium">{title}</div>
 
-      {content && <div className="text-sm text-neutral-600">{content}</div>}
+      {content && <div className="text-sm text-neutral-600 dark:text-neutral-400">{content}</div>}
 
       {children}
 
@@ -52,8 +52,8 @@ export function CustomToast(props: CustomToastProps) {
                 sonnerToast.dismiss(id);
               }}
               className={button.primary
-                ? "px-3 py-1.5 text-sm bg-neutral-800 text-white rounded-md hover:bg-neutral-700"
-                : "px-3 py-1.5 text-sm bg-neutral-200 text-neutral-800 rounded-md hover:bg-neutral-300"}
+                ? "px-3 py-1.5 text-sm bg-neutral-800 text-white dark:bg-neutral-200 dark:text-neutral-800 rounded-md hover:bg-neutral-700 dark:hover:bg-neutral-300"
+                : "px-3 py-1.5 text-sm bg-neutral-200 text-neutral-800 dark:bg-neutral-700 dark:text-neutral-200 rounded-md hover:bg-neutral-300 dark:hover:bg-neutral-600"}
             >
               {button.label}
             </button>
@@ -97,7 +97,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
       toastOptions={{
         classNames: {
           toast:
-            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border group-[.toaster]:border-border group-[.toaster]:shadow-lg group-[.toaster]:rounded-lg group-[.toaster]:overflow-clip group-[.toaster]:w-[300px]",
+            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border dark:group-[.toaster]:border-opacity-20 group-[.toaster]:border-border group-[.toaster]:shadow-lg group-[.toaster]:rounded-lg group-[.toaster]:overflow-clip group-[.toaster]:w-[300px]",
           description: "group-[.toast]:text-muted-foreground",
           actionButton: "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
           cancelButton: "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",

--- a/plugins/windows/src/ext.rs
+++ b/plugins/windows/src/ext.rs
@@ -371,7 +371,7 @@ impl HyprWindow {
         {
             builder = builder
                 .hidden_title(true)
-                .theme(Some(tauri::Theme::Light))
+                .theme(None) // Use system theme
                 .title_bar_style(tauri::TitleBarStyle::Overlay);
         }
 


### PR DESCRIPTION
> - Removed theme toggle from the main toolbar
> - Added dark mode toggle in Settings > General under Language
> - Set up theme synchronization across windows using Tauri events
> - Fixed border styles and visual elements in dark mode
> - Improved toast notifications in dark mode
> - Modified Tauri window creation to follow system theme preferences
> 
> 🤖 Generated with [Claude Code](https://claude.ai/code)

There might be a less verbose way to do this than so many inline Tailwind classes, but I wanted to see if it was possible to do it quickly with Claude Code. Looks good (enough!) to me on the frontend.

Also tried to get it to sync with system/user preference but wasn't able to figure out how to get that to work with Tauri quickly, so for now just implemented as a toggle in Settings > General.