### PR TITLE
Add support for parsing URLs in text

### DIFF
--- a/apps/desktop/src/routes/app.organization.$id.tsx
+++ b/apps/desktop/src/routes/app.organization.$id.tsx
@@ -6,6 +6,8 @@ import { useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
+import { parseUrlsToLinks } from "@/utils/url-parser";
+
 import { MembersList, RecentNotes, UpcomingEvents } from "@/components/organization-profile";
 import { EditableEntityWrapper } from "@/components/toolbar/bars";
 import { useEditMode } from "@/contexts/edit-mode-context";
@@ -103,7 +105,7 @@ function OrgView({ value }: { value: Organization }) {
         <h1 className="text-2xl font-semibold text-center">{value.name}</h1>
         {value.description && (
           <p className="mt-2 text-gray-500 text-center max-w-md">
-            {value.description}
+            {parseUrlsToLinks(value.description)}
           </p>
         )}
       </div>

--- a/apps/desktop/src/utils/url-parser.ts
+++ b/apps/desktop/src/utils/url-parser.ts
@@ -1,0 +1,53 @@
+import React from "react";
+
+export function parseUrlsToLinks(text: string): React.ReactNode[] {
+  if (!text) {
+    return [text];
+  }
+
+  const lines = text.split(/\r?\n/);
+  const result: React.ReactNode[] = [];
+
+  lines.forEach((line, lineIndex) => {
+    if (lineIndex > 0) {
+      result.push(React.createElement("br", { key: `br-${lineIndex}` }));
+    }
+
+    const urlRegex = /(https?:\/\/[^\s]+)|(www\.[^\s]+)/g;
+
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    urlRegex.lastIndex = 0;
+
+    while ((match = urlRegex.exec(line)) !== null) {
+      const url = match[0];
+      const matchIndex = match.index;
+
+      if (matchIndex > lastIndex) {
+        result.push(line.substring(lastIndex, matchIndex));
+      }
+
+      const href = url.startsWith("www.") ? `https://${url}` : url;
+      result.push(
+        React.createElement("a", {
+          key: `url-${lineIndex}-${matchIndex}`,
+          href: href,
+          target: "_blank",
+          rel: "noopener noreferrer",
+          className: "text-blue-600 hover:underline",
+        }, url),
+      );
+
+      lastIndex = matchIndex + url.length;
+    }
+
+    if (lastIndex < line.length) {
+      result.push(line.substring(lastIndex));
+    } else if (lastIndex === 0 && line.length === 0) {
+      result.push("");
+    }
+  });
+
+  return result;
+}


### PR DESCRIPTION
- Add support for parsing URLs in text
- Introduce a new utility function `parseUrlsToLinks` that converts URLs in a string of text to clickable links
- Use a regular expression to identify URLs in the text and wrap them in `<a>` tags with appropriate `href` and `target` attributes
- Handle line breaks in the input text, ensuring the resulting React nodes are properly structured with `<br>` elements