### PR TITLE
Fixed left sidebar grouping

### DIFF
--- a/apps/desktop/src/components/left-sidebar/notes-list.tsx
+++ b/apps/desktop/src/components/left-sidebar/notes-list.tsx
@@ -327,7 +327,7 @@ function NoteItem({
 
 const groupSessions = (sessions: SessionWithEvent[]): [string, SessionWithEvent[]][] => {
   const grouped = sessions.reduce<Record<string, SessionWithEvent[]>>((acc, session) => {
-    const key = formatRelative(session.event?.start_date ?? session.created_at);
+    const key = formatRelative(session.created_at);
 
     return {
       ...acc,

--- a/apps/desktop/src/locales/en/messages.po
+++ b/apps/desktop/src/locales/en/messages.po
@@ -45,13 +45,13 @@ msgstr "In progress"
 
 #. js-lingui-explicit-id
 #: ../../packages/utils/src/datetime.ts:44
-#: ../../packages/utils/src/datetime.ts:88
+#: ../../packages/utils/src/datetime.ts:90
 msgid "Unknown date"
 msgstr "Unknown date"
 
 #. js-lingui-explicit-id
 #: ../../packages/utils/src/datetime.ts:53
-#: ../../packages/utils/src/datetime.ts:97
+#: ../../packages/utils/src/datetime.ts:98
 msgid "Invalid date"
 msgstr "Invalid date"
 
@@ -62,156 +62,157 @@ msgstr "Today"
 
 #. js-lingui-explicit-id
 #: ../../packages/utils/src/datetime.ts:65
-#: ../../packages/utils/src/datetime.ts:183
+#: ../../packages/utils/src/datetime.ts:180
 msgid "Yesterday"
 msgstr "Yesterday"
 
 #. js-lingui-explicit-id
 #: ../../packages/utils/src/datetime.ts:67
-#: ../../packages/utils/src/datetime.ts:185
+#: ../../packages/utils/src/datetime.ts:182
 msgid "{days} days ago"
 msgstr "{days} days ago"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:74
-#: ../../packages/utils/src/datetime.ts:77
+#: ../../packages/utils/src/datetime.ts:69
+#: ../../packages/utils/src/datetime.ts:236
+msgid "{days} days later"
+msgstr "{days} days later"
+
+#. js-lingui-explicit-id
+#: ../../packages/utils/src/datetime.ts:76
+#: ../../packages/utils/src/datetime.ts:79
 msgid "{date}"
 msgstr "{date}"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:82
-#: ../../packages/utils/src/datetime.ts:129
+#: ../../packages/utils/src/datetime.ts:84
+#: ../../packages/utils/src/datetime.ts:130
 msgid "Date error"
 msgstr "Date error"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:108
+#: ../../packages/utils/src/datetime.ts:109
 msgid "Today ({dayOfWeek})"
 msgstr "Today ({dayOfWeek})"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:110
+#: ../../packages/utils/src/datetime.ts:111
 msgid "Yesterday ({dayOfWeek})"
 msgstr "Yesterday ({dayOfWeek})"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:112
+#: ../../packages/utils/src/datetime.ts:113
 msgid "{days} days ago ({dayOfWeek})"
 msgstr "{days} days ago ({dayOfWeek})"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:114
+#: ../../packages/utils/src/datetime.ts:115
 msgid "{days} days later ({dayOfWeek})"
 msgstr "{days} days later ({dayOfWeek})"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:121
-#: ../../packages/utils/src/datetime.ts:124
+#: ../../packages/utils/src/datetime.ts:122
+#: ../../packages/utils/src/datetime.ts:125
 msgid "{date} ({dayOfWeek})"
 msgstr "{date} ({dayOfWeek})"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:171
+#: ../../packages/utils/src/datetime.ts:168
 msgid "just now"
 msgstr "just now"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:173
+#: ../../packages/utils/src/datetime.ts:170
 msgid "{seconds} seconds ago"
 msgstr "{seconds} seconds ago"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:175
+#: ../../packages/utils/src/datetime.ts:172
 msgid "1 minute ago"
 msgstr "1 minute ago"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:177
+#: ../../packages/utils/src/datetime.ts:174
 msgid "{minutes} minutes ago"
 msgstr "{minutes} minutes ago"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:179
+#: ../../packages/utils/src/datetime.ts:176
 msgid "1 hour ago"
 msgstr "1 hour ago"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:181
+#: ../../packages/utils/src/datetime.ts:178
 msgid "{hours} hours ago"
 msgstr "{hours} hours ago"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:187
+#: ../../packages/utils/src/datetime.ts:184
 msgid "1 week ago"
 msgstr "1 week ago"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:189
+#: ../../packages/utils/src/datetime.ts:186
 msgid "{weeks} weeks ago"
 msgstr "{weeks} weeks ago"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:191
+#: ../../packages/utils/src/datetime.ts:188
 msgid "1 month ago"
 msgstr "1 month ago"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:193
+#: ../../packages/utils/src/datetime.ts:190
 msgid "{months} months ago"
 msgstr "{months} months ago"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:195
+#: ../../packages/utils/src/datetime.ts:192
 msgid "1 year ago"
 msgstr "1 year ago"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:197
+#: ../../packages/utils/src/datetime.ts:194
 msgid "{years} years ago"
 msgstr "{years} years ago"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:210
+#: ../../packages/utils/src/datetime.ts:207
 msgid "in progress"
 msgstr "in progress"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:226
+#: ../../packages/utils/src/datetime.ts:223
 msgid "in {seconds} seconds"
 msgstr "in {seconds} seconds"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:228
+#: ../../packages/utils/src/datetime.ts:225
 msgid "in 1 minute"
 msgstr "in 1 minute"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:230
+#: ../../packages/utils/src/datetime.ts:227
 msgid "in {minutes} minutes"
 msgstr "in {minutes} minutes"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:232
+#: ../../packages/utils/src/datetime.ts:229
 msgid "in 1 hour"
 msgstr "in 1 hour"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:234
+#: ../../packages/utils/src/datetime.ts:231
 msgid "in {hours} hours"
 msgstr "in {hours} hours"
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:237
+#: ../../packages/utils/src/datetime.ts:234
 msgid "1 day later"
 msgstr "1 day later"
 
 #. js-lingui-explicit-id
 #: ../../packages/utils/src/datetime.ts:239
-msgid "{days} days later"
-msgstr "{days} days later"
-
-#. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:242
 msgid "{weeks} weeks later"
 msgstr "{weeks} weeks later"
 

--- a/apps/desktop/src/locales/ko/messages.po
+++ b/apps/desktop/src/locales/ko/messages.po
@@ -45,13 +45,13 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: ../../packages/utils/src/datetime.ts:44
-#: ../../packages/utils/src/datetime.ts:88
+#: ../../packages/utils/src/datetime.ts:90
 msgid "Unknown date"
 msgstr ""
 
 #. js-lingui-explicit-id
 #: ../../packages/utils/src/datetime.ts:53
-#: ../../packages/utils/src/datetime.ts:97
+#: ../../packages/utils/src/datetime.ts:98
 msgid "Invalid date"
 msgstr ""
 
@@ -62,156 +62,157 @@ msgstr ""
 
 #. js-lingui-explicit-id
 #: ../../packages/utils/src/datetime.ts:65
-#: ../../packages/utils/src/datetime.ts:183
+#: ../../packages/utils/src/datetime.ts:180
 msgid "Yesterday"
 msgstr ""
 
 #. js-lingui-explicit-id
 #: ../../packages/utils/src/datetime.ts:67
-#: ../../packages/utils/src/datetime.ts:185
+#: ../../packages/utils/src/datetime.ts:182
 msgid "{days} days ago"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:74
-#: ../../packages/utils/src/datetime.ts:77
+#: ../../packages/utils/src/datetime.ts:69
+#: ../../packages/utils/src/datetime.ts:236
+msgid "{days} days later"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: ../../packages/utils/src/datetime.ts:76
+#: ../../packages/utils/src/datetime.ts:79
 msgid "{date}"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:82
-#: ../../packages/utils/src/datetime.ts:129
+#: ../../packages/utils/src/datetime.ts:84
+#: ../../packages/utils/src/datetime.ts:130
 msgid "Date error"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:108
+#: ../../packages/utils/src/datetime.ts:109
 msgid "Today ({dayOfWeek})"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:110
+#: ../../packages/utils/src/datetime.ts:111
 msgid "Yesterday ({dayOfWeek})"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:112
+#: ../../packages/utils/src/datetime.ts:113
 msgid "{days} days ago ({dayOfWeek})"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:114
+#: ../../packages/utils/src/datetime.ts:115
 msgid "{days} days later ({dayOfWeek})"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:121
-#: ../../packages/utils/src/datetime.ts:124
+#: ../../packages/utils/src/datetime.ts:122
+#: ../../packages/utils/src/datetime.ts:125
 msgid "{date} ({dayOfWeek})"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:171
+#: ../../packages/utils/src/datetime.ts:168
 msgid "just now"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:173
+#: ../../packages/utils/src/datetime.ts:170
 msgid "{seconds} seconds ago"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:175
+#: ../../packages/utils/src/datetime.ts:172
 msgid "1 minute ago"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:177
+#: ../../packages/utils/src/datetime.ts:174
 msgid "{minutes} minutes ago"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:179
+#: ../../packages/utils/src/datetime.ts:176
 msgid "1 hour ago"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:181
+#: ../../packages/utils/src/datetime.ts:178
 msgid "{hours} hours ago"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:187
+#: ../../packages/utils/src/datetime.ts:184
 msgid "1 week ago"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:189
+#: ../../packages/utils/src/datetime.ts:186
 msgid "{weeks} weeks ago"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:191
+#: ../../packages/utils/src/datetime.ts:188
 msgid "1 month ago"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:193
+#: ../../packages/utils/src/datetime.ts:190
 msgid "{months} months ago"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:195
+#: ../../packages/utils/src/datetime.ts:192
 msgid "1 year ago"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:197
+#: ../../packages/utils/src/datetime.ts:194
 msgid "{years} years ago"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:210
+#: ../../packages/utils/src/datetime.ts:207
 msgid "in progress"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:226
+#: ../../packages/utils/src/datetime.ts:223
 msgid "in {seconds} seconds"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:228
+#: ../../packages/utils/src/datetime.ts:225
 msgid "in 1 minute"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:230
+#: ../../packages/utils/src/datetime.ts:227
 msgid "in {minutes} minutes"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:232
+#: ../../packages/utils/src/datetime.ts:229
 msgid "in 1 hour"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:234
+#: ../../packages/utils/src/datetime.ts:231
 msgid "in {hours} hours"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:237
+#: ../../packages/utils/src/datetime.ts:234
 msgid "1 day later"
 msgstr ""
 
 #. js-lingui-explicit-id
 #: ../../packages/utils/src/datetime.ts:239
-msgid "{days} days later"
-msgstr ""
-
-#. js-lingui-explicit-id
-#: ../../packages/utils/src/datetime.ts:242
 msgid "{weeks} weeks later"
 msgstr ""
 

--- a/packages/utils/src/datetime.ts
+++ b/packages/utils/src/datetime.ts
@@ -63,8 +63,10 @@ export const formatRelative = (date: string | null | undefined, t?: string) => {
       return i18n._("Today");
     } else if (diffInDays === 1) {
       return i18n._("Yesterday");
-    } else if (diffInDays < 7) {
+    } else if (diffInDays > 0 && diffInDays < 7) {
       return i18n._("{days} days ago", { days: diffInDays });
+    } else if (diffInDays < 0 && diffInDays > -7) {
+      return i18n._("{days} days later", { days: Math.abs(diffInDays) });
     } else {
       const currentYear = now.getFullYear();
       const dateYear = d.getFullYear();
@@ -92,7 +94,6 @@ export const formatRelativeWithDay = (date: string | null | undefined, t?: strin
     const tz = FNS_TZ.tz(t ?? timezone());
     const d = new Date(date);
 
-    // Check for invalid date
     if (isNaN(d.getTime())) {
       return i18n._("Invalid date");
     }
@@ -150,10 +151,6 @@ export const isToday = (d: Parameters<typeof FNS.isToday>[0]) => {
   return FNS.isToday(d, { in: FNS_TZ.tz(timezone()) });
 };
 
-/**
- * Formats a past date relative to now in a human-readable format with i18n support
- * Examples: "just now", "1 minute ago", "2 hours ago", "Yesterday", etc.
- */
 export function formatTimeAgo(date: Date | string): string {
   const pastDate = typeof date === "string" ? new Date(date) : date;
   const now = new Date();
@@ -248,10 +245,13 @@ export function formatDate(date: Date | string): string {
   const now = new Date();
   const diffInDays = FNS.differenceInCalendarDays(now, d);
   if (diffInDays === 0) {
+    // Same day - show time
     return format(d, "h:mm a");
-  } else if (diffInDays > 0) {
+  } else if (diffInDays < 0) {
+    // Future date (d is after now)
     return formatUpcomingTime(d);
   } else {
+    // Past date (d is before now)
     return formatTimeAgo(d);
   }
 }


### PR DESCRIPTION
- Used `created_at` for session grouping in the notes list
- Improved date formatting for past and future dates
  - Displays time in "h:mm a" format for same-day dates
  - Uses `formatUpcomingTime` for future dates
  - Uses `formatTimeAgo` for past dates
- Updated `formatRelative` function to handle future dates (less than 7 days from now) and display the number of days until the date