### PR TITLE
Enhance List Editing UX with Custom Tiptap List Keymap for Enter and Backspace Handling

### DIFF
--- a/packages/tiptap/src/shared/custom-list-keymap.ts
+++ b/packages/tiptap/src/shared/custom-list-keymap.ts
@@ -1,0 +1,54 @@
+import { isNodeActive } from "@tiptap/core";
+import { ListKeymap } from "@tiptap/extension-list-keymap";
+
+export const CustomListKeymap = ListKeymap.extend({
+  addKeyboardShortcuts() {
+    const originalShortcuts = this.parent?.() ?? {};
+
+    const getListItemType = () => this.editor.schema.nodes.listItem;
+
+    return {
+      ...originalShortcuts,
+
+      Enter: () => {
+        const editor = this.editor;
+        const state = editor.state;
+        const { selection } = state;
+        const listNodeType = getListItemType();
+
+        if (!listNodeType) {
+          return false;
+        }
+
+        if (isNodeActive(state, listNodeType.name) && selection.$from.parent.content.size === 0) {
+          return editor.chain().liftListItem(listNodeType.name).run();
+        }
+
+        return originalShortcuts.Enter ? originalShortcuts.Enter({ editor }) : false;
+      },
+
+      Backspace: () => {
+        const editor = this.editor;
+        const state = editor.state;
+        const { selection } = state;
+        const listNodeType = getListItemType();
+
+        if (!listNodeType) {
+          return false;
+        }
+
+        if (
+          isNodeActive(state, listNodeType.name)
+          && selection.$from.parentOffset === 0
+          && selection.$from.parent.content.size === 0
+        ) {
+          return editor.chain().liftListItem(listNodeType.name).run();
+        }
+
+        return originalShortcuts.Backspace ? originalShortcuts.Backspace({ editor }) : false;
+      },
+    };
+  },
+});
+
+export default CustomListKeymap;

--- a/packages/tiptap/src/shared/extensions.ts
+++ b/packages/tiptap/src/shared/extensions.ts
@@ -1,7 +1,6 @@
 import Highlight from "@tiptap/extension-highlight";
 import Image from "@tiptap/extension-image";
 import Link from "@tiptap/extension-link";
-import ListKeymap from "@tiptap/extension-list-keymap";
 import Placeholder from "@tiptap/extension-placeholder";
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
@@ -10,6 +9,7 @@ import StarterKit from "@tiptap/starter-kit";
 
 import { StreamingAnimation } from "./animation";
 import { ClipboardTextSerializer } from "./clipboard";
+import CustomListKeymap from "./custom-list-keymap";
 import { Hashtag } from "./hashtag";
 
 export const extensions = [
@@ -44,7 +44,6 @@ export const extensions = [
 
       return "";
     },
-    emptyNodeClass: "is-empty",
     showOnlyWhenEditable: true,
   }),
   Hashtag,
@@ -85,7 +84,7 @@ export const extensions = [
     nested: true,
   }),
   Highlight,
-  ListKeymap,
+  CustomListKeymap,
   StreamingAnimation,
   ClipboardTextSerializer,
 ];


### PR DESCRIPTION
- Added a custom list keymap that extends the default list keymap provided by the Tiptap library
- The custom keymap handles the Enter and Backspace keys to provide a better user experience when working with list items
- The Enter key now lifts the list item if the current list item is empty, allowing the user to easily exit the list
- The Backspace key also lifts the list item if the current list item is empty and the cursor is at the beginning of the list item, allowing the user to easily remove the list item
- Replaced the `ListKeymap` extension with the new `CustomListKeymap` extension, providing more fine-grained control over the behavior of list items