### PR TITLE
Add scrollbar-none to improve UX

### DIFF
--- a/apps/desktop/src/components/left-sidebar/index.tsx
+++ b/apps/desktop/src/components/left-sidebar/index.tsx
@@ -95,14 +95,14 @@ export default function LeftSidebar() {
 
       {isSearching
         ? (
-          <div className="flex-1 h-full overflow-y-auto">
+          <div className="flex-1 h-full overflow-y-auto scrollbar-none">
             <SearchList matches={matches} />
           </div>
         )
         : (
           <LayoutGroup>
             <AnimatePresence initial={false}>
-              <div className="flex-1 h-full overflow-y-auto">
+              <div className="flex-1 h-full overflow-y-auto scrollbar-none">
                 <div className="h-full space-y-4 px-3 pb-4">
                   <EventsList
                     events={events.data?.filter(


### PR DESCRIPTION
- Added `scrollbar-none` class to the left sidebar's search and event lists to remove default browser scrollbars
- Provides a cleaner, more seamless user experience