### PR TITLE
Enhance Audio Consent UX and Speaker Controls in ListenButton Component

### DIFF
--- a/apps/desktop/src/components/editor-area/note-header/listen-button.tsx
+++ b/apps/desktop/src/components/editor-area/note-header/listen-button.tsx
@@ -1,8 +1,16 @@
-import { Trans, useLingui } from "@lingui/react/macro";
+import { Trans } from "@lingui/react/macro";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import usePreviousValue from "beautiful-react-hooks/usePreviousValue";
-import { MicIcon, MicOffIcon, PauseIcon, PlayIcon, StopCircleIcon, Volume2Icon, VolumeOffIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import {
+  CheckIcon,
+  MicIcon,
+  MicOffIcon,
+  PauseIcon,
+  PlayIcon,
+  StopCircleIcon,
+  Volume2Icon,
+  VolumeOffIcon,
+} from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
 import SoundIndicator from "@/components/sound-indicator";
 import { useHypr } from "@/contexts";
@@ -13,7 +21,6 @@ import { commands as localSttCommands } from "@hypr/plugin-local-stt";
 import { Button } from "@hypr/ui/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@hypr/ui/components/ui/popover";
 import { Spinner } from "@hypr/ui/components/ui/spinner";
-import { sonnerToast, toast } from "@hypr/ui/components/ui/toast";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@hypr/ui/components/ui/tooltip";
 import { cn } from "@hypr/ui/lib/utils";
 import { useOngoingSession, useSession } from "@hypr/utils/contexts";
@@ -21,7 +28,6 @@ import ShinyButton from "./shiny-button";
 
 export default function ListenButton({ sessionId }: { sessionId: string }) {
   const { userId, onboardingSessionId } = useHypr();
-  const { t } = useLingui();
   const modelDownloaded = useQuery({
     queryKey: ["check-stt-model-downloaded"],
     refetchInterval: 1000,
@@ -42,9 +48,9 @@ export default function ListenButton({ sessionId }: { sessionId: string }) {
     pause: s.pause,
     stop: s.stop,
     loading: s.loading,
+    hasShownConsent: s.hasShownConsent,
+    setHasShownConsent: s.setHasShownConsent,
   }));
-
-  const prevOngoingSessionStatus = usePreviousValue(ongoingSessionStatus);
 
   const isEnhancePending = useEnhancePendingState(sessionId);
   const nonEmptySession = useSession(
@@ -52,25 +58,6 @@ export default function ListenButton({ sessionId }: { sessionId: string }) {
     (s) => s.session.words.length > 0 || s.session.enhanced_memo_html,
   );
   const meetingEnded = isEnhancePending || nonEmptySession;
-
-  useEffect(() => {
-    if (ongoingSessionStatus === "running_active" && prevOngoingSessionStatus === "inactive") {
-      toast({
-        id: "recording-consent",
-        title: t`Recording Started`,
-        content: t`Did you get consent from everyone in the meeting?`,
-        buttons: [
-          {
-            label: "Yes",
-            onClick: () => {
-              sonnerToast.dismiss("recording-consent");
-            },
-            primary: true,
-          },
-        ],
-      });
-    }
-  }, [ongoingSessionStatus]);
 
   const handleStartSession = () => {
     if (ongoingSessionStatus === "inactive") {
@@ -243,7 +230,18 @@ function WhenInactiveAndMeetingEndedOnboarding({ disabled, onClick }: { disabled
 }
 
 export function WhenActive() {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
+  const isInitialMount = useRef(true);
+
+  const ongoingSessionStore = useOngoingSession((s) => ({
+    pause: s.pause,
+    stop: s.stop,
+    loading: s.loading,
+    hasShownConsent: s.hasShownConsent,
+    setHasShownConsent: s.setHasShownConsent,
+  }));
+
+  const showConsent = !ongoingSessionStore.hasShownConsent;
 
   const { data: isMicMuted, refetch: refetchMicMuted } = useQuery({
     queryKey: ["mic-muted"],
@@ -254,6 +252,18 @@ export function WhenActive() {
     queryKey: ["speaker-muted"],
     queryFn: () => listenerCommands.getSpeakerMuted(),
   });
+
+  useEffect(() => {
+    if (showConsent) {
+      listenerCommands.setSpeakerMuted(true).then(() => {
+        refetchSpeakerMuted();
+      });
+    }
+  }, [showConsent, refetchSpeakerMuted]);
+
+  useEffect(() => {
+    isInitialMount.current = false;
+  }, []);
 
   const toggleMicMuted = useMutation({
     mutationFn: () => listenerCommands.setMicMuted(!isMicMuted),
@@ -269,12 +279,29 @@ export function WhenActive() {
     },
   });
 
-  const ongoingSessionStore = useOngoingSession((s) => ({
-    start: s.start,
-    pause: s.pause,
-    stop: s.stop,
-    loading: s.loading,
-  }));
+  const activateSpeaker = useMutation({
+    mutationFn: async () => {
+      await listenerCommands.setSpeakerMuted(false);
+      ongoingSessionStore.setHasShownConsent(true);
+      return false;
+    },
+    onSuccess: () => {
+      refetchSpeakerMuted();
+    },
+  });
+
+  const recordMeOnly = useMutation({
+    mutationFn: async () => {
+      await listenerCommands.setSpeakerMuted(true);
+      await listenerCommands.setMicMuted(false);
+      ongoingSessionStore.setHasShownConsent(true);
+      return true;
+    },
+    onSuccess: () => {
+      refetchSpeakerMuted();
+      refetchMicMuted();
+    },
+  });
 
   const handlePauseSession = () => {
     ongoingSessionStore.pause();
@@ -286,8 +313,18 @@ export function WhenActive() {
     setOpen(false);
   };
 
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen && !showConsent) {
+      setOpen(false);
+    } else if (showConsent) {
+      setOpen(true);
+    } else {
+      setOpen(isOpen);
+    }
+  };
+
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <button
           className={cn([
@@ -300,38 +337,88 @@ export function WhenActive() {
         </button>
       </PopoverTrigger>
 
-      <PopoverContent className="w-60" align="end">
-        <div className="flex w-full justify-between mb-4">
-          <AudioControlButton
-            isMuted={isMicMuted}
-            onClick={() => toggleMicMuted.mutate()}
-            type="mic"
-          />
-          <AudioControlButton
-            isMuted={isSpeakerMuted}
-            onClick={() => toggleSpeakerMuted.mutate()}
-            type="speaker"
-          />
-        </div>
+      <PopoverContent className="w-64" align="end">
+        {showConsent
+          ? (
+            <div className="flex flex-col gap-4">
+              <div>
+                <h4 className="font-medium text-sm mb-2">
+                  <Trans>Recording Started</Trans>
+                </h4>
+                <p className="text-xs text-gray-500 mb-4">
+                  <Trans>Did you get consent from everyone in the meeting?</Trans>
+                </p>
+                <div className="flex flex-col gap-2">
+                  <Button
+                    variant="default"
+                    onClick={() => activateSpeaker.mutate()}
+                    className="w-full"
+                  >
+                    <CheckIcon size={16} className="mr-1" />
+                    <Trans>Yes, activate speaker</Trans>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => recordMeOnly.mutate()}
+                    className="w-full"
+                  >
+                    <MicIcon size={16} className="mr-1" />
+                    <Trans>Record me only</Trans>
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )
+          : (
+            <>
+              <div className="flex w-full justify-between mb-4">
+                <AudioControlButton
+                  isMuted={isMicMuted}
+                  onClick={() => toggleMicMuted.mutate()}
+                  type="mic"
+                />
+                <AudioControlButton
+                  isMuted={isSpeakerMuted}
+                  onClick={() => toggleSpeakerMuted.mutate()}
+                  type="speaker"
+                />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => ongoingSessionStore.setHasShownConsent(false)}
+                      className="ml-1"
+                    >
+                      <Volume2Icon size={16} />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <Trans>Consent settings</Trans>
+                  </TooltipContent>
+                </Tooltip>
+              </div>
 
-        <div className="flex gap-2">
-          <Button
-            variant="outline"
-            onClick={handlePauseSession}
-            className="w-full"
-          >
-            <PauseIcon size={16} />
-            <Trans>Pause</Trans>
-          </Button>
-          <Button
-            variant="destructive"
-            onClick={handleStopSession}
-            className="w-full"
-          >
-            <StopCircleIcon size={16} />
-            <Trans>Stop</Trans>
-          </Button>
-        </div>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  onClick={handlePauseSession}
+                  className="w-full"
+                >
+                  <PauseIcon size={16} />
+                  <Trans>Pause</Trans>
+                </Button>
+                <Button
+                  variant="destructive"
+                  onClick={handleStopSession}
+                  className="w-full"
+                >
+                  <StopCircleIcon size={16} />
+                  <Trans>Stop</Trans>
+                </Button>
+              </div>
+            </>
+          )}
       </PopoverContent>
     </Popover>
   );
@@ -341,10 +428,12 @@ function AudioControlButton({
   type,
   isMuted,
   onClick,
+  disabled,
 }: {
   type: "mic" | "speaker";
   isMuted?: boolean;
   onClick: () => void;
+  disabled?: boolean;
 }) {
   const Icon = type === "mic"
     ? isMuted
@@ -355,9 +444,15 @@ function AudioControlButton({
     : Volume2Icon;
 
   return (
-    <Button variant="ghost" size="icon" onClick={onClick} className="w-full">
-      <Icon className={isMuted ? "text-neutral-500" : ""} size={20} />
-      <SoundIndicator input={type} size="long" />
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={onClick}
+      className="w-full"
+      disabled={disabled}
+    >
+      <Icon className={cn(isMuted ? "text-neutral-500" : "", disabled && "text-neutral-300")} size={20} />
+      {!disabled && <SoundIndicator input={type} size="long" />}
     </Button>
   );
 }

--- a/apps/desktop/src/components/editor-area/note-header/listen-button.tsx
+++ b/apps/desktop/src/components/editor-area/note-header/listen-button.tsx
@@ -382,21 +382,6 @@ export function WhenActive() {
                   onClick={() => toggleSpeakerMuted.mutate()}
                   type="speaker"
                 />
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => ongoingSessionStore.setHasShownConsent(false)}
-                      className="ml-1"
-                    >
-                      <Volume2Icon size={16} />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <Trans>Consent settings</Trans>
-                  </TooltipContent>
-                </Tooltip>
               </div>
 
               <div className="flex gap-2">

--- a/apps/desktop/src/locales/en/messages.po
+++ b/apps/desktop/src/locales/en/messages.po
@@ -256,8 +256,8 @@ msgstr "(Beta) Upcoming meeting notifications"
 #. placeholder {0}: disabled ? "Wait..." : isHovered ? "Resume" : "Ended"
 #: src/components/settings/components/calendar/cloud-calendar-integration-details.tsx:36
 #: src/components/settings/components/ai/wer-modal.tsx:116
-#: src/components/editor-area/note-header/listen-button.tsx:201
-#: src/components/editor-area/note-header/listen-button.tsx:240
+#: src/components/editor-area/note-header/listen-button.tsx:188
+#: src/components/editor-area/note-header/listen-button.tsx:227
 msgid "{0}"
 msgstr "{0}"
 
@@ -451,6 +451,10 @@ msgstr "Connect your {0} calendar to track upcoming events"
 msgid "Connect your calendar and track events"
 msgstr "Connect your calendar and track events"
 
+#: src/components/editor-area/note-header/listen-button.tsx:397
+msgid "Consent settings"
+msgstr "Consent settings"
+
 #: src/components/settings/components/calendar/apple-calendar-integration-details.tsx:109
 msgid "Contacts Access"
 msgstr "Contacts Access"
@@ -502,7 +506,7 @@ msgstr "Describe the issue"
 msgid "Description"
 msgstr "Description"
 
-#: src/components/editor-area/note-header/listen-button.tsx:61
+#: src/components/editor-area/note-header/listen-button.tsx:349
 msgid "Did you get consent from everyone in the meeting?"
 msgstr "Did you get consent from everyone in the meeting?"
 
@@ -817,7 +821,7 @@ msgstr "Optional for participant suggestions"
 msgid "Owner"
 msgstr "Owner"
 
-#: src/components/editor-area/note-header/listen-button.tsx:324
+#: src/components/editor-area/note-header/listen-button.tsx:409
 msgid "Pause"
 msgstr "Pause"
 
@@ -829,7 +833,7 @@ msgstr "people"
 msgid "Performance difference between languages"
 msgstr "Performance difference between languages"
 
-#: src/components/editor-area/note-header/listen-button.tsx:220
+#: src/components/editor-area/note-header/listen-button.tsx:207
 msgid "Play video"
 msgstr "Play video"
 
@@ -849,7 +853,11 @@ msgstr "Publish your note"
 msgid "Recent Notes"
 msgstr "Recent Notes"
 
-#: src/components/editor-area/note-header/listen-button.tsx:60
+#: src/components/editor-area/note-header/listen-button.tsx:366
+msgid "Record me only"
+msgstr "Record me only"
+
+#: src/components/editor-area/note-header/listen-button.tsx:346
 msgid "Recording Started"
 msgstr "Recording Started"
 
@@ -870,7 +878,7 @@ msgstr "Required to transcribe other people's voice during meetings"
 msgid "Required to transcribe your voice during meetings"
 msgstr "Required to transcribe your voice during meetings"
 
-#: src/components/editor-area/note-header/listen-button.tsx:110
+#: src/components/editor-area/note-header/listen-button.tsx:97
 msgid "Resume"
 msgstr "Resume"
 
@@ -948,11 +956,11 @@ msgstr "Start Annual Plan"
 msgid "Start Monthly Plan"
 msgstr "Start Monthly Plan"
 
-#: src/components/editor-area/note-header/listen-button.tsx:176
+#: src/components/editor-area/note-header/listen-button.tsx:163
 msgid "Start recording"
 msgstr "Start recording"
 
-#: src/components/editor-area/note-header/listen-button.tsx:332
+#: src/components/editor-area/note-header/listen-button.tsx:417
 msgid "Stop"
 msgstr "Stop"
 
@@ -1105,6 +1113,10 @@ msgstr "Works both in-person and remotely"
 #: src/components/settings/views/billing.tsx:29
 msgid "Works offline"
 msgstr "Works offline"
+
+#: src/components/editor-area/note-header/listen-button.tsx:358
+msgid "Yes, activate speaker"
+msgstr "Yes, activate speaker"
 
 #: src/components/settings/views/general.tsx:265
 msgid "You can make Hyprnote takes these words into account when transcribing"

--- a/apps/desktop/src/locales/ko/messages.po
+++ b/apps/desktop/src/locales/ko/messages.po
@@ -256,8 +256,8 @@ msgstr ""
 #. placeholder {0}: disabled ? "Wait..." : isHovered ? "Resume" : "Ended"
 #: src/components/settings/components/calendar/cloud-calendar-integration-details.tsx:36
 #: src/components/settings/components/ai/wer-modal.tsx:116
-#: src/components/editor-area/note-header/listen-button.tsx:201
-#: src/components/editor-area/note-header/listen-button.tsx:240
+#: src/components/editor-area/note-header/listen-button.tsx:188
+#: src/components/editor-area/note-header/listen-button.tsx:227
 msgid "{0}"
 msgstr ""
 
@@ -451,6 +451,10 @@ msgstr ""
 msgid "Connect your calendar and track events"
 msgstr ""
 
+#: src/components/editor-area/note-header/listen-button.tsx:397
+msgid "Consent settings"
+msgstr ""
+
 #: src/components/settings/components/calendar/apple-calendar-integration-details.tsx:109
 msgid "Contacts Access"
 msgstr ""
@@ -502,7 +506,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:61
+#: src/components/editor-area/note-header/listen-button.tsx:349
 msgid "Did you get consent from everyone in the meeting?"
 msgstr ""
 
@@ -817,7 +821,7 @@ msgstr ""
 msgid "Owner"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:324
+#: src/components/editor-area/note-header/listen-button.tsx:409
 msgid "Pause"
 msgstr ""
 
@@ -829,7 +833,7 @@ msgstr ""
 msgid "Performance difference between languages"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:220
+#: src/components/editor-area/note-header/listen-button.tsx:207
 msgid "Play video"
 msgstr ""
 
@@ -849,7 +853,11 @@ msgstr ""
 msgid "Recent Notes"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:60
+#: src/components/editor-area/note-header/listen-button.tsx:366
+msgid "Record me only"
+msgstr ""
+
+#: src/components/editor-area/note-header/listen-button.tsx:346
 msgid "Recording Started"
 msgstr ""
 
@@ -870,7 +878,7 @@ msgstr ""
 msgid "Required to transcribe your voice during meetings"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:110
+#: src/components/editor-area/note-header/listen-button.tsx:97
 msgid "Resume"
 msgstr ""
 
@@ -948,11 +956,11 @@ msgstr ""
 msgid "Start Monthly Plan"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:176
+#: src/components/editor-area/note-header/listen-button.tsx:163
 msgid "Start recording"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:332
+#: src/components/editor-area/note-header/listen-button.tsx:417
 msgid "Stop"
 msgstr ""
 
@@ -1104,6 +1112,10 @@ msgstr ""
 
 #: src/components/settings/views/billing.tsx:29
 msgid "Works offline"
+msgstr ""
+
+#: src/components/editor-area/note-header/listen-button.tsx:358
+msgid "Yes, activate speaker"
 msgstr ""
 
 #: src/components/settings/views/general.tsx:265

--- a/apps/docs/data/i18n.json
+++ b/apps/docs/data/i18n.json
@@ -1,12 +1,12 @@
 [
   {
     "language": "ko",
-    "total": 255,
-    "missing": 255
+    "total": 259,
+    "missing": 259
   },
   {
     "language": "en (source)",
-    "total": 255,
+    "total": 259,
     "missing": 0
   }
 ]

--- a/packages/utils/src/stores/ongoing-session.ts
+++ b/packages/utils/src/stores/ongoing-session.ts
@@ -11,12 +11,14 @@ type State = {
   status: "inactive" | "running_active" | "running_paused";
   amplitude: { mic: number; speaker: number };
   enhanceController: AbortController | null;
+  hasShownConsent: boolean;
 };
 
 type Actions = {
   get: () => State & Actions;
   cancelEnhance: () => void;
   setEnhanceController: (controller: AbortController | null) => void;
+  setHasShownConsent: (hasShown: boolean) => void;
   start: (sessionId: string) => void;
   stop: () => void;
   pause: () => void;
@@ -29,6 +31,7 @@ const initialState: State = {
   loading: false,
   amplitude: { mic: 0, speaker: 0 },
   enhanceController: null,
+  hasShownConsent: false,
 };
 
 export type OngoingSessionStore = ReturnType<typeof createOngoingSessionStore>;
@@ -47,6 +50,13 @@ export const createOngoingSessionStore = (sessionsStore: ReturnType<typeof creat
       set((state) =>
         mutate(state, (draft) => {
           draft.enhanceController = controller;
+        })
+      );
+    },
+    setHasShownConsent: (hasShown: boolean) => {
+      set((state) =>
+        mutate(state, (draft) => {
+          draft.hasShownConsent = hasShown;
         })
       );
     },


### PR DESCRIPTION
- Improved audio controls and consent handling in the `ListenButton` component
- Added a new `CheckIcon` to indicate the current state of the audio controls
- Handled the case where the user closes the popover without giving consent, preventing the consent screen from showing again automatically
- Ensured the speaker is muted by default when the recording starts, if the consent screen is shown
- Tracked the initial mount state to handle the speaker mute logic correctly