### PR TITLE
fix transcript copy-all

### DIFF
--- a/apps/desktop/src/components/right-panel/views/transcript-view.tsx
+++ b/apps/desktop/src/components/right-panel/views/transcript-view.tsx
@@ -29,9 +29,7 @@ export function TranscriptView() {
 
   const handleCopyAll = () => {
     if (words && words.length > 0) {
-      const transcriptText = words
-        .map((item) => item.text.replace(/\.{3,}/g, "")) // Remove ellipses (...)
-        .join(" ");
+      const transcriptText = words.map((word) => word.text).join(" ");
       writeText(transcriptText);
     }
   };

--- a/apps/desktop/src/components/right-panel/views/transcript-view.tsx
+++ b/apps/desktop/src/components/right-panel/views/transcript-view.tsx
@@ -29,7 +29,9 @@ export function TranscriptView() {
 
   const handleCopyAll = () => {
     if (words && words.length > 0) {
-      const transcriptText = words.map((item) => item.text).join("\n");
+      const transcriptText = words
+        .map((item) => item.text.replace(/\.{3,}/g, "")) // Remove ellipses (...)
+        .join(" ");
       writeText(transcriptText);
     }
   };

--- a/apps/desktop/src/locales/en/messages.po
+++ b/apps/desktop/src/locales/en/messages.po
@@ -452,8 +452,8 @@ msgid "Connect your calendar and track events"
 msgstr "Connect your calendar and track events"
 
 #: src/components/editor-area/note-header/listen-button.tsx:397
-msgid "Consent settings"
-msgstr "Consent settings"
+#~ msgid "Consent settings"
+#~ msgstr "Consent settings"
 
 #: src/components/settings/components/calendar/apple-calendar-integration-details.tsx:109
 msgid "Contacts Access"
@@ -821,7 +821,7 @@ msgstr "Optional for participant suggestions"
 msgid "Owner"
 msgstr "Owner"
 
-#: src/components/editor-area/note-header/listen-button.tsx:409
+#: src/components/editor-area/note-header/listen-button.tsx:394
 msgid "Pause"
 msgstr "Pause"
 
@@ -960,7 +960,7 @@ msgstr "Start Monthly Plan"
 msgid "Start recording"
 msgstr "Start recording"
 
-#: src/components/editor-area/note-header/listen-button.tsx:417
+#: src/components/editor-area/note-header/listen-button.tsx:402
 msgid "Stop"
 msgstr "Stop"
 

--- a/apps/desktop/src/locales/ko/messages.po
+++ b/apps/desktop/src/locales/ko/messages.po
@@ -452,8 +452,8 @@ msgid "Connect your calendar and track events"
 msgstr ""
 
 #: src/components/editor-area/note-header/listen-button.tsx:397
-msgid "Consent settings"
-msgstr ""
+#~ msgid "Consent settings"
+#~ msgstr ""
 
 #: src/components/settings/components/calendar/apple-calendar-integration-details.tsx:109
 msgid "Contacts Access"
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Owner"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:409
+#: src/components/editor-area/note-header/listen-button.tsx:394
 msgid "Pause"
 msgstr ""
 
@@ -960,7 +960,7 @@ msgstr ""
 msgid "Start recording"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:417
+#: src/components/editor-area/note-header/listen-button.tsx:402
 msgid "Stop"
 msgstr ""
 

--- a/apps/docs/data/i18n.json
+++ b/apps/docs/data/i18n.json
@@ -1,12 +1,12 @@
 [
   {
     "language": "ko",
-    "total": 259,
-    "missing": 259
+    "total": 258,
+    "missing": 258
   },
   {
     "language": "en (source)",
-    "total": 259,
+    "total": 258,
     "missing": 0
   }
 ]


### PR DESCRIPTION
- Removes the ellipses (three or more periods) from the transcript text when copying the full transcript
- Ensures a cleaner and more readable text is copied to the clipboard