### PR TITLE
fix: using provided model

### DIFF
--- a/packages/utils/src/ai.ts
+++ b/packages/utils/src/ai.ts
@@ -16,7 +16,7 @@ export const useChat = (options: Parameters<typeof useChat$1>[0]) => {
 };
 
 const getModel = async ({ onboarding }: { onboarding: boolean }) => {
-  const { type, connection: { api_base, api_key } } = await connectorCommands.getLocalLlmConnection();
+  const { type, connection: { api_base, api_key } } = await connectorCommands.getLlmConnection();
 
   const openai = createOpenAICompatible({
     name: "hypr-llm",


### PR DESCRIPTION
Fixed a bug where the bundled/internal LLM model (llama) was being used for AI enhancing even when a custom endpoint and model were selected in the settings.

## Root Cause

The getModel function in `packages/utils/src/ai.ts` was always calling `connectorCommands.getLocalLlmConnection()` instead of `connectorCommands.getLlmConnection()`. 

This meant it was always using the local llama model's connection details (`api_base` and `api_key`), regardless of user settings.

## Fix

Changed the function to use `getLlmConnection()` instead, which correctly returns either the custom connection or the local llama connection based on user settings.

## Changes

Modified `packages/utils/src/ai.ts` to use `getLlmConnection()` instead of `getLocalLlmConnection()`

## Testing

Verified that when a custom endpoint and model are selected in the settings, the AI enhancement feature now correctly uses those settings instead of defaulting to the bundled llama model.