### PR TITLE
feat(right-panel): increase minimum size of right panel

### DIFF
--- a/apps/desktop/src/components/right-panel/index.tsx
+++ b/apps/desktop/src/components/right-panel/index.tsx
@@ -12,7 +12,7 @@ export default function RightPanel() {
   }
 
   return (
-    <ResizablePanel minSize={0} maxSize={50} className="h-full border-l bg-neutral-50 overflow-hidden">
+    <ResizablePanel minSize={30} maxSize={50} className="h-full border-l bg-neutral-50 overflow-hidden">
       {(currentView === "transcript") ? <TranscriptView /> : <ChatView />}
     </ResizablePanel>
   );


### PR DESCRIPTION
Increases the minimum size of the right panel from 0 to 30 pixels. This change ensures that the right panel is always visible and provides a better user experience when the panel is resized.