### PR TITLE
Welcome modal

### DIFF
--- a/apps/desktop/src/components/settings/components/ai/stt-view.tsx
+++ b/apps/desktop/src/components/settings/components/ai/stt-view.tsx
@@ -10,7 +10,7 @@ import { BrainIcon, DownloadIcon, Zap as SpeedIcon } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
-const sttModelMetadata: Record<SupportedModel, {
+export const sttModelMetadata: Record<SupportedModel, {
   name: string;
   description: string;
   intelligence: number;

--- a/apps/desktop/src/components/welcome-modal/model-selection-view.tsx
+++ b/apps/desktop/src/components/welcome-modal/model-selection-view.tsx
@@ -1,0 +1,155 @@
+import { Trans } from "@lingui/react/macro";
+import { useQuery } from "@tanstack/react-query";
+import { BrainIcon, Zap as SpeedIcon } from "lucide-react";
+import React, { useState } from "react";
+
+import { Card, CardContent } from "@hypr/ui/components/ui/card";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@hypr/ui/components/ui/carousel";
+
+import { showLlmModelDownloadToast, showSttModelDownloadToast } from "@/components/toast/shared";
+import { SupportedModel } from "@hypr/plugin-local-stt";
+import { commands as localSttCommands } from "@hypr/plugin-local-stt";
+import PushableButton from "@hypr/ui/components/ui/pushable-button";
+import { cn } from "@hypr/ui/lib/utils";
+import { sttModelMetadata } from "../settings/components/ai/stt-view";
+
+interface ModelInfo {
+  model: string;
+  is_downloaded: boolean;
+}
+
+const RatingDisplay = (
+  { label, rating, maxRating = 3, icon: Icon }: {
+    label: string;
+    rating: number;
+    maxRating?: number;
+    icon: React.ElementType;
+  },
+) => (
+  <div className="flex flex-col items-center px-2">
+    <span className="text-[10px] text-neutral-500 uppercase font-medium tracking-wider mb-1.5">{label}</span>
+    <div className="flex space-x-1">
+      {[...Array(maxRating)].map((_, i) => (
+        <Icon
+          key={i}
+          className={cn(
+            "w-3.5 h-3.5",
+            i < rating ? "text-blue-500" : "text-neutral-300",
+          )}
+        />
+      ))}
+    </div>
+  </div>
+);
+
+export const ModelSelectionView = ({
+  onContinue,
+}: {
+  onContinue: (model: SupportedModel) => void;
+}) => {
+  const [selectedModel, setSelectedModel] = useState<SupportedModel>("QuantizedSmall");
+
+  const supportedSTTModels = useQuery<ModelInfo[]>({
+    queryKey: ["local-stt", "supported-models"],
+    queryFn: async () => {
+      const models = await localSttCommands.listSupportedModels();
+      const downloadedModels = await Promise.all(
+        models.map((model) => localSttCommands.isModelDownloaded(model)),
+      );
+      return models.map((model, index) => ({
+        model,
+        is_downloaded: downloadedModels[index],
+      }));
+    },
+  });
+
+  const handleContinue = () => {
+    showSttModelDownloadToast(selectedModel);
+    showLlmModelDownloadToast();
+    onContinue(selectedModel);
+  };
+
+  return (
+    <div className="flex flex-col items-center">
+      <h2 className="text-xl font-semibold mb-4 flex items-center justify-center">
+        <Trans>Select a transcribing model</Trans>
+      </h2>
+
+      <div className="w-full mb-8">
+        <Carousel
+          opts={{
+            align: "start",
+          }}
+          className="w-full max-w-lg"
+        >
+          <CarouselContent>
+            {supportedSTTModels.data?.map(modelInfo => {
+              const model = modelInfo.model;
+              const metadata = sttModelMetadata[model as SupportedModel];
+              if (!metadata) {
+                return null;
+              }
+
+              const isSelected = selectedModel === model;
+
+              return (
+                <CarouselItem key={model} className="md:basis-1/2 lg:basis-1/3">
+                  <div className="p-1">
+                    <Card
+                      className={cn(
+                        "cursor-pointer transition-all duration-200",
+                        isSelected
+                          ? "ring-2 ring-blue-500 border-blue-500 bg-blue-50"
+                          : "hover:border-gray-400",
+                      )}
+                      onClick={() => setSelectedModel(model as SupportedModel)}
+                    >
+                      <CardContent className="flex flex-col gap-4 justify-between p-5 h-56">
+                        <div className="flex-1 text-center">
+                          <div className="text-lg font-medium mb-4">{metadata.name}</div>
+                          <div className="text-xs text-center text-neutral-600">{metadata.description}</div>
+                        </div>
+
+                        <div>
+                          <div className="flex justify-center divide-x divide-neutral-200">
+                            <RatingDisplay label="Intelligence" rating={metadata.intelligence} icon={BrainIcon} />
+                            <RatingDisplay label="Speed" rating={metadata.speed} icon={SpeedIcon} />
+                          </div>
+
+                          <div className="mt-4 flex justify-center">
+                            <div className="text-xs bg-gray-100 border border-gray-200 rounded-full px-3 py-1 inline-flex items-center">
+                              <span className="text-gray-500 mr-2">Size:</span>
+                              <span className="font-medium">{metadata.size}</span>
+                            </div>
+                          </div>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </div>
+                </CarouselItem>
+              );
+            })}
+          </CarouselContent>
+          <div className="mt-4">
+            <CarouselPrevious className="-left-4" />
+            <CarouselNext className="-right-4" />
+          </div>
+        </Carousel>
+      </div>
+
+      <PushableButton
+        onClick={handleContinue}
+        className="w-full max-w-sm"
+        disabled={!selectedModel}
+      >
+        <Trans>Continue</Trans>
+      </PushableButton>
+    </div>
+  );
+};

--- a/apps/desktop/src/components/welcome-modal/rating-display.tsx
+++ b/apps/desktop/src/components/welcome-modal/rating-display.tsx
@@ -1,0 +1,39 @@
+import { cn } from "@hypr/ui/lib/utils";
+import { GlobeIcon } from "lucide-react";
+import React from "react";
+
+export const RatingDisplay = (
+  { label, rating, maxRating = 3, icon: Icon }: {
+    label: string;
+    rating: number;
+    maxRating?: number;
+    icon: React.ElementType;
+  },
+) => (
+  <div className="flex flex-col items-center px-2">
+    <span className="text-[10px] text-neutral-500 uppercase font-medium tracking-wider mb-1.5">{label}</span>
+    <div className="flex space-x-1">
+      {[...Array(maxRating)].map((_, i) => (
+        <Icon
+          key={i}
+          className={cn(
+            "w-3.5 h-3.5",
+            i < rating ? "text-blue-500" : "text-neutral-300",
+          )}
+        />
+      ))}
+    </div>
+  </div>
+);
+
+export const LanguageDisplay = ({ support }: { support: "multilingual" | "english-only" }) => (
+  <div className="flex flex-col items-center px-2">
+    <span className="text-[10px] text-neutral-500 uppercase font-medium tracking-wider mb-1.5">Language</span>
+    <div className="flex items-center">
+      <GlobeIcon className={cn("w-3.5 h-3.5", support === "multilingual" ? "text-blue-500" : "text-neutral-300")} />
+      <span className="text-xs ml-1">
+        {support === "multilingual" ? "All" : "EN"}
+      </span>
+    </div>
+  </div>
+);

--- a/apps/desktop/src/components/welcome-modal/welcome-view.tsx
+++ b/apps/desktop/src/components/welcome-modal/welcome-view.tsx
@@ -1,0 +1,40 @@
+import PushableButton from "@hypr/ui/components/ui/pushable-button";
+import { TextAnimate } from "@hypr/ui/components/ui/text-animate";
+import { Trans, useLingui } from "@lingui/react/macro";
+import React from "react";
+
+interface WelcomeViewProps {
+  portReady: boolean;
+  onGetStarted: () => void;
+}
+
+export const WelcomeView: React.FC<WelcomeViewProps> = ({ portReady, onGetStarted }) => {
+  const { t } = useLingui();
+
+  return (
+    <div className="flex flex-col items-center">
+      <img
+        src="/assets/logo.svg"
+        alt="HYPRNOTE"
+        className="mb-6 w-[300px]"
+      />
+
+      <TextAnimate
+        animation="slideUp"
+        by="word"
+        once
+        className="mb-20 text-center text-2xl font-medium text-neutral-600"
+      >
+        {t`The AI Meeting Notepad`}
+      </TextAnimate>
+
+      <PushableButton
+        disabled={!portReady}
+        onClick={onGetStarted}
+        className="w-full max-w-sm"
+      >
+        <Trans>Get Started</Trans>
+      </PushableButton>
+    </div>
+  );
+};

--- a/apps/desktop/src/locales/en/messages.po
+++ b/apps/desktop/src/locales/en/messages.po
@@ -326,8 +326,8 @@ msgid "AI"
 msgstr "AI"
 
 #: src/components/login-modal.tsx:97
-msgid "AI notepad for meetings"
-msgstr "AI notepad for meetings"
+#~ msgid "AI notepad for meetings"
+#~ msgstr "AI notepad for meetings"
 
 #: src/components/share-and-permission/participants-selector.tsx:31
 msgid "All Participants"
@@ -396,6 +396,10 @@ msgstr "Calendar Access"
 msgid "Calendar connected"
 msgstr "Calendar connected"
 
+#: src/components/welcome-modal/welcome-view.tsx:28
+#~ msgid "Capture every moment"
+#~ msgstr "Capture every moment"
+
 #: src/components/settings/views/profile.tsx:143
 msgid "CEO"
 msgstr "CEO"
@@ -458,6 +462,10 @@ msgstr "Connect your calendar and track events"
 #: src/components/settings/components/calendar/apple-calendar-integration-details.tsx:109
 msgid "Contacts Access"
 msgstr "Contacts Access"
+
+#: src/components/welcome-modal/model-selection-view.tsx:151
+msgid "Continue"
+msgstr "Continue"
 
 #: src/routes/app.human.$id.tsx:532
 #: src/components/editor-area/note-header/chips/participants-chip.tsx:429
@@ -600,7 +608,7 @@ msgstr "Full name"
 msgid "General"
 msgstr "General"
 
-#: src/components/login-modal.tsx:105
+#: src/components/welcome-modal/welcome-view.tsx:36
 msgid "Get Started"
 msgstr "Get Started"
 
@@ -645,7 +653,7 @@ msgstr "Jargons"
 msgid "Job title"
 msgstr "Job title"
 
-#: src/components/editor-area/note-header/chips/event-chip.tsx:193
+#: src/components/editor-area/note-header/chips/event-chip.tsx:203
 msgid "Join meeting"
 msgstr "Join meeting"
 
@@ -677,7 +685,7 @@ msgstr "Live summary of the meeting"
 msgid "Loading available models..."
 msgstr "Loading available models..."
 
-#: src/components/editor-area/note-header/chips/event-chip.tsx:241
+#: src/components/editor-area/note-header/chips/event-chip.tsx:251
 msgid "Loading events..."
 msgstr "Loading events..."
 
@@ -756,7 +764,7 @@ msgstr "No members found"
 msgid "No models available for this endpoint."
 msgstr "No models available for this endpoint."
 
-#: src/components/editor-area/note-header/chips/event-chip.tsx:253
+#: src/components/editor-area/note-header/chips/event-chip.tsx:263
 msgid "No past events found."
 msgstr "No past events found."
 
@@ -912,6 +920,10 @@ msgstr "Search..."
 msgid "Sections"
 msgstr "Sections"
 
+#: src/components/welcome-modal/model-selection-view.tsx:81
+msgid "Select a transcribing model"
+msgstr "Select a transcribing model"
+
 #: src/components/settings/components/calendar/calendar-selector.tsx:74
 msgid "Select Calendars"
 msgstr "Select Calendars"
@@ -996,6 +1008,10 @@ msgstr "Teamspace"
 #: src/routes/app.settings.tsx:43
 msgid "Templates"
 msgstr "Templates"
+
+#: src/components/welcome-modal/welcome-view.tsx:28
+msgid "The AI Meeting Notepad"
+msgstr "The AI Meeting Notepad"
 
 #: src/components/settings/views/billing.tsx:113
 msgid "There's a plan for everyone"
@@ -1082,7 +1098,7 @@ msgid "View calendar"
 msgstr "View calendar"
 
 #: src/components/left-sidebar/events-list.tsx:193
-#: src/components/editor-area/note-header/chips/event-chip.tsx:198
+#: src/components/editor-area/note-header/chips/event-chip.tsx:208
 msgid "View in calendar"
 msgstr "View in calendar"
 

--- a/apps/desktop/src/locales/ko/messages.po
+++ b/apps/desktop/src/locales/ko/messages.po
@@ -326,8 +326,8 @@ msgid "AI"
 msgstr ""
 
 #: src/components/login-modal.tsx:97
-msgid "AI notepad for meetings"
-msgstr ""
+#~ msgid "AI notepad for meetings"
+#~ msgstr ""
 
 #: src/components/share-and-permission/participants-selector.tsx:31
 msgid "All Participants"
@@ -396,6 +396,10 @@ msgstr ""
 msgid "Calendar connected"
 msgstr ""
 
+#: src/components/welcome-modal/welcome-view.tsx:28
+#~ msgid "Capture every moment"
+#~ msgstr ""
+
 #: src/components/settings/views/profile.tsx:143
 msgid "CEO"
 msgstr ""
@@ -457,6 +461,10 @@ msgstr ""
 
 #: src/components/settings/components/calendar/apple-calendar-integration-details.tsx:109
 msgid "Contacts Access"
+msgstr ""
+
+#: src/components/welcome-modal/model-selection-view.tsx:151
+msgid "Continue"
 msgstr ""
 
 #: src/routes/app.human.$id.tsx:532
@@ -600,7 +608,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: src/components/login-modal.tsx:105
+#: src/components/welcome-modal/welcome-view.tsx:36
 msgid "Get Started"
 msgstr ""
 
@@ -645,7 +653,7 @@ msgstr ""
 msgid "Job title"
 msgstr ""
 
-#: src/components/editor-area/note-header/chips/event-chip.tsx:193
+#: src/components/editor-area/note-header/chips/event-chip.tsx:203
 msgid "Join meeting"
 msgstr ""
 
@@ -677,7 +685,7 @@ msgstr ""
 msgid "Loading available models..."
 msgstr ""
 
-#: src/components/editor-area/note-header/chips/event-chip.tsx:241
+#: src/components/editor-area/note-header/chips/event-chip.tsx:251
 msgid "Loading events..."
 msgstr ""
 
@@ -756,7 +764,7 @@ msgstr ""
 msgid "No models available for this endpoint."
 msgstr ""
 
-#: src/components/editor-area/note-header/chips/event-chip.tsx:253
+#: src/components/editor-area/note-header/chips/event-chip.tsx:263
 msgid "No past events found."
 msgstr ""
 
@@ -912,6 +920,10 @@ msgstr ""
 msgid "Sections"
 msgstr ""
 
+#: src/components/welcome-modal/model-selection-view.tsx:81
+msgid "Select a transcribing model"
+msgstr ""
+
 #: src/components/settings/components/calendar/calendar-selector.tsx:74
 msgid "Select Calendars"
 msgstr ""
@@ -995,6 +1007,10 @@ msgstr ""
 
 #: src/routes/app.settings.tsx:43
 msgid "Templates"
+msgstr ""
+
+#: src/components/welcome-modal/welcome-view.tsx:28
+msgid "The AI Meeting Notepad"
 msgstr ""
 
 #: src/components/settings/views/billing.tsx:113
@@ -1082,7 +1098,7 @@ msgid "View calendar"
 msgstr ""
 
 #: src/components/left-sidebar/events-list.tsx:193
-#: src/components/editor-area/note-header/chips/event-chip.tsx:198
+#: src/components/editor-area/note-header/chips/event-chip.tsx:208
 msgid "View in calendar"
 msgstr ""
 

--- a/apps/desktop/src/routes/app.tsx
+++ b/apps/desktop/src/routes/app.tsx
@@ -3,10 +3,10 @@ import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { useEffect } from "react";
 
 import LeftSidebar from "@/components/left-sidebar";
-import { LoginModal } from "@/components/login-modal";
 import RightPanel from "@/components/right-panel";
 import Notifications from "@/components/toast";
 import Toolbar from "@/components/toolbar";
+import { WelcomeModal } from "@/components/welcome-modal";
 import {
   EditModeProvider,
   HyprProvider,
@@ -72,7 +72,7 @@ function Component() {
                               </ResizablePanelGroup>
                             </div>
                           </div>
-                          <LoginModal
+                          <WelcomeModal
                             isOpen={isOnboardingNeeded}
                             onClose={() => {
                               commands.setOnboardingNeeded(false);

--- a/apps/docs/data/i18n.json
+++ b/apps/docs/data/i18n.json
@@ -1,12 +1,12 @@
 [
   {
     "language": "ko",
-    "total": 258,
-    "missing": 258
+    "total": 262,
+    "missing": 262
   },
   {
     "language": "en (source)",
-    "total": 258,
+    "total": 262,
     "missing": 0
   }
 ]


### PR DESCRIPTION
- Added a new `ModelSelectionView` component that allows the user to select a supported STT model
- Integrated the `ModelSelectionView` into the `WelcomeModal`, providing a seamless transition between the welcome screen and the model selection
- Implemented the logic to set the current STT model using the `localSttCommands.setCurrentModel` mutation
- Improved the overall layout and styling of the `WelcomeModal` to provide a more polished and visually appealing experience
- Refactored the `WelcomeModal` to handle the state and logic for toggling between the welcome view and the model selection view
- Introduced the new `WelcomeModal` component and removed the `LoginModal` component to improve the onboarding process for new users
