### PR TITLE
feat(notification): Spawn event notification in a separate task

### DIFF
--- a/plugins/notification/src/lib.rs
+++ b/plugins/notification/src/lib.rs
@@ -56,11 +56,12 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
             }
 
             if app.get_event_notification().unwrap_or(false) {
-                if let Err(e) =
-                    tokio::runtime::Handle::current().block_on(app.start_event_notification())
-                {
-                    tracing::error!("start_event_notification_failed: {:?}", e);
-                }
+                let app_handle = app.clone();
+                tauri::async_runtime::spawn(async move {
+                    if let Err(e) = app_handle.start_event_notification().await {
+                        tracing::error!("start_event_notification_failed: {:?}", e);
+                    }
+                });
             }
 
             Ok(())


### PR DESCRIPTION
**What was happening**

1. Tauri’s `plugin::Builder::setup()` executes **inside** the app-wide Tokio runtime that Tauri starts for you.
2. Our code tried to run an *async* helper inside that `setup` by doing

```rust
tokio::runtime::Handle::current().block_on(app.start_event_notification())
```

3. `Handle::current().block_on()` starts a **second** runtime and blocks the current thread until the future finishes. Tokio forbids nesting a runtime inside another running runtime – it would dead-lock the executor.
4. Tokio therefore panicked with `Cannot start a runtime from within a runtime`, aborting the process during startup for any user who had *Event Notifications* enabled.

**Why the patch fixes it**

```rust
let app_handle = app.clone();
tauri::async_runtime::spawn(async move {
    if let Err(e) = app_handle.start_event_notification().await { … }
});
```

- `tauri::async_runtime::spawn` schedules the future on the **existing** executor instead of blocking.
- No secondary runtime is created, so Tokio’s nesting guard is happy.
- Startup continues; if `start_event_notification` fails we just log the error instead of panicking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved event notification initialization to run asynchronously in the background, enhancing app responsiveness during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->