### PR TITLE
Add error state and retry button

### DIFF
--- a/apps/desktop/src/components/editor-area/floating-button.tsx
+++ b/apps/desktop/src/components/editor-area/floating-button.tsx
@@ -10,11 +10,13 @@ import { useOngoingSession, useSession } from "@hypr/utils/contexts";
 interface FloatingButtonProps {
   session: Session;
   handleEnhance: () => void;
+  isError: boolean;
 }
 
 export function FloatingButton({
   session,
   handleEnhance,
+  isError,
 }: FloatingButtonProps) {
   const [showRaw, setShowRaw] = useSession(session.id, (s) => [
     s.showRaw,
@@ -48,6 +50,26 @@ export function FloatingButton({
       handleEnhance();
     }
   };
+
+  if (isError) {
+    const errorRetryButtonClasses = cn(
+      "rounded-xl border",
+      "border-border px-4 py-2.5 transition-all ease-in-out",
+      "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+      "hover:scale-105 transition-transform duration-200",
+    );
+
+    return (
+      <button
+        onClick={handleEnhance}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        className={errorRetryButtonClasses}
+      >
+        <RunOrRerun showRefresh={isHovered} />
+      </button>
+    );
+  }
 
   if (!session.enhanced_memo_html && !isEnhancePending) {
     return null;

--- a/apps/desktop/src/components/editor-area/index.tsx
+++ b/apps/desktop/src/components/editor-area/index.tsx
@@ -153,6 +153,7 @@ export default function EditorArea({
               key={`floating-button-${sessionId}`}
               handleEnhance={handleClickEnhance}
               session={sessionStore.session}
+              isError={enhance.status === "error"}
             />
           </div>
         </motion.div>

--- a/apps/desktop/src/components/toast/shared.tsx
+++ b/apps/desktop/src/components/toast/shared.tsx
@@ -128,5 +128,6 @@ export function enhanceFailedToast() {
       </div>
     ),
     dismissible: true,
+    duration: 3000,
   });
 }


### PR DESCRIPTION
Adds a new error state to the floating button component

Adds a retry button to the floating button component, allowing users to retry the enhancement process when an error occurs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The toast notification for failed enhancements now automatically dismisses after 3 seconds, improving user experience.
  - The floating action button now responds to error states with distinct styling and behavior, providing clearer visual feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->