### PR TITLE
Swap event and detect notification settings

### DIFF
--- a/apps/desktop/src/components/settings/views/notifications.tsx
+++ b/apps/desktop/src/components/settings/views/notifications.tsx
@@ -39,27 +39,6 @@ export default function NotificationsComponent() {
     mutationFn: async (v: Schema) => {
       if (v.event) {
         notificationCommands.requestNotificationPermission().then(() => {
-          notificationCommands.setDetectNotification(true);
-        });
-      } else {
-        notificationCommands.setDetectNotification(false);
-      }
-      return v.detect;
-    },
-    onSuccess: (active) => {
-      detectNotification.refetch();
-      if (active) {
-        notificationCommands.startDetectNotification();
-      } else {
-        notificationCommands.stopDetectNotification();
-      }
-    },
-  });
-
-  const detectMutation = useMutation({
-    mutationFn: async (v: Schema) => {
-      if (v.detect) {
-        notificationCommands.requestNotificationPermission().then(() => {
           notificationCommands.setEventNotification(true);
         });
       } else {
@@ -73,6 +52,27 @@ export default function NotificationsComponent() {
         notificationCommands.startEventNotification();
       } else {
         notificationCommands.stopEventNotification();
+      }
+    },
+  });
+
+  const detectMutation = useMutation({
+    mutationFn: async (v: Schema) => {
+      if (v.detect) {
+        notificationCommands.requestNotificationPermission().then(() => {
+          notificationCommands.setDetectNotification(true);
+        });
+      } else {
+        notificationCommands.setDetectNotification(false);
+      }
+      return v.detect;
+    },
+    onSuccess: (active) => {
+      detectNotification.refetch();
+      if (active) {
+        notificationCommands.startDetectNotification();
+      } else {
+        notificationCommands.stopDetectNotification();
       }
     },
   });


### PR DESCRIPTION
This change swaps the behavior of the event and detect notification settings. Previously, the "event" setting controlled whether notifications were shown for events, and the "detect" setting controlled whether notifications were shown for detected changes. This has been reversed, so that the “event" setting now controls detected changes, and the "detect" setting controls events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected notification settings so that changes to event and detect notifications now update the appropriate notification type, ensuring accurate behavior when modifying notification preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->