### PR TITLE
Change audio format to 16-bit integer

### DIFF
--- a/plugins/listener/src/fsm.rs
+++ b/plugins/listener/src/fsm.rs
@@ -223,8 +223,8 @@ impl Session {
                 let wav_spec = hound::WavSpec {
                     channels: 2,
                     sample_rate: SAMPLE_RATE,
-                    bits_per_sample: 32,
-                    sample_format: hound::SampleFormat::Float,
+                    bits_per_sample: 16,
+                    sample_format: hound::SampleFormat::Int,
                 };
 
                 let mut wav = if path.exists() {
@@ -234,8 +234,9 @@ impl Session {
                 };
 
                 while let Some(sample) = save_rx.recv().await {
-                    wav.write_sample(sample).unwrap();
-                    wav.write_sample(sample).unwrap();
+                    let s = (sample * 32767.0).clamp(-32768.0, 32767.0) as i16;
+                    wav.write_sample(s).unwrap();
+                    wav.write_sample(s).unwrap();
                 }
 
                 wav.finalize().unwrap();


### PR DESCRIPTION
The changes in this commit update the audio format used in the `fsm.rs` file. The previous format was 32-bit floating-point, which is not a common format for audio files. The new format is 16-bit integer, which is a more standard and widely supported format.

This change will ensure that the audio files generated by the application are compatible with a wider range of audio players and tools, making it easier for users to work with the generated audio.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audio recording reliability by updating WAV file output to use 16-bit integer samples instead of 32-bit floating-point samples, ensuring better compatibility with standard audio players.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->