### PR TITLE
Add overlay control during the meeting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13912,6 +13912,7 @@ dependencies = [
  "tauri-plugin-auth",
  "tauri-specta",
  "thiserror 2.0.12",
+ "tokio",
  "tracing",
 ]
 

--- a/apps/desktop/src/routeTree.gen.ts
+++ b/apps/desktop/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as AppIndexImport } from './routes/app.index'
 import { Route as AppSettingsImport } from './routes/app.settings'
 import { Route as AppPlansImport } from './routes/app.plans'
 import { Route as AppNewImport } from './routes/app.new'
+import { Route as AppControlImport } from './routes/app.control'
 import { Route as AppCalendarImport } from './routes/app.calendar'
 import { Route as AppOrganizationIdImport } from './routes/app.organization.$id'
 import { Route as AppNoteIdImport } from './routes/app.note.$id'
@@ -58,6 +59,12 @@ const AppPlansRoute = AppPlansImport.update({
 const AppNewRoute = AppNewImport.update({
   id: '/new',
   path: '/new',
+  getParentRoute: () => AppRoute,
+} as any)
+
+const AppControlRoute = AppControlImport.update({
+  id: '/control',
+  path: '/control',
   getParentRoute: () => AppRoute,
 } as any)
 
@@ -114,6 +121,13 @@ declare module '@tanstack/react-router' {
       path: '/calendar'
       fullPath: '/app/calendar'
       preLoaderRoute: typeof AppCalendarImport
+      parentRoute: typeof AppImport
+    }
+    '/app/control': {
+      id: '/app/control'
+      path: '/control'
+      fullPath: '/app/control'
+      preLoaderRoute: typeof AppControlImport
       parentRoute: typeof AppImport
     }
     '/app/new': {
@@ -179,6 +193,7 @@ declare module '@tanstack/react-router' {
 
 interface AppRouteChildren {
   AppCalendarRoute: typeof AppCalendarRoute
+  AppControlRoute: typeof AppControlRoute
   AppNewRoute: typeof AppNewRoute
   AppPlansRoute: typeof AppPlansRoute
   AppSettingsRoute: typeof AppSettingsRoute
@@ -191,6 +206,7 @@ interface AppRouteChildren {
 
 const AppRouteChildren: AppRouteChildren = {
   AppCalendarRoute: AppCalendarRoute,
+  AppControlRoute: AppControlRoute,
   AppNewRoute: AppNewRoute,
   AppPlansRoute: AppPlansRoute,
   AppSettingsRoute: AppSettingsRoute,
@@ -207,6 +223,7 @@ export interface FileRoutesByFullPath {
   '/app': typeof AppRouteWithChildren
   '/video': typeof VideoRoute
   '/app/calendar': typeof AppCalendarRoute
+  '/app/control': typeof AppControlRoute
   '/app/new': typeof AppNewRoute
   '/app/plans': typeof AppPlansRoute
   '/app/settings': typeof AppSettingsRoute
@@ -220,6 +237,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/video': typeof VideoRoute
   '/app/calendar': typeof AppCalendarRoute
+  '/app/control': typeof AppControlRoute
   '/app/new': typeof AppNewRoute
   '/app/plans': typeof AppPlansRoute
   '/app/settings': typeof AppSettingsRoute
@@ -235,6 +253,7 @@ export interface FileRoutesById {
   '/app': typeof AppRouteWithChildren
   '/video': typeof VideoRoute
   '/app/calendar': typeof AppCalendarRoute
+  '/app/control': typeof AppControlRoute
   '/app/new': typeof AppNewRoute
   '/app/plans': typeof AppPlansRoute
   '/app/settings': typeof AppSettingsRoute
@@ -251,6 +270,7 @@ export interface FileRouteTypes {
     | '/app'
     | '/video'
     | '/app/calendar'
+    | '/app/control'
     | '/app/new'
     | '/app/plans'
     | '/app/settings'
@@ -263,6 +283,7 @@ export interface FileRouteTypes {
   to:
     | '/video'
     | '/app/calendar'
+    | '/app/control'
     | '/app/new'
     | '/app/plans'
     | '/app/settings'
@@ -276,6 +297,7 @@ export interface FileRouteTypes {
     | '/app'
     | '/video'
     | '/app/calendar'
+    | '/app/control'
     | '/app/new'
     | '/app/plans'
     | '/app/settings'
@@ -315,6 +337,7 @@ export const routeTree = rootRoute
       "filePath": "app.tsx",
       "children": [
         "/app/calendar",
+        "/app/control",
         "/app/new",
         "/app/plans",
         "/app/settings",
@@ -330,6 +353,10 @@ export const routeTree = rootRoute
     },
     "/app/calendar": {
       "filePath": "app.calendar.tsx",
+      "parent": "/app"
+    },
+    "/app/control": {
+      "filePath": "app.control.tsx",
       "parent": "/app"
     },
     "/app/new": {

--- a/apps/desktop/src/routes/app.control.tsx
+++ b/apps/desktop/src/routes/app.control.tsx
@@ -1,0 +1,152 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Camera, Circle, Grip, Settings, Square } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { commands as windowsCommands } from "@hypr/plugin-windows";
+
+export const Route = createFileRoute("/app/control")({
+  component: Component,
+});
+
+function Component() {
+  const [position, setPosition] = useState(() => {
+    const windowWidth = window.innerWidth;
+    const initialX = (windowWidth - 200) / 2;
+    return { x: initialX, y: window.innerHeight - 80 };
+  });
+
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
+  const [isRecording, setIsRecording] = useState(false);
+  const controlRef = useRef<HTMLDivElement>(null);
+
+  const updateOverlayBounds = () => {
+    if (controlRef.current) {
+      const rect = controlRef.current.getBoundingClientRect();
+      windowsCommands.windowSetOverlayBounds("control-overlay", {
+        x: rect.left,
+        y: rect.top,
+        width: rect.width,
+        height: rect.height,
+      });
+    }
+  };
+
+  useEffect(() => {
+    document.body.style.background = "transparent";
+    document.documentElement.setAttribute("data-transparent-window", "true");
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (isDragging) {
+        setPosition({
+          x: e.clientX - dragOffset.x,
+          y: e.clientY - dragOffset.y,
+        });
+      }
+    };
+
+    const handleMouseUp = () => {
+      setIsDragging(false);
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
+
+    updateOverlayBounds();
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+      windowsCommands.windowRemoveOverlayBounds("control-overlay");
+    };
+  }, [isDragging, dragOffset]);
+
+  useEffect(() => {
+    updateOverlayBounds();
+  }, [position]);
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    setIsDragging(true);
+    setDragOffset({
+      x: e.clientX - position.x,
+      y: e.clientY - position.y,
+    });
+  };
+
+  const captureScreenshot = () => {
+    console.log("Capture screenshot");
+    setTimeout(updateOverlayBounds, 0);
+  };
+
+  const toggleRecording = () => {
+    setIsRecording(!isRecording);
+    console.log(isRecording ? "Stop recording" : "Start recording");
+    setTimeout(updateOverlayBounds, 0);
+  };
+
+  const openSettings = () => {
+    console.log("Open settings");
+    setTimeout(updateOverlayBounds, 0);
+  };
+
+  return (
+    <div
+      className="w-screen h-[100vh] bg-transparent relative overflow-y-hidden"
+      style={{ scrollbarColor: "auto transparent" }}
+    >
+      <div
+        className="absolute"
+        style={{
+          left: position.x,
+          top: position.y,
+          transition: isDragging ? "none" : "all 0.1s ease",
+        }}
+        ref={controlRef}
+      >
+        <div
+          className="bg-black/10 backdrop-blur-sm rounded-xl border border-white/30 shadow-lg cursor-move flex items-center justify-center transition-all duration-200 p-2"
+          onMouseDown={handleMouseDown}
+        >
+          <div className="flex gap-2 items-center">
+            <IconButton onClick={captureScreenshot} tooltip="Take Screenshot">
+              <Camera size={16} />
+            </IconButton>
+            <IconButton
+              onClick={toggleRecording}
+              tooltip={isRecording ? "Stop Recording" : "Start Recording"}
+              className={isRecording ? "bg-red-500/50 hover:bg-red-500/70" : ""}
+            >
+              {isRecording ? <Square size={16} /> : <Circle size={16} />}
+            </IconButton>
+            <IconButton onClick={openSettings} tooltip="Settings">
+              <Settings size={16} />
+            </IconButton>
+            <div
+              className="ml-1 text-white/50 cursor-move"
+              onMouseDown={handleMouseDown}
+            >
+              <Grip size={16} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function IconButton({ onClick, children, className = "", tooltip = "" }: {
+  onClick?: ((e: React.MouseEvent<HTMLButtonElement>) => void) | (() => void);
+  children: React.ReactNode;
+  className?: string;
+  tooltip?: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`p-1.5 bg-white/20 backdrop-blur-sm rounded-full text-xs shadow-md hover:bg-white/30 transition-colors duration-200 flex items-center justify-center ${className}`}
+      title={tooltip}
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/desktop/src/routes/app.control.tsx
+++ b/apps/desktop/src/routes/app.control.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Camera, Circle, Grip, Settings, Square } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { commands as windowsCommands } from "@hypr/plugin-windows";
 
@@ -9,6 +10,8 @@ export const Route = createFileRoute("/app/control")({
 });
 
 function Component() {
+  const currentWindowLabel = useMemo(() => getCurrentWindow().label, []);
+
   const [position, setPosition] = useState(() => {
     const windowWidth = window.innerWidth;
     const initialX = (windowWidth - 200) / 2;
@@ -20,10 +23,10 @@ function Component() {
   const [isRecording, setIsRecording] = useState(false);
   const controlRef = useRef<HTMLDivElement>(null);
 
-  const updateOverlayBounds = () => {
+  const updateOverlayBounds = async () => {
     if (controlRef.current) {
       const rect = controlRef.current.getBoundingClientRect();
-      windowsCommands.windowSetOverlayBounds("control-overlay", {
+      await windowsCommands.windowSetOverlayBounds(currentWindowLabel, {
         x: rect.left,
         y: rect.top,
         width: rect.width,
@@ -57,7 +60,7 @@ function Component() {
     return () => {
       window.removeEventListener("mousemove", handleMouseMove);
       window.removeEventListener("mouseup", handleMouseUp);
-      windowsCommands.windowRemoveOverlayBounds("control-overlay");
+      windowsCommands.windowRemoveOverlayBounds(currentWindowLabel);
     };
   }, [isDragging, dragOffset]);
 

--- a/plugins/listener/src/fsm.rs
+++ b/plugins/listener/src/fsm.rs
@@ -416,7 +416,7 @@ impl Session {
         }
     }
 
-    #[state(superstate = "common")]
+    #[state(superstate = "common", entry_action = "enter_running_active")]
     async fn running_active(&mut self, event: &StateEvent) -> Response<State> {
         match event {
             StateEvent::Start(incoming_session_id) => match &self.session_id {
@@ -471,10 +471,23 @@ impl Session {
     }
 
     #[action]
+    async fn enter_running_active(&mut self) {
+        {
+            use tauri_plugin_windows::{HyprWindow, WindowsPluginExt};
+            let _ = self.app.window_show(HyprWindow::Control);
+        }
+    }
+
+    #[action]
     async fn enter_inactive(&mut self) {
         {
             use tauri_plugin_tray::TrayPluginExt;
             let _ = self.app.set_start_disabled(false);
+        }
+
+        {
+            use tauri_plugin_windows::{HyprWindow, WindowsPluginExt};
+            let _ = self.app.window_hide(HyprWindow::Control);
         }
 
         self.teardown_resources().await;

--- a/plugins/windows/Cargo.toml
+++ b/plugins/windows/Cargo.toml
@@ -28,4 +28,5 @@ tauri-plugin-analytics = { workspace = true }
 tauri-plugin-auth = { workspace = true }
 
 thiserror = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }

--- a/plugins/windows/build.rs
+++ b/plugins/windows/build.rs
@@ -9,6 +9,8 @@ const COMMANDS: &[&str] = &[
     "window_emit_navigate",
     "window_is_visible",
     "window_resize_default",
+    "window_set_overlay_bounds",
+    "window_remove_overlay_bounds",
 ];
 
 fn main() {

--- a/plugins/windows/build.rs
+++ b/plugins/windows/build.rs
@@ -1,5 +1,6 @@
 const COMMANDS: &[&str] = &[
     "window_show",
+    "window_close",
     "window_hide",
     "window_destroy",
     "window_position",

--- a/plugins/windows/js/bindings.gen.ts
+++ b/plugins/windows/js/bindings.gen.ts
@@ -10,6 +10,9 @@ export const commands = {
 async windowShow(window: HyprWindow) : Promise<null> {
     return await TAURI_INVOKE("plugin:windows|window_show", { window });
 },
+async windowClose(window: HyprWindow) : Promise<null> {
+    return await TAURI_INVOKE("plugin:windows|window_close", { window });
+},
 async windowHide(window: HyprWindow) : Promise<null> {
     return await TAURI_INVOKE("plugin:windows|window_hide", { window });
 },

--- a/plugins/windows/js/bindings.gen.ts
+++ b/plugins/windows/js/bindings.gen.ts
@@ -36,6 +36,12 @@ async windowEmitNavigate(window: HyprWindow, path: string) : Promise<null> {
 },
 async windowIsVisible(window: HyprWindow) : Promise<boolean> {
     return await TAURI_INVOKE("plugin:windows|window_is_visible", { window });
+},
+async windowSetOverlayBounds(name: string, bounds: OverlayBound) : Promise<null> {
+    return await TAURI_INVOKE("plugin:windows|window_set_overlay_bounds", { name, bounds });
+},
+async windowRemoveOverlayBounds(name: string) : Promise<null> {
+    return await TAURI_INVOKE("plugin:windows|window_remove_overlay_bounds", { name });
 }
 }
 
@@ -58,10 +64,11 @@ windowDestroyed: "plugin:windows:window-destroyed"
 
 /** user-defined types **/
 
-export type HyprWindow = { type: "main" } | { type: "note"; value: string } | { type: "human"; value: string } | { type: "organization"; value: string } | { type: "calendar" } | { type: "settings" } | { type: "video"; value: string } | { type: "plans" }
+export type HyprWindow = { type: "main" } | { type: "note"; value: string } | { type: "human"; value: string } | { type: "organization"; value: string } | { type: "calendar" } | { type: "settings" } | { type: "video"; value: string } | { type: "plans" } | { type: "control" }
 export type KnownPosition = "left-half" | "right-half" | "center"
 export type MainWindowState = { left_sidebar_expanded: boolean | null; right_panel_expanded: boolean | null }
 export type Navigate = { path: string }
+export type OverlayBound = { x: number; y: number; width: number; height: number }
 export type WindowDestroyed = { window: HyprWindow }
 
 /** tauri-specta globals **/

--- a/plugins/windows/permissions/autogenerated/commands/window_close.toml
+++ b/plugins/windows/permissions/autogenerated/commands/window_close.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-window-close"
+description = "Enables the window_close command without any pre-configured scope."
+commands.allow = ["window_close"]
+
+[[permission]]
+identifier = "deny-window-close"
+description = "Denies the window_close command without any pre-configured scope."
+commands.deny = ["window_close"]

--- a/plugins/windows/permissions/autogenerated/commands/window_remove_overlay_bounds.toml
+++ b/plugins/windows/permissions/autogenerated/commands/window_remove_overlay_bounds.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-window-remove-overlay-bounds"
+description = "Enables the window_remove_overlay_bounds command without any pre-configured scope."
+commands.allow = ["window_remove_overlay_bounds"]
+
+[[permission]]
+identifier = "deny-window-remove-overlay-bounds"
+description = "Denies the window_remove_overlay_bounds command without any pre-configured scope."
+commands.deny = ["window_remove_overlay_bounds"]

--- a/plugins/windows/permissions/autogenerated/commands/window_set_overlay_bounds.toml
+++ b/plugins/windows/permissions/autogenerated/commands/window_set_overlay_bounds.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-window-set-overlay-bounds"
+description = "Enables the window_set_overlay_bounds command without any pre-configured scope."
+commands.allow = ["window_set_overlay_bounds"]
+
+[[permission]]
+identifier = "deny-window-set-overlay-bounds"
+description = "Denies the window_set_overlay_bounds command without any pre-configured scope."
+commands.deny = ["window_set_overlay_bounds"]

--- a/plugins/windows/permissions/autogenerated/reference.md
+++ b/plugins/windows/permissions/autogenerated/reference.md
@@ -209,6 +209,32 @@ Denies the window_position command without any pre-configured scope.
 <tr>
 <td>
 
+`windows:allow-window-remove-overlay-bounds`
+
+</td>
+<td>
+
+Enables the window_remove_overlay_bounds command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`windows:deny-window-remove-overlay-bounds`
+
+</td>
+<td>
+
+Denies the window_remove_overlay_bounds command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `windows:allow-window-resize-default`
 
 </td>
@@ -254,6 +280,32 @@ Enables the window_set_floating command without any pre-configured scope.
 <td>
 
 Denies the window_set_floating command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`windows:allow-window-set-overlay-bounds`
+
+</td>
+<td>
+
+Enables the window_set_overlay_bounds command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`windows:deny-window-set-overlay-bounds`
+
+</td>
+<td>
+
+Denies the window_set_overlay_bounds command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/windows/permissions/autogenerated/reference.md
+++ b/plugins/windows/permissions/autogenerated/reference.md
@@ -27,6 +27,32 @@ Default permissions for the plugin
 <tr>
 <td>
 
+`windows:allow-window-close`
+
+</td>
+<td>
+
+Enables the window_close command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`windows:deny-window-close`
+
+</td>
+<td>
+
+Denies the window_close command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `windows:allow-window-destroy`
 
 </td>

--- a/plugins/windows/permissions/schemas/schema.json
+++ b/plugins/windows/permissions/schemas/schema.json
@@ -295,6 +295,18 @@
       "type": "string",
       "oneOf": [
         {
+          "description": "Enables the window_close command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-window-close",
+          "markdownDescription": "Enables the window_close command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the window_close command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-window-close",
+          "markdownDescription": "Denies the window_close command without any pre-configured scope."
+        },
+        {
           "description": "Enables the window_destroy command without any pre-configured scope.",
           "type": "string",
           "const": "allow-window-destroy",

--- a/plugins/windows/permissions/schemas/schema.json
+++ b/plugins/windows/permissions/schemas/schema.json
@@ -379,6 +379,18 @@
           "markdownDescription": "Denies the window_position command without any pre-configured scope."
         },
         {
+          "description": "Enables the window_remove_overlay_bounds command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-window-remove-overlay-bounds",
+          "markdownDescription": "Enables the window_remove_overlay_bounds command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the window_remove_overlay_bounds command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-window-remove-overlay-bounds",
+          "markdownDescription": "Denies the window_remove_overlay_bounds command without any pre-configured scope."
+        },
+        {
           "description": "Enables the window_resize_default command without any pre-configured scope.",
           "type": "string",
           "const": "allow-window-resize-default",
@@ -401,6 +413,18 @@
           "type": "string",
           "const": "deny-window-set-floating",
           "markdownDescription": "Denies the window_set_floating command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the window_set_overlay_bounds command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-window-set-overlay-bounds",
+          "markdownDescription": "Enables the window_set_overlay_bounds command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the window_set_overlay_bounds command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-window-set-overlay-bounds",
+          "markdownDescription": "Denies the window_set_overlay_bounds command without any pre-configured scope."
         },
         {
           "description": "Enables the window_show command without any pre-configured scope.",

--- a/plugins/windows/src/commands.rs
+++ b/plugins/windows/src/commands.rs
@@ -108,3 +108,39 @@ pub async fn window_emit_navigate(
         .map_err(|e| e.to_string())?;
     Ok(())
 }
+
+#[tauri::command]
+#[specta::specta]
+pub async fn window_set_overlay_bounds(
+    window: tauri::Window,
+    state: tauri::State<'_, crate::OverlayState>,
+    name: String,
+    bounds: crate::OverlayBound,
+) -> Result<(), String> {
+    let mut state = state.bounds.write().await;
+    let map = state.entry(window.label().to_string()).or_default();
+    map.insert(name, bounds);
+
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn window_remove_overlay_bounds(
+    window: tauri::Window,
+    state: tauri::State<'_, crate::OverlayState>,
+    name: String,
+) -> Result<(), String> {
+    let mut state = state.bounds.write().await;
+    let Some(map) = state.get_mut(window.label()) else {
+        return Ok(());
+    };
+
+    map.remove(&name);
+
+    if map.is_empty() {
+        state.remove(window.label());
+    }
+
+    Ok(())
+}

--- a/plugins/windows/src/commands.rs
+++ b/plugins/windows/src/commands.rs
@@ -12,6 +12,16 @@ pub async fn window_show(
 
 #[tauri::command]
 #[specta::specta]
+pub async fn window_close(
+    app: tauri::AppHandle<tauri::Wry>,
+    window: HyprWindow,
+) -> Result<(), String> {
+    app.window_close(window).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+#[specta::specta]
 pub async fn window_hide(
     app: tauri::AppHandle<tauri::Wry>,
     window: HyprWindow,

--- a/plugins/windows/src/ext.rs
+++ b/plugins/windows/src/ext.rs
@@ -382,19 +382,16 @@ impl HyprWindow {
                             use tauri_nspanel::cocoa::appkit::{NSWindowCollectionBehavior,NSMainMenuWindowLevel};
                             use tauri_nspanel::WebviewWindowExt as NSPanelWebviewWindowExt;
 
-                            let panel = window.to_panel().unwrap();
+                            if let Ok(panel) = window.to_panel() {
+                                panel.set_level(NSMainMenuWindowLevel);
+                                panel.set_collection_behaviour(
+                                    NSWindowCollectionBehavior::NSWindowCollectionBehaviorTransient
+                                        | NSWindowCollectionBehavior::NSWindowCollectionBehaviorMoveToActiveSpace
+                                        | NSWindowCollectionBehavior::NSWindowCollectionBehaviorFullScreenAuxiliary
+                                        | NSWindowCollectionBehavior::NSWindowCollectionBehaviorIgnoresCycle,
+                                );
 
-                            panel.set_level(NSMainMenuWindowLevel);
-                            panel.set_collection_behaviour(
-                                NSWindowCollectionBehavior::NSWindowCollectionBehaviorTransient
-                                    | NSWindowCollectionBehavior::NSWindowCollectionBehaviorMoveToActiveSpace
-                                    | NSWindowCollectionBehavior::NSWindowCollectionBehaviorFullScreenAuxiliary
-                                    | NSWindowCollectionBehavior::NSWindowCollectionBehaviorIgnoresCycle,
-                            );
-
-                            #[allow(non_upper_case_globals)]
-                            const NSWindowStyleMaskNonActivatingPanel: i32 = 1 << 7;
-                            panel.set_style_mask(NSWindowStyleMaskNonActivatingPanel);
+                            }
                         }
                     })
                     .ok();

--- a/plugins/windows/src/ext.rs
+++ b/plugins/windows/src/ext.rs
@@ -25,6 +25,8 @@ pub enum HyprWindow {
     Video(String),
     #[serde(rename = "plans")]
     Plans,
+    #[serde(rename = "control")]
+    Control,
 }
 
 impl std::fmt::Display for HyprWindow {
@@ -38,6 +40,7 @@ impl std::fmt::Display for HyprWindow {
             Self::Settings => write!(f, "settings"),
             Self::Video(id) => write!(f, "video-{}", id),
             Self::Plans => write!(f, "plans"),
+            Self::Control => write!(f, "control"),
         }
     }
 }
@@ -143,6 +146,7 @@ impl HyprWindow {
             Self::Settings => "Settings".into(),
             Self::Video(_) => "Video".into(),
             Self::Plans => "Plans".into(),
+            Self::Control => "Control".into(),
         }
     }
 
@@ -161,6 +165,7 @@ impl HyprWindow {
             Self::Settings => LogicalSize::new(800.0, 600.0),
             Self::Video(_) => LogicalSize::new(640.0, 360.0),
             Self::Plans => LogicalSize::new(900.0, 600.0),
+            Self::Control => LogicalSize::new(100.0, 100.0),
         }
     }
 
@@ -174,6 +179,7 @@ impl HyprWindow {
             Self::Settings => LogicalSize::new(800.0, 600.0),
             Self::Video(_) => LogicalSize::new(640.0, 360.0),
             Self::Plans => LogicalSize::new(900.0, 600.0),
+            Self::Control => LogicalSize::new(100.0, 100.0),
         }
     }
 
@@ -271,6 +277,7 @@ impl HyprWindow {
                     Self::Settings => "/app/settings",
                     Self::Video(id) => &format!("/video?id={}", id),
                     Self::Plans => "/app/plans",
+                    Self::Control => "/app/control",
                 };
                 (self.window_builder(app, url).build()?, true)
             }
@@ -360,6 +367,18 @@ impl HyprWindow {
                     window.set_min_size(Some(min_size))?;
                 }
                 Self::Plans => {
+                    window.hide()?;
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+
+                    window.set_maximizable(false)?;
+                    window.set_minimizable(false)?;
+
+                    window.set_size(default_size)?;
+                    window.set_min_size(Some(min_size))?;
+
+                    window.center()?;
+                }
+                Self::Control => {
                     window.hide()?;
                     std::thread::sleep(std::time::Duration::from_millis(100));
 

--- a/plugins/windows/src/lib.rs
+++ b/plugins/windows/src/lib.rs
@@ -2,10 +2,12 @@ mod commands;
 mod errors;
 mod events;
 mod ext;
+mod overlay;
 
 pub use errors::*;
 pub use events::*;
 pub use ext::*;
+use overlay::*;
 
 const PLUGIN_NAME: &str = "windows";
 
@@ -42,6 +44,8 @@ fn make_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             commands::window_navigate,
             commands::window_emit_navigate,
             commands::window_is_visible,
+            commands::window_set_overlay_bounds,
+            commands::window_remove_overlay_bounds,
         ])
         .error_handling(tauri_specta::ErrorHandlingMode::Throw)
 }
@@ -53,8 +57,17 @@ pub fn init() -> tauri::plugin::TauriPlugin<tauri::Wry> {
         .invoke_handler(specta_builder.invoke_handler())
         .setup(move |app, _api| {
             specta_builder.mount_events(app);
-            let state = ManagedState::default();
-            app.manage(state);
+
+            {
+                let state = ManagedState::default();
+                app.manage(state);
+            }
+
+            {
+                let state = OverlayState::default();
+                app.manage(state);
+            }
+
             Ok(())
         })
         .build()

--- a/plugins/windows/src/lib.rs
+++ b/plugins/windows/src/lib.rs
@@ -35,6 +35,7 @@ fn make_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
         ])
         .commands(tauri_specta::collect_commands![
             commands::window_show,
+            commands::window_close,
             commands::window_hide,
             commands::window_destroy,
             commands::window_position,

--- a/plugins/windows/src/overlay.rs
+++ b/plugins/windows/src/overlay.rs
@@ -1,0 +1,73 @@
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use tauri::{AppHandle, Manager, WebviewWindow};
+use tokio::{sync::RwLock, time::sleep};
+
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize, specta::Type)]
+pub struct OverlayBound {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+#[derive(Default)]
+pub struct OverlayState {
+    pub bounds: Arc<RwLock<HashMap<String, HashMap<String, OverlayBound>>>>,
+}
+
+pub fn spwan_overlay_listener(app: AppHandle, window: WebviewWindow) {
+    window.set_ignore_cursor_events(true).ok();
+
+    tokio::spawn(async move {
+        let state = app.state::<OverlayState>();
+
+        loop {
+            sleep(Duration::from_millis(1000 / 20)).await;
+
+            let map = state.bounds.read().await;
+
+            let Some(windows) = map.get(window.label()) else {
+                window.set_ignore_cursor_events(true).ok();
+                continue;
+            };
+
+            let (Ok(window_position), Ok(mouse_position), Ok(scale_factor)) = (
+                window.outer_position(),
+                window.cursor_position(),
+                window.scale_factor(),
+            ) else {
+                let _ = window.set_ignore_cursor_events(true);
+                continue;
+            };
+
+            let mut ignore = true;
+
+            for bounds in windows.values() {
+                let x_min = (window_position.x as f64) + bounds.x * scale_factor;
+                let x_max = (window_position.x as f64) + (bounds.x + bounds.width) * scale_factor;
+                let y_min = (window_position.y as f64) + bounds.y * scale_factor;
+                let y_max = (window_position.y as f64) + (bounds.y + bounds.height) * scale_factor;
+
+                if mouse_position.x >= x_min
+                    && mouse_position.x <= x_max
+                    && mouse_position.y >= y_min
+                    && mouse_position.y <= y_max
+                {
+                    ignore = false;
+                    break;
+                }
+            }
+
+            window.set_ignore_cursor_events(ignore).ok();
+
+            let focused = window.is_focused().unwrap_or(false);
+            if !ignore {
+                if !focused {
+                    window.set_focus().ok();
+                }
+            } else if focused {
+                window.set_ignore_cursor_events(ignore).ok();
+            }
+        }
+    });
+}

--- a/plugins/windows/src/overlay.rs
+++ b/plugins/windows/src/overlay.rs
@@ -15,7 +15,7 @@ pub struct OverlayState {
     pub bounds: Arc<RwLock<HashMap<String, HashMap<String, OverlayBound>>>>,
 }
 
-pub fn spwan_overlay_listener(app: AppHandle, window: WebviewWindow) {
+pub fn spawn_overlay_listener(app: AppHandle, window: WebviewWindow) {
     window.set_ignore_cursor_events(true).ok();
 
     tokio::spawn(async move {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a draggable floating control panel overlay accessible via the `/app/control` route in the desktop app, featuring screenshot, recording, and settings buttons.
  - Added support for overlay window management, allowing interactive overlays that respond to cursor position.
- **Improvements**
  - Enhanced window management capabilities with new overlay bounds and window close commands, including associated permissions.
  - Updated documentation to reflect new overlay-related permissions and commands.
  - Added automatic show/hide behavior for the control panel tied to app session states.
- **Bug Fixes**
  - Ensured overlay windows properly handle cursor events and focus based on user interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->