### PR TITLE
improve-event-and-note-filtering

### DIFF
--- a/apps/desktop/src/components/left-sidebar/index.tsx
+++ b/apps/desktop/src/components/left-sidebar/index.tsx
@@ -104,21 +104,35 @@ export default function LeftSidebar() {
                 <div className="h-full space-y-4 px-3 pb-4">
                   <EventsList
                     events={events.data?.filter(
-                      (event) =>
-                        !(
+                      (event) => {
+                        const eventDate = new Date(event.start_date);
+                        const now = new Date();
+                        const isFutureEvent = eventDate > now;
+                        const isNotOngoingOrIsActive = !(
                           event.session?.id
                           && ongoingSessionId
                           && event.session.id === ongoingSessionId
                           && event.session.id !== activeSessionId
-                        ),
+                        );
+
+                        return isFutureEvent && isNotOngoingOrIsActive;
+                      },
                     )}
                     activeSessionId={activeSessionId}
                   />
                   <NotesList
-                    filter={(session) =>
-                      events.data?.every(
-                        (event) => event.session?.id !== session.id,
-                      ) ?? true}
+                    filter={(session) => {
+                      const hasFutureEvent = events.data?.some((event) => {
+                        if (event.session?.id !== session.id) {
+                          return false;
+                        }
+                        const eventDate = new Date(event.start_date);
+                        const now = new Date();
+                        return eventDate > now;
+                      }) ?? false;
+
+                      return !hasFutureEvent;
+                    }}
                     ongoingSessionId={ongoingSessionId}
                   />
                 </div>

--- a/apps/desktop/src/locales/en/messages.po
+++ b/apps/desktop/src/locales/en/messages.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/settings/views/general.tsx:274
+#: src/components/settings/views/general.tsx:275
 msgid "Type jargons (e.g., Blitz Meeting, PaC Squad)"
 msgstr "Type jargons (e.g., Blitz Meeting, PaC Squad)"
 
@@ -303,7 +303,7 @@ msgstr "Access granted"
 msgid "Access Granted"
 msgstr "Access Granted"
 
-#: src/components/settings/views/template.tsx:115
+#: src/components/settings/views/template.tsx:230
 msgid "Add a description..."
 msgstr "Add a description..."
 
@@ -359,7 +359,7 @@ msgid "Apple"
 msgstr "Apple"
 
 #: src/components/toolbar/buttons/delete-note-button.tsx:43
-#: src/components/left-sidebar/notes-list.tsx:262
+#: src/components/left-sidebar/notes-list.tsx:267
 msgid "Are you sure you want to delete this note?"
 msgstr "Are you sure you want to delete this note?"
 
@@ -379,6 +379,7 @@ msgstr "Billing"
 msgid "Billing features are currently under development and will be available in a future update."
 msgstr "Billing features are currently under development and will be available in a future update."
 
+#: src/components/settings/views/templates.tsx:278
 #: src/components/settings/components/templates-sidebar.tsx:68
 msgid "Built-in Templates"
 msgstr "Built-in Templates"
@@ -412,11 +413,11 @@ msgstr "CEO"
 #~ msgid "Choose the language you want to use for the speech-to-text model and language model"
 #~ msgstr "Choose the language you want to use for the speech-to-text model and language model"
 
-#: src/components/settings/views/general.tsx:176
+#: src/components/settings/views/general.tsx:177
 msgid "Choose whether to save your recordings locally."
 msgstr "Choose whether to save your recordings locally."
 
-#: src/components/settings/views/general.tsx:229
+#: src/components/settings/views/general.tsx:230
 msgid "Choose your preferred language of use"
 msgstr "Choose your preferred language of use"
 
@@ -488,6 +489,10 @@ msgstr "Create new note"
 msgid "Create Note"
 msgstr "Create Note"
 
+#: src/components/settings/views/templates.tsx:268
+msgid "Create your first template to get started"
+msgstr "Create your first template to get started"
+
 #: src/components/settings/views/billing.tsx:66
 msgid "Current Plan"
 msgstr "Current Plan"
@@ -500,13 +505,13 @@ msgstr "Custom Endpoint"
 #~ msgid "Default (llama-3.2-3b-q4)"
 #~ msgstr "Default (llama-3.2-3b-q4)"
 
-#: src/components/settings/views/template.tsx:86
+#: src/components/settings/views/template.tsx:206
 #: src/components/settings/views/team.tsx:165
-#: src/components/left-sidebar/notes-list.tsx:329
+#: src/components/left-sidebar/notes-list.tsx:334
 msgid "Delete"
 msgstr "Delete"
 
-#: src/components/settings/components/template-sections.tsx:125
+#: src/components/settings/components/template-sections.tsx:154
 msgid "Describe the content and purpose of this section"
 msgstr "Describe the content and purpose of this section"
 
@@ -514,7 +519,7 @@ msgstr "Describe the content and purpose of this section"
 msgid "Describe the issue"
 msgstr "Describe the issue"
 
-#: src/components/settings/views/template.tsx:109
+#: src/components/settings/views/template.tsx:224
 msgid "Description"
 msgstr "Description"
 
@@ -527,7 +532,7 @@ msgstr "Description"
 msgid "Download {0}"
 msgstr "Download {0}"
 
-#: src/components/settings/views/template.tsx:82
+#: src/components/settings/views/template.tsx:198
 msgid "Duplicate"
 msgstr "Duplicate"
 
@@ -543,6 +548,10 @@ msgstr "Email addresses"
 msgid "Email separated by commas"
 msgstr "Email separated by commas"
 
+#: src/components/settings/views/template.tsx:157
+msgid "Emoji"
+msgstr "Emoji"
+
 #: src/components/settings/views/sound.tsx:59
 msgid "Enable"
 msgstr "Enable"
@@ -551,7 +560,7 @@ msgstr "Enable"
 msgid "Enhancing"
 msgstr "Enhancing"
 
-#: src/components/settings/components/template-sections.tsx:119
+#: src/components/settings/components/template-sections.tsx:144
 msgid "Enter a section title"
 msgstr "Enter a section title"
 
@@ -637,7 +646,7 @@ msgstr "Get Started"
 msgid "Grant Access"
 msgstr "Grant Access"
 
-#: src/components/settings/views/general.tsx:202
+#: src/components/settings/views/general.tsx:203
 msgid "Help us improve Hyprnote by sharing anonymous usage data"
 msgstr "Help us improve Hyprnote by sharing anonymous usage data"
 
@@ -651,6 +660,10 @@ msgstr "Help us improve the Hyprnote experience by providing feedback."
 #: src/components/individualization-modal/how-heard-view.tsx:33
 msgid "Help us tailor your Hyprnote experience"
 msgstr "Help us tailor your Hyprnote experience"
+
+#: src/components/left-sidebar/events-list.tsx:307
+msgid "Hide Event"
+msgstr "Hide Event"
 
 #: src/components/settings/views/feedback.tsx:19
 msgid "Hmm... this is off..."
@@ -676,7 +689,7 @@ msgstr "Invite"
 msgid "Invite members"
 msgstr "Invite members"
 
-#: src/components/settings/views/general.tsx:262
+#: src/components/settings/views/general.tsx:263
 msgid "Jargons"
 msgstr "Jargons"
 
@@ -696,7 +709,7 @@ msgstr "Key decisions"
 msgid "Lab"
 msgstr "Lab"
 
-#: src/components/settings/views/general.tsx:226
+#: src/components/settings/views/general.tsx:227
 msgid "Language"
 msgstr "Language"
 
@@ -719,6 +732,10 @@ msgstr "Loading available models..."
 #: src/components/editor-area/note-header/chips/event-chip.tsx:289
 msgid "Loading events..."
 msgstr "Loading events..."
+
+#: src/components/settings/views/templates.tsx:216
+msgid "Loading templates..."
+msgstr "Loading templates..."
 
 #: src/components/workspace-calendar/event-card.tsx:163
 #: src/components/settings/components/calendar/calendar-selector.tsx:95
@@ -778,8 +795,8 @@ msgstr "My Templates"
 msgid "New note"
 msgstr "New note"
 
-#: src/components/left-sidebar/notes-list.tsx:306
-#: src/components/left-sidebar/events-list.tsx:181
+#: src/components/left-sidebar/notes-list.tsx:311
+#: src/components/left-sidebar/events-list.tsx:284
 msgid "New window"
 msgstr "New window"
 
@@ -811,7 +828,11 @@ msgstr "No recent notes for this organization"
 msgid "No speech-to-text models available or failed to load."
 msgstr "No speech-to-text models available or failed to load."
 
-#: src/components/left-sidebar/events-list.tsx:95
+#: src/components/settings/views/templates.tsx:265
+msgid "No templates yet"
+msgstr "No templates yet"
+
+#: src/components/left-sidebar/events-list.tsx:166
 msgid "No upcoming events"
 msgstr "No upcoming events"
 
@@ -925,7 +946,11 @@ msgstr "Resume"
 msgid "Role"
 msgstr "Role"
 
-#: src/components/settings/views/general.tsx:173
+#: src/components/settings/views/templates.tsx:193
+msgid "Save and close"
+msgstr "Save and close"
+
+#: src/components/settings/views/general.tsx:174
 msgid "Save recordings"
 msgstr "Save recordings"
 
@@ -950,13 +975,17 @@ msgstr "Search..."
 #~ msgid "Searching..."
 #~ msgstr "Searching..."
 
-#: src/components/settings/views/template.tsx:121
+#: src/components/settings/views/template.tsx:237
 msgid "Sections"
 msgstr "Sections"
 
 #: src/components/settings/components/ai/llm-view.tsx:254
 msgid "Select a model from the dropdown (if available) or manually enter the model name required by your endpoint."
 msgstr "Select a model from the dropdown (if available) or manually enter the model name required by your endpoint."
+
+#: src/components/settings/views/templates.tsx:233
+msgid "Select a template to enhance your meeting notes"
+msgstr "Select a template to enhance your meeting notes"
 
 #: src/components/welcome-modal/model-selection-view.tsx:81
 msgid "Select a transcribing model"
@@ -978,7 +1007,7 @@ msgstr "Send invite"
 msgid "Settings"
 msgstr "Settings"
 
-#: src/components/settings/views/general.tsx:199
+#: src/components/settings/views/general.tsx:200
 msgid "Share usage data"
 msgstr "Share usage data"
 
@@ -1044,6 +1073,7 @@ msgid "Teamspace"
 msgstr "Teamspace"
 
 #: src/routes/app.settings.tsx:43
+#: src/routes/app.settings.tsx:95
 msgid "Templates"
 msgstr "Templates"
 
@@ -1099,11 +1129,11 @@ msgstr "Ugh! Can't use it!"
 msgid "Untitled"
 msgstr "Untitled"
 
-#: src/components/settings/views/template.tsx:68
+#: src/components/settings/views/template.tsx:182
 msgid "Untitled Template"
 msgstr "Untitled Template"
 
-#: src/components/left-sidebar/events-list.tsx:62
+#: src/components/left-sidebar/events-list.tsx:100
 msgid "Upcoming"
 msgstr "Upcoming"
 
@@ -1131,11 +1161,11 @@ msgstr "User:"
 msgid "username"
 msgstr "username"
 
-#: src/components/left-sidebar/notes-list.tsx:317
+#: src/components/left-sidebar/notes-list.tsx:322
 msgid "View calendar"
 msgstr "View calendar"
 
-#: src/components/left-sidebar/events-list.tsx:193
+#: src/components/left-sidebar/events-list.tsx:296
 #: src/components/editor-area/note-header/chips/event-chip.tsx:246
 msgid "View in calendar"
 msgstr "View in calendar"
@@ -1184,7 +1214,7 @@ msgstr "Works offline"
 #~ msgid "Yes, activate speaker"
 #~ msgstr "Yes, activate speaker"
 
-#: src/components/settings/views/general.tsx:265
+#: src/components/settings/views/general.tsx:266
 msgid "You can make Hyprnote takes these words into account when transcribing"
 msgstr "You can make Hyprnote takes these words into account when transcribing"
 
@@ -1196,6 +1226,7 @@ msgstr "Your LinkedIn username (the part after linkedin.com/in/)"
 msgid "Your Name"
 msgstr "Your Name"
 
+#: src/components/settings/views/templates.tsx:230
 #: src/components/settings/components/templates-sidebar.tsx:45
 msgid "Your Templates"
 msgstr "Your Templates"

--- a/apps/desktop/src/locales/ko/messages.po
+++ b/apps/desktop/src/locales/ko/messages.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/settings/views/general.tsx:274
+#: src/components/settings/views/general.tsx:275
 msgid "Type jargons (e.g., Blitz Meeting, PaC Squad)"
 msgstr ""
 
@@ -303,7 +303,7 @@ msgstr ""
 msgid "Access Granted"
 msgstr ""
 
-#: src/components/settings/views/template.tsx:115
+#: src/components/settings/views/template.tsx:230
 msgid "Add a description..."
 msgstr ""
 
@@ -359,7 +359,7 @@ msgid "Apple"
 msgstr ""
 
 #: src/components/toolbar/buttons/delete-note-button.tsx:43
-#: src/components/left-sidebar/notes-list.tsx:262
+#: src/components/left-sidebar/notes-list.tsx:267
 msgid "Are you sure you want to delete this note?"
 msgstr ""
 
@@ -379,6 +379,7 @@ msgstr ""
 msgid "Billing features are currently under development and will be available in a future update."
 msgstr ""
 
+#: src/components/settings/views/templates.tsx:278
 #: src/components/settings/components/templates-sidebar.tsx:68
 msgid "Built-in Templates"
 msgstr ""
@@ -412,11 +413,11 @@ msgstr ""
 #~ msgid "Choose the language you want to use for the speech-to-text model and language model"
 #~ msgstr ""
 
-#: src/components/settings/views/general.tsx:176
+#: src/components/settings/views/general.tsx:177
 msgid "Choose whether to save your recordings locally."
 msgstr ""
 
-#: src/components/settings/views/general.tsx:229
+#: src/components/settings/views/general.tsx:230
 msgid "Choose your preferred language of use"
 msgstr ""
 
@@ -488,6 +489,10 @@ msgstr ""
 msgid "Create Note"
 msgstr ""
 
+#: src/components/settings/views/templates.tsx:268
+msgid "Create your first template to get started"
+msgstr ""
+
 #: src/components/settings/views/billing.tsx:66
 msgid "Current Plan"
 msgstr ""
@@ -500,13 +505,13 @@ msgstr ""
 #~ msgid "Default (llama-3.2-3b-q4)"
 #~ msgstr ""
 
-#: src/components/settings/views/template.tsx:86
+#: src/components/settings/views/template.tsx:206
 #: src/components/settings/views/team.tsx:165
-#: src/components/left-sidebar/notes-list.tsx:329
+#: src/components/left-sidebar/notes-list.tsx:334
 msgid "Delete"
 msgstr ""
 
-#: src/components/settings/components/template-sections.tsx:125
+#: src/components/settings/components/template-sections.tsx:154
 msgid "Describe the content and purpose of this section"
 msgstr ""
 
@@ -514,7 +519,7 @@ msgstr ""
 msgid "Describe the issue"
 msgstr ""
 
-#: src/components/settings/views/template.tsx:109
+#: src/components/settings/views/template.tsx:224
 msgid "Description"
 msgstr ""
 
@@ -527,7 +532,7 @@ msgstr ""
 msgid "Download {0}"
 msgstr ""
 
-#: src/components/settings/views/template.tsx:82
+#: src/components/settings/views/template.tsx:198
 msgid "Duplicate"
 msgstr ""
 
@@ -543,6 +548,10 @@ msgstr ""
 msgid "Email separated by commas"
 msgstr ""
 
+#: src/components/settings/views/template.tsx:157
+msgid "Emoji"
+msgstr ""
+
 #: src/components/settings/views/sound.tsx:59
 msgid "Enable"
 msgstr ""
@@ -551,7 +560,7 @@ msgstr ""
 msgid "Enhancing"
 msgstr ""
 
-#: src/components/settings/components/template-sections.tsx:119
+#: src/components/settings/components/template-sections.tsx:144
 msgid "Enter a section title"
 msgstr ""
 
@@ -637,7 +646,7 @@ msgstr ""
 msgid "Grant Access"
 msgstr ""
 
-#: src/components/settings/views/general.tsx:202
+#: src/components/settings/views/general.tsx:203
 msgid "Help us improve Hyprnote by sharing anonymous usage data"
 msgstr ""
 
@@ -650,6 +659,10 @@ msgstr ""
 #: src/components/individualization-modal/industry-view.tsx:63
 #: src/components/individualization-modal/how-heard-view.tsx:33
 msgid "Help us tailor your Hyprnote experience"
+msgstr ""
+
+#: src/components/left-sidebar/events-list.tsx:307
+msgid "Hide Event"
 msgstr ""
 
 #: src/components/settings/views/feedback.tsx:19
@@ -676,7 +689,7 @@ msgstr ""
 msgid "Invite members"
 msgstr ""
 
-#: src/components/settings/views/general.tsx:262
+#: src/components/settings/views/general.tsx:263
 msgid "Jargons"
 msgstr ""
 
@@ -696,7 +709,7 @@ msgstr ""
 msgid "Lab"
 msgstr ""
 
-#: src/components/settings/views/general.tsx:226
+#: src/components/settings/views/general.tsx:227
 msgid "Language"
 msgstr ""
 
@@ -718,6 +731,10 @@ msgstr ""
 
 #: src/components/editor-area/note-header/chips/event-chip.tsx:289
 msgid "Loading events..."
+msgstr ""
+
+#: src/components/settings/views/templates.tsx:216
+msgid "Loading templates..."
 msgstr ""
 
 #: src/components/workspace-calendar/event-card.tsx:163
@@ -778,8 +795,8 @@ msgstr ""
 msgid "New note"
 msgstr ""
 
-#: src/components/left-sidebar/notes-list.tsx:306
-#: src/components/left-sidebar/events-list.tsx:181
+#: src/components/left-sidebar/notes-list.tsx:311
+#: src/components/left-sidebar/events-list.tsx:284
 msgid "New window"
 msgstr ""
 
@@ -811,7 +828,11 @@ msgstr ""
 msgid "No speech-to-text models available or failed to load."
 msgstr ""
 
-#: src/components/left-sidebar/events-list.tsx:95
+#: src/components/settings/views/templates.tsx:265
+msgid "No templates yet"
+msgstr ""
+
+#: src/components/left-sidebar/events-list.tsx:166
 msgid "No upcoming events"
 msgstr ""
 
@@ -925,7 +946,11 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: src/components/settings/views/general.tsx:173
+#: src/components/settings/views/templates.tsx:193
+msgid "Save and close"
+msgstr ""
+
+#: src/components/settings/views/general.tsx:174
 msgid "Save recordings"
 msgstr ""
 
@@ -950,12 +975,16 @@ msgstr ""
 #~ msgid "Searching..."
 #~ msgstr ""
 
-#: src/components/settings/views/template.tsx:121
+#: src/components/settings/views/template.tsx:237
 msgid "Sections"
 msgstr ""
 
 #: src/components/settings/components/ai/llm-view.tsx:254
 msgid "Select a model from the dropdown (if available) or manually enter the model name required by your endpoint."
+msgstr ""
+
+#: src/components/settings/views/templates.tsx:233
+msgid "Select a template to enhance your meeting notes"
 msgstr ""
 
 #: src/components/welcome-modal/model-selection-view.tsx:81
@@ -978,7 +1007,7 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: src/components/settings/views/general.tsx:199
+#: src/components/settings/views/general.tsx:200
 msgid "Share usage data"
 msgstr ""
 
@@ -1044,6 +1073,7 @@ msgid "Teamspace"
 msgstr ""
 
 #: src/routes/app.settings.tsx:43
+#: src/routes/app.settings.tsx:95
 msgid "Templates"
 msgstr ""
 
@@ -1099,11 +1129,11 @@ msgstr ""
 msgid "Untitled"
 msgstr ""
 
-#: src/components/settings/views/template.tsx:68
+#: src/components/settings/views/template.tsx:182
 msgid "Untitled Template"
 msgstr ""
 
-#: src/components/left-sidebar/events-list.tsx:62
+#: src/components/left-sidebar/events-list.tsx:100
 msgid "Upcoming"
 msgstr ""
 
@@ -1131,11 +1161,11 @@ msgstr ""
 msgid "username"
 msgstr ""
 
-#: src/components/left-sidebar/notes-list.tsx:317
+#: src/components/left-sidebar/notes-list.tsx:322
 msgid "View calendar"
 msgstr ""
 
-#: src/components/left-sidebar/events-list.tsx:193
+#: src/components/left-sidebar/events-list.tsx:296
 #: src/components/editor-area/note-header/chips/event-chip.tsx:246
 msgid "View in calendar"
 msgstr ""
@@ -1184,7 +1214,7 @@ msgstr ""
 #~ msgid "Yes, activate speaker"
 #~ msgstr ""
 
-#: src/components/settings/views/general.tsx:265
+#: src/components/settings/views/general.tsx:266
 msgid "You can make Hyprnote takes these words into account when transcribing"
 msgstr ""
 
@@ -1196,6 +1226,7 @@ msgstr ""
 msgid "Your Name"
 msgstr ""
 
+#: src/components/settings/views/templates.tsx:230
 #: src/components/settings/components/templates-sidebar.tsx:45
 msgid "Your Templates"
 msgstr ""

--- a/apps/docs/data/i18n.json
+++ b/apps/docs/data/i18n.json
@@ -1,12 +1,12 @@
 [
   {
     "language": "ko",
-    "total": 274,
-    "missing": 274
+    "total": 281,
+    "missing": 281
   },
   {
     "language": "en (source)",
-    "total": 274,
+    "total": 281,
     "missing": 0
   }
 ]


### PR DESCRIPTION
- Improved event and note filtering logic in the left sidebar
- Events now only show future events not part of the ongoing or active session
- Notes now only show sessions without any future events associated with them
- Ensures the left sidebar displays the most relevant information to the user