### PR TITLE
patch

### DIFF
--- a/apps/desktop/src/components/editor-area/note-header/listen-button.tsx
+++ b/apps/desktop/src/components/editor-area/note-header/listen-button.tsx
@@ -17,8 +17,6 @@ import { cn } from "@hypr/ui/lib/utils";
 import { useOngoingSession, useSession } from "@hypr/utils/contexts";
 import ShinyButton from "./shiny-button";
 
-let consentReminderTimeoutId: NodeJS.Timeout | null = null;
-
 const showConsentNotification = () => {
   toast({
     id: "recording-consent-reminder",
@@ -32,21 +30,8 @@ const showConsentNotification = () => {
         },
         primary: true,
       },
-      {
-        label: "Remind me in 30s",
-        onClick: () => {
-          if (consentReminderTimeoutId) {
-            clearTimeout(consentReminderTimeoutId);
-          }
-          consentReminderTimeoutId = setTimeout(() => {
-            showConsentNotification();
-            consentReminderTimeoutId = null;
-          }, 30000);
-        },
-      },
     ],
-    dismissible: true,
-    duration: 15000,
+    dismissible: false,
   });
 };
 

--- a/apps/desktop/src/locales/en/messages.po
+++ b/apps/desktop/src/locales/en/messages.po
@@ -256,8 +256,8 @@ msgstr "(Beta) Upcoming meeting notifications"
 #. placeholder {0}: disabled ? "Wait..." : isHovered ? "Resume" : "Ended"
 #: src/components/settings/components/calendar/cloud-calendar-integration-details.tsx:36
 #: src/components/settings/components/ai/wer-modal.tsx:116
-#: src/components/editor-area/note-header/listen-button.tsx:191
-#: src/components/editor-area/note-header/listen-button.tsx:230
+#: src/components/editor-area/note-header/listen-button.tsx:176
+#: src/components/editor-area/note-header/listen-button.tsx:215
 msgid "{0}"
 msgstr "{0}"
 
@@ -881,7 +881,7 @@ msgstr "Optional for participant suggestions"
 msgid "Owner"
 msgstr "Owner"
 
-#: src/components/editor-area/note-header/listen-button.tsx:317
+#: src/components/editor-area/note-header/listen-button.tsx:302
 msgid "Pause"
 msgstr "Pause"
 
@@ -893,7 +893,7 @@ msgstr "people"
 msgid "Performance difference between languages"
 msgstr "Performance difference between languages"
 
-#: src/components/editor-area/note-header/listen-button.tsx:210
+#: src/components/editor-area/note-header/listen-button.tsx:195
 msgid "Play video"
 msgstr "Play video"
 
@@ -937,7 +937,7 @@ msgstr "Required to transcribe other people's voice during meetings"
 msgid "Required to transcribe your voice during meetings"
 msgstr "Required to transcribe your voice during meetings"
 
-#: src/components/editor-area/note-header/listen-button.tsx:119
+#: src/components/editor-area/note-header/listen-button.tsx:104
 msgid "Resume"
 msgstr "Resume"
 
@@ -1035,11 +1035,11 @@ msgstr "Start Annual Plan"
 msgid "Start Monthly Plan"
 msgstr "Start Monthly Plan"
 
-#: src/components/editor-area/note-header/listen-button.tsx:166
+#: src/components/editor-area/note-header/listen-button.tsx:151
 msgid "Start recording"
 msgstr "Start recording"
 
-#: src/components/editor-area/note-header/listen-button.tsx:325
+#: src/components/editor-area/note-header/listen-button.tsx:310
 msgid "Stop"
 msgstr "Stop"
 

--- a/apps/desktop/src/locales/ko/messages.po
+++ b/apps/desktop/src/locales/ko/messages.po
@@ -256,8 +256,8 @@ msgstr ""
 #. placeholder {0}: disabled ? "Wait..." : isHovered ? "Resume" : "Ended"
 #: src/components/settings/components/calendar/cloud-calendar-integration-details.tsx:36
 #: src/components/settings/components/ai/wer-modal.tsx:116
-#: src/components/editor-area/note-header/listen-button.tsx:191
-#: src/components/editor-area/note-header/listen-button.tsx:230
+#: src/components/editor-area/note-header/listen-button.tsx:176
+#: src/components/editor-area/note-header/listen-button.tsx:215
 msgid "{0}"
 msgstr ""
 
@@ -881,7 +881,7 @@ msgstr ""
 msgid "Owner"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:317
+#: src/components/editor-area/note-header/listen-button.tsx:302
 msgid "Pause"
 msgstr ""
 
@@ -893,7 +893,7 @@ msgstr ""
 msgid "Performance difference between languages"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:210
+#: src/components/editor-area/note-header/listen-button.tsx:195
 msgid "Play video"
 msgstr ""
 
@@ -937,7 +937,7 @@ msgstr ""
 msgid "Required to transcribe your voice during meetings"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:119
+#: src/components/editor-area/note-header/listen-button.tsx:104
 msgid "Resume"
 msgstr ""
 
@@ -1035,11 +1035,11 @@ msgstr ""
 msgid "Start Monthly Plan"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:166
+#: src/components/editor-area/note-header/listen-button.tsx:151
 msgid "Start recording"
 msgstr ""
 
-#: src/components/editor-area/note-header/listen-button.tsx:325
+#: src/components/editor-area/note-header/listen-button.tsx:310
 msgid "Stop"
 msgstr ""
 


### PR DESCRIPTION
- Removed the consent reminder timeout functionality from the listen button component
- Simplified the listen button component by eliminating the unnecessary consent notification timeout

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #1077 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #1047 
<!-- GitButler Footer Boundary Bottom -->

