### PR TITLE
feat(left-sidebar): update settings button link

### DIFF
--- a/apps/desktop/src/components/left-sidebar/top-area/settings-button.tsx
+++ b/apps/desktop/src/components/left-sidebar/top-area/settings-button.tsx
@@ -56,7 +56,7 @@ export function SettingsButton() {
   const handleClickTalkToFounders = async () => {
     setOpen(false);
     try {
-      await openURL("https://hyprnote.canny.io/others-general-feedback/p/talk-to-founders");
+      await openURL("https://cal.com/team/hyprnote/intro");
     } catch (error) {
       console.error("Failed to open talk to founders:", error);
     }


### PR DESCRIPTION
The changes update the link in the settings button to point to the
"Talk to Founders" page on the Cal.com website. This change is
intended to provide users with a more direct way to contact the
Hyprnote team.