### PR TITLE
before merge

### DIFF
--- a/plugins/apple-calendar/src/sync.rs
+++ b/plugins/apple-calendar/src/sync.rs
@@ -338,6 +338,14 @@ async fn list_system_events_for_calendars(
                 }
             };
 
+            for event in &events {
+                tracing::info!(
+                    "System event: '{}' | participants: {:?}",
+                    event.name,
+                    event.participants
+                );
+            }
+
             results.insert(calendar_tracking_id.clone(), events);
         }
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improved participant handling in note sessions to avoid duplicate entries for users without emails, and added logging for Apple Calendar event participants.

- **Bug Fixes**
  - Prevented adding duplicate participants by name when email is missing.

- **Debugging**
  - Added logs to show Apple Calendar event names and their participants.

<!-- End of auto-generated description by cubic. -->

