### PR TITLE
new onboarding

### DIFF
--- a/apps/desktop/src/locales/en/messages.po
+++ b/apps/desktop/src/locales/en/messages.po
@@ -443,8 +443,7 @@ msgstr "Audio Permissions"
 msgid "Autonomy Selector"
 msgstr "Autonomy Selector"
 
-#: src/components/welcome-modal/index.tsx:350
-#: src/components/welcome-modal/index.tsx:361
+#: src/components/welcome-modal/index.tsx:349
 msgid "Back"
 msgstr "Back"
 

--- a/apps/desktop/src/locales/ko/messages.po
+++ b/apps/desktop/src/locales/ko/messages.po
@@ -443,8 +443,7 @@ msgstr ""
 msgid "Autonomy Selector"
 msgstr ""
 
-#: src/components/welcome-modal/index.tsx:350
-#: src/components/welcome-modal/index.tsx:361
+#: src/components/welcome-modal/index.tsx:349
 msgid "Back"
 msgstr ""
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Simplified the onboarding flow by removing the manual model selection step and automatically selecting the default model for users.

- **Refactors**
  - Users now skip model selection; the 'small' model is chosen automatically after LLM or custom endpoint selection.
  - Cleaned up related code and removed unused translations.

<!-- End of auto-generated description by cubic. -->

