### PR TITLE
made eventlist more reliable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10277,7 +10277,7 @@ dependencies = [
 
 [[package]]
 name = "owhisper-server"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "agc",
  "aide",

--- a/apps/desktop/src/components/left-sidebar/events-list.tsx
+++ b/apps/desktop/src/components/left-sidebar/events-list.tsx
@@ -78,7 +78,7 @@ export default function EventsList({
         ? (
           <div>
             {events
-              .sort((a, b) => a.start_date.localeCompare(b.start_date))
+              // .sort((a, b) => a.start_date.localeCompare(b.start_date)) - commented out to show the closest events at the bottom
               .map((event) => (
                 <EventItem
                   key={event.id}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improved the event list in the left sidebar to show the closest ongoing or upcoming events first and ensure events are displayed until they end.

- **Bug Fixes**
 - Increased the event fetch limit to prevent missing events.
 - Updated filtering to use event end dates, so events stay visible until finished.
 - Adjusted sorting and display order to show the nearest events at the top.

<!-- End of auto-generated description by cubic. -->

