### PR TITLE
Fix incorrect filename iteration.

### DIFF
--- a/owhisper/owhisper-server/src/server.rs
+++ b/owhisper/owhisper-server/src/server.rs
@@ -171,17 +171,20 @@ fn build_whisper_cpp_service(
 fn build_moonshine_service(
     config: &owhisper_config::MoonshineModelConfig,
 ) -> anyhow::Result<hypr_transcribe_moonshine::TranscribeService> {
-    let mut files = std::fs::read_dir(&config.assets_dir)?;
+    let files: Vec<_> = std::fs::read_dir(&config.assets_dir)?.filter_map(Result::ok).collect();
 
     let tokenizer = files
-        .find(|f| f.is_ok() && f.as_ref().unwrap().file_name() == "tokenizer.json")
-        .ok_or(anyhow::anyhow!("tokenizer.json not found"))??;
+        .iter()
+        .find(|f| f.file_name() == "tokenizer.json")
+        .ok_or(anyhow::anyhow!("tokenizer.json not found"))?;
     let encoder = files
-        .find(|f| f.is_ok() && f.as_ref().unwrap().file_name() == "encoder_model.onnx")
-        .ok_or(anyhow::anyhow!("encoder_model.onnx not found"))??;
+        .iter()
+        .find(|f| f.file_name() == "encoder_model.onnx")
+        .ok_or(anyhow::anyhow!("encoder_model.onnx not found"))?;
     let decoder = files
-        .find(|f| f.is_ok() && f.as_ref().unwrap().file_name() == "decoder_model_merged.onnx")
-        .ok_or(anyhow::anyhow!("decoder_model_merged.onnx not found"))??;
+        .iter()
+        .find(|f| f.file_name() == "decoder_model_merged.onnx")
+        .ok_or(anyhow::anyhow!("decoder_model_merged.onnx not found"))?;
 
     Ok(hypr_transcribe_moonshine::TranscribeService::builder()
         .model_size(config.size.clone())


### PR DESCRIPTION
What was there before would keep iterating through the same iterator and try and find files with matching names. If the `read_dir` call did not result in the files in that directory exactly matching the order that they were written in the file, it would fail to find them, and then prevent the model from loading.

Instead we evaluate the iterator, and then try and find each of the filenames once.

Fixes #1344
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where the model loader failed if asset files were not returned in a specific order from the directory listing. Now, files are collected once and searched by name to ensure reliable loading.

- **Bug Fixes**
 - Collect all files upfront and look up each required filename separately.
 - Prevents failures when files appear in a different order.

<!-- End of auto-generated description by cubic. -->

