### PR TITLE
Add correct timestamp for segment based on session timer

### DIFF
--- a/crates/transcribe-whisper-local/src/service/streaming.rs
+++ b/crates/transcribe-whisper-local/src/service/streaming.rs
@@ -297,6 +297,8 @@ where
                 Ok(chunk) => Some(hypr_whisper_local::SimpleAudioChunk {
                     samples: chunk.samples,
                     meta: Some(serde_json::json!({ "source": source_name })),
+                    start_timestamp_ms: Some(chunk.start_timestamp_ms),
+                    end_timestamp_ms: Some(chunk.end_timestamp_ms),
                 }),
             })
         })


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds session-based start/end timestamps to audio chunks and uses them to set segment start/end during transcription. This fixes inaccurate segment timing and falls back when timestamps aren’t provided.

- **New Features**
  - AudioChunk now includes start_timestamp_ms and end_timestamp_ms.
  - SimpleAudioChunk stores these fields; streaming fills them from the session timer.
  - Transcription sets segment.start/end from these timestamps (ms to seconds).
  - VAD test updated to ignore the new fields.

- **Migration**
  - If you implement AudioChunk, add start_timestamp_ms and end_timestamp_ms. Return None if not available.

<!-- End of auto-generated description by cubic. -->

