### PR TITLE
am finalize message

### DIFF
--- a/crates/vad/src/continuous.rs
+++ b/crates/vad/src/continuous.rs
@@ -7,7 +7,7 @@ use std::{
 
 use futures_util::{future, Stream, StreamExt};
 use kalosm_sound::AsyncSource;
-use silero_rs::{VadConfig, VadSession, VadTransition};
+pub use silero_rs::{VadConfig, VadSession, VadTransition};
 
 #[derive(Debug, Clone)]
 pub enum VadStreamItem {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Auto-finalizes messages at end-of-speech and fixes duplicate final words in transcripts. Adds a control channel for finalize events and re-exports VAD types for plugin use.

- New Features
  - Detects SpeechEnd via a new VAD session (mixes mic+speaker) and sends ControlMessage::Finalize.
  - Merges audio and control into a single stream as MixedMessage::{Audio, Control}.
  - Re-exports VadConfig, VadSession, VadTransition from the VAD crate.
  - Tunes VAD timing (70ms redemption and pre-speech pad).

- Bug Fixes
  - Removes duplicate final words using start/end timestamp dedupe.
  - Keeps a sorted final_words list, separate from partial_words.
  - Trims partial_words only after the latest newly finalized word.

<!-- End of auto-generated description by cubic. -->

