### PR TITLE
Fix external stt server startups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14734,6 +14734,7 @@ dependencies = [
  "tauri-plugin",
  "tauri-plugin-store",
  "tauri-plugin-store2",
+ "tauri-plugin-windows",
  "tauri-specta",
  "thiserror 2.0.12",
  "tokio",

--- a/apps/desktop/src-tauri/Entitlements.plist
+++ b/apps/desktop/src-tauri/Entitlements.plist
@@ -8,7 +8,5 @@
     <true/>
     <key>com.apple.security.personal-information.addressbook</key>
     <true/>
-    <key>com.apple.developer.usernotifications.time-sensitive</key>
-    <true/>
 </dict>
 </plist>

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -236,10 +236,6 @@ pub async fn main() {
                         }
                     }
                 }
-
-                tokio::spawn(async move {
-                    app_clone.setup_local_ai().await.unwrap();
-                });
             });
 
             Ok(())

--- a/apps/desktop/src/components/settings/components/ai/stt-view-local.tsx
+++ b/apps/desktop/src/components/settings/components/ai/stt-view-local.tsx
@@ -250,7 +250,7 @@ function ProModelsSection({
         {proModels.data?.map((model) => (
           <ModelEntry
             key={model.key}
-            disabled={true}
+            disabled={false}
             model={model}
             selectedSTTModel={selectedSTTModel}
             setSelectedSTTModel={setSelectedSTTModel}

--- a/crates/detect/src/mic/macos.rs
+++ b/crates/detect/src/mic/macos.rs
@@ -208,9 +208,9 @@ impl crate::Observer for Detector {
                     system_listener,
                     system_listener_ptr,
                 ) {
-                    println!("Failed to add system listener: {:?}", e);
+                    tracing::error!("adding_system_listener_failed: {:?}", e);
                 } else {
-                    println!("✅ System listener added successfully");
+                    tracing::info!("adding_system_listener_success");
                 }
 
                 if let Ok(device) = ca::System::default_input_device() {
@@ -229,7 +229,7 @@ impl crate::Observer for Detector {
                         )
                         .is_ok()
                     {
-                        println!("✅ Device listener added successfully");
+                        tracing::info!("adding_device_listener_success");
 
                         if let Ok(mut device_guard) = current_device.lock() {
                             *device_guard = Some(device);
@@ -244,10 +244,10 @@ impl crate::Observer for Detector {
                             }
                         }
                     } else {
-                        println!("❌ Failed to add device listener");
+                        tracing::error!("adding_device_listener_failed");
                     }
                 } else {
-                    println!("⚠️ No default input device found");
+                    tracing::warn!("no_default_input_device_found");
                 }
 
                 let _ = tx.blocking_send(());

--- a/plugins/local-llm/Cargo.toml
+++ b/plugins/local-llm/Cargo.toml
@@ -31,6 +31,7 @@ hypr-llama = { workspace = true }
 
 tauri = { workspace = true, features = ["test"] }
 tauri-plugin-store2 = { workspace = true }
+tauri-plugin-windows = { workspace = true }
 tauri-specta = { workspace = true, features = ["derive", "typescript"] }
 
 thiserror = { workspace = true }

--- a/plugins/local-llm/src/events.rs
+++ b/plugins/local-llm/src/events.rs
@@ -1,4 +1,4 @@
-use crate::LocalSttPluginExt;
+use crate::LocalLlmPluginExt;
 use tauri_plugin_windows::HyprWindow;
 
 pub fn on_event<R: tauri::Runtime>(app: &tauri::AppHandle<R>, event: &tauri::RunEvent) {
@@ -20,7 +20,7 @@ pub fn on_event<R: tauri::Runtime>(app: &tauri::AppHandle<R>, event: &tauri::Run
                 tauri::WindowEvent::Focused(true) => {
                     tokio::task::block_in_place(|| {
                         tokio::runtime::Handle::current().block_on(async {
-                            let _ = app.start_server(None).await;
+                            let _ = app.start_server().await;
                         });
                     });
                 }

--- a/plugins/local-llm/src/lib.rs
+++ b/plugins/local-llm/src/lib.rs
@@ -6,6 +6,7 @@ use tokio::sync::Mutex;
 
 mod commands;
 mod error;
+mod events;
 mod ext;
 mod manager;
 mod model;
@@ -13,6 +14,7 @@ mod server;
 mod store;
 
 pub use error::*;
+use events::*;
 pub use ext::*;
 pub use manager::*;
 pub use model::*;
@@ -83,6 +85,7 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
 
             Ok(())
         })
+        .on_event(on_event)
         .build()
 }
 

--- a/plugins/local-stt/src/events.rs
+++ b/plugins/local-stt/src/events.rs
@@ -20,7 +20,10 @@ pub fn on_event<R: tauri::Runtime>(app: &tauri::AppHandle<R>, event: &tauri::Run
                 tauri::WindowEvent::Focused(true) => {
                     tokio::task::block_in_place(|| {
                         tokio::runtime::Handle::current().block_on(async {
-                            let _ = app.start_server(None).await;
+                            match app.start_server(None).await {
+                                Ok(_) => tracing::info!("server_started"),
+                                Err(e) => tracing::error!("server_start_failed: {:?}", e),
+                            }
                         });
                     });
                 }

--- a/plugins/local-stt/src/ext.rs
+++ b/plugins/local-stt/src/ext.rs
@@ -252,7 +252,7 @@ impl<R: Runtime, T: Manager<R>> LocalSttPluginExt<R> for T {
                     self.shell()
                         .sidecar("stt")?
                         .current_dir(dirs::home_dir().unwrap())
-                        .args(["serve", "-v"])
+                        .args(["serve", "-v", "-d"])
                 };
 
                 let server = external::run_server(cmd, am_key).await?;

--- a/plugins/local-stt/src/lib.rs
+++ b/plugins/local-stt/src/lib.rs
@@ -10,7 +10,6 @@ mod model;
 mod server;
 mod store;
 mod types;
-mod utils;
 
 pub use error::*;
 use events::*;
@@ -18,7 +17,6 @@ pub use ext::*;
 pub use model::*;
 pub use store::*;
 pub use types::*;
-use utils::*;
 
 pub type SharedState = std::sync::Arc<tokio::sync::Mutex<State>>;
 

--- a/plugins/local-stt/src/server/external.rs
+++ b/plugins/local-stt/src/server/external.rs
@@ -58,6 +58,7 @@ pub async fn run_server(
 ) -> Result<ServerHandle, crate::Error> {
     let port = 50060;
     let _ = port_killer::kill(port);
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
     let (mut rx, child) = cmd.args(["--port", &port.to_string()]).spawn()?;
     let base_url = format!("http://localhost:{}", port);

--- a/plugins/local-stt/src/server/external.rs
+++ b/plugins/local-stt/src/server/external.rs
@@ -7,12 +7,12 @@ pub struct ServerHandle {
     client: hypr_am::Client,
 }
 
-impl Drop for ServerHandle {
-    fn drop(&mut self) {
-        tracing::info!("stopping");
-        let _ = self.shutdown.send(());
-    }
-}
+// impl Drop for ServerHandle {
+//     fn drop(&mut self) {
+//         tracing::info!("stopping");
+//         let _ = self.shutdown.send(());
+//     }
+// }
 
 impl ServerHandle {
     pub async fn health(&self) -> ServerHealth {
@@ -62,7 +62,7 @@ pub async fn run_server(
 
     tracing::info!("spwaning_started");
     let (mut rx, child) = cmd.args(["--port", &port.to_string()]).spawn()?;
-    tracing::info!("spwaning_started");
+    tracing::info!("spwaning_ended");
 
     let base_url = format!("http://localhost:{}", port);
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(());

--- a/plugins/local-stt/src/server/external.rs
+++ b/plugins/local-stt/src/server/external.rs
@@ -60,7 +60,10 @@ pub async fn run_server(
     let _ = port_killer::kill(port);
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
+    tracing::info!("spwaning_started");
     let (mut rx, child) = cmd.args(["--port", &port.to_string()]).spawn()?;
+    tracing::info!("spwaning_started");
+
     let base_url = format!("http://localhost:{}", port);
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(());
     let client = hypr_am::Client::new(&base_url);
@@ -119,7 +122,8 @@ pub async fn run_server(
         }
     });
 
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    tracing::info!("returning_handle");
 
     Ok(ServerHandle {
         api_key: Some(am_key),

--- a/plugins/local-stt/src/server/internal.rs
+++ b/plugins/local-stt/src/server/internal.rs
@@ -55,7 +55,7 @@ pub struct ServerHandle {
 
 impl Drop for ServerHandle {
     fn drop(&mut self) {
-        tracing::info!("stopping");
+        tracing::info!("stopping: {}", self.base_url);
         let _ = self.shutdown.send(());
     }
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes unreliable external STT server startup by launching servers only when the main window is focused and waiting after freeing the port. Also adds the same focus-based start for local LLM, improves logging, and enables Pro STT model selection.

- **Bug Fixes**
  - Start STT and LLM servers on Main window focus via tauri-plugin-windows events.
  - Wait 500ms after killing port 50060 before spawning the external STT server to avoid race conditions.
  - Better diagnostics: switch macOS mic logs to tracing and include server base URL on shutdown.

- **Refactors**
  - Remove eager setup_local_ai and its spawn; move startup logic into plugin on_event handlers.
  - Simplify STT plugin (drop close/destroy shutdown handling and unused utils).
  - Enable selecting Pro STT models in STT settings.
  - Add tauri-plugin-windows to local-llm.

<!-- End of auto-generated description by cubic. -->

