### PR TITLE
Settings redesign 0825

### DIFF
--- a/apps/desktop/src/components/right-panel/components/chat/markdown-card.tsx
+++ b/apps/desktop/src/components/right-panel/components/chat/markdown-card.tsx
@@ -1,7 +1,7 @@
 import { commands as miscCommands } from "@hypr/plugin-misc";
 import Renderer from "@hypr/tiptap/renderer";
 import { Button } from "@hypr/ui/components/ui/button";
-import { CopyIcon, FileTextIcon, PlayIcon } from "lucide-react";
+import { FileTextIcon, PlayIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 
 interface MarkdownCardProps {
@@ -16,21 +16,10 @@ export function MarkdownCard(
   { content, isComplete, sessionTitle, onApplyMarkdown, hasEnhancedNote = false }: MarkdownCardProps,
 ) {
   const [htmlContent, setHtmlContent] = useState<string>("");
-  const [isCopied, setIsCopied] = useState(false);
 
   const handleApplyClick = () => {
     if (onApplyMarkdown) {
       onApplyMarkdown(content);
-    }
-  };
-
-  const handleCopyClick = async () => {
-    try {
-      await navigator.clipboard.writeText(content);
-      setIsCopied(true);
-      setTimeout(() => setIsCopied(false), 2000); // Reset after 2 seconds
-    } catch (error) {
-      console.error("Failed to copy to clipboard:", error);
     }
   };
 
@@ -129,9 +118,6 @@ export function MarkdownCard(
             {sessionTitle || "Hyprnote Suggestion"}
           </div>
 
-          {/* Conditional button based on hasEnhancedNote */}
-          {hasEnhancedNote
-            ? (
               <Button
                 variant="ghost"
                 className="hover:bg-neutral-200 h-6 px-2 text-xs text-neutral-600 flex items-center gap-1"
@@ -140,17 +126,7 @@ export function MarkdownCard(
                 <PlayIcon className="size-3" />
                 Apply
               </Button>
-            )
-            : (
-              <Button
-                variant="ghost"
-                className="hover:bg-neutral-200 h-6 px-2 text-xs text-neutral-600 flex items-center gap-1"
-                onClick={handleCopyClick}
-              >
-                <CopyIcon className="size-3" />
-                {isCopied ? "Copied" : "Copy"}
-              </Button>
-            )}
+            
         </div>
 
         {/* Content section - Add selectable class */}

--- a/apps/desktop/src/components/right-panel/components/chat/markdown-card.tsx
+++ b/apps/desktop/src/components/right-panel/components/chat/markdown-card.tsx
@@ -118,15 +118,14 @@ export function MarkdownCard(
             {sessionTitle || "Hyprnote Suggestion"}
           </div>
 
-              <Button
-                variant="ghost"
-                className="hover:bg-neutral-200 h-6 px-2 text-xs text-neutral-600 flex items-center gap-1"
-                onClick={handleApplyClick}
-              >
-                <PlayIcon className="size-3" />
-                Apply
-              </Button>
-            
+          <Button
+            variant="ghost"
+            className="hover:bg-neutral-200 h-6 px-2 text-xs text-neutral-600 flex items-center gap-1"
+            onClick={handleApplyClick}
+          >
+            <PlayIcon className="size-3" />
+            Apply
+          </Button>
         </div>
 
         {/* Content section - Add selectable class */}

--- a/apps/desktop/src/components/right-panel/hooks/useChatLogic.ts
+++ b/apps/desktop/src/components/right-panel/hooks/useChatLogic.ts
@@ -94,8 +94,20 @@ export function useChatLogic({
 
     try {
       const html = await miscCommands.opinionatedMdToHtml(markdownContent);
-
-      sessionStore.getState().updateEnhancedNote(html);
+      
+      const { session, showRaw } = sessionStore.getState();
+      
+      const hasEnhancedNote = !!session.enhanced_memo_html;
+      
+      if (!hasEnhancedNote) {
+        sessionStore.getState().updateRawNote(html);
+      } else {
+        if (showRaw) {
+          sessionStore.getState().updateRawNote(html);
+        } else {
+          sessionStore.getState().updateEnhancedNote(html);
+        }
+      }
     } catch (error) {
       console.error("Failed to apply markdown content:", error);
     }

--- a/apps/desktop/src/components/right-panel/hooks/useChatLogic.ts
+++ b/apps/desktop/src/components/right-panel/hooks/useChatLogic.ts
@@ -94,11 +94,11 @@ export function useChatLogic({
 
     try {
       const html = await miscCommands.opinionatedMdToHtml(markdownContent);
-      
+
       const { session, showRaw } = sessionStore.getState();
-      
+
       const hasEnhancedNote = !!session.enhanced_memo_html;
-      
+
       if (!hasEnhancedNote) {
         sessionStore.getState().updateRawNote(html);
       } else {

--- a/apps/desktop/src/components/settings/components/ai/llm-local-view.tsx
+++ b/apps/desktop/src/components/settings/components/ai/llm-local-view.tsx
@@ -1,11 +1,12 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { openPath } from "@tauri-apps/plugin-opener";
 import { open } from "@tauri-apps/plugin-shell";
-import { CloudIcon, DownloadIcon, FolderIcon, HelpCircleIcon } from "lucide-react";
+import { CloudIcon, DownloadIcon, FolderIcon } from "lucide-react";
 import { useEffect } from "react";
 
 import { useLicense } from "@/hooks/use-license";
 import { commands as localLlmCommands, type SupportedModel } from "@hypr/plugin-local-llm";
+import { commands as windowsCommands } from "@hypr/plugin-windows";
 import { Button } from "@hypr/ui/components/ui/button";
 import { cn } from "@hypr/ui/lib/utils";
 import { type LLMModel, SharedLLMProps } from "./shared";
@@ -91,43 +92,68 @@ export function LLMLocalView({
           <div
             className={cn(
               "group relative p-3 rounded-lg border-2 transition-all",
-              isPro ? "" : "opacity-50",
               isHyprCloudSelected
                 ? "border-solid border-blue-500 bg-blue-50"
                 : "border-dashed border-gray-300 hover:border-gray-400 bg-white",
             )}
           >
             <div className="flex items-center justify-between">
-              <button
-                onClick={handleHyprCloudSelection}
-                disabled={!isPro}
-                className={cn(
-                  buttonResetClass,
-                  isPro ? "cursor-pointer" : "cursor-not-allowed",
-                  "flex-1 min-w-0 block",
-                )}
-              >
-                <div className="flex items-center gap-4">
-                  <div className="min-w-0">
-                    <h3 className="font-semibold text-base text-gray-900 flex items-center gap-2">
-                      <CloudIcon className="w-4 h-4" />
-                      HyprCloud
-                    </h3>
-                    <p className="text-sm text-gray-600">
-                      Connect to Hyprnote's Cloud hosted AI model. 
-                    </p>
+              <div className="relative flex-1">
+                {/* Main button */}
+                <button
+                  onClick={handleHyprCloudSelection}
+                  disabled={!isPro}
+                  className={cn(
+                    buttonResetClass,
+                    isPro ? "cursor-pointer" : "cursor-not-allowed",
+                    "block w-full",
+                  )}
+                >
+                  <div className="flex items-center gap-4">
+                    <div className="min-w-0">
+                      <h3 className="font-semibold text-base text-gray-900 flex items-center gap-2">
+                        <CloudIcon className={cn("w-4 h-4", isPro ? "" : "opacity-50")} />
+                        <span className={isPro ? "" : "opacity-50"}>HyprCloud</span>
+                      </h3>
+                      <p className={cn("text-sm text-gray-600", isPro ? "" : "opacity-50")}>
+                        Connect to Hyprnote's Cloud hosted AI model.
+                      </p>
+                    </div>
                   </div>
-                </div>
-              </button>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  open("https://docs.hyprnote.com/pro/cloud");
-                }}
-                className="text-blue-600 hover:text-blue-800 transition-colors relative z-10 ml-2"
-              >
-                <HelpCircleIcon className="w-4 h-4" />
-              </button>
+                </button>
+
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    console.log("help button clicked");
+                    open("https://docs.hyprnote.com/pro/cloud");
+                  }}
+                  className="absolute top-[-2px] left-[113px] z-10"
+                >
+                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-200 text-blue-800 hover:bg-blue-100 transition-colors">
+                    Pro
+                  </span>
+                </button>
+              </div>
+
+              {!isPro && (
+                <Button
+                  onClick={() => {
+                    windowsCommands.windowShow({ type: "settings" }).then(() => {
+                      setTimeout(() => {
+                        windowsCommands.windowEmitNavigate({ type: "settings" }, {
+                          path: "/app/settings",
+                          search: { tab: "billing" },
+                        });
+                      }, 500);
+                    });
+                  }}
+                  size="sm"
+                  className="ml-4 bg-blue-600 hover:bg-blue-700 text-white"
+                >
+                  Upgrade to Pro
+                </Button>
+              )}
             </div>
           </div>
 

--- a/apps/desktop/src/components/settings/components/ai/llm-local-view.tsx
+++ b/apps/desktop/src/components/settings/components/ai/llm-local-view.tsx
@@ -114,7 +114,7 @@ export function LLMLocalView({
                       HyprCloud
                     </h3>
                     <p className="text-sm text-gray-600">
-                      Managed LLM endpoint for Pro users. Click blue button to learn more.
+                      Connect to Hyprnote's Cloud hosted AI model. 
                     </p>
                   </div>
                 </div>

--- a/apps/desktop/src/components/settings/components/ai/llm-local-view.tsx
+++ b/apps/desktop/src/components/settings/components/ai/llm-local-view.tsx
@@ -125,7 +125,6 @@ export function LLMLocalView({
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
-                    console.log("help button clicked");
                     open("https://docs.hyprnote.com/pro/cloud");
                   }}
                   className="absolute top-[-2px] left-[113px] z-10"
@@ -244,9 +243,7 @@ export function LLMLocalView({
                       size="sm"
                       variant="outline"
                       onClick={(e) => {
-                        console.log("model download clicked");
                         e.stopPropagation();
-                        console.log("model download clicked 2");
                         handleModelDownload(model.key);
                       }}
                       className="text-xs h-7 px-2 flex items-center gap-1"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Enables Apply-from-anywhere for chat Markdown suggestions and refreshes the HyprCloud settings card with a Pro badge and upgrade flow. Apply now updates the note you're viewing (Raw or Enhanced) and defaults to Raw if no Enhanced note exists.

- New Features
  - Chat: Removed Copy; always show Apply on Markdown cards.
  - Apply behavior: Convert MD to HTML, then update Raw or Enhanced based on current view; if no Enhanced note exists, update Raw.
  - Settings > AI > Local LLM: Updated HyprCloud card with clearer copy, a “Pro” badge linking to docs, and an “Upgrade to Pro” button that opens Settings → Billing. Icon/text dim when locked (container no longer dimmed).

- Dependencies
  - Added @hypr/plugin-windows to open Settings and navigate to Billing.

<!-- End of auto-generated description by cubic. -->

