### PR TITLE
event worker and meeting detector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14817,6 +14817,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-plugin-db",
+ "tauri-plugin-listener",
  "tauri-plugin-store",
  "tauri-plugin-store2",
  "tauri-plugin-windows",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14819,6 +14819,7 @@ dependencies = [
  "tauri-plugin-db",
  "tauri-plugin-store",
  "tauri-plugin-store2",
+ "tauri-plugin-windows",
  "tauri-specta",
  "thiserror 2.0.12",
  "tokio",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -262,16 +262,6 @@ pub async fn main() {
                         });
                     }
                 }
-
-                // Start event notification after DB is initialized
-                {
-                    use tauri_plugin_notification::NotificationPluginExt;
-                    if app_clone.get_event_notification().unwrap_or(false) {
-                        if let Err(e) = app_clone.start_event_notification().await {
-                            tracing::error!("start_event_notification_failed: {:?}", e);
-                        }
-                    }
-                }
             });
 
             Ok(())

--- a/apps/desktop/src/components/settings/views/notifications.tsx
+++ b/apps/desktop/src/components/settings/views/notifications.tsx
@@ -39,12 +39,6 @@ export default function NotificationsComponent() {
     mutationFn: async (v: Schema) => {
       if (v.event) {
         notificationCommands.setEventNotification(true);
-        notificationCommands.showNotification({
-          title: "Test",
-          message: "Test",
-          url: "https://hypr.ai",
-          timeout: { secs: 5, nanos: 0 },
-        });
       } else {
         notificationCommands.setEventNotification(false);
       }
@@ -54,6 +48,12 @@ export default function NotificationsComponent() {
       eventNotification.refetch();
       if (active) {
         notificationCommands.startEventNotification();
+        notificationCommands.showNotification({
+          title: "You're all set!",
+          message: "This is how notifications look.",
+          timeout: { secs: 10, nanos: 0 },
+          url: null,
+        });
       } else {
         notificationCommands.stopEventNotification();
       }
@@ -64,12 +64,6 @@ export default function NotificationsComponent() {
     mutationFn: async (v: Schema) => {
       if (v.detect) {
         notificationCommands.setDetectNotification(true);
-        notificationCommands.showNotification({
-          title: "Test",
-          message: "Test",
-          url: "https://hypr.ai",
-          timeout: { secs: 5, nanos: 0 },
-        });
       } else {
         notificationCommands.setDetectNotification(false);
       }
@@ -79,6 +73,12 @@ export default function NotificationsComponent() {
       detectNotification.refetch();
       if (active) {
         notificationCommands.startDetectNotification();
+        notificationCommands.showNotification({
+          title: "You're all set!",
+          message: "This is how notifications look.",
+          timeout: { secs: 10, nanos: 0 },
+          url: null,
+        });
       } else {
         notificationCommands.stopDetectNotification();
       }

--- a/apps/desktop/src/locales/en/messages.po
+++ b/apps/desktop/src/locales/en/messages.po
@@ -248,11 +248,11 @@ msgstr "{weeks} weeks later"
 #~ msgid "in {hours} hours"
 #~ msgstr "in {hours} hours"
 
-#: src/components/settings/views/notifications.tsx:105
+#: src/components/settings/views/notifications.tsx:113
 msgid "(Beta) Detect meetings automatically"
 msgstr "(Beta) Detect meetings automatically"
 
-#: src/components/settings/views/notifications.tsx:132
+#: src/components/settings/views/notifications.tsx:140
 msgid "(Beta) Upcoming meeting notifications"
 msgstr "(Beta) Upcoming meeting notifications"
 
@@ -1428,11 +1428,11 @@ msgstr "Share usage data"
 msgid "Shorten summary"
 msgstr "Shorten summary"
 
-#: src/components/settings/views/notifications.tsx:135
+#: src/components/settings/views/notifications.tsx:143
 msgid "Show notifications when you have meetings starting soon in your calendar."
 msgstr "Show notifications when you have meetings starting soon in your calendar."
 
-#: src/components/settings/views/notifications.tsx:108
+#: src/components/settings/views/notifications.tsx:116
 msgid "Show notifications when you join a meeting."
 msgstr "Show notifications when you join a meeting."
 

--- a/apps/desktop/src/locales/ko/messages.po
+++ b/apps/desktop/src/locales/ko/messages.po
@@ -248,11 +248,11 @@ msgstr ""
 #~ msgid "in {hours} hours"
 #~ msgstr ""
 
-#: src/components/settings/views/notifications.tsx:105
+#: src/components/settings/views/notifications.tsx:113
 msgid "(Beta) Detect meetings automatically"
 msgstr ""
 
-#: src/components/settings/views/notifications.tsx:132
+#: src/components/settings/views/notifications.tsx:140
 msgid "(Beta) Upcoming meeting notifications"
 msgstr ""
 
@@ -1428,11 +1428,11 @@ msgstr ""
 msgid "Shorten summary"
 msgstr ""
 
-#: src/components/settings/views/notifications.tsx:135
+#: src/components/settings/views/notifications.tsx:143
 msgid "Show notifications when you have meetings starting soon in your calendar."
 msgstr ""
 
-#: src/components/settings/views/notifications.tsx:108
+#: src/components/settings/views/notifications.tsx:116
 msgid "Show notifications when you join a meeting."
 msgstr ""
 

--- a/crates/detect/src/lib.rs
+++ b/crates/detect/src/lib.rs
@@ -7,7 +7,7 @@ pub use mic::*;
 
 use utils::*;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum DetectEvent {
     MicStarted,
     MicStopped,

--- a/crates/notification-macos/examples/test_notification.rs
+++ b/crates/notification-macos/examples/test_notification.rs
@@ -5,8 +5,10 @@ use std::time::Duration;
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2::{define_class, msg_send, MainThreadOnly};
-use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy, NSApplicationDelegate};
-use objc2_foundation::{MainThreadMarker, NSObject, NSObjectProtocol};
+use objc2_app_kit::{
+    NSAppearance, NSApplication, NSApplicationActivationPolicy, NSApplicationDelegate,
+};
+use objc2_foundation::{ns_string, MainThreadMarker, NSObject, NSObjectProtocol};
 
 #[derive(Debug, Default)]
 struct AppDelegateIvars {}
@@ -35,6 +37,10 @@ fn main() {
     let app = NSApplication::sharedApplication(mtm);
     app.setActivationPolicy(NSApplicationActivationPolicy::Regular);
 
+    if let Some(appearance) = NSAppearance::appearanceNamed(ns_string!("NSAppearanceNameAqua")) {
+        app.setAppearance(Some(&appearance));
+    }
+
     let delegate = AppDelegate::new(mtm);
     app.setDelegate(Some(&ProtocolObject::from_ref(&*delegate)));
 
@@ -46,11 +52,11 @@ fn main() {
             .title("Test Notification")
             .message("Hover/click should now react")
             .url("https://example.com")
-            .timeout(Duration::from_secs(20))
+            .timeout(Duration::from_secs(30))
             .build();
 
         show(&notification);
-        std::thread::sleep(Duration::from_secs(5));
+        std::thread::sleep(Duration::from_secs(30));
         std::process::exit(0);
     });
 

--- a/crates/notification/src/lib.rs
+++ b/crates/notification/src/lib.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 pub use hypr_notification_interface::*;
 
 static RECENT_NOTIFICATIONS: OnceLock<Mutex<HashMap<String, Instant>>> = OnceLock::new();
+
 const DEDUPE_WINDOW: Duration = Duration::from_secs(60 * 5);
 
 #[cfg(target_os = "macos")]

--- a/crates/whisper-local/src/model.rs
+++ b/crates/whisper-local/src/model.rs
@@ -304,7 +304,6 @@ impl Segment {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures_util::StreamExt;
 
     #[test]
     fn test_whisper() {

--- a/plugins/notification/Cargo.toml
+++ b/plugins/notification/Cargo.toml
@@ -21,6 +21,7 @@ hypr-notification = { workspace = true }
 
 tauri-plugin-db = { workspace = true }
 tauri-plugin-store2 = { workspace = true }
+tauri-plugin-windows = { workspace = true }
 
 serde = { workspace = true }
 specta = { workspace = true }

--- a/plugins/notification/Cargo.toml
+++ b/plugins/notification/Cargo.toml
@@ -20,6 +20,7 @@ hypr-detect = { workspace = true }
 hypr-notification = { workspace = true }
 
 tauri-plugin-db = { workspace = true }
+tauri-plugin-listener = { workspace = true }
 tauri-plugin-store2 = { workspace = true }
 tauri-plugin-windows = { workspace = true }
 

--- a/plugins/notification/src/detect.rs
+++ b/plugins/notification/src/detect.rs
@@ -1,0 +1,57 @@
+pub struct DetectState {
+    tx: std::sync::mpsc::Sender<hypr_detect::DetectEvent>,
+    handle: Option<std::thread::JoinHandle<()>>,
+    detector: hypr_detect::Detector,
+}
+
+impl DetectState {
+    pub fn new(app_handle: tauri::AppHandle<tauri::Wry>) -> Self {
+        let (tx, rx) = std::sync::mpsc::channel::<hypr_detect::DetectEvent>();
+
+        let handle = std::thread::spawn(move || {
+            while let Ok(event) = rx.recv() {
+                match event {
+                    hypr_detect::DetectEvent::MicStarted => {
+                        let visible = {
+                            use tauri_plugin_windows::{HyprWindow, WindowsPluginExt};
+                            app_handle
+                                .window_is_visible(HyprWindow::Main)
+                                .unwrap_or(false)
+                        };
+
+                        if !visible {
+                            hypr_notification::show(
+                                &hypr_notification::Notification::builder()
+                                    .title("Meeting detected")
+                                    .message("Click here to start writing a note")
+                                    .url("hypr://hyprnote.com/notification")
+                                    .timeout(std::time::Duration::from_secs(10))
+                                    .build(),
+                            );
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        Self {
+            tx,
+            handle: Some(handle),
+            detector: hypr_detect::Detector::default(),
+        }
+    }
+
+    pub fn start(&mut self) {
+        let tx = self.tx.clone();
+        self.detector.start(hypr_detect::new_callback(move |e| {
+            let _ = tx.send(e);
+        }));
+    }
+
+    pub fn stop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}

--- a/plugins/notification/src/detect.rs
+++ b/plugins/notification/src/detect.rs
@@ -1,65 +1,38 @@
-use crate::error::Error;
+use crate::{
+    handler::{NotificationHandler, NotificationTrigger, NotificationTriggerDetect},
+    Error,
+};
 
 pub struct DetectState {
-    tx: Option<std::sync::mpsc::Sender<hypr_detect::DetectEvent>>,
-    handle: Option<std::thread::JoinHandle<()>>,
     detector: Option<hypr_detect::Detector>,
-    app_handle: tauri::AppHandle<tauri::Wry>,
+    notification_tx: Option<std::sync::mpsc::Sender<NotificationTrigger>>,
 }
 
 impl DetectState {
-    pub fn new(app_handle: tauri::AppHandle<tauri::Wry>) -> Self {
+    pub fn new(notification_handler: &NotificationHandler) -> Self {
         Self {
-            tx: None,
-            handle: None,
             detector: None,
-            app_handle,
+            notification_tx: notification_handler.sender(),
         }
     }
 
     pub fn start(&mut self) -> Result<(), Error> {
         self.stop()?;
 
-        let (tx, rx) = std::sync::mpsc::channel::<hypr_detect::DetectEvent>();
-
-        let app_handle = self.app_handle.clone();
-        let handle = std::thread::spawn(move || {
-            while let Ok(event) = rx.recv() {
-                match event {
-                    hypr_detect::DetectEvent::MicStarted => {
-                        let visible = {
-                            use tauri_plugin_windows::{HyprWindow, WindowsPluginExt};
-                            app_handle
-                                .window_is_visible(HyprWindow::Main)
-                                .unwrap_or(false)
-                        };
-
-                        if !visible {
-                            hypr_notification::show(
-                                &hypr_notification::Notification::builder()
-                                    .title("Meeting detected")
-                                    .message("Based on your microphone activity")
-                                    .url("hypr://hyprnote.com/app/new?record=true")
-                                    .timeout(std::time::Duration::from_secs(30))
-                                    .build(),
-                            );
-                        }
-                    }
-                    hypr_detect::DetectEvent::MicStopped => {}
-                    _ => {}
+        {
+            let notification_tx = self.notification_tx.as_ref().unwrap().clone();
+            let mut detector = hypr_detect::Detector::default();
+            detector.start(hypr_detect::new_callback(move |event| {
+                if let Err(e) =
+                    notification_tx.send(NotificationTrigger::Detect(NotificationTriggerDetect {
+                        event,
+                    }))
+                {
+                    tracing::error!("{}", e);
                 }
-            }
-        });
-
-        let mut detector = hypr_detect::Detector::default();
-        let tx_clone = tx.clone();
-        detector.start(hypr_detect::new_callback(move |e| {
-            let _ = tx_clone.send(e);
-        }));
-
-        self.tx = Some(tx);
-        self.handle = Some(handle);
-        self.detector = Some(detector);
+            }));
+            self.detector = Some(detector);
+        }
 
         Ok(())
     }
@@ -69,17 +42,11 @@ impl DetectState {
             detector.stop();
         }
 
-        self.tx = None;
-
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
-
         Ok(())
     }
 
     pub fn _is_running(&self) -> bool {
-        self.detector.is_some() && self.handle.is_some()
+        self.detector.is_some()
     }
 }
 

--- a/plugins/notification/src/event.rs
+++ b/plugins/notification/src/event.rs
@@ -2,6 +2,8 @@ use apalis::prelude::{Data, Error, WorkerBuilder, WorkerFactoryFn};
 use chrono::{DateTime, Duration, Utc};
 use hypr_db_user::{ListEventFilter, ListEventFilterCommon, ListEventFilterSpecific};
 
+use crate::handler::{NotificationTrigger, NotificationTriggerEvent};
+
 #[allow(unused)]
 #[derive(Default, Debug, Clone)]
 pub struct Job(DateTime<Utc>);
@@ -10,6 +12,7 @@ pub struct Job(DateTime<Utc>);
 pub struct WorkerState {
     pub db: hypr_db_user::UserDatabase,
     pub user_id: String,
+    pub notification_tx: std::sync::mpsc::Sender<NotificationTrigger>,
 }
 
 impl From<DateTime<Utc>> for Job {
@@ -39,32 +42,22 @@ pub async fn perform_event_notification(_job: Job, ctx: Data<WorkerState>) -> Re
         .map_err(|e| crate::Error::Db(e).as_worker_error())?;
 
     if let Some(event) = latest_event.first() {
-        tracing::info!("Found upcoming event - showing notification");
+        tracing::info!("found_upcoming_event: {}", event.name);
 
-        if let Err(e) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hypr_notification::show(
-                &hypr_notification::Notification::builder()
-                    .key(&event.id)
-                    .title(event.name.clone())
-                    .message("Meeting starting in 5 minutes")
-                    .url(format!(
-                        "hypr://hyprnote.com/notification?event_id={}",
-                        event.id
-                    ))
-                    .timeout(std::time::Duration::from_secs(10))
-                    .build(),
-            );
-        })) {
-            let panic_msg = if let Some(s) = e.downcast_ref::<&str>() {
-                s.to_string()
-            } else if let Some(s) = e.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "Unknown panic".to_string()
-            };
-            tracing::error!("Notification panic: {}", panic_msg);
-        } else {
-            tracing::info!("Notification shown");
+        let minutes_until_start = event
+            .start_date
+            .signed_duration_since(Utc::now())
+            .num_minutes();
+
+        if let Err(e) =
+            ctx.notification_tx
+                .send(NotificationTrigger::Event(NotificationTriggerEvent {
+                    event_id: event.id.clone(),
+                    event_name: event.name.clone(),
+                    minutes_until_start,
+                }))
+        {
+            tracing::error!("{}", e);
         }
     }
 

--- a/plugins/notification/src/event.rs
+++ b/plugins/notification/src/event.rs
@@ -44,6 +44,7 @@ pub async fn perform_event_notification(_job: Job, ctx: Data<WorkerState>) -> Re
         if let Err(e) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             hypr_notification::show(
                 &hypr_notification::Notification::builder()
+                    .key(&event.id)
                     .title("Meeting starting in 5 minutes")
                     .message(event.name.clone())
                     .url(format!(

--- a/plugins/notification/src/event.rs
+++ b/plugins/notification/src/event.rs
@@ -45,8 +45,8 @@ pub async fn perform_event_notification(_job: Job, ctx: Data<WorkerState>) -> Re
             hypr_notification::show(
                 &hypr_notification::Notification::builder()
                     .key(&event.id)
-                    .title("Meeting starting in 5 minutes")
-                    .message(event.name.clone())
+                    .title(event.name.clone())
+                    .message("Meeting starting in 5 minutes")
                     .url(format!(
                         "hypr://hyprnote.com/notification?event_id={}",
                         event.id

--- a/plugins/notification/src/ext.rs
+++ b/plugins/notification/src/ext.rs
@@ -38,7 +38,7 @@ impl<R: tauri::Runtime, T: tauri::Manager<R>> NotificationPluginExt<R> for T {
         store
             .get(crate::StoreKey::EventNotification)
             .map_err(Error::Store)
-            .map(|v| v.unwrap_or(true))
+            .map(|v| v.unwrap_or(false))
     }
 
     #[tracing::instrument(skip(self))]
@@ -55,7 +55,7 @@ impl<R: tauri::Runtime, T: tauri::Manager<R>> NotificationPluginExt<R> for T {
         store
             .get(crate::StoreKey::DetectNotification)
             .map_err(Error::Store)
-            .map(|v| v.unwrap_or(true))
+            .map(|v| v.unwrap_or(false))
     }
 
     #[tracing::instrument(skip(self))]
@@ -101,17 +101,17 @@ impl<R: tauri::Runtime, T: tauri::Manager<R>> NotificationPluginExt<R> for T {
 
     #[tracing::instrument(skip(self))]
     fn start_detect_notification(&self) -> Result<(), Error> {
-        let (tx, rx) = std::sync::mpsc::channel::<hypr_detect::DetectEvent>();
+        let state = self.state::<crate::SharedState>();
+        let mut guard = state.lock().unwrap();
 
-        let cb = hypr_detect::new_callback(move |event| {
-            let _ = tx.send(event); // Send event through channel
-        });
-
-        Ok(())
+        guard.detect_state.start()
     }
 
     #[tracing::instrument(skip(self))]
     fn stop_detect_notification(&self) -> Result<(), Error> {
-        Ok(())
+        let state = self.state::<crate::SharedState>();
+        let mut guard = state.lock().unwrap();
+
+        guard.detect_state.stop()
     }
 }

--- a/plugins/notification/src/handler.rs
+++ b/plugins/notification/src/handler.rs
@@ -1,0 +1,138 @@
+use std::sync::mpsc::{Receiver, Sender};
+use std::thread::JoinHandle;
+use tauri::AppHandle;
+use tauri_plugin_windows::{HyprWindow, WindowsPluginExt};
+
+#[derive(Debug, Clone)]
+pub enum NotificationTrigger {
+    Detect(NotificationTriggerDetect),
+    Event(NotificationTriggerEvent),
+}
+
+#[derive(Debug, Clone)]
+pub struct NotificationTriggerDetect {
+    pub event: hypr_detect::DetectEvent,
+}
+
+#[derive(Debug, Clone)]
+pub struct NotificationTriggerEvent {
+    pub event_id: String,
+    pub event_name: String,
+    pub minutes_until_start: i64,
+}
+
+pub struct NotificationHandler {
+    tx: Option<Sender<NotificationTrigger>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl NotificationHandler {
+    pub fn new(app_handle: AppHandle<tauri::Wry>) -> Self {
+        let (tx, rx) = std::sync::mpsc::channel::<NotificationTrigger>();
+
+        let handle = std::thread::spawn(move || {
+            Self::worker_loop(rx, app_handle);
+        });
+
+        Self {
+            tx: Some(tx),
+            handle: Some(handle),
+        }
+    }
+
+    pub fn sender(&self) -> Option<Sender<NotificationTrigger>> {
+        self.tx.clone()
+    }
+
+    fn worker_loop(rx: Receiver<NotificationTrigger>, app_handle: AppHandle<tauri::Wry>) {
+        while let Ok(trigger) = rx.recv() {
+            match trigger {
+                NotificationTrigger::Detect(t) => {
+                    Self::handle_detect_event(&app_handle, t);
+                }
+                NotificationTrigger::Event(e) => {
+                    Self::handle_calendar_event(&app_handle, e);
+                }
+            }
+        }
+    }
+
+    fn handle_detect_event(app_handle: &AppHandle<tauri::Wry>, trigger: NotificationTriggerDetect) {
+        let window_visible = app_handle
+            .window_is_visible(HyprWindow::Main)
+            .unwrap_or(false);
+
+        match trigger.event {
+            hypr_detect::DetectEvent::MicStarted => {
+                if !window_visible {
+                    hypr_notification::show(
+                        &hypr_notification::Notification::builder()
+                            .title("Meeting detected")
+                            .message("Based on your microphone activity")
+                            .url("hypr://hyprnote.com/app/new?record=true")
+                            .timeout(std::time::Duration::from_secs(60))
+                            .build(),
+                    );
+                }
+            }
+            hypr_detect::DetectEvent::MicStopped => {
+                use tauri_plugin_listener::ListenerPluginExt;
+                app_handle.pause_session();
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_calendar_event(
+        app_handle: &AppHandle<tauri::Wry>,
+        trigger: NotificationTriggerEvent,
+    ) {
+        let window_visible = app_handle
+            .window_is_visible(HyprWindow::Main)
+            .unwrap_or(false);
+
+        if !window_visible || trigger.minutes_until_start < 3 {
+            if let Err(e) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                hypr_notification::show(
+                    &hypr_notification::Notification::builder()
+                        .key(&format!(
+                            "event_{}_{}",
+                            trigger.event_id,
+                            trigger.minutes_until_start < 3
+                        ))
+                        .title(trigger.event_name.clone())
+                        .message(format!(
+                            "Meeting starting in {} minutes",
+                            if trigger.minutes_until_start < 3 {
+                                1
+                            } else {
+                                trigger.minutes_until_start
+                            }
+                        ))
+                        .url(format!(
+                            "hypr://hyprnote.com/app/new?calendar_event_id={}",
+                            trigger.event_id
+                        ))
+                        .timeout(std::time::Duration::from_secs(10))
+                        .build(),
+                );
+            })) {
+                tracing::error!("{:?}", e);
+            }
+        }
+    }
+
+    pub fn stop(&mut self) {
+        self.tx = None;
+
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for NotificationHandler {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}

--- a/plugins/notification/src/handler.rs
+++ b/plugins/notification/src/handler.rs
@@ -77,7 +77,9 @@ impl NotificationHandler {
             }
             hypr_detect::DetectEvent::MicStopped => {
                 use tauri_plugin_listener::ListenerPluginExt;
-                app_handle.pause_session();
+                tokio::spawn(async move {
+                    app_handle.pause_session();
+                });
             }
             _ => {}
         }

--- a/plugins/notification/src/lib.rs
+++ b/plugins/notification/src/lib.rs
@@ -6,6 +6,7 @@ mod detect;
 mod error;
 mod event;
 mod ext;
+mod handler;
 mod store;
 
 pub use error::*;
@@ -19,13 +20,18 @@ pub type SharedState = Mutex<State>;
 pub struct State {
     worker_handle: Option<tokio::task::JoinHandle<()>>,
     detect_state: detect::DetectState,
+    notification_handler: handler::NotificationHandler,
 }
 
 impl State {
     pub fn new(app_handle: tauri::AppHandle<tauri::Wry>) -> Self {
+        let notification_handler = handler::NotificationHandler::new(app_handle.clone());
+        let detect_state = detect::DetectState::new(&notification_handler);
+
         Self {
             worker_handle: None,
-            detect_state: detect::DetectState::new(app_handle),
+            detect_state,
+            notification_handler,
         }
     }
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a microphone-based meeting detector and reworks event notifications to start from the plugin based on user settings. Refreshes the macOS notification UI and makes both notification types opt-in by default.

- New Features
  - Meeting detector runs in the background and shows “Meeting detected” only when the main window is hidden; opens hypr://hyprnote.com/app/new?record=true; 30s timeout.
  - Event notifications use a stable notification key (event.id) for better deduping and clearer copy.
  - Settings toggles now start/stop workers and show a short “You’re all set!” preview.

- Refactors
  - Moved worker logic to plugins/notification/event.rs and introduced DetectState; plugin starts/stops workers on RunEvent::Ready using stored flags (removes app-init start).
  - Defaults for event and detect notifications are now disabled until the user opts in.
  - macOS notification polish: lighter button, larger icon, 1-line body, “Take Notes” action; added tauri-plugin-windows to check window visibility.

<!-- End of auto-generated description by cubic. -->

