### PR TITLE
Offline issue fix

### DIFF
--- a/apps/desktop/src/components/editor-area/index.tsx
+++ b/apps/desktop/src/components/editor-area/index.tsx
@@ -418,6 +418,7 @@ export function useEnhanceMutation({
       await new Promise(resolve => setTimeout(resolve, 100));
 
       const getWordsFunc = sessionId === onboardingSessionId ? dbCommands.getWordsOnboarding : dbCommands.getWords;
+
       const [{ type, connection }, config, words] = await Promise.all([
         connectorCommands.getLlmConnection(),
         dbCommands.getConfig(),

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -40,6 +40,10 @@ const queryClient = new QueryClient({
     queries: {
       // for most case, we don't want cache
       gcTime: 0,
+      networkMode: "always",
+    },
+    mutations: {
+      networkMode: "always",
     },
   },
 });


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Ensure the desktop app works offline by forcing TanStack Query to run in "always" network mode. This fixes mutations and queries pausing when there’s no internet.

- **Bug Fixes**
  - Set QueryClient defaults to networkMode: "always" for queries and mutations to prevent offline pauses in Electron.

<!-- End of auto-generated description by cubic. -->

