### PR TITLE
centralize frontend error logging and replace console.error (Refs: #1465)

### DIFF
--- a/apps/desktop/src/routes/app.new.tsx
+++ b/apps/desktop/src/routes/app.new.tsx
@@ -3,6 +3,7 @@ import { zodValidator } from "@tanstack/zod-adapter";
 import { z } from "zod";
 
 import { commands as dbCommands } from "@hypr/plugin-db";
+import { logFrontendError } from "@/logging/frontend-logger";
 
 const schema = z.object({
   record: z.boolean().optional(),
@@ -86,7 +87,7 @@ export const Route = createFileRoute("/app/new")({
         params: { id: sessionId },
       });
     } catch (error) {
-      console.error(error);
+      logFrontendError("route.new.create_session_failed", error, { calendarEventId, record });
       return redirect({ to: "/app" });
     }
   },

--- a/apps/desktop/src/routes/app.note.$id.tsx
+++ b/apps/desktop/src/routes/app.note.$id.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
+import { logFrontendError } from "@/logging/frontend-logger";
 
 import EditorArea from "@/components/editor-area";
 import { useHypr } from "@/contexts";
@@ -27,7 +28,7 @@ export const Route = createFileRoute("/app/note/$id")({
           ]);
           session = s;
         } catch (e) {
-          console.error(e);
+          logFrontendError("route.note.load_session_failed", e, { id });
         }
 
         if (!session) {
@@ -101,7 +102,7 @@ export const Route = createFileRoute("/app/note/$id")({
               }
             }
           } catch (error) {
-            console.error("Failed to sync participants:", error);
+            logFrontendError("route.note.sync_participants_failed", error, { id });
           }
         }
 
@@ -150,7 +151,7 @@ function Component() {
       queryClient.invalidateQueries({ queryKey: ["sessions"] });
     },
     onError: (error) => {
-      console.error(error);
+      logFrontendError("route.note.delete_session_failed", error, { sessionId });
     },
   });
 

--- a/apps/desktop/src/stores/search.ts
+++ b/apps/desktop/src/stores/search.ts
@@ -9,6 +9,7 @@ import {
 import { debounce } from "lodash-es";
 import type React from "react";
 import { createStore } from "zustand";
+import { logFrontendError } from "@/logging/frontend-logger";
 
 export type SearchMatch = {
   type: "session";
@@ -131,7 +132,7 @@ export const createSearchStore = (userId: string) => {
 
       setState({ matches, isSearching: false });
     } catch (error) {
-      console.error("Search error:", error);
+      logFrontendError("search.perform_failed", error, { query });
       setState({ isSearching: false });
     }
   }, 200);

--- a/apps/desktop/src/utils/tag-generation.ts
+++ b/apps/desktop/src/utils/tag-generation.ts
@@ -4,6 +4,7 @@ import { commands as connectorCommands } from "@hypr/plugin-connector";
 import { commands as dbCommands } from "@hypr/plugin-db";
 import { commands as templateCommands, type Grammar } from "@hypr/plugin-template";
 import { generateText, localProviderName, modelProvider } from "@hypr/utils/ai";
+import { logFrontendError } from "@/logging/frontend-logger";
 
 const extractHashtags = (text: string): string[] => {
   const hashtagRegex = /#(\w+)/g;
@@ -71,7 +72,7 @@ export async function generateTagsForSession(sessionId: string): Promise<string[
     const parsed = schema.safeParse(result.text);
     return parsed.success ? parsed.data : [];
   } catch (error) {
-    console.error("Tag generation failed:", error);
+    logFrontendError("tags.generate_for_session_failed", error, { sessionId });
     return [];
   }
 }
@@ -137,7 +138,7 @@ export async function autoTagGeneration(sessionId: string): Promise<string[]> {
     const parsed = schema.safeParse(result.text);
     return parsed.success ? parsed.data : [];
   } catch (error) {
-    console.error("Tag generation failed:", error);
+    logFrontendError("tags.auto_generate_failed", error, { sessionId });
     return [];
   }
 }

--- a/apps/desktop/src/utils/template-service.ts
+++ b/apps/desktop/src/utils/template-service.ts
@@ -1,4 +1,5 @@
 import type { Template } from "@hypr/plugin-db";
+import { logFrontendError } from "@/logging/frontend-logger";
 import { commands as dbCommands } from "@hypr/plugin-db";
 import { DEFAULT_TEMPLATES, isDefaultTemplate } from "./default-templates";
 
@@ -11,7 +12,7 @@ export class TemplateService {
 
       return [...DEFAULT_TEMPLATES, ...filteredDbTemplates];
     } catch (error) {
-      console.error("Failed to load database templates:", error);
+      logFrontendError("templates.load_all_failed", error);
 
       return DEFAULT_TEMPLATES;
     }
@@ -27,7 +28,7 @@ export class TemplateService {
       const dbTemplates = await dbCommands.listTemplates();
       return dbTemplates.find(t => t.id === templateId) || null;
     } catch (error) {
-      console.error("Failed to load database template:", error);
+      logFrontendError("templates.load_one_failed", error, { templateId });
       return null;
     }
   }


### PR DESCRIPTION
Centralizes frontend error logging via apps/desktop/src/logging/frontend-logger.ts, which writes to the Tauri logs directory (via @hypr/plugin-tracing).
Replaces remaining console.error usages in key desktop flows with logFrontendError for consistent, persistent logging.

Changes:
apps/desktop/src/utils/template-service.ts: use logFrontendError on template load failures
apps/desktop/src/utils/tag-generation.ts: use logFrontendError in tag generation paths
apps/desktop/src/stores/search.ts: use logFrontendError in debounced search
apps/desktop/src/routes/app.note.$id.tsx: use logFrontendError for session load and participant sync errors
apps/desktop/src/routes/app.new.tsx: use logFrontendError in session creation flow

Notes:
Related components already using the centralized logger include share-button-header, chat-view, and settings/views/mcp.
This aligns with issue request to add frontend error logs, not just backend.v