### PR TITLE
feat(netlify): Add Supabase image CDN remote path

### DIFF
--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -9,4 +9,5 @@ NODE_VERSION = "22"
 # https://docs.netlify.com/build/image-cdn/overview/#remote-path
 remote_images = [
   "https://hyprnote\\.com/.*",
+  "https://ijoptyyjrfqwaqhyxkxj\\.supabase\\.co/.*",
 ]


### PR DESCRIPTION
Extend remote images configuration to include Supabase
storage CDN path for improved image loading and hosting
support