### PR TITLE
Only send increasing download progress updates

### DIFF
--- a/plugins/local-llm/src/ext/plugin.rs
+++ b/plugins/local-llm/src/ext/plugin.rs
@@ -117,16 +117,29 @@ impl<R: Runtime, T: Manager<R>> LocalLlmPluginExt<R> for T {
         }
 
         let task = tokio::spawn(async move {
-            let callback = |progress: DownloadProgress| match progress {
-                DownloadProgress::Started => {
-                    let _ = channel.send(0);
-                }
-                DownloadProgress::Progress(downloaded, total_size) => {
-                    let percent = (downloaded as f64 / total_size as f64) * 100.0;
-                    let _ = channel.send(percent as i8);
-                }
-                DownloadProgress::Finished => {
-                    let _ = channel.send(100);
+            let last_progress = std::sync::Arc::new(std::sync::Mutex::new(0i8));
+
+            let callback = |progress: DownloadProgress| {
+                let mut last = last_progress.lock().unwrap();
+
+                match progress {
+                    DownloadProgress::Started => {
+                        *last = 0;
+                        let _ = channel.send(0);
+                    }
+                    DownloadProgress::Progress(downloaded, total_size) => {
+                        let percent = (downloaded as f64 / total_size as f64) * 100.0;
+                        let current = percent as i8;
+
+                        if current > *last {
+                            *last = current;
+                            let _ = channel.send(current);
+                        }
+                    }
+                    DownloadProgress::Finished => {
+                        *last = 100;
+                        let _ = channel.send(100);
+                    }
                 }
             };
 


### PR DESCRIPTION
Prevent redundant or regressing progress notifications by tracking the last
reported percentage and only sending updates when the current percent is
greater. This reduces noisy/channel-flooding updates during downloads and
ensures the progress stream is monotonic (0 -> ... -> 100).

Applied this logic to both local-llm and local-stt plugins:

- local-llm: wrap callback with Arc<Mutex<i8>> last_progress and only send
  when current percent > last.
- local-stt: same change for create_progress_callback, using a move
  closure with Arc<Mutex<i8>> to maintain per-callback state.