### PR TITLE
again fix bucket name

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -136,7 +136,7 @@ jobs:
       - if: ${{ inputs.channel != 'staging' && matrix.platform == 'macos' }}
         run: |
           aws s3 cp "apps/desktop/src-tauri/target/${{ matrix.target }}/release/bundle/dmg/" \
-            "s3://hyprote-build/desktop/${{ inputs.channel }}/${{ steps.version.outputs.version }}/" \
+            "s3://hyprnote-build/desktop/${{ inputs.channel }}/${{ steps.version.outputs.version }}/" \
             --recursive \
             --exclude "*" \
             --include "*.dmg" \


### PR DESCRIPTION
Fix the S3 bucket name used when uploading macOS (.dmg) release 
artifacts. The workflow previously referenced the incorrect 
"hyprote-build" bucket; this updates the path to the correct 
"hyprnote-build" bucket so builds are uploaded to the intended storage 
location.