### PR TITLE
Use tauri.conf.json version for release draft

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -167,6 +167,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+      - run: ./scripts/version.sh "./apps/desktop/src-tauri/tauri.conf.json" "${{ needs.build.outputs.version }}"
       - uses: ./.github/actions/cn_release
         with:
           cmd: publish


### PR DESCRIPTION
Ensure the cn release action uses the package version from src-tauri/tauri.conf.json when creating drafts and publishing. The change runs a script to inject the built version into the tauri.conf.json before invoking the cn_release action so the release shows the correct version (e.g. 1.0.0-nightly.1) instead of the incorrect src-tauri/Cargo.toml fallback.