### PR TITLE
Validate Tiptap doc JSON before initializing editor

### DIFF
--- a/apps/desktop/src/components/main/body/sessions/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/components/main/body/sessions/note-input/enhanced/editor.tsx
@@ -2,7 +2,7 @@ import { forwardRef, useEffect, useMemo, useState } from "react";
 
 import { type JSONContent, TiptapEditor } from "@hypr/tiptap/editor";
 import NoteEditor from "@hypr/tiptap/editor";
-import { EMPTY_TIPTAP_DOC } from "@hypr/tiptap/shared";
+import { EMPTY_TIPTAP_DOC, isValidTiptapContent } from "@hypr/tiptap/shared";
 
 import * as main from "../../../../../../store/tinybase/main";
 
@@ -19,7 +19,12 @@ export const EnhancedEditor = forwardRef<
       const value = store.getCell("enhanced_notes", enhancedNoteId, "content");
       if (value && typeof value === "string" && value.trim()) {
         try {
-          setInitialContent(JSON.parse(value));
+          const parsed = JSON.parse(value);
+          if (isValidTiptapContent(parsed)) {
+            setInitialContent(parsed);
+          } else {
+            setInitialContent(EMPTY_TIPTAP_DOC);
+          }
         } catch {
           setInitialContent(EMPTY_TIPTAP_DOC);
         }

--- a/apps/desktop/src/components/main/body/sessions/note-input/raw.tsx
+++ b/apps/desktop/src/components/main/body/sessions/note-input/raw.tsx
@@ -6,6 +6,7 @@ import NoteEditor, {
 } from "@hypr/tiptap/editor";
 import {
   EMPTY_TIPTAP_DOC,
+  isValidTiptapContent,
   type PlaceholderFunction,
 } from "@hypr/tiptap/shared";
 
@@ -25,7 +26,12 @@ export const RawEditor = forwardRef<
       const value = store.getCell("sessions", sessionId, "raw_md");
       if (value && typeof value === "string" && value.trim()) {
         try {
-          setInitialContent(JSON.parse(value));
+          const parsed = JSON.parse(value);
+          if (isValidTiptapContent(parsed)) {
+            setInitialContent(parsed);
+          } else {
+            setInitialContent(EMPTY_TIPTAP_DOC);
+          }
         } catch {
           setInitialContent(EMPTY_TIPTAP_DOC);
         }

--- a/packages/tiptap/src/editor/index.tsx
+++ b/packages/tiptap/src/editor/index.tsx
@@ -100,7 +100,9 @@ const Editor = forwardRef<{ editor: TiptapEditor | null }, EditorProps>(
       {
         extensions,
         editable,
-        content: initialContent || shared.EMPTY_TIPTAP_DOC,
+        content: shared.isValidTiptapContent(initialContent)
+          ? initialContent
+          : shared.EMPTY_TIPTAP_DOC,
         onCreate: ({ editor }) => {
           editor.view.dom.setAttribute("spellcheck", "false");
           editor.view.dom.setAttribute("autocomplete", "off");
@@ -129,7 +131,7 @@ const Editor = forwardRef<{ editor: TiptapEditor | null }, EditorProps>(
         previousContentRef.current = initialContent;
         if (setContentFromOutside) {
           const { from, to } = editor.state.selection;
-          if (initialContent) {
+          if (shared.isValidTiptapContent(initialContent)) {
             editor.commands.markNewContent();
           }
 
@@ -137,7 +139,7 @@ const Editor = forwardRef<{ editor: TiptapEditor | null }, EditorProps>(
             editor.commands.setTextSelection({ from, to });
           }
         } else if (!editor.isFocused) {
-          if (initialContent) {
+          if (shared.isValidTiptapContent(initialContent)) {
             editor.commands.setContent(initialContent, {
               parseOptions: { preserveWhitespace: "full" },
             });

--- a/packages/tiptap/src/shared/utils.ts
+++ b/packages/tiptap/src/shared/utils.ts
@@ -7,6 +7,15 @@ import { getExtensions } from "./extensions";
 
 export const EMPTY_TIPTAP_DOC: JSONContent = { type: "doc", content: [] };
 
+export function isValidTiptapContent(content: unknown): content is JSONContent {
+  if (!content || typeof content !== "object") {
+    return false;
+  }
+
+  const obj = content as Record<string, unknown>;
+  return obj.type === "doc" && Array.isArray(obj.content);
+}
+
 const turndown = new TurndownService({ headingStyle: "atx" });
 
 turndown.addRule("p", {


### PR DESCRIPTION
Prevent crashes caused by invalid or empty Tiptap JSON when navigating notes by validating parsed content before passing it to the editor. If the parsed JSON isn't a valid Tiptap `doc` with a `content` array, fall back to EMPTY_TIPTAP_DOC. This adds an isValidTiptapDoc helper and uses it in editor and raw input components to avoid RangeError from malformed or empty node content.
Validate tiptap content correctly

Fix incorrect validation function name and implementation for Tiptap JSON content.

- Rename isValidTiptapDoc to isValidTiptapContent where used so components check the correct predicate.
- Change editor initialization and content-setting logic to use isValidTiptapContent before using incoming content, falling back to EMPTY_TIPTAP_DOC when invalid.
- Simplify the validation implementation to correctly verify that the value is an object with type === "doc" and an array content, preventing empty-string or malformed values from being passed to Tiptap which caused RangeError: Invalid content for node doc.

These changes prevent invalid/empty payloads from being treated as valid Tiptap documents and avoid runtime errors in the Editor component.