### PR TITLE
Fix web typecheck command to use project tsconfig

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
     "dev": "env-cmd --silent -f ./.env -- vite dev --port 3000",
     "build": "vite build",
     "serve": "vite preview",
-    "typecheck": "pnpm -F @hypr/web build && tsc --noEmit"
+    "typecheck": "pnpm -F @hypr/web build && tsc --project tsconfig.json --noEmit"
   },
   "dependencies": {
     "@hypr/ui": "workspace:*",


### PR DESCRIPTION
Ensure TypeScript typecheck runs with the correct tsconfig by passing --project tsconfig.json to tsc. The CI typecheck was failing due to implicit-any and missing module resolution because tsc was not using the app's local tsconfig; this change makes the command explicit so pnpm -r typecheck passes in CI.