### PR TITLE
Show only version string for OTA status

### DIFF
--- a/apps/desktop/src/components/main/sidebar/profile/ota/index.tsx
+++ b/apps/desktop/src/components/main/sidebar/profile/ota/index.tsx
@@ -33,11 +33,7 @@ export function UpdateChecker() {
     return (
       <MenuItem
         icon={CheckCircle}
-        label={
-          currentVersion
-            ? `You're up to date (v${currentVersion})`
-            : "You're up to date"
-        }
+        label={currentVersion ? `v${currentVersion}` : "No updates available"}
         onClick={() => {}}
       />
     );

--- a/apps/desktop/src/components/main/sidebar/profile/shared.tsx
+++ b/apps/desktop/src/components/main/sidebar/profile/shared.tsx
@@ -24,7 +24,7 @@ export function MenuItem({
       onClick={onClick}
     >
       <Icon className={cn("h-4 w-4 flex-shrink-0", "text-black")} />
-      <span className={cn(["flex-1", "text-left", "truncate"])}>{label}</span>
+      <span className={cn(["flex-1", "text-left"])}>{label}</span>
       {badge &&
         (typeof badge === "number" ? (
           <span


### PR DESCRIPTION
Display the truncated version string (e.g. "v1.2.3") instead of the verbose "You're up to date (v...)" message so the sidebar OTA menu item is concise and avoids the previous truncated/wordy display. Also remove text truncation on shared profile labels to prevent duplicate truncation styling and ensure labels render cleanly.