### PR TITLE
Add S3 download step to desktop CD workflow

### DIFF
--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -175,6 +175,15 @@ jobs:
           channel: ${{ env.RELEASE_CHANNEL }}
           framework: tauri
           working-directory: ./apps/desktop
+      - run: |
+          aws s3 cp \
+            "s3://hyprnote-build/desktop/${{ needs.build.outputs.version }}/hyprnote.dmg" \
+            "hyprnote.dmg" \
+            --endpoint-url ${{ secrets.CLOUDFLARE_R2_ENDPOINT_URL }} \
+            --region auto
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
       - uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add an aws s3 cp step to the desktop continuous-deployment workflow to download the built hyprnote.dmg from the S3/R2 bucket into the runner. This is needed so subsequent steps (e.g., tagging or release publishing) have the generated DMG available locally. The step uses Cloudflare R2 endpoint and credentials from secrets.