### PR TITLE
Warn when audio samples are dropped

### DIFF
--- a/crates/audio/src/speaker/macos.rs
+++ b/crates/audio/src/speaker/macos.rs
@@ -260,6 +260,11 @@ where
 fn process_audio_data(ctx: &mut Ctx, data: &[f32]) {
     let pushed = ctx.producer.push_slice(data);
 
+    if pushed < data.len() {
+        let dropped = data.len() - pushed;
+        tracing::warn!(dropped, "samples_dropped");
+    }
+
     if pushed > 0 {
         let should_wake = {
             let mut waker_state = ctx.waker_state.lock().unwrap();

--- a/crates/audio/src/speaker/windows.rs
+++ b/crates/audio/src/speaker/windows.rs
@@ -143,6 +143,8 @@ impl SpeakerStream {
 
                             let len = queue.len();
                             if len > 8192 {
+                                let dropped = len - 8192;
+                                tracing::warn!(dropped, "samples_dropped");
                                 queue.drain(0..(len - 8192));
                             }
                         }


### PR DESCRIPTION
Log a tracing::warn whenever audio samples are dropped in the macOS and Windows speaker code paths so we can observe and diagnose underruns/overflow events. In macOS, warn with the number of samples that couldn't be pushed into the producer buffer. In Windows, warn when the internal queue exceeds the 8192 sample cap and we drop the excess.