### PR TITLE
Show "Create other format" only for enhanced tab

### DIFF
--- a/apps/desktop/src/components/main/body/sessions/note-input/header.tsx
+++ b/apps/desktop/src/components/main/body/sessions/note-input/header.tsx
@@ -351,10 +351,12 @@ export function Header({
               </HeaderTab>
             );
           })}
-          <CreateOtherFormatButton
-            sessionId={sessionId}
-            handleTabChange={handleTabChange}
-          />
+          {currentTab.type === "enhanced" && (
+            <CreateOtherFormatButton
+              sessionId={sessionId}
+              handleTabChange={handleTabChange}
+            />
+          )}
         </div>
         {showProgress && <TranscriptionProgress sessionId={sessionId} />}
         {showEditingControls && (


### PR DESCRIPTION
Restrict the "Create other format" button to appear only when the 
current tab is of type "enhanced". This prevents the button from showing
in other tab types and keeps the UI consistent with the enhanced-type 
functionality.