### PR TITLE
Gate GTK and GLib dependencies to Linux targets

### DIFF
--- a/crates/notification-linux/Cargo.toml
+++ b/crates/notification-linux/Cargo.toml
@@ -11,12 +11,14 @@ name = "test_notification"
 required-features = ["linux-examples"]
 
 [dependencies]
-glib = "0.20"
-gtk4 = "0.9"
 hypr-notification-interface = { workspace = true }
 once_cell = "1.20"
 open = "5.3"
 uuid = { version = "1.11", features = ["v4"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+glib = "0.20"
+gtk4 = "0.9"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 tokio = { workspace = true }


### PR DESCRIPTION
On macOS the Linux-specific GTK/GLib crates should not be compiled. Move
glib and gtk4 into the [target.'cfg(target_os = "linux")'.dependencies] 
section so they are only pulled in for Linux builds. This prevents macOS
builds from attempting to compile Linux GUI dependencies and keeps the 
crate platform-specific.