### PR TITLE
Make WebviewWindow builder mutable

### DIFF
--- a/plugins/windows/src/window/v1.rs
+++ b/plugins/windows/src/window/v1.rs
@@ -56,7 +56,7 @@ impl AppWindow {
     ) -> tauri::WebviewWindowBuilder<'a, tauri::Wry, tauri::AppHandle<tauri::Wry>> {
         use tauri::{WebviewUrl, WebviewWindow};
 
-        let builder = WebviewWindow::builder(app, self.label(), WebviewUrl::App(url.into()))
+        let mut builder = WebviewWindow::builder(app, self.label(), WebviewUrl::App(url.into()))
             .title(self.title())
             .disable_drag_drop_handler();
 


### PR DESCRIPTION
Fix a compile error caused by reassigning an immutable `builder` 
variable. The builder is now declared `mut` so subsequent modifications 
or reassignments are allowed, resolving Rust error E0384 during 
compilation of the tauri-plugin-windows crate.