### PR TITLE
fix(listener): improve error handling in session lifecycle

### DIFF
--- a/plugins/listener/src/actors/recorder.rs
+++ b/plugins/listener/src/actors/recorder.rs
@@ -165,9 +165,7 @@ impl Actor for RecorderActor {
                 &st.wav_path,
                 &temp_ogg_path,
                 VorbisEncodeSettings::default(),
-            )
-            .map_err(into_actor_err)
-            {
+            ) {
                 Ok(_) => {
                     std::fs::rename(&temp_ogg_path, &st.ogg_path)?;
                     std::fs::remove_file(&st.wav_path)?;
@@ -175,7 +173,7 @@ impl Actor for RecorderActor {
                 Err(e) => {
                     tracing::error!(error = ?e, "wav_to_ogg_failed_keeping_wav");
                     let _ = std::fs::remove_file(&temp_ogg_path);
-                    return Err(e);
+                    // Keep WAV as a fallback, but don't cause an actor failure
                 }
             }
         }


### PR DESCRIPTION
## Summary

Implements error handling improvements for the listener plugin based on code review feedback. The changes make the session lifecycle more robust by treating certain failures as non-fatal:

1. **ext.rs**: Replace `.unwrap()` on `SessionEvent::emit()` with error logging - prevents panics if Tauri fails to emit events (e.g., window closed, runtime shutting down)

2. **recorder.rs**: Don't treat WAV-to-OGG encode failures as fatal in `post_stop` - keeps the WAV file as fallback instead of triggering supervisor restarts during shutdown

3. **listener.rs**: 
   - Treat `StreamResponse` emit failures as non-fatal (log instead of propagate error)
   - Break the websocket stream loop if `send_message` to the actor fails - prevents task leaks when the actor is killed/panicked

## Review & Testing Checklist for Human

- [ ] Verify that logging errors instead of panicking on event emit failures is acceptable for your observability needs
- [ ] Confirm that keeping WAV files when OGG encoding fails (instead of restarting the recorder) is the desired fallback behavior
- [ ] Test a session start/stop cycle to ensure events are still emitted correctly in the happy path
- [ ] Consider testing with a closed window or during app shutdown to verify the non-fatal error handling works as expected

### Notes

Link to Devin run: https://app.devin.ai/sessions/b8820a375ae045bea131b4e4af47cb0e
Requested by: yujonglee (@yujonglee)

These changes address issues 2.1, 2.2, 2.3, and 2.4 from the code review.