### PR TITLE
Redesign templates page with card-based layout

### DIFF
--- a/apps/web/src/routes/_view/templates.tsx
+++ b/apps/web/src/routes/_view/templates.tsx
@@ -1,12 +1,8 @@
 import { Icon } from "@iconify-icon/react";
 import { createFileRoute } from "@tanstack/react-router";
 import { allTemplates } from "content-collections";
-import { useMemo, useState } from "react";
 
 import { cn } from "@hypr/utils";
-
-import { DownloadButton } from "@/components/download-button";
-import { SlashSeparator } from "@/components/slash-separator";
 
 export const Route = createFileRoute("/_view/templates")({
   component: Component,
@@ -30,185 +26,47 @@ export const Route = createFileRoute("/_view/templates")({
   }),
 });
 
+const gradients = [
+  "from-emerald-100 via-teal-50 to-cyan-100",
+  "from-amber-100 via-orange-50 to-yellow-100",
+  "from-violet-100 via-purple-50 to-fuchsia-100",
+  "from-sky-100 via-blue-50 to-indigo-100",
+  "from-rose-100 via-pink-50 to-red-100",
+  "from-lime-100 via-green-50 to-emerald-100",
+];
+
 function Component() {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-
-  const templatesByCategory = getTemplatesByCategory();
-  const categories = Object.keys(templatesByCategory);
-
-  const filteredTemplates = useMemo(() => {
-    let templates = allTemplates;
-
-    // Filter by category
-    if (selectedCategory) {
-      templates = templates.filter((t) => t.category === selectedCategory);
-    }
-
-    // Filter by search query
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase();
-      templates = templates.filter(
-        (t) =>
-          t.title.toLowerCase().includes(query) ||
-          t.description.toLowerCase().includes(query) ||
-          t.category.toLowerCase().includes(query),
-      );
-    }
-
-    return templates;
-  }, [searchQuery, selectedCategory]);
-
-  const filteredByCategory = useMemo(() => {
-    return filteredTemplates.reduce(
-      (acc, template) => {
-        const category = template.category;
-        if (!acc[category]) {
-          acc[category] = [];
-        }
-        acc[category].push(template);
-        return acc;
-      },
-      {} as Record<string, typeof allTemplates>,
-    );
-  }, [filteredTemplates]);
-
   return (
-    <div
-      className="bg-linear-to-b from-white via-stone-50/20 to-white min-h-screen"
-      style={{ backgroundImage: "url(/patterns/dots.svg)" }}
-    >
-      <div className="max-w-6xl mx-auto border-x border-neutral-100 bg-white">
-        {/* Hero Section */}
-        <div className="bg-linear-to-b from-stone-50/30 to-stone-100/30">
-          <section className="flex flex-col items-center text-center gap-12 py-24 px-4 laptop:px-0">
-            <div className="space-y-6 max-w-4xl">
-              <h1 className="text-4xl sm:text-5xl font-serif tracking-tight text-stone-600">
-                Meeting templates for <br className="hidden sm:block" />
-                every conversation
-              </h1>
-              <p className="text-lg sm:text-xl text-neutral-600">
-                Choose from {allTemplates.length} templates to structure your AI
-                summaries. <br className="hidden sm:block" />
-                From sprint planning to sales calls, find the perfect format.
-              </p>
-            </div>
+    <div className="min-h-screen bg-gradient-to-b from-sky-100/50 via-white to-white">
+      <div className="max-w-6xl mx-auto">
+        <div className="bg-white rounded-3xl shadow-sm border border-neutral-100 mx-4 my-8 overflow-hidden">
+          <div className="px-8 pt-10 pb-6">
+            <h1 className="text-3xl font-bold text-neutral-800">Templates</h1>
+            <p className="text-neutral-500 mt-1">
+              Browse and use meeting templates for better AI summaries.
+            </p>
+          </div>
 
-            {/* Search Bar */}
-            <div className="w-full max-w-xs">
-              <div className="relative flex items-center border-2 border-neutral-200 focus-within:border-stone-500 rounded-full overflow-hidden transition-all duration-200">
-                <input
-                  type="text"
-                  placeholder="Search templates..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="flex-1 px-4 py-2.5 text-sm outline-none bg-white text-center placeholder:text-center"
+          <div className="px-8 pb-4">
+            <h2 className="text-sm font-medium text-neutral-500">
+              Featured templates
+            </h2>
+          </div>
+
+          <div className="px-8 pb-10">
+            <div className="flex gap-4 overflow-x-auto pb-4 -mx-8 px-8 scrollbar-hide">
+              {allTemplates.map((template, index) => (
+                <TemplateCard
+                  key={template.slug}
+                  template={template}
+                  gradientIndex={index % gradients.length}
                 />
-              </div>
-            </div>
-
-            {/* Category Chips */}
-            <div className="flex flex-wrap gap-2 justify-center max-w-2xl">
-              <button
-                onClick={() => setSelectedCategory(null)}
-                className={cn([
-                  "px-3 py-1.5 rounded-full text-xs font-medium transition-colors",
-                  selectedCategory === null
-                    ? "bg-stone-600 text-white"
-                    : "bg-stone-100 text-stone-600 hover:bg-stone-200",
-                ])}
-              >
-                All
-              </button>
-              {categories.map((category) => (
-                <button
-                  key={category}
-                  onClick={() => setSelectedCategory(category)}
-                  className={cn([
-                    "px-3 py-1.5 rounded-full text-xs font-medium transition-colors",
-                    selectedCategory === category
-                      ? "bg-stone-600 text-white"
-                      : "bg-stone-100 text-stone-600 hover:bg-stone-200",
-                  ])}
-                >
-                  {category}
-                </button>
               ))}
             </div>
-          </section>
-        </div>
-
-        <SlashSeparator />
-
-        {/* Templates List */}
-        <div className="px-6 py-12 lg:py-20">
-          {/* Templates List */}
-          <section>
-            {filteredTemplates.length === 0 ? (
-              <div className="text-center py-12">
-                <Icon
-                  icon="mdi:file-search"
-                  className="text-6xl text-neutral-300 mb-4 mx-auto"
-                />
-                <p className="text-neutral-600">
-                  No templates found matching your search.
-                </p>
-              </div>
-            ) : (
-              Object.entries(filteredByCategory).map(
-                ([category, templates]) => (
-                  <div key={category} className="mb-12">
-                    <h3 className="text-xl font-serif text-stone-600 mb-6 pb-2 border-b border-neutral-200">
-                      {category}
-                    </h3>
-                    <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-                      {templates.map((template) => (
-                        <TemplateCard key={template.slug} template={template} />
-                      ))}
-                    </div>
-                  </div>
-                ),
-              )
-            )}
-          </section>
-        </div>
-
-        <SlashSeparator />
-
-        {/* CTA Section */}
-        <section className="py-16 px-6 text-center">
-          <div className="max-w-2xl mx-auto space-y-6">
-            <h2 className="text-3xl sm:text-4xl font-serif text-stone-600">
-              Ready to transform your meetings?
-            </h2>
-            <p className="text-lg text-neutral-600">
-              Download Hyprnote and start using these templates to capture
-              perfect meeting notes with AI.
-            </p>
-            <div className="flex flex-col items-center gap-4 pt-4">
-              <DownloadButton />
-              <p className="text-sm text-neutral-500">
-                Free to use. No credit card required.
-              </p>
-            </div>
           </div>
-        </section>
+        </div>
       </div>
     </div>
-  );
-}
-
-function getTemplatesByCategory() {
-  return allTemplates.reduce(
-    (acc, template) => {
-      const category = template.category;
-      if (!acc[category]) {
-        acc[category] = [];
-      }
-      acc[category].push(template);
-      return acc;
-    },
-    {} as Record<string, typeof allTemplates>,
   );
 }
 
@@ -235,42 +93,54 @@ function getIconForTemplate(title: string): string {
   return iconMap[title] || "mdi:file-document";
 }
 
-function TemplateCard({ template }: { template: (typeof allTemplates)[0] }) {
+function TemplateCard({
+  template,
+  gradientIndex,
+}: {
+  template: (typeof allTemplates)[0];
+  gradientIndex: number;
+}) {
   const icon = getIconForTemplate(template.title);
+  const gradient = gradients[gradientIndex];
 
   return (
-    <div className="group p-6 border border-neutral-200 rounded-lg bg-white hover:shadow-md hover:border-neutral-300 transition-all">
-      <div className="flex items-start gap-4 mb-4">
-        <div className="shrink-0 w-10 h-10 rounded-lg bg-stone-100 flex items-center justify-center group-hover:bg-stone-200 transition-colors">
-          <Icon icon={icon} className="text-xl text-stone-600" />
+    <div
+      className={cn([
+        "flex-shrink-0 w-80 rounded-2xl overflow-hidden",
+        "bg-gradient-to-br",
+        gradient,
+        "shadow-sm hover:shadow-md transition-shadow",
+      ])}
+    >
+      <div className="p-5 h-full flex flex-col">
+        <div className="flex-1">
+          <div className="space-y-1.5">
+            {template.sections.slice(0, 6).map((section) => (
+              <p
+                key={section.title}
+                className="text-sm text-neutral-600/80 truncate"
+              >
+                {section.title}
+              </p>
+            ))}
+            {template.sections.length > 6 && (
+              <p className="text-sm text-neutral-500/60">
+                +{template.sections.length - 6} more
+              </p>
+            )}
+          </div>
         </div>
-        <div className="flex-1 min-w-0">
-          <h3 className="font-serif text-lg text-stone-600 mb-1 group-hover:text-stone-800 transition-colors">
-            {template.title}
-          </h3>
-          <p className="text-sm text-neutral-600 line-clamp-2">
-            {template.description}
-          </p>
-        </div>
-      </div>
-      <div className="pt-4 border-t border-neutral-100">
-        <div className="text-xs font-medium text-neutral-400 uppercase tracking-wider mb-2">
-          Sections
-        </div>
-        <div className="flex flex-wrap gap-2">
-          {template.sections.slice(0, 3).map((section) => (
-            <span
-              key={section.title}
-              className="text-xs px-2 py-1 bg-stone-50 text-stone-600 rounded"
-            >
-              {section.title}
+
+        <div className="mt-6 pt-4 border-t border-white/40">
+          <div className="flex items-center gap-2">
+            <div className="w-6 h-6 rounded bg-amber-200/80 flex items-center justify-center">
+              <Icon icon={icon} className="text-sm text-amber-700" />
+            </div>
+            <span className="font-semibold text-neutral-800">
+              {template.title}
             </span>
-          ))}
-          {template.sections.length > 3 && (
-            <span className="text-xs px-2 py-1 text-neutral-500">
-              +{template.sections.length - 3} more
-            </span>
-          )}
+          </div>
+          <p className="text-sm text-neutral-500 mt-1">{template.category}</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Redesign templates page with card-based layout

## Summary
Redesigns the `/templates` page to use a card-based horizontal scroll layout with gradient backgrounds, similar to the reference screenshot provided. The new design features a cleaner look with a "Featured templates" section displaying all templates as scrollable cards.

Key changes:
- Replaced the search/filter-based layout with a horizontal scrollable card list
- Added gradient backgrounds to cards (6 rotating color schemes)
- Simplified card design showing section titles, template name with icon, and category
- Changed page background to a sky-blue gradient with a white rounded container

**Removed features:**
- Search functionality
- Category filtering
- Download CTA section at the bottom

## Local Testing
Verified locally by running `pnpm -F web dev` and navigating to `/templates`:

![Local testing screenshot](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctODQxY2U0NGNiNzFkNGRhM2EzMjg2NzZiYTBlZTJjNDUiLCJ1c2VyX2lkIjoiZ2l0aHVifDYxNTAzNzM5IiwiYnVja2V0X25hbWUiOiJkZXZpbmF0dGFjaG1lbnRzIiwiYnVja2V0X2tleSI6ImF0dGFjaG1lbnRzX3ByaXZhdGUvb3JnLTg0MWNlNDRjYjcxZDRkYTNhMzI4Njc2YmEwZWUyYzQ1LzIzOWI3ZmQyLTdlODMtNGRiMi05NGI3LTBmOWQzZGMzZjBiZiIsImlhdCI6MTc2NDE1Nzg2OCwiZXhwIjoxNzY0NzYyNjY4fQ.-m9TaYDsJ8elJP5unhdIqyvy5ISJaMxElODBvI5eQrA)

## CI Status
- All checks passing except **argos/web** which shows "2 changed — waiting for your decision"
- This is expected behavior for a visual redesign; Argos detected the visual changes and requires manual approval
- Preview deployment: https://deploy-preview-1925--hyprnote.netlify.app/templates

## Review & Testing Checklist for Human
- [ ] **Confirm feature removal is acceptable**: Search, category filtering, and download CTA were removed - verify this is intentional based on the reference screenshot
- [ ] **Verify design matches intent**: Compare the new page against the reference screenshot to ensure this is the desired look
- [ ] **Test mobile responsiveness**: Fixed-width cards (320px) may need adjustment for smaller screens
- [ ] **Approve Argos visual changes**: Review and approve the 2 visual diffs in Argos CI

**Recommended test plan:**
1. Visit the preview deployment at https://deploy-preview-1925--hyprnote.netlify.app/templates
2. Test horizontal scroll on desktop and mobile viewports
3. Verify all 17 templates render correctly with their sections and icons
4. Approve Argos changes if the visual diffs look correct

### Notes
- Link to Devin run: https://app.devin.ai/sessions/96d25035dc6e4d31b1d5f65c2ab70bbf
- Requested by: yujonglee (yujonglee.dev@gmail.com) / @yujonglee