### PR TITLE
feat(desktop): add ONBOARDING=0 env var to skip onboarding

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -140,6 +140,14 @@ pub async fn main() {
         .build(tauri::generate_context!())
         .unwrap();
 
+    // Skip onboarding if ONBOARDING=0 is set
+    if std::env::var("ONBOARDING")
+        .map(|v| v == "0")
+        .unwrap_or(false)
+    {
+        app.set_onboarding_needed(false).unwrap();
+    }
+
     {
         let app_handle = app.handle().clone();
         if app.get_onboarding_needed().unwrap_or(true) {


### PR DESCRIPTION
## Summary

Adds support for skipping onboarding via the `ONBOARDING=0` environment variable. When set, the app writes `OnboardingNeeded2=false` to the store file at startup, which persists the setting and skips the onboarding flow.

Usage: `ONBOARDING=0 pnpm -F desktop tauri dev`

## Review & Testing Checklist for Human

- [ ] Test that `ONBOARDING=0 pnpm -F desktop tauri dev` skips onboarding and shows the main window
- [ ] Verify the store file is updated correctly (check that `OnboardingNeeded2` is set to `false` in the store)
- [ ] Confirm subsequent launches without the env var still skip onboarding (since the store was updated)

### Local Testing

Verified locally on Linux - the app shows the main window directly when launched with `ONBOARDING=0`:

![Local testing screenshot](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctODQxY2U0NGNiNzFkNGRhM2EzMjg2NzZiYTBlZTJjNDUiLCJ1c2VyX2lkIjoiZ2l0aHVifDYxNTAzNzM5IiwiYnVja2V0X25hbWUiOiJkZXZpbmF0dGFjaG1lbnRzIiwiYnVja2V0X2tleSI6ImF0dGFjaG1lbnRzX3ByaXZhdGUvb3JnLTg0MWNlNDRjYjcxZDRkYTNhMzI4Njc2YmEwZWUyYzQ1L2VmZTU5MzQ5LWQ4NDEtNGNhZS05ZDE1LTI2ZDI3MjI2ZTM1YSIsImlhdCI6MTc2NDE2MDEyNywiZXhwIjoxNzY0NzY0OTI3fQ.7yIflqlU7UlVq2hLpryRzKQykkWX1NGCgSqag3geS_U)

### Notes

Requested by yujonglee (@yujonglee)
[Link to Devin run](https://app.devin.ai/sessions/36bfc2fd74b74ea897feb4ac30b57bb3)