### PR TITLE
feat: sync STT health check status in listen button

### DIFF
--- a/apps/desktop/src/components/main/body/sessions/shared.tsx
+++ b/apps/desktop/src/components/main/body/sessions/shared.tsx
@@ -75,15 +75,22 @@ export function useListenButtonState(sessionId: string) {
   const taskId = createTaskId(sessionId, "enhance");
   const { status } = useAITaskTask(taskId, "enhance");
   const generating = status === "generating";
-  const { conn: sttConnection } = useSTTConnection();
+  const { conn: sttConnection, local } = useSTTConnection();
+
+  const localServerStatus = local.data?.status ?? "unavailable";
+  const isLocalServerLoading = localServerStatus === "loading";
 
   const shouldRender = !active && !generating;
-  const isDisabled = !sttConnection || batching;
-  const warningMessage = !sttConnection
-    ? "Transcription model not available."
-    : batching
-      ? "Batch transcription in progress."
-      : "";
+  const isDisabled = !sttConnection || batching || isLocalServerLoading;
+
+  let warningMessage = "";
+  if (isLocalServerLoading) {
+    warningMessage = "Local STT server is starting up...";
+  } else if (!sttConnection) {
+    warningMessage = "Transcription model not available.";
+  } else if (batching) {
+    warningMessage = "Batch transcription in progress.";
+  }
 
   return {
     shouldRender,


### PR DESCRIPTION
## Summary

When a user selects a local STT provider/model and the server is still starting up (loading state), the listen button now shows "Local STT server is starting up..." instead of the confusing "Transcription model not available." message.

This syncs the health check behavior between the settings page (`HealthCheckForConnection` in `health.tsx`) and the listen button (`useListenButtonState` in `shared.tsx`).

**Before**: User sees "Transcription model not available" while local STT server is loading (yellow indicator in settings)
**After**: User sees "Local STT server is starting up..." which matches the settings page behavior

## Review & Testing Checklist for Human

- [ ] Test with a local STT model (e.g., QuantizedTinyEn): verify "Local STT server is starting up..." appears while loading, then button becomes enabled when ready
- [ ] Test with cloud STT model: verify no false "loading" messages appear and button works normally
- [ ] Verify the yellow health indicator in settings and the listen button tooltip are now in sync

### Notes

- Link to Devin run: https://app.devin.ai/sessions/6b29b8a19dcd4b6699b14b04ef798aca
- Requested by: yujonglee (@yujonglee)