### PR TITLE
fix: exclude extensions from release build

### DIFF
--- a/apps/desktop/src/components/main/body/extensions/registry.ts
+++ b/apps/desktop/src/components/main/body/extensions/registry.ts
@@ -4,21 +4,12 @@ import { commands, type ExtensionInfo } from "@hypr/plugin-extensions";
 
 import type { ExtensionViewProps } from "../../../../types/extensions";
 
-const bundledExtensionModules = import.meta.glob<{
-  default: ComponentType<ExtensionViewProps>;
-}>("@extensions/*/ui.tsx", { eager: true });
-
+// Bundled extensions are no longer included at build time.
+// Extensions are expected to be loaded at runtime via the extensions plugin.
 export const bundledExtensionComponents: Record<
   string,
   ComponentType<ExtensionViewProps>
 > = {};
-
-for (const path in bundledExtensionModules) {
-  const mod = bundledExtensionModules[path];
-  const parts = path.split("/");
-  const extensionId = parts[parts.length - 2];
-  bundledExtensionComponents[extensionId] = mod.default;
-}
 
 const dynamicExtensionComponents: Record<
   string,

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -21,10 +21,7 @@
     "noFallthroughCasesInSwitch": true,
 
     /* Path aliases */
-    "baseUrl": ".",
-    "paths": {
-      "@extensions/*": ["../../extensions/*"]
-    }
+    "baseUrl": "."
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -19,7 +19,6 @@ export default defineConfig(() => ({
             "@tauri-apps/plugin-updater": "/src/mocks/updater.ts",
           }
         : {}),
-      "@extensions": path.resolve(__dirname, "../../extensions"),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Fixes the release build failure caused by Rollup trying to resolve `@hypr/ui/components/ui/button` from the extensions folder. The `extensions/` folder contains example extensions that are meant to be loaded at runtime, not bundled at build time.

This PR removes:
- The `@extensions` alias from vite.config.ts
- The `@extensions/*` path mapping from tsconfig.json  
- The `import.meta.glob` that was bundling extension UI components

The `bundledExtensionComponents` export is preserved as an empty object to maintain API compatibility. Extensions should be loaded at runtime via the extensions plugin.

## Review & Testing Checklist for Human

- [ ] **Verify the release build passes** - This was the original issue; confirm the build no longer fails with the `@hypr/ui` resolution error
- [ ] **Confirm runtime extension loading is the intended architecture** - The `dynamicExtensionComponents` object exists but isn't populated yet; verify this aligns with the planned extension system
- [ ] **Check if any features depend on bundled extensions** - The hello-world extension will no longer be available unless loaded at runtime

**Test plan:** Run `pnpm -F desktop tauri build` and verify it completes without the Rollup resolution error.

### Notes

- Link to Devin run: https://app.devin.ai/sessions/bda135c8a9194e31b3026ccab5d19fbb
- Requested by: yujonglee (@yujonglee)