### PR TITLE
chore: update pnpm version to 10.23.0

### DIFF
--- a/.github/actions/pnpm_install/action.yaml
+++ b/.github/actions/pnpm_install/action.yaml
@@ -3,7 +3,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@v4
       with:
-        version: "10.21.0"
+        version: "10.23.0"
         run_install: false
 
     - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@10.21.0",
+  "packageManager": "pnpm@10.23.0",
   "devDependencies": {
     "@prettier/plugin-oxc": "^0.0.4",
     "@trivago/prettier-plugin-sort-imports": "^6.0.0",


### PR DESCRIPTION
## Summary
Updates pnpm from version 10.21.0 to 10.23.0 in both the root `package.json` and the GitHub Actions pnpm install action.

## Review & Testing Checklist for Human
- [ ] Verify CI workflows pass with the new pnpm version

### Notes
- Link to Devin run: https://app.devin.ai/sessions/f605adfd2de0463ba96d1be2f46bcf69
- Requested by: yujonglee (yujonglee.dev@gmail.com) / @yujonglee