### PR TITLE
feat(ci): use Ubuntu 22.04 container for Linux builds to improve glibc compatibility

### DIFF
--- a/.github/docker/linux-builder.Dockerfile
+++ b/.github/docker/linux-builder.Dockerfile
@@ -1,0 +1,17 @@
+# Ubuntu 22.04 base image for building Tauri AppImage with older glibc (2.35)
+# This ensures compatibility with older Linux distributions.
+# See: https://v2.tauri.app/distribute/appimage/
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y \
+      sudo \
+      git \
+      git-lfs \
+      ca-certificates \
+      curl \
+      wget \
+      xz-utils \
+    && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/desktop_cd.yaml
+++ b/.github/workflows/desktop_cd.yaml
@@ -183,6 +183,11 @@ jobs:
     permissions:
       contents: write
     runs-on: depot-ubuntu-24.04-8
+    # Use Ubuntu 22.04 container for older glibc (2.35) compatibility
+    # This ensures the AppImage works on older Linux distributions
+    # See: https://v2.tauri.app/distribute/appimage/
+    container:
+      image: ghcr.io/fastrepl/hyprnote/linux-builder:ubuntu22.04
     defaults:
       run:
         shell: bash

--- a/.github/workflows/linux_builder_image.yaml
+++ b/.github/workflows/linux_builder_image.yaml
@@ -1,0 +1,38 @@
+name: Build Linux Builder Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/docker/linux-builder.Dockerfile"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/linux-builder
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/docker/linux-builder.Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu22.04
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
## Summary

This PR addresses glibc compatibility issues for Linux AppImage builds by running the Linux build job inside an Ubuntu 22.04 Docker container instead of directly on the Ubuntu 24.04 runner.

**Problem**: Binaries built on Ubuntu 24.04 (glibc 2.39) fail on older systems with `GLIBC_2.xx not found` errors.

**Solution**: Use Ubuntu 22.04 container (glibc 2.35) for the build, which is the practical minimum for Tauri v2 with webkit2gtk-4.1.

Changes:
- Add `linux-builder.Dockerfile` based on Ubuntu 22.04 with basic build tools
- Add `linux_builder_image.yaml` workflow to build/push the image to GHCR
- Update `desktop_cd.yaml` to use `container:` directive for the `build-linux` job

## Review & Testing Checklist for Human

- [ ] **Verify Depot runner compatibility**: Confirm that `depot-ubuntu-24.04-8` runners support the `container:` job property. If not, may need to switch to `ubuntu-22.04` GitHub-hosted runners.
- [ ] **Build the Docker image first**: Before the CD workflow can work, manually trigger the `Build Linux Builder Image` workflow (or merge this PR and wait for it to run on the Dockerfile path change).
- [ ] **Test a staging release**: After the image is published, run a staging channel release to verify the full pipeline works (build, e2e tests, artifact upload).
- [ ] **Verify glibc version**: Check the resulting AppImage actually requires glibc 2.35 instead of 2.39 (can use `ldd` or test on an Ubuntu 22.04 system).

### Notes

- The existing composite actions (`install_desktop_deps`, `rust_install`, `pnpm_install`) should continue to work inside the container since it has `sudo` and `git` installed.
- Ubuntu 22.04 is the oldest distro that has `libwebkit2gtk-4.1-dev` (required by Tauri v2). Going older would require downgrading to webkit2gtk-4.0 which may not be supported.
- Reference: https://v2.tauri.app/distribute/appimage/

Requested by: @yujonglee (yujonglee.dev@gmail.com)
Link to Devin run: https://app.devin.ai/sessions/ca82a8b722d444d2a5fb1480e7d281cb