### PR TITLE
fix: add root tsconfig.json for extensions DX and consolidate ExtensionViewProps

### DIFF
--- a/apps/desktop/src/components/main/body/extensions/registry.ts
+++ b/apps/desktop/src/components/main/body/extensions/registry.ts
@@ -4,10 +4,9 @@ import type { ComponentType } from "react";
 import {
   commands,
   type ExtensionInfo,
+  type ExtensionViewProps,
   type PanelInfo,
 } from "@hypr/plugin-extensions";
-
-import type { ExtensionViewProps } from "../../../../types/extensions";
 
 export const bundledExtensionComponents: Record<
   string,

--- a/apps/desktop/src/types/extensions.d.ts
+++ b/apps/desktop/src/types/extensions.d.ts
@@ -1,6 +1,0 @@
-import type { ComponentType } from "react";
-
-export interface ExtensionViewProps {
-  extensionId: string;
-  state?: Record<string, unknown>;
-}

--- a/plugins/extensions/js/index.ts
+++ b/plugins/extensions/js/index.ts
@@ -1,1 +1,6 @@
 export * from "./bindings.gen";
+
+export interface ExtensionViewProps {
+  extensionId: string;
+  state?: Record<string, unknown>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./apps/desktop" },
+    { "path": "./extensions" },
+    { "path": "./packages/ui" }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes TypeScript IDE errors in the `extensions/` folder by adding a root `tsconfig.json` with project references. This helps VSCode recognize `extensions/tsconfig.json` as the correct config for files in that folder.

Also consolidates the `ExtensionViewProps` type into `@hypr/plugin-extensions` package and removes the redundant local type definition from the desktop app.

**Changes:**
- Add root `tsconfig.json` with project references to `apps/desktop`, `extensions`, and `packages/ui`
- Move `ExtensionViewProps` interface to `plugins/extensions/js/index.ts`
- Update `registry.ts` to import from `@hypr/plugin-extensions`
- Remove redundant `apps/desktop/src/types/extensions.d.ts`

## Review & Testing Checklist for Human

- [ ] **Verify the DX fix works**: Open `extensions/hello-world/ui.tsx` in VSCode and confirm the `react/jsx-runtime` error is gone. Run `TypeScript: Go to Project Configuration` command to verify it points to `extensions/tsconfig.json`
- [ ] **Test desktop app builds**: Run `pnpm -F desktop tauri dev` to ensure the app still works after the import change
- [ ] **Consider extension authoring**: Note that extensions themselves can't import `ExtensionViewProps` from `@hypr/plugin-extensions` since that package has Tauri dependencies - extension authors will still define this interface locally

### Notes

- The root tsconfig uses `"files": []` to prevent it from becoming a catch-all project
- This is a minimal fix focused on IDE DX; no runtime behavior changes

Link to Devin run: https://app.devin.ai/sessions/aeff7a7a730f458bbe86029a3b44b75d
Requested by: yujonglee (@yujonglee)