### PR TITLE
fix(web): toggle mobile menu and scroll to hero on CTA click

### DIFF
--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,6 +1,6 @@
 import { Link, useRouterState } from "@tanstack/react-router";
 import { ChevronDown, ChevronUp, Menu } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 
 import { getPlatformCTA, usePlatform } from "@/hooks/use-platform";
 


### PR DESCRIPTION
## Summary

Fixes two issues in the mobile header:

1. **Hamburger menu toggle**: The menu wasn't collapsing when clicked while already expanded. The button's onClick handler was only setting `isMenuOpen` to `true`, so clicking it when the menu was already open had no effect.

2. **CTA button scroll**: The "Get reminder" / "Join waitlist" CTA button wasn't scrolling to the hero section when clicked while already on `/#hero`. TanStack Router doesn't re-trigger scroll when navigating to the same hash.

**Changes:**
- Toggle menu state instead of always setting to true
- Add `aria-expanded` attribute for accessibility
- Make `aria-label` dynamic to reflect current menu state
- Add `scrollToHero()` helper function that smoothly scrolls to the hero element
- Add onClick handler to all three CTA buttons (desktop header, mobile header, mobile menu) to ensure scroll to hero

## Review & Testing Checklist for Human

- [ ] Test hamburger menu toggle: open menu, click hamburger again to close
- [ ] Test CTA scroll on home page: scroll down on `/`, click "Get reminder"/"Join waitlist" button, verify it scrolls back to hero
- [ ] Test CTA navigation from other pages: go to `/pricing`, click CTA button, verify it navigates to home AND scrolls to hero
- [ ] Test on actual mobile device (not just emulator) to verify smooth scroll behavior
- [ ] Verify clicking backdrop overlay and navigation links still close the menu

**Recommended test plan:** On mobile viewport, navigate to `/pricing`, click the CTA button in header, verify navigation to home with hero visible. Then scroll down and click CTA again to verify it scrolls back up.

### Notes

Argos visual regression check shows 2 changed screenshots (homepage and download page). After investigation, the visual differences are due to the chat widget being captured in different states (closed vs. showing "Hi, Need any help?" popup) - this is a timing variation in test execution, not related to the code changes. The page layout and content are identical. Manual approval of the new baseline is required.

Requested by: @ComputelessComputer (john@hyprnote.com)
[Link to Devin run](https://app.devin.ai/sessions/319041f0a80f44a7932464d386064836)