### PR TITLE
Add FAQ section to documentation

### DIFF
--- a/apps/web/content/docs/faq/0.general.mdx
+++ b/apps/web/content/docs/faq/0.general.mdx
@@ -1,0 +1,13 @@
+---
+title: "General"
+section: "FAQ"
+description: "General questions about Hyprnote and how it works."
+---
+
+## What is Hyprnote?
+
+Hyprnote is a desktop notetaking application that captures both your microphone and system audio. It uses local AI to transcribe conversations, generate summaries, and help you organize your notes - all while keeping your data private on your device.
+
+## How is Hyprnote different from other meeting recorders?
+
+Unlike bot-based recorders that join your meetings, Hyprnote runs locally on your computer and captures audio directly from your system. This means it works with any application, doesn't require meeting permissions, and keeps all your data private.

--- a/apps/web/content/docs/faq/1.features.mdx
+++ b/apps/web/content/docs/faq/1.features.mdx
@@ -1,0 +1,17 @@
+---
+title: "Features"
+section: "FAQ"
+description: "Questions about Hyprnote's features and capabilities."
+---
+
+## What apps does Hyprnote work with?
+
+Hyprnote works with any application on your computer - Zoom, Google Meet, Microsoft Teams, Slack, Discord, and more. It captures system audio, so it doesn't depend on specific integrations.
+
+## Can I record in-person conversations?
+
+Yes! Hyprnote captures your microphone input, so you can record in-person meetings, phone calls, or any conversation where you're using your computer's microphone.
+
+## What languages does Hyprnote support?
+
+Currently, Hyprnote supports English transcription. We're working on adding support for more languages in upcoming releases.

--- a/apps/web/content/docs/faq/2.privacy.mdx
+++ b/apps/web/content/docs/faq/2.privacy.mdx
@@ -1,0 +1,17 @@
+---
+title: "Privacy"
+section: "FAQ"
+description: "Questions about data privacy and security in Hyprnote."
+---
+
+## Where is my data stored?
+
+All your recordings and notes are stored locally on your device. Hyprnote doesn't send your audio or transcripts to external servers. Everything is processed on-device using local AI.
+
+## Is my data encrypted?
+
+Yes, all your data is encrypted at rest on your device. Your recordings, transcripts, and notes are protected with industry-standard encryption.
+
+## Can my employer see my Hyprnote recordings?
+
+No. Hyprnote stores everything locally on your device. Unless you explicitly share your notes or recordings, they remain private to you.

--- a/apps/web/content/docs/faq/3.technical.mdx
+++ b/apps/web/content/docs/faq/3.technical.mdx
@@ -1,0 +1,17 @@
+---
+title: "Technical"
+section: "FAQ"
+description: "Technical requirements and specifications for Hyprnote."
+---
+
+## What are the system requirements?
+
+Hyprnote requires macOS 12.0 or later with Apple Silicon (M1/M2/M3) or Intel processor. We recommend at least 8GB of RAM for optimal performance with local AI features.
+
+## How much storage space does Hyprnote need?
+
+The app itself is about 200MB. Recording storage depends on your usage - a 1-hour meeting uses approximately 50-100MB. We recommend having at least 5GB of free space.
+
+## Does Hyprnote work offline?
+
+Yes! Since Hyprnote uses local AI, it works completely offline. You don't need an internet connection to record, transcribe, or generate summaries.

--- a/apps/web/content/docs/faq/4.pricing.mdx
+++ b/apps/web/content/docs/faq/4.pricing.mdx
@@ -1,0 +1,13 @@
+---
+title: "Pricing"
+section: "FAQ"
+description: "Questions about Hyprnote pricing and subscription plans."
+---
+
+## Is Hyprnote free?
+
+Hyprnote offers a free tier with core features. Pro features like unlimited recording time, advanced templates, and priority support are available through our paid plans.
+
+## Can I try Pro features before subscribing?
+
+Yes! New users get a 14-day free trial of Hyprnote Pro to try all features before committing to a subscription.

--- a/apps/web/content/docs/faq/5.support.mdx
+++ b/apps/web/content/docs/faq/5.support.mdx
@@ -1,0 +1,13 @@
+---
+title: "Support"
+section: "FAQ"
+description: "Questions about getting help and support for Hyprnote."
+---
+
+## How do I get help if something isn't working?
+
+You can reach our support team at support@hyprnote.com or join our Discord community for quick help. We also have comprehensive documentation at docs.hyprnote.com.
+
+## Do you offer refunds?
+
+Yes, we offer a 30-day money-back guarantee. If you're not satisfied with Hyprnote Pro, contact us within 30 days of purchase for a full refund.


### PR DESCRIPTION
## Summary

Migrates FAQ content from the standalone `/faq` page (`apps/web/src/routes/_view/faq.tsx`) to the documentation site as a new "FAQ" section. The content is organized into 6 MDX files by category: General, Features, Privacy, Technical, Pricing, and Support.

All 15 Q&As from the original FAQ page have been transferred to the new docs structure, following the existing docs conventions (numbered files, frontmatter with title/section/description).

## Review & Testing Checklist for Human

- [ ] Verify the FAQ section appears correctly in the docs navigation sidebar
- [ ] Check that all FAQ pages render properly at their respective URLs (e.g., `/docs/faq/general`, `/docs/faq/features`, etc.)
- [ ] Confirm the content matches the original FAQ page - no Q&As were missed or altered
- [ ] Decide whether to remove or redirect the original `/faq` route to avoid duplicate content

**Test plan**: Run `pnpm -F web dev` and navigate to the docs section to verify the FAQ pages appear and render correctly.

### Notes

- The original `/faq` route and component were not removed - you may want to handle that separately (redirect or delete)
- Link to Devin run: https://app.devin.ai/sessions/97b9a22d8e6d444b9670c4c8b17456ff
- Requested by: john@hyprnote.com (@ComputelessComputer)