### PR TITLE
fix: match mobile search button style to desktop version

### DIFF
--- a/apps/web/src/routes/_view/product/ai-notetaking.tsx
+++ b/apps/web/src/routes/_view/product/ai-notetaking.tsx
@@ -1072,7 +1072,7 @@ function SearchSection() {
             <Link
               to="/product/mini-apps"
               hash="advanced-search"
-              className="sm:hidden w-full px-4 h-10 inline-flex items-center justify-center gap-2 text-sm bg-linear-to-t from-neutral-200 to-neutral-100 text-neutral-900 rounded-full shadow-sm hover:shadow-md active:scale-[98%] transition-all"
+              className="sm:hidden w-full px-4 h-10 inline-flex items-center justify-center gap-2 text-sm bg-linear-to-t from-neutral-200 to-neutral-100 text-neutral-900 rounded-full shadow-sm hover:shadow-md hover:scale-[102%] active:scale-[98%] transition-all"
             >
               Go to Advanced Search
               <ArrowRightIcon className="size-4" />


### PR DESCRIPTION
## Summary

Adds the missing `hover:scale-[102%]` class to the mobile "Go to Advanced Search" button in the SearchSection of the ai-notetaking page, making it consistent with the desktop version's hover behavior.

**Before:** Mobile button only had `active:scale-[98%]` (press effect) but no hover scale effect
**After:** Mobile button now has both `hover:scale-[102%]` and `active:scale-[98%]`, matching desktop

## Review & Testing Checklist for Human

- [ ] View the ai-notetaking page on mobile viewport (< 640px) and verify the "Go to Advanced Search" button scales up slightly on hover
- [ ] Confirm the hover effect matches the desktop button behavior

### Notes

- Link to Devin run: https://app.devin.ai/sessions/b6a5a90cfd1f48bca67e3c8d86ba2807
- Requested by: john@hyprnote.com (@ComputelessComputer)