### PR TITLE
Clarify early beta features in Hyprnote Pro on join-waitlist page

### DIFF
--- a/apps/web/src/routes/join-waitlist.tsx
+++ b/apps/web/src/routes/join-waitlist.tsx
@@ -59,12 +59,12 @@ function Header() {
         Quick chat with founders
       </h1>
       <p className="text-lg text-stone-600 mb-8 text-center">
-        Hop on a 20 minute chat and get early access to{" "}
+        Hop on a 20 minute chat and get early access to beta features in{" "}
         <Link
           to="/pricing"
           className="underline decoration-dotted hover:text-stone-800"
         >
-          Pro
+          Hyprnote Pro
         </Link>
       </p>
     </>


### PR DESCRIPTION
# Clarify early beta features in Hyprnote Pro on join-waitlist page

## Summary
Updates the join-waitlist page copy to clarify that users get access to early beta features in Hyprnote Pro. The text now reads "get early access to beta features in Hyprnote Pro" instead of "get early access to Pro".

## Review & Testing Checklist for Human
- [ ] Verify the updated copy matches the intended messaging ("early access to beta features in Hyprnote Pro")
- [ ] Check the /join-waitlist page visually to ensure the text flows well and looks correct

### Notes
- Link to Devin run: https://app.devin.ai/sessions/031a4e421c4042c5856809d452778e07
- Requested by: john@hyprnote.com (@ComputelessComputer)