### PR TITLE
feat: show Homebrew section only for macOS users

### DIFF
--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -1,7 +1,7 @@
 import { Icon } from "@iconify-icon/react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Check, Copy } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { cn } from "@hypr/utils";
 
@@ -13,6 +13,12 @@ export const Route = createFileRoute("/_view/download/")({
 });
 
 function Component() {
+  const [isMac, setIsMac] = useState(false);
+
+  useEffect(() => {
+    setIsMac(navigator.userAgent.toLowerCase().includes("mac"));
+  }, []);
+
   return (
     <div
       className="bg-linear-to-b from-white via-blue-50/20 to-white min-h-screen"
@@ -78,14 +84,16 @@ function Component() {
               </div>
             </div>
 
-            <div className="mb-16">
-              <h2 className="text-2xl font-serif tracking-tight mb-6 text-center">
-                Homebrew
-              </h2>
-              <div className="max-w-2xl mx-auto">
-                <HomebrewCard />
+            {isMac && (
+              <div className="mb-16">
+                <h2 className="text-2xl font-serif tracking-tight mb-6 text-center">
+                  Homebrew
+                </h2>
+                <div className="max-w-2xl mx-auto">
+                  <HomebrewCard />
+                </div>
               </div>
-            </div>
+            )}
 
             <div>
               <h2 className="text-2xl font-serif tracking-tight mb-6 text-center">


### PR DESCRIPTION
## Summary

Conditionally renders the Homebrew installation section on the download page only for macOS users. The detection uses `navigator.userAgent` to check for "mac" in the user agent string.

The Homebrew section will now be hidden for Windows, Linux, and other non-Mac platforms since Homebrew is a macOS-specific package manager.

## Review & Testing Checklist for Human

- [ ] **Verify on macOS browser**: Visit `/download` page and confirm the Homebrew section appears
- [ ] **Verify on non-Mac browser**: Visit `/download` page (or use browser dev tools to spoof a Windows/Linux user agent) and confirm the Homebrew section is hidden
- [ ] **Check for layout shift**: Since `isMac` initializes to `false` and updates after mount, there may be a brief flash where the section appears after page load on Mac - verify this is acceptable

### Notes

The initial state is `false` to handle SSR (where `navigator` is unavailable), which means the Homebrew section won't be in the initial server-rendered HTML and will appear after hydration on Mac clients.

**Link to Devin run**: https://app.devin.ai/sessions/d63f9cd90ef74f1ab2bc5d00c3dd57ae
**Requested by**: john@hyprnote.com (@ComputelessComputer)