### PR TITLE
Update download button to use white-ish gradient style from pricing.tsx

### DIFF
--- a/apps/web/src/routes/_view/opensource.tsx
+++ b/apps/web/src/routes/_view/opensource.tsx
@@ -101,8 +101,8 @@ function HeroSection() {
               href="https://hyprnote.com/download"
               className={cn([
                 "inline-flex items-center justify-center px-8 py-3 text-base font-medium rounded-full",
-                "border border-neutral-300 text-stone-600",
-                "hover:bg-stone-50 transition-colors",
+                "bg-linear-to-t from-neutral-200 to-neutral-100 text-neutral-900 shadow-sm",
+                "hover:shadow-md hover:scale-[102%] active:scale-[98%] transition-all",
               ])}
             >
               Download for free


### PR DESCRIPTION
# Update download button to use white-ish gradient style on opensource page

## Summary
Updates the "Download for free" button in the HeroSection of the opensource page to use the white-ish gradient button style from pricing.tsx, replacing the previous bordered/outline style.

**Before:** `border border-neutral-300 text-stone-600` with `hover:bg-stone-50`
**After:** `bg-linear-to-t from-neutral-200 to-neutral-100 text-neutral-900 shadow-sm` with scale hover effects

## Review & Testing Checklist for Human
- [ ] Verify the button styling visually matches the "Download for free" button in the Free plan card on `/pricing`
- [ ] Confirm if only the HeroSection download button should be updated, or if the CTASection download button (line 467-476) should also use this style
- [ ] Test hover and active states on the button

### Notes
- Only the HeroSection download button was updated based on the request mentioning "the download button" (singular)
- The CTASection also has a "Download for free" button but it uses a dark gradient (`from-stone-600 to-stone-500`) - left unchanged

Link to Devin run: https://app.devin.ai/sessions/4e967d586c6a4bd2902426771ac50ae7
Requested by: john@hyprnote.com (@ComputelessComputer)