### PR TITLE
Add free forever section between hero and cards on landing page

### DIFF
--- a/apps/web/src/routes/_view/index.tsx
+++ b/apps/web/src/routes/_view/index.tsx
@@ -149,6 +149,8 @@ function Component() {
           heroInputRef={heroInputRef}
         />
         <SlashSeparator />
+        <FreeForeverSection />
+        <SlashSeparator />
         <HowItWorksSection />
         <SlashSeparator />
         <CoolStuffSection />
@@ -456,6 +458,22 @@ function ValuePropsGrid() {
         </p>
       </div>
     </div>
+  );
+}
+
+function FreeForeverSection() {
+  return (
+    <section className="py-16 px-6">
+      <div className="max-w-3xl mx-auto text-center">
+        <h2 className="text-2xl sm:text-3xl font-serif text-stone-600 mb-4">
+          Free forever
+        </h2>
+        <p className="text-base sm:text-lg text-neutral-600 leading-relaxed">
+          Hyprnote can theoretically be used for free forever. All core features
+          run locally on your device with no subscription required.
+        </p>
+      </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary

Adds a new "Free forever" section to the landing page between the hero section and the "How it works" section. The section highlights that Hyprnote can theoretically be used for free forever since all core features run locally.

## Review & Testing Checklist for Human

- [ ] Verify the section placement is correct - I interpreted "cards" as the HowItWorksSection. Confirm this is the intended location
- [ ] Review the copy: "Hyprnote can theoretically be used for free forever. All core features run locally on your device with no subscription required." - ensure this messaging is accurate
- [ ] Check visual appearance on desktop and mobile to ensure styling matches the rest of the landing page

### Notes

- Link to Devin run: https://app.devin.ai/sessions/00e4fa76e9ec41bd90f92f3e9047dd35
- Requested by: john@hyprnote.com (@ComputelessComputer)