### PR TITLE
fix(bot): add explicit process command to fly.toml

### DIFF
--- a/apps/bot/fly.toml
+++ b/apps/bot/fly.toml
@@ -9,6 +9,9 @@ primary_region = 'sjc'
 [build]
 dockerfile = "Dockerfile"
 
+[processes]
+app = "node ./lib/server.js"
+
 [deploy]
 strategy = 'bluegreen'
 


### PR DESCRIPTION
## Summary

Fixes the bot deployment failing with `App ID is missing` error on fly.io. The Fly app was running the Probot CLI (`probot run ./lib/index.js`) instead of the programmatic server (`node ./lib/server.js`) because the Dockerfile CMD was being overridden by Fly's stored configuration.

Adding an explicit `[processes]` section ensures Fly uses the correct entrypoint that reads `GITHUB_BOT_*` environment variables instead of the CLI's expected `APP_ID`.

## Review & Testing Checklist for Human

- [ ] Verify Fly secrets include `GITHUB_BOT_APP_ID`, `GITHUB_BOT_PRIVATE_KEY`, and `GITHUB_BOT_WEBHOOK_SECRET` (not `APP_ID`, `PRIVATE_KEY`, `WEBHOOK_SECRET`)
- [ ] After merging, redeploy to fly.io and check logs to confirm the bot starts with `node ./lib/server.js`
- [ ] Test the `/health` endpoint responds with "OK"

### Notes

- Link to Devin run: https://app.devin.ai/sessions/2a3a229a53154e3e91b1d82b35bf93b9
- Requested by: yujonglee (yujonglee.dev@gmail.com) / @yujonglee