### PR TITLE
Add Flatpak packaging configuration for Flathub distribution

### DIFF
--- a/apps/desktop/flatpak/com.hyprnote.Hyprnote.desktop
+++ b/apps/desktop/flatpak/com.hyprnote.Hyprnote.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Name=Hyprnote
+GenericName=AI Meeting Notes
+Comment=The AI notepad for private meetings
+Exec=hyprnote %U
+Icon=com.hyprnote.Hyprnote
+Terminal=false
+Type=Application
+Categories=Office;AudioVideo;Recorder;
+Keywords=notes;meeting;transcription;ai;audio;recording;
+StartupNotify=true
+StartupWMClass=hyprnote
+MimeType=x-scheme-handler/hypr;

--- a/apps/desktop/flatpak/com.hyprnote.Hyprnote.metainfo.xml
+++ b/apps/desktop/flatpak/com.hyprnote.Hyprnote.metainfo.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.hyprnote.Hyprnote</id>
+
+  <name>Hyprnote</name>
+  <summary>The AI notepad for private meetings</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+
+  <description>
+    <p>
+      Hyprnote is an AI notetaking app specifically designed to take meeting notes.
+      With Hyprnote, you can transcribe all kinds of meetings whether it be online or offline.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Listens to your meetings so you can only jot down important stuff</li>
+      <li>No bots joining your meetings - Hyprnote listens directly to sounds coming in and out of your computer</li>
+      <li>Crafts perfect summaries based on your memos, right after the meeting is over</li>
+      <li>Run completely offline by using LM Studio or Ollama</li>
+      <li>Bring your own LLM - use local models via Ollama or third-party APIs like Gemini, Claude, or Azure-hosted GPT</li>
+      <li>Note templates - choose from predefined templates or create your own</li>
+      <li>AI Chat - ask follow-ups right inside your notes</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">com.hyprnote.Hyprnote.desktop</launchable>
+
+  <url type="homepage">https://hyprnote.com</url>
+  <url type="bugtracker">https://github.com/fastrepl/hyprnote/issues</url>
+  <url type="vcs-browser">https://github.com/fastrepl/hyprnote</url>
+  <url type="contribute">https://github.com/fastrepl/hyprnote/blob/main/CONTRIBUTING.md</url>
+
+  <developer id="com.hyprnote">
+    <name>Fastrepl</name>
+  </developer>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#f5f5f5</color>
+    <color type="primary" scheme_preference="dark">#1a1a1a</color>
+  </branding>
+
+  <content_rating type="oars-1.1" />
+
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+  </supports>
+
+  <requires>
+    <display_length compare="ge">768</display_length>
+  </requires>
+
+  <categories>
+    <category>Office</category>
+    <category>AudioVideo</category>
+    <category>Recorder</category>
+  </categories>
+
+  <keywords>
+    <keyword>notes</keyword>
+    <keyword>meeting</keyword>
+    <keyword>transcription</keyword>
+    <keyword>ai</keyword>
+    <keyword>audio</keyword>
+    <keyword>recording</keyword>
+    <keyword>speech-to-text</keyword>
+  </keywords>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>Notepad view for taking notes during meetings</caption>
+      <image>https://github.com/user-attachments/assets/268ab859-a194-484b-b895-bc640df18dd4</image>
+    </screenshot>
+    <screenshot>
+      <caption>Real-time transcript while you stay engaged in the conversation</caption>
+      <image>https://github.com/user-attachments/assets/e63ce73f-1a5f-49ce-a14d-dd8ba161e5bc</image>
+    </screenshot>
+    <screenshot>
+      <caption>Bring your own LLM - use local models or third-party APIs</caption>
+      <image>https://github.com/user-attachments/assets/a6552c99-acbc-4d47-9d21-7f1925989344</image>
+    </screenshot>
+    <screenshot>
+      <caption>AI Chat - ask follow-ups right inside your notes</caption>
+      <image>https://github.com/user-attachments/assets/52b7dc14-906f-445f-91f9-b0089d40a495</image>
+    </screenshot>
+  </screenshots>
+
+  <releases>
+    <release version="0.1.0" date="2025-01-01">
+      <description>
+        <p>Initial Flatpak release</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/apps/desktop/flatpak/com.hyprnote.Hyprnote.yml
+++ b/apps/desktop/flatpak/com.hyprnote.Hyprnote.yml
@@ -1,0 +1,108 @@
+# Flatpak manifest for Hyprnote
+# https://docs.flathub.org/docs/for-app-authors/requirements
+#
+# To generate vendored dependencies:
+#   flatpak-node-generator pnpm -o flatpak/pnpm-sources.json pnpm-lock.yaml
+#   flatpak-cargo-generator.py -d Cargo.lock -o flatpak/cargo-sources.json
+#
+# To build locally:
+#   flatpak-builder --user --install --force-clean flatpak-build-dir flatpak/com.hyprnote.Hyprnote.yml
+#
+# To run:
+#   flatpak run com.hyprnote.Hyprnote
+
+id: com.hyprnote.Hyprnote
+
+runtime: org.gnome.Platform
+runtime-version: "47"
+sdk: org.gnome.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+  - org.freedesktop.Sdk.Extension.node22
+
+command: hyprnote
+
+finish-args:
+  # Display - Wayland and X11 fallback
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+
+  # Audio - for microphone and speaker capture
+  - --socket=pulseaudio
+
+  # Network - for cloud AI services and calendar sync
+  - --share=network
+
+  # Notifications
+  - --talk-name=org.freedesktop.Notifications
+
+  # System tray (StatusNotifier)
+  - --talk-name=org.kde.StatusNotifierWatcher
+
+  # Single instance D-Bus
+  - --own-name=com.hyprnote.Hyprnote
+
+  # Filesystem access for user documents and notes
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+
+  # Environment variable to detect Flatpak
+  - --env=FLATPAK=1
+
+build-options:
+  append-path: /usr/lib/sdk/node22/bin:/usr/lib/sdk/rust-stable/bin
+  env:
+    CARGO_HOME: /run/build/hyprnote/cargo
+    npm_config_nodedir: /usr/lib/sdk/node22
+
+modules:
+  - name: hyprnote
+    buildsystem: simple
+
+    sources:
+      # The application source code
+      # For Flathub submission, this should be a git source with a specific tag/commit
+      - type: dir
+        path: ../..
+
+      # Vendored pnpm dependencies
+      # Generate with: flatpak-node-generator pnpm -o flatpak/pnpm-sources.json pnpm-lock.yaml
+      - pnpm-sources.json
+
+      # Vendored Cargo dependencies
+      # Generate with: flatpak-cargo-generator.py -d Cargo.lock -o flatpak/cargo-sources.json
+      - cargo-sources.json
+
+    build-options:
+      env:
+        XDG_CACHE_HOME: /run/build/hyprnote/cache
+        npm_config_cache: /run/build/hyprnote/npm-cache
+        npm_config_offline: "true"
+
+    build-commands:
+      # Install pnpm dependencies offline
+      - pnpm install --offline --frozen-lockfile
+
+      # Build UI components
+      - pnpm -F ui build
+
+      # Build the Tauri app without bundling (Flatpak handles packaging)
+      - pnpm -F desktop tauri build --no-bundle --target x86_64-unknown-linux-gnu --config src-tauri/tauri.conf.flatpak.json
+
+      # Install the binary
+      - install -Dm755 apps/desktop/src-tauri/target/x86_64-unknown-linux-gnu/release/hyprnote /app/bin/hyprnote
+
+      # Install desktop file
+      - install -Dm644 apps/desktop/flatpak/com.hyprnote.Hyprnote.desktop /app/share/applications/com.hyprnote.Hyprnote.desktop
+
+      # Install metainfo
+      - install -Dm644 apps/desktop/flatpak/com.hyprnote.Hyprnote.metainfo.xml /app/share/metainfo/com.hyprnote.Hyprnote.metainfo.xml
+
+      # Install icons
+      - install -Dm644 apps/desktop/src-tauri/icons/stable/32x32.png /app/share/icons/hicolor/32x32/apps/com.hyprnote.Hyprnote.png
+      - install -Dm644 apps/desktop/src-tauri/icons/stable/64x64.png /app/share/icons/hicolor/64x64/apps/com.hyprnote.Hyprnote.png
+      - install -Dm644 apps/desktop/src-tauri/icons/stable/128x128.png /app/share/icons/hicolor/128x128/apps/com.hyprnote.Hyprnote.png
+      - install -Dm644 apps/desktop/src-tauri/icons/stable/128x128@2x.png /app/share/icons/hicolor/256x256/apps/com.hyprnote.Hyprnote.png
+      - install -Dm644 apps/desktop/src-tauri/icons/stable/icon.png /app/share/icons/hicolor/512x512/apps/com.hyprnote.Hyprnote.png

--- a/apps/desktop/src-tauri/tauri.conf.flatpak.json
+++ b/apps/desktop/src-tauri/tauri.conf.flatpak.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Hyprnote",
+  "mainBinaryName": "hyprnote",
+  "identifier": "com.hyprnote.Hyprnote",
+  "plugins": {
+    "updater": {
+      "active": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds the foundational configuration files needed to package Hyprnote as a Flatpak for distribution on Flathub. It follows the "build from source" strategy (Strategy B from the research), which is the preferred approach for Flathub submissions.

**Files added:**
- `apps/desktop/flatpak/com.hyprnote.Hyprnote.yml` - Flatpak manifest using GNOME Platform 47 with Rust and Node SDK extensions
- `apps/desktop/flatpak/com.hyprnote.Hyprnote.desktop` - Desktop entry file for application menu integration
- `apps/desktop/flatpak/com.hyprnote.Hyprnote.metainfo.xml` - AppStream metadata for Flathub listing
- `apps/desktop/src-tauri/tauri.conf.flatpak.json` - Tauri config with updater disabled (Flathub handles updates)
- `apps/desktop/FLATPAK.md` - Documentation for building and Flathub submission process

## Review & Testing Checklist for Human

- [ ] **Generate vendored dependencies and test the build** - The manifest references `pnpm-sources.json` and `cargo-sources.json` which must be generated before building. Follow FLATPAK.md instructions and run `flatpak-builder` to verify the build works end-to-end.
- [ ] **Verify binary name** - The flatpak config sets `mainBinaryName: "hyprnote"` (lowercase). Confirm this matches what Tauri produces with the flatpak config.
- [ ] **Review Flatpak permissions** - Check `finish-args` in the manifest for appropriate sandbox permissions (audio, filesystem, network, D-Bus names).
- [ ] **Validate screenshot URLs** - The metainfo.xml uses GitHub user-attachments URLs. Flathub may require stable hosted screenshots.
- [ ] **Confirm app ID** - Using `com.hyprnote.Hyprnote` which differs from existing identifiers. Verify this is the desired Flathub app ID.

**Recommended test plan:**
1. Install flatpak-builder-tools and generate the vendored dependency files
2. Run `flatpak-builder --user --install --force-clean flatpak-build-dir apps/desktop/flatpak/com.hyprnote.Hyprnote.yml`
3. Run `flatpak run com.hyprnote.Hyprnote` and verify the app launches correctly
4. Test audio capture, notifications, and file access work within the sandbox

### Notes

This PR provides the configuration scaffolding but **does not include the generated vendored dependency files** (pnpm-sources.json, cargo-sources.json). These must be generated before the Flatpak can be built, as documented in FLATPAK.md.

Link to Devin run: https://app.devin.ai/sessions/7162f1aad45343bea7293698fca0d061
Requested by: yujonglee (@yujonglee)