### PR TITLE
fix: install desktop-file-utils for desktop-e2e-linux CI

### DIFF
--- a/scripts/setup-desktop-e2e.sh
+++ b/scripts/setup-desktop-e2e.sh
@@ -30,6 +30,15 @@ else
   echo "webkit2gtk-driver package already installed"
 fi
 
+# Install desktop-file-utils for update-desktop-database (required by tauri-plugin-deep-link)
+if ! command -v update-desktop-database >/dev/null 2>&1; then
+  echo "Installing desktop-file-utils..."
+  sudo apt-get update
+  sudo apt-get install -y desktop-file-utils
+else
+  echo "update-desktop-database already available in PATH"
+fi
+
 # Ensure WebKitWebDriver is actually callable from PATH
 if ! command -v WebKitWebDriver >/dev/null 2>&1; then
   echo "WebKitWebDriver not on PATH, trying to locate binary from webkit2gtk-driver package..."


### PR DESCRIPTION
## Summary

Fixes the desktop-e2e-linux CI failure by installing `desktop-file-utils` package in the E2E setup script. The `tauri-plugin-deep-link` plugin requires `update-desktop-database` command on Linux, which was missing in the CI environment, causing the app to panic during setup.

The error was:
```
ERROR tauri_plugin_deep_link::error: Failed to run OS command `update-desktop-database`: No such file or directory (os error 2)
thread 'main' panicked at: Failed to setup app: error encountered during setup hook: No such file or directory (os error 2)
```

## Review & Testing Checklist for Human

- [ ] Trigger the desktop CD workflow with `staging` channel to verify the E2E tests pass
- [ ] Confirm `desktop-file-utils` is the correct package for Ubuntu (it is standard and should be available)

### Notes

The fix follows the same pattern already used for `webkit2gtk-driver` installation in the same script.

Link to Devin run: https://app.devin.ai/sessions/8fe759f7db05415da02ed01e58bc07a3
Requested by: yujonglee (@yujonglee)