### PR TITLE
feat(web): update meta titles for templates, docs, blog, and changelog pages

### DIFF
--- a/apps/web/src/routes/_view/blog/$slug.tsx
+++ b/apps/web/src/routes/_view/blog/$slug.tsx
@@ -57,15 +57,15 @@ export const Route = createFileRoute("/_view/blog/$slug")({
 
     return {
       meta: [
-        { title: article.title },
+        { title: `${article.title} - Hyprnote Blog` },
         { name: "description", content: article.meta_description },
-        { property: "og:title", content: article.title },
+        { property: "og:title", content: `${article.title} - Hyprnote Blog` },
         { property: "og:description", content: article.meta_description },
         { property: "og:type", content: "article" },
         { property: "og:url", content: url },
         { property: "og:image", content: ogImage },
         { name: "twitter:card", content: "summary_large_image" },
-        { name: "twitter:title", content: article.title },
+        { name: "twitter:title", content: `${article.title} - Hyprnote Blog` },
         { name: "twitter:description", content: article.meta_description },
         { name: "twitter:image", content: ogImage },
         ...(article.author

--- a/apps/web/src/routes/_view/blog/index.tsx
+++ b/apps/web/src/routes/_view/blog/index.tsx
@@ -36,12 +36,12 @@ export const Route = createFileRoute("/_view/blog/")({
   },
   head: () => ({
     meta: [
-      { title: "Blog - Hyprnote" },
+      { title: "Blog - Hyprnote Blog" },
       {
         name: "description",
         content: "Insights, updates, and stories from the Hyprnote team",
       },
-      { property: "og:title", content: "Blog - Hyprnote" },
+      { property: "og:title", content: "Blog - Hyprnote Blog" },
       {
         property: "og:description",
         content: "Insights, updates, and stories from the Hyprnote team",

--- a/apps/web/src/routes/_view/changelog/$slug.tsx
+++ b/apps/web/src/routes/_view/changelog/$slug.tsx
@@ -66,7 +66,7 @@ export const Route = createFileRoute("/_view/changelog/$slug")({
     const currentVersion = semver.parse(changelog.version);
     const isNightly = currentVersion && currentVersion.prerelease.length > 0;
 
-    const title = `Hyprnote Changelog - Version ${changelog.version}`;
+    const title = `Version ${changelog.version} - Hyprnote Changelog`;
     const description = `Explore what's new in Hyprnote version ${changelog.version}${isNightly ? " (Nightly)" : ""}.`;
     const url = `https://hyprnote.com/changelog/${changelog.slug}`;
     const ogImageUrl = `https://hyprnote.com/og?type=changelog&version=${encodeURIComponent(changelog.version)}`;

--- a/apps/web/src/routes/_view/changelog/index.tsx
+++ b/apps/web/src/routes/_view/changelog/index.tsx
@@ -11,6 +11,22 @@ export const Route = createFileRoute("/_view/changelog/")({
     const changelogs = getChangelogList();
     return { changelogs };
   },
+  head: () => ({
+    meta: [
+      { title: "Changelog - Hyprnote Changelog" },
+      {
+        name: "description",
+        content: "Track every update, improvement, and fix to Hyprnote",
+      },
+      { property: "og:title", content: "Changelog - Hyprnote Changelog" },
+      {
+        property: "og:description",
+        content: "Track every update, improvement, and fix to Hyprnote",
+      },
+      { property: "og:type", content: "website" },
+      { property: "og:url", content: "https://hyprnote.com/changelog" },
+    ],
+  }),
 });
 
 type SemanticVersionGroup = {

--- a/apps/web/src/routes/_view/docs/$.tsx
+++ b/apps/web/src/routes/_view/docs/$.tsx
@@ -50,15 +50,21 @@ export const Route = createFileRoute("/_view/docs/$")({
 
     return {
       meta: [
-        { title: doc.title },
+        { title: `${doc.title} - Hyprnote Documentation` },
         { name: "description", content: doc.summary || doc.title },
-        { property: "og:title", content: doc.title },
+        {
+          property: "og:title",
+          content: `${doc.title} - Hyprnote Documentation`,
+        },
         { property: "og:description", content: doc.summary || doc.title },
         { property: "og:type", content: "article" },
         { property: "og:url", content: url },
         { property: "og:image", content: ogImageUrl },
         { name: "twitter:card", content: "summary_large_image" },
-        { name: "twitter:title", content: doc.title },
+        {
+          name: "twitter:title",
+          content: `${doc.title} - Hyprnote Documentation`,
+        },
         { name: "twitter:description", content: doc.summary || doc.title },
         { name: "twitter:image", content: ogImageUrl },
       ],

--- a/apps/web/src/routes/_view/templates/$slug.tsx
+++ b/apps/web/src/routes/_view/templates/$slug.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/_view/templates/$slug")({
 
     return {
       meta: [
-        { title: `${template.title} - Meeting Template - Hyprnote` },
+        { title: `${template.title} - Hyprnote Templates` },
         { name: "description", content: template.description },
         {
           property: "og:title",

--- a/apps/web/src/routes/_view/templates/index.tsx
+++ b/apps/web/src/routes/_view/templates/index.tsx
@@ -23,13 +23,16 @@ export const Route = createFileRoute("/_view/templates/")({
   },
   head: () => ({
     meta: [
-      { title: "Meeting Templates - Hyprnote" },
+      { title: "Meeting Templates - Hyprnote Templates" },
       {
         name: "description",
         content:
           "Discover our library of AI meeting templates. Get structured summaries for sprint planning, sales calls, 1:1s, and more. Create custom templates for your workflow.",
       },
-      { property: "og:title", content: "Meeting Templates - Hyprnote" },
+      {
+        property: "og:title",
+        content: "Meeting Templates - Hyprnote Templates",
+      },
       {
         property: "og:description",
         content:


### PR DESCRIPTION
## Summary

Updates meta titles across the web app to follow a consistent format: `"Page Title - Hyprnote [Section]"`. This affects templates, docs, blog, and changelog pages.

**Changes by section:**
- **Templates**: `"Meeting Templates - Hyprnote Templates"` and `"${template.title} - Hyprnote Templates"`
- **Docs**: `"${doc.title} - Hyprnote Documentation"`
- **Blog**: `"Blog - Hyprnote Blog"` and `"${article.title} - Hyprnote Blog"`
- **Changelog**: Added missing `head` function with `"Changelog - Hyprnote Changelog"` and `"Version ${version} - Hyprnote Changelog"`

Also updates corresponding `og:title` and `twitter:title` meta tags for consistency.

## Review & Testing Checklist for Human

- [ ] **Verify the index page titles aren't too redundant** - titles like "Blog - Hyprnote Blog" and "Changelog - Hyprnote Changelog" repeat the section name. Confirm this matches the intended format or if index pages should use something like "Hyprnote Blog" instead.
- [ ] **Test meta titles in browser** - visit each page type (templates index, template detail, docs, blog index, blog post, changelog index, changelog version) and verify the browser tab shows the correct title
- [ ] **Check social sharing previews** - test that og:title appears correctly when sharing links on social platforms

**Recommended test plan:** Deploy to preview environment and manually check browser tabs on:
1. `/templates` and `/templates/[any-slug]`
2. `/docs/[any-slug]`
3. `/blog` and `/blog/[any-slug]`
4. `/changelog` and `/changelog/[any-slug]`

### Notes
- Requested by: john@hyprnote.com (@ComputelessComputer)
- Devin session: https://app.devin.ai/sessions/a50af39a3cd04c02bf46b9e2d6d372e9