### PR TITLE
feat(web): add status page link to footer

### DIFF
--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -106,6 +106,17 @@ export function Footer() {
                     <ExternalLinkIcon className="size-3" />
                   </a>
                 </li>
+                <li>
+                  <a
+                    href="https://status.hyprnote.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-neutral-600 hover:text-stone-600 transition-colors inline-flex items-center gap-1"
+                  >
+                    Status
+                    <ExternalLinkIcon className="size-3" />
+                  </a>
+                </li>
               </ul>
             </div>
 


### PR DESCRIPTION
## Summary
Adds a link to the status page (https://status.hyprnote.com) in the website footer under the Product section, with an external link icon.

![Footer with Status link](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctODQxY2U0NGNiNzFkNGRhM2EzMjg2NzZiYTBlZTJjNDUiLCJ1c2VyX2lkIjoiZ2l0aHVifDYxNTAzNzM5IiwiYnVja2V0X25hbWUiOiJkZXZpbmF0dGFjaG1lbnRzIiwiYnVja2V0X2tleSI6ImF0dGFjaG1lbnRzX3ByaXZhdGUvb3JnLTg0MWNlNDRjYjcxZDRkYTNhMzI4Njc2YmEwZWUyYzQ1LzkxNTMyYTVmLWU3MWQtNGVkMy04OTYyLTYyOTA3MjhhMjUxNyIsImlhdCI6MTc2NDU1MzQ4NCwiZXhwIjoxNzY1MTU4Mjg0fQ.nuwf80ZkTWlLfo3OP66Vk5S1R8ftz0rCM3Wrg6X5Do8)

## Review & Testing Checklist for Human
- [ ] Verify the status page URL (https://status.hyprnote.com) is correct and accessible
- [ ] Visually confirm the link appears in the footer under the Product section after GitHub
- [ ] Approve the Argos visual regression diffs (3 changed screenshots expected due to footer update)

### Notes
- Requested by @yujonglee
- Link to Devin run: https://app.devin.ai/sessions/4fd2694c257c4d4e9d468e533bc9dec8