### PR TITLE
fix: use platform.Icon instead of non-existent Icon component

### DIFF
--- a/apps/web/src/routes/_view/changelog/$slug.tsx
+++ b/apps/web/src/routes/_view/changelog/$slug.tsx
@@ -226,10 +226,7 @@ function DownloadButtons({ version }: { version: string }) {
                   onClick={() => setIsOpen(false)}
                   className="flex items-center gap-3 px-4 py-3 hover:bg-stone-50 transition-colors border-b border-stone-100 last:border-b-0"
                 >
-                  <Icon
-                    icon={platform.icon}
-                    className="text-lg text-stone-600"
-                  />
+                  <platform.Icon className="w-4 h-4 text-stone-600" />
                   <span className="text-sm font-medium text-stone-700">
                     {platform.label}
                   </span>


### PR DESCRIPTION
## Summary
Fixes TypeScript errors in the changelog page's download dropdown. The code was referencing a non-existent `Icon` component and accessing `platform.icon` (lowercase) when the property is actually `platform.Icon` (capitalized).

The fix uses `platform.Icon` directly as a React component, which is correct since the `platforms` array stores Lucide icon components in the `Icon` property.

## Review & Testing Checklist for Human
- [ ] Verify the icons render correctly in the "other platforms" dropdown on a changelog page (e.g., `/changelog/0.0.1`)
- [ ] Check that the icon size (`w-4 h-4`) looks visually appropriate - it was changed from `text-lg`

### Notes
- Link to Devin run: https://app.devin.ai/sessions/79c1ca36c59a4beeb0d5aa09bb5c7b6d
- Requested by: yujonglee (@yujonglee)