### PR TITLE
feat(bot): add details_url to Devin check for direct session link

### DIFF
--- a/apps/bot/src/features/devin-status.ts
+++ b/apps/bot/src/features/devin-status.ts
@@ -80,6 +80,7 @@ async function checkDevinSession(
     name: CHECK_NAME,
     head_sha: headSha,
     status: "in_progress",
+    details_url: `https://app.devin.ai/sessions/${session.session_id}`,
     output: {
       title: "Devin is working",
       summary: `Devin session ${session.session_id} is currently working on this PR.`,

--- a/apps/bot/src/github/check.ts
+++ b/apps/bot/src/github/check.ts
@@ -25,6 +25,7 @@ export async function createOrUpdateCheck(
       check_run_id: existingCheck.id,
       status: params.status,
       conclusion: params.conclusion,
+      details_url: params.details_url,
       output: params.output,
     });
   } else {


### PR DESCRIPTION
## Summary

Adds a `details_url` to GitHub Check runs for Devin sessions, allowing users to click directly to the Devin session page (`https://app.devin.ai/sessions/<ID>`) from the GitHub PR checks UI when Devin is working on a PR.

Changes:
- Added `details_url` parameter to check creation in `devin-status.ts`
- Updated `updateCheckStatus` method in `poller.ts` to accept `sessionId` and include `details_url` in all check updates
- Updated `createOrUpdateCheck` in `check.ts` to pass through `details_url` when updating existing checks
- Updated `OctokitLike` interface to include `details_url` in type definitions

## Review & Testing Checklist for Human

- [ ] Verify the Devin session URL format (`https://app.devin.ai/sessions/${sessionId}`) is correct and accessible
- [ ] Test with a real PR that has an active Devin session to confirm the "Details" link appears and works in GitHub's checks UI
- [ ] Verify the link appears for all Devin check states (working, blocked, finished, expired)

### Notes

Requested by: yujonglee (@yujonglee)
Link to Devin run: https://app.devin.ai/sessions/9dd691a894354cbfb1558e3002227078

Local tests pass (`pnpm -F bot test`), but the existing tests don't specifically verify `details_url` functionality - end-to-end testing with a real Devin session is recommended.