### PR TITLE
fix: show static.webp fallback for mobile features carousel

### DIFF
--- a/apps/web/src/routes/_view/index.tsx
+++ b/apps/web/src/routes/_view/index.tsx
@@ -1220,11 +1220,17 @@ function FeaturesMobileCarousel({
             <div key={index} className="w-full shrink-0 snap-center">
               <div className="border-y border-neutral-100 overflow-hidden flex flex-col">
                 <div className="aspect-video border-b border-neutral-100 overflow-hidden">
-                  {feature.image && (
+                  {feature.image ? (
                     <Image
                       src={feature.image}
                       alt={`${feature.title} feature`}
                       className="w-full h-full object-contain"
+                    />
+                  ) : (
+                    <img
+                      src="/api/images/hyprnote/static.webp"
+                      alt={`${feature.title} feature`}
+                      className="w-full h-full object-cover"
                     />
                   )}
                 </div>


### PR DESCRIPTION
## Summary

Fixed an issue where the static gif/webp fallback was not showing for features without images in the mobile view of the features section.

The `FeaturesDesktopGrid` component already had a fallback to display `/api/images/hyprnote/static.webp` when a feature doesn't have an image (e.g., "Coming Soon" features like Floating Panel and Daily Note). However, `FeaturesMobileCarousel` was only conditionally rendering when `feature.image` existed, leaving an empty container for features without images.

This change adds the same fallback pattern to the mobile carousel, making it consistent with the desktop grid behavior.

## Review & Testing Checklist for Human

- [ ] Verify the static.webp displays correctly on mobile viewport for "Floating Panel" and "Daily Note" features (the Coming Soon items)
- [ ] Confirm the `object-cover` styling looks appropriate on mobile screens

### Notes

- Link to Devin run: https://app.devin.ai/sessions/c100534211794c7aab7689bdcdcb4d40
- Requested by: john@hyprnote.com (@ComputelessComputer)