### PR TITLE
chore: replace moonrepo/setup-rust with dtolnay/rust-toolchain + Swatinem/rust-cache

### DIFF
--- a/.github/actions/rust_install/action.yaml
+++ b/.github/actions/rust_install/action.yaml
@@ -6,45 +6,44 @@ runs:
   using: "composite"
   steps:
     - if: inputs.platform == 'macos'
-      uses: moonrepo/setup-rust@v1
+      uses: dtolnay/rust-toolchain@master
       with:
-        channel: "1.91.1"
+        toolchain: "1.91.1"
         targets: aarch64-apple-darwin,x86_64-apple-darwin
-        cache-target: release
     - if: inputs.platform == 'ios'
-      uses: moonrepo/setup-rust@v1
+      uses: dtolnay/rust-toolchain@master
       with:
-        channel: "1.91.1"
+        toolchain: "1.91.1"
         targets: aarch64-apple-ios,x86_64-apple-ios,aarch64-apple-ios-sim
-        cache-target: release
     - if: inputs.platform == 'android'
-      uses: moonrepo/setup-rust@v1
+      uses: dtolnay/rust-toolchain@master
       with:
-        channel: "1.91.1"
+        toolchain: "1.91.1"
         targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
-        cache-target: release
     - if: inputs.platform == 'windows'
-      uses: moonrepo/setup-rust@v1
+      uses: dtolnay/rust-toolchain@master
       with:
-        channel: "1.91.1"
+        toolchain: "1.91.1"
         targets: x86_64-pc-windows-msvc
-        bins: trusted-signing-cli
-        cache-target: release
+    - if: inputs.platform == 'windows'
+      run: cargo install trusted-signing-cli
+      shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
     - if: inputs.platform == 'linux'
-      uses: moonrepo/setup-rust@v1
+      uses: dtolnay/rust-toolchain@master
       with:
-        channel: "1.91.1"
+        toolchain: "1.91.1"
         targets: x86_64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-unknown-linux-gnu
-        cache-target: release
     - if: inputs.platform == 'linux'
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc-aarch64-linux-gnu libasound2-dev
       shell: bash
     - if: inputs.platform == ''
-      uses: moonrepo/setup-rust@v1
+      uses: dtolnay/rust-toolchain@master
       with:
-        channel: "1.91.1"
-        cache-target: release
+        toolchain: "1.91.1"
+    - uses: Swatinem/rust-cache@v2
+      with:
+        cache-targets: "true"


### PR DESCRIPTION
## Summary

Replaces `moonrepo/setup-rust@v1` with `dtolnay/rust-toolchain@master` and `Swatinem/rust-cache@v2` in the `rust_install` composite action.

The `moonrepo/setup-rust` action was causing CI slowdowns due to `cargo-cache` installation failures (403 rate limits from GitHub API and 402 Payment Required from warehouse-clerk-tmp.vercel.app). The new actions are more widely used in the Rust ecosystem and don't depend on cargo-binstall or the problematic quickinstall service.

## Review & Testing Checklist for Human

- [ ] **Verify CI passes on macOS and Linux builds** - These are the primary platforms used in `desktop_cd.yaml` and `desktop_ci.yaml`
- [ ] **Check caching behavior** - The old action used `cache-target: release`, while `Swatinem/rust-cache` caches all targets by default. Verify cache sizes are reasonable.
- [ ] **Windows builds (if used)** - The `trusted-signing-cli` installation changed from `bins:` (cargo-binstall) to `cargo install` (compiles from source), which will be slower

**Recommended test plan:** Trigger a `desktop_cd` workflow run on staging channel and verify it completes without the cargo-cache timeout errors.

### Notes

- Link to Devin run: https://app.devin.ai/sessions/1fd87615faff420dba92727287282cf6
- Requested by: yujonglee (@yujonglee)