### PR TITLE
Fix external STT server lifecycle to ensure single instance and proper cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7257,6 +7257,7 @@ dependencies = [
  "mac_address2",
  "machine-uid",
  "sysinfo 0.37.2",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/host/Cargo.toml
+++ b/crates/host/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 mac_address2 = "2.0.2"
 machine-uid = "0.5.4"
 sysinfo = { workspace = true }
+tokio = { workspace = true, features = ["time"] }

--- a/plugins/local-stt/src/server/supervisor.rs
+++ b/plugins/local-stt/src/server/supervisor.rs
@@ -125,6 +125,10 @@ pub async fn stop_stt_server(
         ServerType::External => wait_for_actor_shutdown(ExternalSTTActor::name()).await,
     }
 
+    if matches!(server_type, ServerType::External) {
+        wait_for_process_cleanup().await;
+    }
+
     Ok(())
 }
 
@@ -142,5 +146,20 @@ async fn wait_for_actor_shutdown(actor_name: ractor::ActorName) {
             break;
         }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_process_cleanup() {
+    let process_terminated =
+        hypr_host::wait_for_processes_to_terminate(hypr_host::ProcessMatcher::Sidecar, 5000, 100)
+            .await;
+
+    if !process_terminated {
+        tracing::warn!("external_stt_process_did_not_terminate_in_time");
+        let killed = hypr_host::kill_processes_by_matcher(hypr_host::ProcessMatcher::Sidecar);
+        if killed > 0 {
+            tracing::info!("force_killed_stt_processes: {}", killed);
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes a race condition in external STT server lifecycle management that caused multiple server processes to accumulate when switching between models (e.g., ParakeetV2 ↔ ParakeetV3).

When switching models, `stop_stt_server()` would wait for the actor to be removed from the registry, but the actual process cleanup happened asynchronously in the `post_stop()` hook. This meant new servers could start spawning before old processes were fully terminated.

The fix adds `wait_for_process_cleanup()` that verifies external STT processes are actually terminated before returning from `stop_stt_server()`. It waits up to 5 seconds for graceful termination (checking every 100ms), then falls back to force kill if the process doesn't terminate in time.

Based on the approach from PR #1829 (without the unrelated owhisper schema changes).

## Review & Testing Checklist for Human

- [ ] **Test model switching**: Switch between ParakeetV2 and ParakeetV3 multiple times and verify only ONE "stt" process is running at any time (use `ps aux | grep stt` or Activity Monitor)
- [ ] **Verify process matching safety**: Confirm the "stt" substring matching doesn't accidentally match/kill unrelated processes on your system
- [ ] **Test timing**: Verify the 5-second timeout is appropriate - model switching shouldn't feel sluggish
- [ ] **Test app shutdown**: Quit the app and verify all STT processes are cleaned up properly

### Recommended Test Plan
1. Start the app and select an external STT model (ParakeetV2 or ParakeetV3)
2. Open Activity Monitor / Task Manager and filter for "stt" processes
3. Switch to a different external STT model
4. Verify only one "stt" process exists after the switch completes
5. Repeat steps 3-4 several times to ensure consistency
6. Quit the app and verify all "stt" processes are terminated

### Notes
- This fix only applies to `ServerType::External` (Am models), not `ServerType::Internal` (Whisper models) since internal servers don't spawn external processes
- The process matching uses substring matching on process names containing "stt"
- **This PR has NOT been tested with actual STT server processes running** - manual testing is essential

**Session:** https://app.devin.ai/sessions/ed914cd74ddb40fcb4656a899ff0b4c6
**Requested by:** yujonglee (@yujonglee)