### PR TITLE
Add Company Handbook link to footer

### DIFF
--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -169,6 +169,14 @@ export function Footer() {
                     Prompt Gallery
                   </Link>
                 </li>
+                <li>
+                  <Link
+                    to="/company-handbook"
+                    className="text-sm text-neutral-600 hover:text-stone-600 transition-colors underline decoration-dotted hover:decoration-solid"
+                  >
+                    Company Handbook
+                  </Link>
+                </li>
               </ul>
             </div>
 


### PR DESCRIPTION
Add a "Company Handbook" link under Resources in the footer component so users can access the company handbook page from the site's footer. This inserts a new list item with a styled Link to /company-handbook to match the existing resource links.