### PR TITLE
feat(desktop): add fancy NotFound and ErrorBoundary components with animations

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -15,6 +15,7 @@ import {
 } from "@hypr/plugin-windows";
 import "@hypr/ui/globals.css";
 
+import { ErrorComponent, NotFoundComponent } from "./components/control";
 import { TaskManager } from "./components/task-manager";
 import { createToolRegistry } from "./contexts/tool-registry/core";
 import { initExtensionGlobals } from "./extension-globals";
@@ -28,7 +29,12 @@ const toolRegistry = createToolRegistry();
 const listenerStore = createListenerStore();
 const queryClient = new QueryClient();
 
-const router = createRouter({ routeTree, context: undefined });
+const router = createRouter({
+  routeTree,
+  context: undefined,
+  defaultErrorComponent: ErrorComponent,
+  defaultNotFoundComponent: NotFoundComponent,
+});
 
 declare module "@tanstack/react-router" {
   interface Register {

--- a/apps/desktop/src/routes/__root.tsx
+++ b/apps/desktop/src/routes/__root.tsx
@@ -7,7 +7,6 @@ import { lazy, Suspense } from "react";
 
 import type { DeepLink } from "@hypr/plugin-deeplink2";
 
-import { ErrorComponent, NotFoundComponent } from "../components/control";
 import type { Context } from "../types";
 import { isExtHostPath } from "../utils/ext-host";
 
@@ -21,8 +20,6 @@ const MainAppLayout = lazy(() => import("../components/main-app-layout"));
 
 export const Route = createRootRouteWithContext<Partial<Context>>()({
   component: Component,
-  errorComponent: ErrorComponent,
-  notFoundComponent: NotFoundComponent,
 });
 
 function Component() {

--- a/apps/desktop/src/routes/app/route.tsx
+++ b/apps/desktop/src/routes/app/route.tsx
@@ -2,15 +2,12 @@ import { createFileRoute, Outlet, useLocation } from "@tanstack/react-router";
 
 import { TooltipProvider } from "@hypr/ui/components/ui/tooltip";
 
-import { ErrorComponent, NotFoundComponent } from "../../components/control";
 import { useConfigSideEffects } from "../../config/use-config";
 import { ListenerProvider } from "../../contexts/listener";
 import { isExtHostPath } from "../../utils/ext-host";
 
 export const Route = createFileRoute("/app")({
   component: Component,
-  errorComponent: ErrorComponent,
-  notFoundComponent: NotFoundComponent,
   loader: async ({ context: { listenerStore } }) => {
     return { listenerStore: listenerStore! };
   },


### PR DESCRIPTION
## Summary

Redesigned the `NotFoundComponent` and `ErrorComponent` for TanStack Router with animated, visually polished UI. Both components now feature spring animations using motion/react, gradient backgrounds, glassmorphism card effects, and lucide-react icons. Each includes a "Go to Home" button that navigates to `/app/main`.

The components are configured as router-level defaults (`defaultErrorComponent`/`defaultNotFoundComponent`) in `createRouter()`, providing a single global configuration that applies to all routes.

## Updates since last revision

- Refactored to use router-level defaults in `main.tsx` instead of configuring on individual routes (`__root.tsx`, `/app/route.tsx`)
- This provides a cleaner single-source configuration that applies globally to all routes

## Review & Testing Checklist for Human

- [ ] **Test 404 page**: Navigate to a non-existent route (e.g., `/app/nonexistent`) to see the NotFoundComponent with animations
- [ ] **Test error boundary**: Temporarily throw an error in a route component to verify ErrorComponent displays correctly with the error message
- [ ] **Verify home navigation**: Confirm clicking "Go to Home" navigates to the correct route (`/app/main`)
- [ ] **Check animation performance**: Ensure the infinite pulse animation doesn't cause performance issues over time

**Test plan**: Run the desktop app with `ONBOARDING=0 pnpm -F desktop tauri dev`, then navigate to `/app/nonexistent` via devtools console (`window.location.href = '/app/nonexistent'`) to trigger the NotFound page. Verify the "Go to Home" button returns to the main app.

### Notes

- The pulse animation uses `repeat: Infinity` - worth monitoring for any performance impact
- Uses existing dependencies (`motion`, `lucide-react`) already in package.json
- Local testing confirmed NotFoundComponent displays correctly and "Go to Home" navigation works with router-level defaults
- Requested by: @yujonglee (yujonglee.dev@gmail.com)
- Devin run: https://app.devin.ai/sessions/630e2c91430c426e9f6cc6b370d1addc

### Demo

![NotFound Component Demo](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctODQxY2U0NGNiNzFkNGRhM2EzMjg2NzZiYTBlZTJjNDUiLCJ1c2VyX2lkIjoiZ2l0aHVifDYxNTAzNzM5IiwiYnVja2V0X25hbWUiOiJkZXZpbmF0dGFjaG1lbnRzIiwiYnVja2V0X2tleSI6ImF0dGFjaG1lbnRzX3ByaXZhdGUvb3JnLTg0MWNlNDRjYjcxZDRkYTNhMzI4Njc2YmEwZWUyYzQ1LzcxMDc0ZDU5LTdiZjItNGM0Ni05NTYzLWE1NTNhYWUxYjNjNyIsImlhdCI6MTc2NDcyNzA5MCwiZXhwIjoxNzY1MzMxODkwfQ.HzB2hmhHhzw9-wyKjnOjOvEcI-NOIMbVuaPsX3nwsUY)


[View original video (rec-18e63843751f47cea2833eb72907338e-edited.mp4)](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctODQxY2U0NGNiNzFkNGRhM2EzMjg2NzZiYTBlZTJjNDUiLCJ1c2VyX2lkIjoiZ2l0aHVifDYxNTAzNzM5IiwiYnVja2V0X25hbWUiOiJkZXZpbmF0dGFjaG1lbnRzIiwiYnVja2V0X2tleSI6ImF0dGFjaG1lbnRzX3ByaXZhdGUvb3JnLTg0MWNlNDRjYjcxZDRkYTNhMzI4Njc2YmEwZWUyYzQ1L2FkNmJhNTI4LTE5ZjAtNGZiZi1iNjViLWYwNmNmODYyZDI4YSIsImlhdCI6MTc2NDcyNzA5MCwiZXhwIjoxNzY1MzMxODkwfQ.yagzja6bXjuMJzvUaViFHK2K3DlwQIFOR86QlV9bewo)