### PR TITLE
feat(og): add cache headers for generated images

### DIFF
--- a/apps/web/netlify/edge-functions/og.tsx
+++ b/apps/web/netlify/edge-functions/og.tsx
@@ -316,7 +316,11 @@ export default async function handler(req: Request) {
       ]
       : undefined;
 
-    return new ImageResponse(response, { fonts });
+    const imageResponse = new ImageResponse(response, { fonts });
+    imageResponse.headers.set("Netlify-CDN-Cache-Control", "public, s-maxage=31536000");
+    imageResponse.headers.set("Cache-Control", "public, max-age=31536000, immutable");
+    imageResponse.headers.set("Netlify-Vary", "query");
+    return imageResponse;
   } catch (error) {
     console.error("OG image generation failed:", error);
     return new Response(JSON.stringify({ error: "image_generation_failed" }), {


### PR DESCRIPTION
this pr is made to fix the following issue.

local dev
<img width="1450" height="1049" alt="image" src="https://github.com/user-attachments/assets/724491a0-a119-4a18-ba01-0109342699dd" />

prod
<img width="1450" height="1049" alt="image" src="https://github.com/user-attachments/assets/f561490f-6b7c-45c2-90b3-0c96f6804d52" />

the og endpoint seems to return the same image even though they're different.