### PR TITLE
Enable sitemap host and copy sitemap to build output

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "VITE_APP_URL=\"http://localhost:3000\" dotenvx run --ignore MISSING_ENV_FILE -f ../../.env.supabase -f ../../.env.restate -f .env -- vite dev --port 3000",
-    "build": "vite build && pagefind --site ./dist/client",
+    "build": "vite build && cp public/sitemap.xml dist/client/sitemap.xml && pagefind --site ./dist/client",
     "serve": "vite preview",
     "test": "playwright test",
     "typecheck": "CI=true pnpm -F @hypr/web build && tsc --project tsconfig.json --noEmit",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -15,6 +15,9 @@ const config = defineConfig(() => ({
     viteTsConfigPaths({ projects: ["./tsconfig.json"] }),
     tailwindcss(),
     tanstackStart({
+      sitemap: {
+        host: "https://hyprnote.com",
+      },
       prerender: {
         enabled: true,
         crawlLinks: true,


### PR DESCRIPTION
Set the sitemap host for TanStack's prerender to "https://hyprnote.com" so sitemap generation is enabled and avoids the typecheck hint about missing sitemap.host. Also copy the prebuilt public/sitemap.xml into the Vite build output (dist/client) before running pagefind so the sitemap is present at /sitemap.xml and not 404. This resolves the collision between TanStack's sitemap handling and the existing apps/web sitemap file; it preserves using apps/web/content-collections.ts for content sources.