### PR TITLE
fix: handle undefined loaderData in head function for docs routes

### DIFF
--- a/apps/web/src/routes/_view/company-handbook/$.tsx
+++ b/apps/web/src/routes/_view/company-handbook/$.tsx
@@ -44,7 +44,11 @@ export const Route = createFileRoute("/_view/company-handbook/$")({
     return { doc: doc! };
   },
   head: ({ loaderData }) => {
-    const { doc } = loaderData!;
+    const doc = loaderData?.doc;
+    if (!doc) {
+      return { meta: [] };
+    }
+
     const url = `https://hyprnote.com/company-handbook/${doc.slug}`;
 
     return {

--- a/apps/web/src/routes/_view/docs/$.tsx
+++ b/apps/web/src/routes/_view/docs/$.tsx
@@ -44,7 +44,11 @@ export const Route = createFileRoute("/_view/docs/$")({
     return { doc: doc! };
   },
   head: ({ loaderData }) => {
-    const { doc } = loaderData!;
+    const doc = loaderData?.doc;
+    if (!doc) {
+      return { meta: [] };
+    }
+
     const url = `https://hyprnote.com/docs/${doc.slug}`;
     const ogImageUrl = `https://hyprnote.com/og?type=docs&title=${encodeURIComponent(doc.title)}&section=${encodeURIComponent(doc.section)}${doc.summary ? `&description=${encodeURIComponent(doc.summary)}` : ""}&v=1`;
 


### PR DESCRIPTION
## Summary

Fixes the white page / hydration error on `/docs/faq` (and similar redirect-only doc routes). The error was:

```
Error during hydration for route /_view/docs/$: TypeError: Cannot destructure property 'doc' of 't' as it is undefined.
```

**Root cause:** When `beforeLoad` throws a redirect (e.g., `/docs/faq` → `/docs/faq/general`), the `head` function can be called before the loader runs, resulting in `loaderData` being undefined. The code was using non-null assertions (`loaderData!`) which crashed.

**Fix:** Changed to optional chaining (`loaderData?.doc`) with an early return of empty meta array when `doc` is undefined. Applied to both `/docs/$` and `/company-handbook/$` routes which share the same pattern.

## Review & Testing Checklist for Human

- [ ] Navigate to `/docs/faq` and verify it no longer shows a white page (should redirect to `/docs/faq/general`)
- [ ] Navigate to `/docs/pro` and verify it still works correctly
- [ ] Check if other routes with similar redirect patterns need the same fix (e.g., `/company-handbook/about`)

### Notes

- Link to Devin run: https://app.devin.ai/sessions/f88e7d8140034b31827590d662b1db01
- Requested by: john@hyprnote.com (@ComputelessComputer)