### PR TITLE
feat(web): preserve scroll position and add query params to about and brand pages

### DIFF
--- a/apps/web/src/routes/_view/about.tsx
+++ b/apps/web/src/routes/_view/about.tsx
@@ -163,11 +163,15 @@ function Component() {
       const founder = founders.find((f) => f.id === search.id);
       if (founder) {
         setSelectedItem({ type: "founder", data: founder });
+      } else {
+        setSelectedItem(null);
       }
     } else if (search.type === "photo" && search.id) {
       const photo = teamPhotos.find((p) => p.id === search.id);
       if (photo) {
         setSelectedItem({ type: "photo", data: photo });
+      } else {
+        setSelectedItem(null);
       }
     } else {
       setSelectedItem(null);
@@ -177,13 +181,19 @@ function Component() {
   const handleSetSelectedItem = (item: SelectedItem | null) => {
     setSelectedItem(item);
     if (item === null) {
-      navigate({ search: {} });
+      navigate({ search: {}, resetScroll: false });
     } else if (item.type === "story") {
-      navigate({ search: { type: "story" } });
+      navigate({ search: { type: "story" }, resetScroll: false });
     } else if (item.type === "founder") {
-      navigate({ search: { type: "founder", id: item.data.id } });
+      navigate({
+        search: { type: "founder", id: item.data.id },
+        resetScroll: false,
+      });
     } else if (item.type === "photo") {
-      navigate({ search: { type: "photo", id: item.data.id } });
+      navigate({
+        search: { type: "photo", id: item.data.id },
+        resetScroll: false,
+      });
     }
   };
 


### PR DESCRIPTION
# feat(web): preserve scroll position and add query params to about/brand pages

## Summary
This PR makes two related improvements to the about and brand pages:

1. **Scroll Position Preservation**: Added `resetScroll: false` to all `navigate()` calls in both pages so the global scroll position is maintained when navigating between items inside the MockWindow component.

2. **Query Params for Brand Page**: Added URL query parameter support to brand.tsx (matching the existing pattern in about.tsx) so users can deep link to specific items:
   - `/brand?type=visual&id=icon`
   - `/brand?type=typography&id=primary-font`
   - `/brand?type=color&id=stone-600`

3. **Invalid Deep Link Handling**: Added else branches to clear selection when a valid type is provided but the ID doesn't match any item (fixes a potential stale state issue).

## Review & Testing Checklist for Human
- [ ] **Test scroll preservation**: Navigate to `/about` or `/brand`, scroll down the page, then click on items in the MockWindow. The page scroll position should NOT reset to top.
- [ ] **Test deep linking on brand page**: Try URLs like `/brand?type=visual&id=logo` and verify the correct item is selected on page load.
- [ ] **Test invalid deep links**: Try `/brand?type=visual&id=nonexistent` and verify the selection is cleared (not stuck on stale state).

### Notes
- Link to Devin run: https://app.devin.ai/sessions/62b6ca676cae46f8937a939c23228cef
- Requested by: john@hyprnote.com (@ComputelessComputer)
- The `resetScroll: false` pattern is already used in gallery, templates, blog, and shortcuts pages in this codebase.