### PR TITLE
feat(web): add SEO-focused platform integration landing pages

### DIFF
--- a/apps/web/content-collections.ts
+++ b/apps/web/content-collections.ts
@@ -409,6 +409,50 @@ const vs = defineCollection({
   },
 });
 
+const integrations = defineCollection({
+  name: "integrations",
+  directory: "content/integrations",
+  include: "**/*.mdx",
+  exclude: "AGENTS.md",
+  schema: z.object({
+    platform: z.string(),
+    icon: z.string(),
+    headline: z.string(),
+    description: z.string(),
+    metaDescription: z.string(),
+    features: z.array(z.string()).optional(),
+  }),
+  transform: async (document, context) => {
+    const mdx = await compileMDX(context, document, {
+      remarkPlugins: [remarkGfm, mdxMermaid],
+      rehypePlugins: [
+        rehypeSlug,
+        [
+          rehypeAutolinkHeadings,
+          {
+            behavior: "wrap",
+            properties: {
+              className: ["anchor"],
+            },
+          },
+        ],
+      ],
+    });
+
+    const pathParts = document._meta.path.split("/");
+    const fileName = pathParts.pop()!.replace(/\.mdx$/, "");
+    const category = pathParts[0] || "general";
+    const slug = fileName;
+
+    return {
+      ...document,
+      mdx,
+      slug,
+      category,
+    };
+  },
+});
+
 const shortcuts = defineCollection({
   name: "shortcuts",
   directory: "content/shortcuts",
@@ -586,6 +630,7 @@ export default defineConfig({
     hooks,
     deeplinks,
     vs,
+    integrations,
     handbook,
     roadmap,
     ossFriends,

--- a/apps/web/content/integrations/google-meet/meeting-assistant.mdx
+++ b/apps/web/content/integrations/google-meet/meeting-assistant.mdx
@@ -1,0 +1,12 @@
+---
+platform: Google Meet
+icon: /icons/google-meet.svg
+headline: Your Private AI Assistant for Google Meet
+description: Get real-time AI assistance during Google Meet calls. Ask questions, get summaries, and capture action items — all without sending your audio to the cloud.
+metaDescription: AI meeting assistant for Google Meet that works locally. Get real-time answers, summaries, and action items without compromising your meeting privacy.
+features:
+  - Real-time AI Chat
+  - Action Items
+  - Meeting Summaries
+  - Context-Aware Answers
+---

--- a/apps/web/content/integrations/google-meet/notetaker.mdx
+++ b/apps/web/content/integrations/google-meet/notetaker.mdx
@@ -1,0 +1,12 @@
+---
+platform: Google Meet
+icon: /icons/google-meet.svg
+headline: The Privacy-First Google Meet Notetaker
+description: Take intelligent meeting notes during Google Meet calls without any bots joining your meetings. Hyprnote captures, transcribes, and summarizes your conversations locally.
+metaDescription: AI notetaker for Google Meet that respects your privacy. No bots, no cloud recording — just smart, local note-taking with real-time transcription and summaries.
+features:
+  - AI Summaries
+  - Real-time Notes
+  - Template Support
+  - Offline Capable
+---

--- a/apps/web/content/integrations/google-meet/transcription.mdx
+++ b/apps/web/content/integrations/google-meet/transcription.mdx
@@ -1,0 +1,12 @@
+---
+platform: Google Meet
+icon: /icons/google-meet.svg
+headline: AI-Powered Google Meet Transcription Without Bots
+description: Get real-time transcription for your Google Meet calls with Hyprnote. No meeting bots, no cloud uploads — just accurate, private transcription that runs locally on your device.
+metaDescription: Transcribe Google Meet calls in real-time with Hyprnote. Privacy-first AI transcription without bots joining your meetings. Works offline, keeps your data local.
+features:
+  - Real-time Transcription
+  - Speaker Identification
+  - Local Processing
+  - No Meeting Bots
+---

--- a/apps/web/content/integrations/teams/meeting-assistant.mdx
+++ b/apps/web/content/integrations/teams/meeting-assistant.mdx
@@ -1,0 +1,12 @@
+---
+platform: Microsoft Teams
+icon: /icons/teams.svg
+headline: Your Private AI Assistant for Teams Meetings
+description: Get real-time AI assistance during Microsoft Teams meetings. Ask questions, get summaries, and capture action items — all without sending your audio to the cloud.
+metaDescription: AI meeting assistant for Microsoft Teams that works locally. Get real-time answers, summaries, and action items without compromising your meeting privacy.
+features:
+  - Real-time AI Chat
+  - Action Items
+  - Meeting Summaries
+  - Context-Aware Answers
+---

--- a/apps/web/content/integrations/teams/notetaker.mdx
+++ b/apps/web/content/integrations/teams/notetaker.mdx
@@ -1,0 +1,12 @@
+---
+platform: Microsoft Teams
+icon: /icons/teams.svg
+headline: The Privacy-First Teams Notetaker
+description: Take intelligent meeting notes during Microsoft Teams calls without any bots joining your meetings. Hyprnote captures, transcribes, and summarizes your conversations locally.
+metaDescription: AI notetaker for Microsoft Teams meetings that respects your privacy. No bots, no cloud recording — just smart, local note-taking with real-time transcription and summaries.
+features:
+  - AI Summaries
+  - Real-time Notes
+  - Template Support
+  - Offline Capable
+---

--- a/apps/web/content/integrations/teams/transcription.mdx
+++ b/apps/web/content/integrations/teams/transcription.mdx
@@ -1,0 +1,12 @@
+---
+platform: Microsoft Teams
+icon: /icons/teams.svg
+headline: AI-Powered Teams Transcription Without Bots
+description: Get real-time transcription for your Microsoft Teams meetings with Hyprnote. No meeting bots, no cloud uploads — just accurate, private transcription that runs locally on your device.
+metaDescription: Transcribe Microsoft Teams meetings in real-time with Hyprnote. Privacy-first AI transcription without bots joining your calls. Works offline, keeps your data local.
+features:
+  - Real-time Transcription
+  - Speaker Identification
+  - Local Processing
+  - No Meeting Bots
+---

--- a/apps/web/content/integrations/webex/meeting-assistant.mdx
+++ b/apps/web/content/integrations/webex/meeting-assistant.mdx
@@ -1,0 +1,12 @@
+---
+platform: Webex
+icon: /icons/webex.svg
+headline: Your Private AI Assistant for Webex Meetings
+description: Get real-time AI assistance during Webex meetings. Ask questions, get summaries, and capture action items — all without sending your audio to the cloud.
+metaDescription: AI meeting assistant for Webex that works locally. Get real-time answers, summaries, and action items without compromising your meeting privacy.
+features:
+  - Real-time AI Chat
+  - Action Items
+  - Meeting Summaries
+  - Context-Aware Answers
+---

--- a/apps/web/content/integrations/webex/notetaker.mdx
+++ b/apps/web/content/integrations/webex/notetaker.mdx
@@ -1,0 +1,12 @@
+---
+platform: Webex
+icon: /icons/webex.svg
+headline: The Privacy-First Webex Notetaker
+description: Take intelligent meeting notes during Webex meetings without any bots joining your calls. Hyprnote captures, transcribes, and summarizes your conversations locally.
+metaDescription: AI notetaker for Webex meetings that respects your privacy. No bots, no cloud recording — just smart, local note-taking with real-time transcription and summaries.
+features:
+  - AI Summaries
+  - Real-time Notes
+  - Template Support
+  - Offline Capable
+---

--- a/apps/web/content/integrations/webex/transcription.mdx
+++ b/apps/web/content/integrations/webex/transcription.mdx
@@ -1,0 +1,12 @@
+---
+platform: Webex
+icon: /icons/webex.svg
+headline: AI-Powered Webex Transcription Without Bots
+description: Get real-time transcription for your Webex meetings with Hyprnote. No meeting bots, no cloud uploads — just accurate, private transcription that runs locally on your device.
+metaDescription: Transcribe Webex meetings in real-time with Hyprnote. Privacy-first AI transcription without bots joining your calls. Works offline, keeps your data local.
+features:
+  - Real-time Transcription
+  - Speaker Identification
+  - Local Processing
+  - No Meeting Bots
+---

--- a/apps/web/content/integrations/zoom/meeting-assistant.mdx
+++ b/apps/web/content/integrations/zoom/meeting-assistant.mdx
@@ -1,0 +1,12 @@
+---
+platform: Zoom
+icon: /icons/zoom.svg
+headline: Your Private AI Assistant for Zoom Meetings
+description: Get real-time AI assistance during Zoom meetings. Ask questions, get summaries, and capture action items — all without sending your audio to the cloud.
+metaDescription: AI meeting assistant for Zoom that works locally. Get real-time answers, summaries, and action items without compromising your meeting privacy.
+features:
+  - Real-time AI Chat
+  - Action Items
+  - Meeting Summaries
+  - Context-Aware Answers
+---

--- a/apps/web/content/integrations/zoom/notetaker.mdx
+++ b/apps/web/content/integrations/zoom/notetaker.mdx
@@ -1,0 +1,12 @@
+---
+platform: Zoom
+icon: /icons/zoom.svg
+headline: The Privacy-First Zoom Notetaker
+description: Take intelligent meeting notes during Zoom calls without any bots joining your meetings. Hyprnote captures, transcribes, and summarizes your conversations locally.
+metaDescription: AI notetaker for Zoom meetings that respects your privacy. No bots, no cloud recording — just smart, local note-taking with real-time transcription and summaries.
+features:
+  - AI Summaries
+  - Real-time Notes
+  - Template Support
+  - Offline Capable
+---

--- a/apps/web/content/integrations/zoom/transcription.mdx
+++ b/apps/web/content/integrations/zoom/transcription.mdx
@@ -1,0 +1,12 @@
+---
+platform: Zoom
+icon: /icons/zoom.svg
+headline: AI-Powered Zoom Transcription Without Bots
+description: Get real-time transcription for your Zoom meetings with Hyprnote. No meeting bots, no cloud uploads — just accurate, private transcription that runs locally on your device.
+metaDescription: Transcribe Zoom meetings in real-time with Hyprnote. Privacy-first AI transcription without bots joining your calls. Works offline, keeps your data local.
+features:
+  - Real-time Transcription
+  - Speaker Identification
+  - Local Processing
+  - No Meeting Bots
+---

--- a/apps/web/public/icons/google-meet.svg
+++ b/apps/web/public/icons/google-meet.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48">
+  <rect width="48" height="48" rx="8" fill="#00897B"/>
+  <path d="M10 14h18c1.1 0 2 .9 2 2v16c0 1.1-.9 2-2 2H10c-1.1 0-2-.9-2-2V16c0-1.1.9-2 2-2z" fill="white"/>
+  <path d="M32 18l8-6v24l-8-6V18z" fill="#FFC107"/>
+  <path d="M32 18l8-6v12l-8 6V18z" fill="#4CAF50"/>
+  <path d="M32 30l8 6V24l-8 6z" fill="#1E88E5"/>
+</svg>

--- a/apps/web/public/icons/teams.svg
+++ b/apps/web/public/icons/teams.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48">
+  <rect width="48" height="48" rx="8" fill="#6264A7"/>
+  <circle cx="32" cy="16" r="5" fill="white"/>
+  <path d="M26 22h12c1.1 0 2 .9 2 2v10c0 1.1-.9 2-2 2H26c-1.1 0-2-.9-2-2V24c0-1.1.9-2 2-2z" fill="white" opacity="0.8"/>
+  <circle cx="18" cy="14" r="6" fill="white"/>
+  <path d="M10 22h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H10c-1.1 0-2-.9-2-2V24c0-1.1.9-2 2-2z" fill="white"/>
+</svg>

--- a/apps/web/public/icons/webex.svg
+++ b/apps/web/public/icons/webex.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48">
+  <rect width="48" height="48" rx="8" fill="#00BCF2"/>
+  <circle cx="24" cy="24" r="14" fill="white"/>
+  <circle cx="24" cy="24" r="10" fill="#00BCF2"/>
+  <circle cx="24" cy="24" r="6" fill="white"/>
+  <circle cx="24" cy="24" r="3" fill="#00BCF2"/>
+</svg>

--- a/apps/web/public/icons/zoom.svg
+++ b/apps/web/public/icons/zoom.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48">
+  <rect width="48" height="48" rx="8" fill="#2D8CFF"/>
+  <path d="M12 16h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H12c-1.1 0-2-.9-2-2V18c0-1.1.9-2 2-2z" fill="white"/>
+  <path d="M32 20l6-4v16l-6-4V20z" fill="white"/>
+</svg>

--- a/apps/web/src/routes/_view/integrations/$category.$slug.tsx
+++ b/apps/web/src/routes/_view/integrations/$category.$slug.tsx
@@ -1,0 +1,189 @@
+import { createFileRoute, notFound } from "@tanstack/react-router";
+import { allIntegrations } from "content-collections";
+import { useRef, useState } from "react";
+
+import { cn } from "@hypr/utils";
+
+import { GitHubOpenSource } from "@/components/github-open-source";
+import { SlashSeparator } from "@/components/slash-separator";
+import {
+  CoolStuffSection,
+  CTASection,
+  DetailsSection,
+  HowItWorksSection,
+  MainFeaturesSection,
+} from "@/routes/_view/index";
+
+export const Route = createFileRoute("/_view/integrations/$category/$slug")({
+  component: Component,
+  loader: async ({ params }) => {
+    const doc = allIntegrations.find(
+      (doc) => doc.category === params.category && doc.slug === params.slug,
+    );
+    if (!doc) {
+      throw notFound();
+    }
+
+    return { doc };
+  },
+  head: ({ loaderData }) => {
+    const { doc } = loaderData!;
+    const metaTitle = `${doc.platform} ${doc.slug.charAt(0).toUpperCase() + doc.slug.slice(1).replace(/-/g, " ")} - Hyprnote`;
+
+    return {
+      meta: [
+        { title: metaTitle },
+        { name: "description", content: doc.metaDescription },
+        { property: "og:title", content: metaTitle },
+        { property: "og:description", content: doc.metaDescription },
+        { property: "og:type", content: "website" },
+        {
+          property: "og:url",
+          content: `https://hyprnote.com/integrations/${doc.category}/${doc.slug}`,
+        },
+        { name: "twitter:card", content: "summary" },
+        { name: "twitter:title", content: metaTitle },
+        { name: "twitter:description", content: doc.metaDescription },
+      ],
+    };
+  },
+});
+
+function Component() {
+  const { doc } = Route.useLoaderData();
+  const [selectedDetail, setSelectedDetail] = useState(0);
+  const [selectedFeature, setSelectedFeature] = useState(0);
+  const detailsScrollRef = useRef<HTMLDivElement>(null);
+  const featuresScrollRef = useRef<HTMLDivElement>(null);
+  const heroInputRef = useRef<HTMLInputElement>(null);
+
+  const scrollToDetail = (index: number) => {
+    setSelectedDetail(index);
+    if (detailsScrollRef.current) {
+      const container = detailsScrollRef.current;
+      const scrollLeft = container.offsetWidth * index;
+      container.scrollTo({ left: scrollLeft, behavior: "smooth" });
+    }
+  };
+
+  const scrollToFeature = (index: number) => {
+    setSelectedFeature(index);
+    if (featuresScrollRef.current) {
+      const container = featuresScrollRef.current;
+      const scrollLeft = container.offsetWidth * index;
+      container.scrollTo({ left: scrollLeft, behavior: "smooth" });
+    }
+  };
+
+  return (
+    <div
+      className="bg-linear-to-b from-white via-stone-50/20 to-white min-h-screen"
+      style={{ backgroundImage: "url(/patterns/dots.svg)" }}
+    >
+      <div className="max-w-6xl mx-auto border-x border-neutral-100 bg-white">
+        <HeroSection
+          platformIcon={doc.icon}
+          platformName={doc.platform}
+          headline={doc.headline}
+          description={doc.description}
+          features={doc.features}
+        />
+        <SlashSeparator />
+        <HowItWorksSection />
+        <SlashSeparator />
+        <CoolStuffSection />
+        <SlashSeparator />
+        <MainFeaturesSection
+          featuresScrollRef={featuresScrollRef}
+          selectedFeature={selectedFeature}
+          setSelectedFeature={setSelectedFeature}
+          scrollToFeature={scrollToFeature}
+        />
+        <SlashSeparator />
+        <DetailsSection
+          detailsScrollRef={detailsScrollRef}
+          selectedDetail={selectedDetail}
+          setSelectedDetail={setSelectedDetail}
+          scrollToDetail={scrollToDetail}
+        />
+        <SlashSeparator />
+        <GitHubOpenSource />
+        <SlashSeparator />
+        <CTASection heroInputRef={heroInputRef} />
+      </div>
+    </div>
+  );
+}
+
+function HeroSection({
+  platformIcon,
+  platformName,
+  headline,
+  description,
+  features,
+}: {
+  platformIcon: string;
+  platformName: string;
+  headline: string;
+  description: string;
+  features?: string[];
+}) {
+  return (
+    <div className="bg-linear-to-b from-stone-50/30 to-stone-100/30 px-6 py-12 lg:py-20">
+      <header className="text-center max-w-4xl mx-auto">
+        <div className="flex items-center justify-center mb-12">
+          <div className="size-32 shadow-2xl border border-neutral-100 flex justify-center items-center rounded-[36px] bg-white">
+            <img
+              src={platformIcon}
+              alt={platformName}
+              className="size-24 rounded-[28px]"
+            />
+          </div>
+          <div className="text-2xl sm:text-3xl text-neutral-400 font-light px-6">
+            +
+          </div>
+          <div className="size-32 shadow-2xl border border-neutral-100 flex justify-center items-center rounded-[36px] bg-white">
+            <img
+              src="/api/images/hyprnote/icon.png"
+              alt="Hyprnote"
+              className="size-24 rounded-[28px]"
+            />
+          </div>
+        </div>
+
+        <h1 className="text-3xl sm:text-4xl lg:text-5xl font-serif tracking-tight text-stone-600 mb-6">
+          {headline}
+        </h1>
+        <p className="text-lg sm:text-xl text-neutral-600 mb-8">
+          {description}
+        </p>
+
+        {features && features.length > 0 && (
+          <div className="flex flex-wrap justify-center gap-3 mb-8">
+            {features.map((feature) => (
+              <span
+                key={feature}
+                className="px-4 py-2 bg-stone-100 text-stone-600 rounded-full text-sm font-medium"
+              >
+                {feature}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div className="mt-8">
+          <a
+            href="https://hyprnote.com/download"
+            className={cn([
+              "inline-block px-8 py-3 text-base font-medium rounded-full",
+              "bg-linear-to-t from-stone-600 to-stone-500 text-white",
+              "hover:scale-105 active:scale-95 transition-transform",
+            ])}
+          >
+            Download Hyprnote for free
+          </a>
+        </div>
+      </header>
+    </div>
+  );
+}


### PR DESCRIPTION
# feat(web): add SEO-focused platform integration landing pages

## Summary

Adds SEO-focused landing pages for meeting platform integrations, similar to the existing `vs/$slug.tsx` pattern. Creates pages for Zoom, Microsoft Teams, Google Meet, and Webex with three feature variants each (transcription, notetaker, meeting-assistant).

**URL structure**: `/integrations/{platform}/{feature}` (e.g., `/integrations/zoom/transcription`)

**Changes:**
- New `integrations` content collection in `content-collections.ts`
- New route handler at `src/routes/_view/integrations/$category.$slug.tsx`
- 12 MDX content files (4 platforms × 3 features)
- 4 simplified SVG platform icons in `public/icons/`

**Preview:** https://deploy-preview-2101--hyprnote.netlify.app/integrations/zoom/transcription

## Review & Testing Checklist for Human

- [ ] **Replace SVG icons** - I created simplified placeholder icons, not official brand icons. You should replace these with proper brand assets before production
- [ ] **Verify all 12 URLs** - I tested Zoom transcription and Google Meet notetaker on the preview; please verify the remaining 10 pages render correctly
- [ ] **Check meta titles for SEO** - the title generation converts "meeting-assistant" to "Meeting assistant" (note lowercase 'a'). Verify this is acceptable
- [ ] **Consider sitemap** - new pages may need to be added to sitemap.xml for SEO discoverability

**Test URLs on preview:**
- https://deploy-preview-2101--hyprnote.netlify.app/integrations/zoom/transcription
- https://deploy-preview-2101--hyprnote.netlify.app/integrations/teams/notetaker
- https://deploy-preview-2101--hyprnote.netlify.app/integrations/google-meet/meeting-assistant
- https://deploy-preview-2101--hyprnote.netlify.app/integrations/webex/transcription

### Notes

Inspired by deeptrue.org's platform-specific landing pages structure. The user specifically requested not to add footer links like deeptrue.org does.

**Requested by:** john@hyprnote.com (@ComputelessComputer)
**Devin session:** https://app.devin.ai/sessions/bf1c781146654b2e8da06049984fc89a