### PR TITLE
docs: add supported languages doc URLs to STT adapters

### DIFF
--- a/owhisper/owhisper-client/src/adapter/argmax/mod.rs
+++ b/owhisper/owhisper-client/src/adapter/argmax/mod.rs
@@ -3,6 +3,7 @@ mod keywords;
 mod language;
 mod live;
 
+// https://github.com/argmaxinc/WhisperKit
 #[derive(Clone, Default)]
 pub struct ArgmaxAdapter;
 

--- a/owhisper/owhisper-client/src/adapter/assemblyai/mod.rs
+++ b/owhisper/owhisper-client/src/adapter/assemblyai/mod.rs
@@ -1,6 +1,7 @@
 mod batch;
 mod live;
 
+// https://www.assemblyai.com/docs/getting-started/supported-languages
 #[derive(Clone, Default)]
 pub struct AssemblyAIAdapter;
 

--- a/owhisper/owhisper-client/src/adapter/deepgram/mod.rs
+++ b/owhisper/owhisper-client/src/adapter/deepgram/mod.rs
@@ -3,6 +3,7 @@ mod keywords;
 mod language;
 mod live;
 
+// https://developers.deepgram.com/docs/models-languages-overview
 const SUPPORTED_LANGUAGES: &[&str] = &[
     "en", "es", "fr", "de", "hi", "ru", "pt", "ja", "it", "nl", "ko", "zh", "pl", "tr", "uk", "sv",
     "da", "fi", "no", "id", "ms", "th", "vi", "ta", "tl",

--- a/owhisper/owhisper-client/src/adapter/fireworks/mod.rs
+++ b/owhisper/owhisper-client/src/adapter/fireworks/mod.rs
@@ -4,6 +4,7 @@ mod live;
 pub(crate) const DEFAULT_API_HOST: &str = "api.fireworks.ai";
 const WS_PATH: &str = "/v1/audio/transcriptions/streaming";
 
+// https://docs.fireworks.ai/guides/querying-asr-models
 #[derive(Clone, Default)]
 pub struct FireworksAdapter;
 

--- a/owhisper/owhisper-client/src/adapter/soniox/mod.rs
+++ b/owhisper/owhisper-client/src/adapter/soniox/mod.rs
@@ -4,6 +4,7 @@ mod live;
 pub(crate) const DEFAULT_API_HOST: &str = "api.soniox.com";
 pub(crate) const DEFAULT_WS_HOST: &str = "stt-rt.soniox.com";
 
+// https://soniox.com/docs/stt/supported-languages
 #[derive(Clone, Default)]
 pub struct SonioxAdapter;
 


### PR DESCRIPTION
## Summary

Adds documentation URL comments to each STT adapter in `owhisper/owhisper-client/src/adapter/` pointing to the official supported languages documentation for each provider:

- **Argmax**: WhisperKit GitHub repo (uses Whisper models)
- **AssemblyAI**: Official supported languages docs
- **Deepgram**: Models & languages overview
- **Fireworks**: ASR models guide
- **Soniox**: Supported languages docs

## Review & Testing Checklist for Human

- [ ] Verify each URL is accessible and points to the correct documentation page
- [ ] Confirm the Argmax link to WhisperKit GitHub is appropriate (since it uses Whisper models which support 99+ languages, there's no dedicated languages page)

### Notes

- Documentation-only change, no functional code modifications
- Link to Devin run: https://app.devin.ai/sessions/a996bd0bf1cd4300b68a9cf97ac21c97
- Requested by: yujonglee (@yujonglee)