### PR TITLE
feat: add banner image field to templates and shortcuts frontmatter

### DIFF
--- a/apps/web/content-collections.ts
+++ b/apps/web/content-collections.ts
@@ -245,6 +245,7 @@ const templates = defineCollection({
     description: z.string(),
     category: z.string(),
     targets: z.array(z.string()),
+    banner: z.string().optional(),
     sections: z.array(
       z.object({
         title: z.string(),
@@ -419,6 +420,7 @@ const shortcuts = defineCollection({
     description: z.string(),
     category: z.string(),
     prompt: z.string(),
+    banner: z.string().optional(),
     targets: z.array(z.string()).optional(),
   }),
   transform: async (document, context) => {


### PR DESCRIPTION
## Summary

Adds an optional `banner` field (string) to the templates and shortcuts content collection schemas in `content-collections.ts`. This allows templates and shortcuts MDX files to specify a banner image URL in their frontmatter.

The field follows the same pattern as `coverImage` in the articles schema - an optional string field.

## Review & Testing Checklist for Human

- [ ] Verify the field name `banner` is the desired name (vs `bannerImage` or similar)
- [ ] If you plan to use this field immediately, add a banner to a template/shortcut MDX file and verify the build succeeds

### Notes

- This is a schema-only change; no UI code has been added to display the banner images yet
- Existing templates and shortcuts will continue to work since the field is optional

**Link to Devin run:** https://app.devin.ai/sessions/ec497c7b729e4cabacb5b86ea9158064
**Requested by:** john@hyprnote.com (@ComputelessComputer)