### PR TITLE
feat(owhisper-client): Phase 10 - Test Utilities Consolidation

### DIFF
--- a/owhisper/owhisper-client/src/adapter/argmax/live.rs
+++ b/owhisper/owhisper-client/src/adapter/argmax/live.rs
@@ -54,40 +54,16 @@ impl RealtimeSttAdapter for ArgmaxAdapter {
 #[cfg(test)]
 mod tests {
     use super::ArgmaxAdapter;
-    use crate::test_utils::{run_dual_test, run_single_test};
-    use crate::ListenClient;
 
-    #[tokio::test]
-    #[ignore]
-    async fn test_build_single() {
-        let client = ListenClient::builder()
-            .adapter::<ArgmaxAdapter>()
-            .api_base("ws://localhost:50060/v1")
-            .api_key("")
-            .params(owhisper_interface::ListenParams {
-                model: Some("large-v3-v20240930_626MB".to_string()),
-                languages: vec![hypr_language::ISO639::En.into()],
-                ..Default::default()
-            })
-            .build_single();
-
-        run_single_test(client, "argmax").await;
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_build_dual() {
-        let client = ListenClient::builder()
-            .adapter::<ArgmaxAdapter>()
-            .api_base("ws://localhost:50060/v1")
-            .api_key("")
-            .params(owhisper_interface::ListenParams {
-                model: Some("large-v3-v20240930_626MB".to_string()),
-                languages: vec![hypr_language::ISO639::En.into()],
-                ..Default::default()
-            })
-            .build_dual();
-
-        run_dual_test(client, "argmax").await;
+    crate::adapter_integration_tests! {
+        adapter: ArgmaxAdapter,
+        provider: "argmax",
+        api_base: "ws://localhost:50060/v1",
+        api_key_env: "",
+        params: owhisper_interface::ListenParams {
+            model: Some("large-v3-v20240930_626MB".to_string()),
+            languages: vec![hypr_language::ISO639::En.into()],
+            ..Default::default()
+        }
     }
 }

--- a/owhisper/owhisper-client/src/adapter/assemblyai/live.rs
+++ b/owhisper/owhisper-client/src/adapter/assemblyai/live.rs
@@ -287,40 +287,16 @@ impl AssemblyAIAdapter {
 #[cfg(test)]
 mod tests {
     use super::AssemblyAIAdapter;
-    use crate::test_utils::{run_dual_test, run_single_test};
-    use crate::ListenClient;
 
-    #[tokio::test]
-    #[ignore]
-    async fn test_build_single() {
-        let client = ListenClient::builder()
-            .adapter::<AssemblyAIAdapter>()
-            .api_base("wss://streaming.assemblyai.com")
-            .api_key(std::env::var("ASSEMBLYAI_API_KEY").expect("ASSEMBLYAI_API_KEY not set"))
-            .params(owhisper_interface::ListenParams {
-                model: Some("universal-streaming-english".to_string()),
-                languages: vec![hypr_language::ISO639::En.into()],
-                ..Default::default()
-            })
-            .build_single();
-
-        run_single_test(client, "assemblyai").await;
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_build_dual() {
-        let client = ListenClient::builder()
-            .adapter::<AssemblyAIAdapter>()
-            .api_base("wss://streaming.assemblyai.com")
-            .api_key(std::env::var("ASSEMBLYAI_API_KEY").expect("ASSEMBLYAI_API_KEY not set"))
-            .params(owhisper_interface::ListenParams {
-                model: Some("universal-streaming-english".to_string()),
-                languages: vec![hypr_language::ISO639::En.into()],
-                ..Default::default()
-            })
-            .build_dual();
-
-        run_dual_test(client, "assemblyai").await;
+    crate::adapter_integration_tests! {
+        adapter: AssemblyAIAdapter,
+        provider: "assemblyai",
+        api_base: "wss://streaming.assemblyai.com",
+        api_key_env: "ASSEMBLYAI_API_KEY",
+        params: owhisper_interface::ListenParams {
+            model: Some("universal-streaming-english".to_string()),
+            languages: vec![hypr_language::ISO639::En.into()],
+            ..Default::default()
+        }
     }
 }

--- a/owhisper/owhisper-client/src/adapter/deepgram/live.rs
+++ b/owhisper/owhisper-client/src/adapter/deepgram/live.rs
@@ -55,38 +55,17 @@ impl RealtimeSttAdapter for DeepgramAdapter {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::{run_dual_test, run_single_test};
-    use crate::ListenClient;
+    use super::DeepgramAdapter;
 
-    #[tokio::test]
-    #[ignore]
-    async fn test_build_single() {
-        let client = ListenClient::builder()
-            .api_base("https://api.deepgram.com/v1")
-            .api_key(std::env::var("DEEPGRAM_API_KEY").expect("DEEPGRAM_API_KEY not set"))
-            .params(owhisper_interface::ListenParams {
-                model: Some("nova-3".to_string()),
-                languages: vec![hypr_language::ISO639::En.into()],
-                ..Default::default()
-            })
-            .build_single();
-
-        run_single_test(client, "deepgram").await;
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_build_dual() {
-        let client = ListenClient::builder()
-            .api_base("https://api.deepgram.com/v1")
-            .api_key(std::env::var("DEEPGRAM_API_KEY").expect("DEEPGRAM_API_KEY not set"))
-            .params(owhisper_interface::ListenParams {
-                model: Some("nova-3".to_string()),
-                languages: vec![hypr_language::ISO639::En.into()],
-                ..Default::default()
-            })
-            .build_dual();
-
-        run_dual_test(client, "deepgram").await;
+    crate::adapter_integration_tests! {
+        adapter: DeepgramAdapter,
+        provider: "deepgram",
+        api_base: "https://api.deepgram.com/v1",
+        api_key_env: "DEEPGRAM_API_KEY",
+        params: owhisper_interface::ListenParams {
+            model: Some("nova-3".to_string()),
+            languages: vec![hypr_language::ISO639::En.into()],
+            ..Default::default()
+        }
     }
 }

--- a/owhisper/owhisper-client/src/adapter/fireworks/live.rs
+++ b/owhisper/owhisper-client/src/adapter/fireworks/live.rs
@@ -212,38 +212,15 @@ struct FireworksWord {
 #[cfg(test)]
 mod tests {
     use super::FireworksAdapter;
-    use crate::test_utils::{run_dual_test, run_single_test};
-    use crate::ListenClient;
 
-    #[tokio::test]
-    #[ignore]
-    async fn test_build_single() {
-        let client = ListenClient::builder()
-            .adapter::<FireworksAdapter>()
-            .api_base("https://api.fireworks.ai")
-            .api_key(std::env::var("FIREWORKS_API_KEY").expect("FIREWORKS_API_KEY not set"))
-            .params(owhisper_interface::ListenParams {
-                languages: vec![hypr_language::ISO639::En.into()],
-                ..Default::default()
-            })
-            .build_single();
-
-        run_single_test(client, "fireworks").await;
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_build_dual() {
-        let client = ListenClient::builder()
-            .adapter::<FireworksAdapter>()
-            .api_base("https://api.fireworks.ai")
-            .api_key(std::env::var("FIREWORKS_API_KEY").expect("FIREWORKS_API_KEY not set"))
-            .params(owhisper_interface::ListenParams {
-                languages: vec![hypr_language::ISO639::En.into()],
-                ..Default::default()
-            })
-            .build_dual();
-
-        run_dual_test(client, "fireworks").await;
+    crate::adapter_integration_tests! {
+        adapter: FireworksAdapter,
+        provider: "fireworks",
+        api_base: "https://api.fireworks.ai",
+        api_key_env: "FIREWORKS_API_KEY",
+        params: owhisper_interface::ListenParams {
+            languages: vec![hypr_language::ISO639::En.into()],
+            ..Default::default()
+        }
     }
 }

--- a/owhisper/owhisper-client/src/adapter/soniox/live.rs
+++ b/owhisper/owhisper-client/src/adapter/soniox/live.rs
@@ -277,40 +277,16 @@ impl SonioxAdapter {
 #[cfg(test)]
 mod tests {
     use super::SonioxAdapter;
-    use crate::test_utils::{run_dual_test, run_single_test};
-    use crate::ListenClient;
 
-    #[tokio::test]
-    #[ignore]
-    async fn test_build_single() {
-        let client = ListenClient::builder()
-            .adapter::<SonioxAdapter>()
-            .api_base("https://api.soniox.com")
-            .api_key(std::env::var("SONIOX_API_KEY").expect("SONIOX_API_KEY not set"))
-            .params(owhisper_interface::ListenParams {
-                model: Some("stt-v3".to_string()),
-                languages: vec![hypr_language::ISO639::En.into()],
-                ..Default::default()
-            })
-            .build_single();
-
-        run_single_test(client, "soniox").await;
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_build_dual() {
-        let client = ListenClient::builder()
-            .adapter::<SonioxAdapter>()
-            .api_base("https://api.soniox.com")
-            .api_key(std::env::var("SONIOX_API_KEY").expect("SONIOX_API_KEY not set"))
-            .params(owhisper_interface::ListenParams {
-                model: Some("stt-v3".to_string()),
-                languages: vec![hypr_language::ISO639::En.into()],
-                ..Default::default()
-            })
-            .build_dual();
-
-        run_dual_test(client, "soniox").await;
+    crate::adapter_integration_tests! {
+        adapter: SonioxAdapter,
+        provider: "soniox",
+        api_base: "https://api.soniox.com",
+        api_key_env: "SONIOX_API_KEY",
+        params: owhisper_interface::ListenParams {
+            model: Some("stt-v3".to_string()),
+            languages: vec![hypr_language::ISO639::En.into()],
+            ..Default::default()
+        }
     }
 }

--- a/owhisper/owhisper-client/src/test_utils.rs
+++ b/owhisper/owhisper-client/src/test_utils.rs
@@ -8,6 +8,55 @@ use owhisper_interface::MixedMessage;
 use crate::live::{FinalizeHandle, ListenClientDualInput, ListenClientInput};
 use crate::{ListenClient, ListenClientDual, RealtimeSttAdapter};
 
+#[macro_export]
+macro_rules! adapter_integration_tests {
+    (
+        adapter: $adapter:ty,
+        provider: $provider:expr,
+        api_base: $api_base:expr,
+        api_key_env: $api_key_env:expr,
+        params: $params:expr
+    ) => {
+        #[tokio::test]
+        #[ignore]
+        async fn test_build_single() {
+            let api_key = if $api_key_env.is_empty() {
+                String::new()
+            } else {
+                std::env::var($api_key_env).expect(concat!($api_key_env, " not set"))
+            };
+
+            let client = $crate::ListenClient::builder()
+                .adapter::<$adapter>()
+                .api_base($api_base)
+                .api_key(api_key)
+                .params($params)
+                .build_single();
+
+            $crate::test_utils::run_single_test(client, $provider).await;
+        }
+
+        #[tokio::test]
+        #[ignore]
+        async fn test_build_dual() {
+            let api_key = if $api_key_env.is_empty() {
+                String::new()
+            } else {
+                std::env::var($api_key_env).expect(concat!($api_key_env, " not set"))
+            };
+
+            let client = $crate::ListenClient::builder()
+                .adapter::<$adapter>()
+                .api_base($api_base)
+                .api_key(api_key)
+                .params($params)
+                .build_dual();
+
+            $crate::test_utils::run_dual_test(client, $provider).await;
+        }
+    };
+}
+
 fn timeout_secs() -> u64 {
     std::env::var("TEST_TIMEOUT_SECS")
         .ok()


### PR DESCRIPTION
# feat(owhisper-client): add adapter_integration_tests! macro for test consolidation

## Summary
Implements Phase 10: Test Utilities Consolidation for the owhisper-client crate. Creates an `adapter_integration_tests!` macro that generates standardized `test_build_single()` and `test_build_dual()` tests for STT adapter integration testing.

The macro takes adapter type, provider name, api_base, api_key_env, and ListenParams, then generates both test functions with `#[tokio::test]` and `#[ignore]` attributes.

Refactored all 5 adapter test modules (deepgram, assemblyai, soniox, argmax, fireworks) to use this macro, eliminating ~67 lines of duplicated test code (99 insertions, 166 deletions).

## Review & Testing Checklist for Human
- [ ] Verify the macro's api_key handling: empty `api_key_env` uses `String::new()`, non-empty uses `std::env::var()`. Argmax uses empty string - confirm this is equivalent to the previous `.api_key("")` behavior.
- [ ] Deepgram tests now explicitly call `.adapter::<DeepgramAdapter>()` when previously it relied on the default. Verify this doesn't change behavior.
- [ ] To test the refactoring works, run ignored tests with API keys: `cargo test -p owhisper-client --ignored -- test_build_single` (requires actual API credentials)

### Notes
- All tests have `#[ignore]` attribute so they won't run in normal CI - this is intentional as they require external API credentials
- The macro is exported at crate level via `#[macro_export]`

Link to Devin run: https://app.devin.ai/sessions/b04719086af84aa7bb20332eab590b33
Requested by: yujonglee (@yujonglee)