### PR TITLE
feat(owhisper-client): add polling abstraction for batch STT adapters

### DIFF
--- a/owhisper/owhisper-client/src/lib.rs
+++ b/owhisper/owhisper-client/src/lib.rs
@@ -2,6 +2,7 @@ mod adapter;
 mod batch;
 mod error;
 mod live;
+pub(crate) mod polling;
 
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/owhisper/owhisper-client/src/polling.rs
+++ b/owhisper/owhisper-client/src/polling.rs
@@ -1,0 +1,63 @@
+use std::future::Future;
+use std::time::Duration;
+
+use crate::error::Error;
+
+pub struct PollingConfig {
+    pub interval: Duration,
+    pub max_attempts: usize,
+    pub timeout_error: String,
+}
+
+impl Default for PollingConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(2),
+            max_attempts: 300,
+            timeout_error: "polling timed out".to_string(),
+        }
+    }
+}
+
+impl PollingConfig {
+    pub fn with_interval(mut self, interval: Duration) -> Self {
+        self.interval = interval;
+        self
+    }
+
+    pub fn with_max_attempts(mut self, max_attempts: usize) -> Self {
+        self.max_attempts = max_attempts;
+        self
+    }
+
+    pub fn with_timeout_error(mut self, timeout_error: impl Into<String>) -> Self {
+        self.timeout_error = timeout_error.into();
+        self
+    }
+}
+
+pub enum PollingResult<T> {
+    Complete(T),
+    Continue,
+    Failed(String),
+}
+
+pub async fn poll_until<T, Fut, F>(poll_fn: F, config: PollingConfig) -> Result<T, Error>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<PollingResult<T>, Error>>,
+{
+    for _ in 0..config.max_attempts {
+        match poll_fn().await? {
+            PollingResult::Complete(result) => return Ok(result),
+            PollingResult::Continue => {
+                tokio::time::sleep(config.interval).await;
+            }
+            PollingResult::Failed(error) => {
+                return Err(Error::AudioProcessing(error));
+            }
+        }
+    }
+
+    Err(Error::AudioProcessing(config.timeout_error))
+}


### PR DESCRIPTION
## Summary

Implements Phase 5: Polling Abstraction for the owhisper-client crate. This PR introduces a reusable `poll_until` function that eliminates duplicate polling loop code across batch STT adapters.

**New module `polling.rs`:**
- `PollingConfig` struct with configurable interval (default 2s), max_attempts (default 300), and timeout_error message
- `PollingResult<T>` enum with `Complete(T)`, `Continue`, and `Failed(String)` variants
- Generic `poll_until<T, Fut, F>` async function that handles the polling loop

**Refactored adapters:**
- `assemblyai/batch.rs`: Replaced ~50 line manual polling loop with `poll_until` (preserves 3s interval)
- `soniox/batch.rs`: Replaced ~50 line manual polling loop with `poll_until` (preserves 2s default interval)

## Review & Testing Checklist for Human

- [ ] **Verify soniox debug logging removal is acceptable**: The original `poll_transcription` had `tracing::debug!` calls logging each polling attempt with attempt number. This was removed in the refactoring. Confirm this loss of observability is okay.
- [ ] **Test batch transcription end-to-end**: The polling logic is critical for batch transcription. Test with both AssemblyAI and Soniox to verify transcriptions complete successfully.
- [ ] **Verify timeout behavior**: Confirm that long-running transcriptions that exceed max_attempts (300 * interval) properly return timeout errors.

**Suggested test plan:** Run a batch transcription through both adapters with a real audio file to verify the polling completes and returns results correctly.

### Notes
- Cargo reports unused warning for `with_max_attempts` method - this is expected as both adapters use the default value of 300
- Session: https://app.devin.ai/sessions/c40e2ca9a16741b1b2c1589ec5c3ccf5
- Requested by: @yujonglee