### PR TITLE
feat(owhisper-client): add QueryParamBuilder for URL building improvements

### DIFF
--- a/owhisper/owhisper-client/src/adapter/mod.rs
+++ b/owhisper/owhisper-client/src/adapter/mod.rs
@@ -5,6 +5,9 @@ mod deepgram_compat;
 mod fireworks;
 mod owhisper;
 mod soniox;
+mod url_builder;
+
+pub use url_builder::QueryParamBuilder;
 
 pub use argmax::*;
 pub use assemblyai::*;

--- a/owhisper/owhisper-client/src/adapter/url_builder.rs
+++ b/owhisper/owhisper-client/src/adapter/url_builder.rs
@@ -1,0 +1,186 @@
+use owhisper_interface::ListenParams;
+
+#[derive(Default)]
+pub struct QueryParamBuilder {
+    params: Vec<(String, String)>,
+}
+
+impl QueryParamBuilder {
+    pub fn new() -> Self {
+        Self { params: Vec::new() }
+    }
+
+    pub fn add<V: ToString>(&mut self, key: &str, value: V) -> &mut Self {
+        self.params.push((key.to_string(), value.to_string()));
+        self
+    }
+
+    pub fn add_opt<V: ToString>(&mut self, key: &str, value: Option<V>) -> &mut Self {
+        if let Some(v) = value {
+            self.params.push((key.to_string(), v.to_string()));
+        }
+        self
+    }
+
+    pub fn add_bool(&mut self, key: &str, value: bool) -> &mut Self {
+        self.params.push((
+            key.to_string(),
+            if value { "true" } else { "false" }.to_string(),
+        ));
+        self
+    }
+
+    pub fn add_common_listen_params(&mut self, params: &ListenParams, channels: u8) -> &mut Self {
+        let model = params.model.as_deref().unwrap_or("hypr-whisper");
+        self.add("model", model)
+            .add("channels", channels)
+            .add("sample_rate", params.sample_rate)
+            .add("encoding", "linear16")
+            .add_bool("diarize", true)
+            .add_bool("punctuate", true)
+            .add_bool("smart_format", true)
+            .add_bool("numerals", true)
+            .add_bool("filler_words", false)
+            .add_bool("mip_opt_out", true)
+    }
+
+    pub fn apply_to(&self, url: &mut url::Url) {
+        let mut query_pairs = url.query_pairs_mut();
+        for (key, value) in &self.params {
+            query_pairs.append_pair(key, value);
+        }
+    }
+
+    pub fn build(&self) -> Vec<(String, String)> {
+        self.params.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_creates_empty_builder() {
+        let builder = QueryParamBuilder::new();
+        assert!(builder.build().is_empty());
+    }
+
+    #[test]
+    fn test_add_string_value() {
+        let mut builder = QueryParamBuilder::new();
+        builder.add("model", "nova-3");
+        assert_eq!(builder.build(), vec![("model".into(), "nova-3".into())]);
+    }
+
+    #[test]
+    fn test_add_numeric_value() {
+        let mut builder = QueryParamBuilder::new();
+        builder.add("channels", 2);
+        assert_eq!(builder.build(), vec![("channels".into(), "2".into())]);
+    }
+
+    #[test]
+    fn test_add_opt_some() {
+        let mut builder = QueryParamBuilder::new();
+        builder.add_opt("model", Some("nova-3"));
+        assert_eq!(builder.build(), vec![("model".into(), "nova-3".into())]);
+    }
+
+    #[test]
+    fn test_add_opt_none() {
+        let mut builder = QueryParamBuilder::new();
+        builder.add_opt::<&str>("model", None);
+        assert!(builder.build().is_empty());
+    }
+
+    #[test]
+    fn test_add_bool_true() {
+        let mut builder = QueryParamBuilder::new();
+        builder.add_bool("diarize", true);
+        assert_eq!(builder.build(), vec![("diarize".into(), "true".into())]);
+    }
+
+    #[test]
+    fn test_add_bool_false() {
+        let mut builder = QueryParamBuilder::new();
+        builder.add_bool("diarize", false);
+        assert_eq!(builder.build(), vec![("diarize".into(), "false".into())]);
+    }
+
+    #[test]
+    fn test_chaining() {
+        let mut builder = QueryParamBuilder::new();
+        builder
+            .add("model", "nova-3")
+            .add("channels", 2)
+            .add_bool("diarize", true);
+        assert_eq!(
+            builder.build(),
+            vec![
+                ("model".into(), "nova-3".into()),
+                ("channels".into(), "2".into()),
+                ("diarize".into(), "true".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_apply_to_url() {
+        let mut builder = QueryParamBuilder::new();
+        builder.add("model", "nova-3").add_bool("diarize", true);
+
+        let mut url: url::Url = "https://api.example.com/listen".parse().unwrap();
+        builder.apply_to(&mut url);
+
+        assert_eq!(
+            url.as_str(),
+            "https://api.example.com/listen?model=nova-3&diarize=true"
+        );
+    }
+
+    #[test]
+    fn test_add_common_listen_params() {
+        let mut builder = QueryParamBuilder::new();
+        let params = ListenParams {
+            model: Some("nova-3".to_string()),
+            sample_rate: 16000,
+            ..Default::default()
+        };
+        builder.add_common_listen_params(&params, 2);
+
+        let result = builder.build();
+        assert!(result.iter().any(|(k, v)| k == "model" && v == "nova-3"));
+        assert!(result.iter().any(|(k, v)| k == "channels" && v == "2"));
+        assert!(result
+            .iter()
+            .any(|(k, v)| k == "sample_rate" && v == "16000"));
+        assert!(result
+            .iter()
+            .any(|(k, v)| k == "encoding" && v == "linear16"));
+        assert!(result.iter().any(|(k, v)| k == "diarize" && v == "true"));
+        assert!(result.iter().any(|(k, v)| k == "punctuate" && v == "true"));
+        assert!(result
+            .iter()
+            .any(|(k, v)| k == "smart_format" && v == "true"));
+        assert!(result.iter().any(|(k, v)| k == "numerals" && v == "true"));
+        assert!(result
+            .iter()
+            .any(|(k, v)| k == "filler_words" && v == "false"));
+        assert!(result
+            .iter()
+            .any(|(k, v)| k == "mip_opt_out" && v == "true"));
+    }
+
+    #[test]
+    fn test_add_common_listen_params_default_model() {
+        let mut builder = QueryParamBuilder::new();
+        let params = ListenParams::default();
+        builder.add_common_listen_params(&params, 1);
+
+        let result = builder.build();
+        assert!(result
+            .iter()
+            .any(|(k, v)| k == "model" && v == "hypr-whisper"));
+    }
+}


### PR DESCRIPTION
# feat(owhisper-client): add QueryParamBuilder for URL building improvements

## Summary
Implements Phase 4 URL Building Improvements for the owhisper-client crate. Creates a `QueryParamBuilder` in `adapter/url_builder.rs` that provides a fluent API for building URL query parameters, replacing repetitive `query_pairs_mut().append_pair()` calls in `deepgram_compat/mod.rs`.

The builder provides:
- `new()` constructor
- `add<V: ToString>(key, value)` for generic values
- `add_opt<V: ToString>(key, Option<V>)` for optional values
- `add_bool(key, bool)` for boolean values as "true"/"false" strings
- `add_common_listen_params(params, channels)` for common STT parameters
- `apply_to(url)` to apply accumulated params to a URL
- `build()` to return params as `Vec<(String, String)>`

Both `build_listen_ws_url` and `build_batch_url` have been refactored to use this builder pattern.

## Review & Testing Checklist for Human
- [ ] **Verify URL parameter equivalence**: The refactoring changes parameter ordering. Compare generated URLs from old vs new code to ensure all parameters are present (order shouldn't matter for HTTP, but worth verifying)
- [ ] **Check `build_listen_ws_url` params**: Confirm these params are all present: model, channels, sample_rate, encoding, diarize, punctuate, smart_format, numerals, filler_words, mip_opt_out, interim_results, multichannel, vad_events, redemption_time_ms
- [ ] **Integration test**: If possible, run with a real STT service (Deepgram) to verify the URLs work correctly end-to-end

**Suggested test plan**: Run the desktop app with Deepgram STT enabled and verify transcription still works correctly.

### Notes
- `add_opt` and `build` methods show as unused (compiler warnings) but are intentionally part of the public API for future use
- Language and keyword strategies still use `query_pairs_mut` directly since they have their own trait-based append logic
- All 25 unit tests pass; 18 integration tests were skipped (require API keys)

Link to Devin run: https://app.devin.ai/sessions/2fab045214364df7bb73182a3a30a414
Requested by: yujonglee (@yujonglee)