### PR TITLE
Refactor OpenAI adapter and add model support

### DIFF
--- a/apps/desktop/src/components/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/components/settings/ai/stt/shared.tsx
@@ -44,6 +44,14 @@ export const displayModelId = (model: string) => {
     return "Whisper 1";
   }
 
+  if (model === "gpt-4o-transcribe") {
+    return "GPT-4o Transcribe";
+  }
+
+  if (model === "gpt-4o-mini-transcribe") {
+    return "GPT-4o mini Transcribe";
+  }
+
   if (model.startsWith("am-")) {
     const am = model as AmModel;
     if (am == "am-parakeet-v2") {
@@ -153,7 +161,7 @@ export const PROVIDERS = [
     badge: "Beta",
     icon: <OpenAI size={16} />,
     baseUrl: "https://api.openai.com/v1",
-    models: ["whisper-1"],
+    models: ["gpt-4o-transcribe", "gpt-4o-mini-transcribe", "whisper-1"],
     requiresPro: false,
   },
   {

--- a/owhisper/owhisper-client/src/adapter/openai/live.rs
+++ b/owhisper/owhisper-client/src/adapter/openai/live.rs
@@ -7,6 +7,12 @@ use super::OpenAIAdapter;
 use crate::adapter::parsing::{calculate_time_span, WordBuilder};
 use crate::adapter::RealtimeSttAdapter;
 
+// Voice Activity Detection (VAD) configuration defaults
+const VAD_DETECTION_TYPE: &str = "server_vad";
+const VAD_THRESHOLD: f32 = 0.5;
+const VAD_PREFIX_PADDING_MS: u32 = 300;
+const VAD_SILENCE_DURATION_MS: u32 = 500;
+
 impl RealtimeSttAdapter for OpenAIAdapter {
     fn provider_name(&self) -> &'static str {
         "openai"
@@ -78,10 +84,10 @@ impl RealtimeSttAdapter for OpenAIAdapter {
                             language,
                         }),
                         turn_detection: Some(TurnDetection {
-                            detection_type: "server_vad".to_string(),
-                            threshold: Some(0.5),
-                            prefix_padding_ms: Some(300),
-                            silence_duration_ms: Some(500),
+                            detection_type: VAD_DETECTION_TYPE.to_string(),
+                            threshold: Some(VAD_THRESHOLD),
+                            prefix_padding_ms: Some(VAD_PREFIX_PADDING_MS),
+                            silence_duration_ms: Some(VAD_SILENCE_DURATION_MS),
                         }),
                     }),
                 }),

--- a/owhisper/owhisper-client/src/adapter/openai/mod.rs
+++ b/owhisper/owhisper-client/src/adapter/openai/mod.rs
@@ -3,6 +3,12 @@ mod live;
 
 pub(crate) const DEFAULT_WS_HOST: &str = "api.openai.com";
 pub(crate) const WS_PATH: &str = "/v1/realtime";
+
+// OpenAI STT Models:
+// - whisper-1: Legacy model, supports verbose_json with word timestamps (batch only)
+// - gpt-4o-transcribe: High quality, supports both batch (json only) and realtime
+// - gpt-4o-mini-transcribe: Cost-efficient, supports both batch (json only) and realtime
+// - gpt-4o-transcribe-diarize: Speaker diarization (batch only, not yet supported here)
 pub(crate) const DEFAULT_TRANSCRIPTION_MODEL: &str = "gpt-4o-transcribe";
 
 #[derive(Clone, Default)]


### PR DESCRIPTION
## Summary

This PR refactors the OpenAI STT adapter and adds support for the newer gpt-4o transcription models. Key changes:

**Adapter refactoring:**
- Removed dead code (`OpenAISegment` struct and `segments` field that were never used)
- Extracted magic values to named constants (VAD config, response formats)

**Model-aware request building:**
- `whisper-1`: Uses `verbose_json` with word-level timestamps (existing behavior)
- `gpt-4o-transcribe` / `gpt-4o-mini-transcribe`: Uses `json` format (no word timestamps, per OpenAI API limitations)

**UI updates:**
- Added gpt-4o-transcribe and gpt-4o-mini-transcribe to the OpenAI provider model list
- Added display names for the new models

## Review & Testing Checklist for Human

- [ ] **Verify model selection flow**: Select gpt-4o-transcribe in Settings → STT and confirm the adapter receives the correct model parameter during transcription
- [ ] **Test batch transcription with gpt-4o models**: The response will have an empty `words` array - verify downstream features (word highlighting, scrubber, etc.) handle this gracefully
- [ ] **Confirm whisper-1 still works**: Ensure the existing whisper-1 path with word timestamps is not regressed
- [ ] **Check realtime transcription**: The realtime API already uses gpt-4o-transcribe by default - verify live transcription still works

**Recommended test plan:**
1. Start a recording session with OpenAI provider + gpt-4o-transcribe model
2. Verify live transcription works
3. Stop recording and verify batch transcription completes (will have no word timestamps)
4. Repeat with whisper-1 model and verify word timestamps are present

### Notes

The gpt-4o models provide higher quality transcription but don't support word-level timestamps in the batch API. This is an OpenAI limitation, not a bug. Users who need word timestamps should use whisper-1.

Link to Devin run: https://app.devin.ai/sessions/02cc0fe084c3495db89f417c806c67f5
Requested by: yujonglee (@yujonglee)