### PR TITLE
Add STT E2E workflow for testing STT adapters

### DIFF
--- a/.github/workflows/stt_e2e.yaml
+++ b/.github/workflows/stt_e2e.yaml
@@ -1,0 +1,31 @@
+on:
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: "STT provider (adapter name)"
+        required: true
+        type: choice
+        options:
+          - deepgram
+          - assemblyai
+          - soniox
+          - gladia
+          - fireworks
+          - openai
+jobs:
+  batch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/rust_install
+        with:
+          platform: linux
+      - run: infisical run --env=dev --projectId=87dad7b5-72a6-4791-9228-b3b86b169db1 --path="/stt" -- cargo test -p owhisper-client adapter::${{ inputs.provider }}::batch --ignored -- --nocapture
+  live:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/rust_install
+        with:
+          platform: linux
+      - run: infisical run --env=dev --projectId=87dad7b5-72a6-4791-9228-b3b86b169db1 --path="/stt" -- cargo test -p owhisper-client adapter::${{ inputs.provider }}::live --ignored -- --nocapture


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow `stt_e2e.yaml` for running end-to-end tests against STT (speech-to-text) provider adapters. The workflow is manually triggered via `workflow_dispatch` with a provider selection input, and runs both batch and live tests using infisical for secrets management.

Supported providers: deepgram, assemblyai, soniox, gladia, fireworks, openai

## Review & Testing Checklist for Human

- [ ] **Verify infisical is available**: The workflow doesn't install infisical - confirm it's pre-installed on the runner or add an installation step
- [ ] **Test filter pattern correctness**: Verify that `adapter::${{ inputs.provider }}::batch` and `adapter::${{ inputs.provider }}::live` correctly match the test module paths (e.g., `owhisper_client::adapter::deepgram::live::tests::*`)
- [ ] **Batch test coverage**: Not all providers have batch tests (only gladia and openai have explicit batch tests) - the batch job may fail or be a no-op for other providers
- [ ] **Run the workflow manually** for at least one provider (e.g., deepgram) to verify it works end-to-end

### Notes

- Link to Devin run: https://app.devin.ai/sessions/f3f59b24c8e84b1d8871fd3d40efed12
- Requested by: yujonglee (@yujonglee)