### PR TITLE
feat: add downloadable extensions support

### DIFF
--- a/.github/workflows/extensions_cd.yaml
+++ b/.github/workflows/extensions_cd.yaml
@@ -1,9 +1,18 @@
 on:
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish extensions to R2"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  EXTENSIONS_BUCKET: hyprnote-extensions
 
 jobs:
   build:
@@ -13,10 +22,93 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
-      - working-directory: ./extensions
+      - name: Build extensions
+        working-directory: ./extensions
         run: deno task build
+
+      - name: Package extensions
+        run: |
+          mkdir -p dist/extensions
+          for dir in extensions/*/; do
+            if [ -f "$dir/extension.json" ] && [ -d "$dir/dist" ]; then
+              name=$(basename "$dir")
+              version=$(jq -r '.version' "$dir/extension.json")
+
+              # Create a clean package directory
+              mkdir -p "dist/packages/$name"
+              cp "$dir/extension.json" "dist/packages/$name/"
+              cp "$dir/main.js" "dist/packages/$name/" 2>/dev/null || true
+              cp -r "$dir/dist" "dist/packages/$name/"
+
+              # Create zip archive
+              (cd "dist/packages" && zip -r "../extensions/$name-$version.zip" "$name")
+
+              # Calculate checksum
+              sha256sum "dist/extensions/$name-$version.zip" | cut -d' ' -f1 > "dist/extensions/$name-$version.zip.sha256"
+
+              echo "Packaged: $name v$version"
+            fi
+          done
+
+      - name: Generate registry
+        run: |
+          echo '{"version":1,"extensions":[' > dist/extensions/registry.json
+          first=true
+          for dir in extensions/*/; do
+            if [ -f "$dir/extension.json" ] && [ -d "$dir/dist" ]; then
+              name=$(basename "$dir")
+              version=$(jq -r '.version' "$dir/extension.json")
+              ext_name=$(jq -r '.name' "$dir/extension.json")
+              description=$(jq -r '.description // ""' "$dir/extension.json")
+              api_version=$(jq -r '.api_version // "0.1"' "$dir/extension.json")
+              checksum=$(cat "dist/extensions/$name-$version.zip.sha256")
+              size=$(stat -c%s "dist/extensions/$name-$version.zip")
+
+              if [ "$first" = true ]; then
+                first=false
+              else
+                echo ',' >> dist/extensions/registry.json
+              fi
+
+              jq -n \
+                --arg id "$name" \
+                --arg name "$ext_name" \
+                --arg version "$version" \
+                --arg api_version "$api_version" \
+                --arg description "$description" \
+                --arg download_url "https://pub-hyprnote.r2.dev/extensions/$name-$version.zip" \
+                --arg checksum "$checksum" \
+                --argjson size "$size" \
+                '{id: $id, name: $name, version: $version, api_version: $api_version, description: $description, download_url: $download_url, checksum: $checksum, size: $size}' \
+                >> dist/extensions/registry.json
+            fi
+          done
+          echo ']}' >> dist/extensions/registry.json
+          cat dist/extensions/registry.json
+
       - uses: actions/upload-artifact@v4
         with:
           name: extensions
-          path: extensions/*/dist/
+          path: dist/extensions/
           retention-days: 7
+
+      - name: Upload to R2
+        if: ${{ inputs.publish }}
+        run: |
+          # Upload extension packages
+          for file in dist/extensions/*.zip; do
+            aws s3 cp "$file" "s3://${{ env.EXTENSIONS_BUCKET }}/extensions/$(basename "$file")" \
+              --endpoint-url ${{ secrets.CLOUDFLARE_R2_ENDPOINT_URL }} \
+              --region auto
+          done
+
+          # Upload registry
+          aws s3 cp dist/extensions/registry.json "s3://${{ env.EXTENSIONS_BUCKET }}/extensions/registry.json" \
+            --endpoint-url ${{ secrets.CLOUDFLARE_R2_ENDPOINT_URL }} \
+            --region auto \
+            --content-type "application/json"
+
+          echo "Published extensions to R2"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,6 +2311,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cached"
 version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,6 +3137,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "content_inspector"
@@ -3959,6 +3984,12 @@ dependencies = [
  "adler32",
  "byteorder",
 ]
+
+[[package]]
+name = "deflate64"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 
 [[package]]
 name = "deno_core"
@@ -9329,6 +9360,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11406,6 +11458,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -15822,8 +15884,11 @@ name = "tauri-plugin-extensions"
 version = "0.1.0"
 dependencies = [
  "extensions-runtime",
+ "hex",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
+ "sha2",
  "specta",
  "specta-typescript",
  "tauri",
@@ -15832,6 +15897,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -19943,6 +20009,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4de5f056fb9dc8b7908754867544e26145767187aaac5a98495e88ad7cb8a80f"
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20239,6 +20314,36 @@ dependencies = [
 
 [[package]]
 name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap 2.12.0",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror 2.0.17",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zip"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
@@ -20247,6 +20352,46 @@ dependencies = [
  "crc32fast",
  "indexmap 2.12.0",
  "memchr",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/apps/desktop/src/components/main/body/extensions/index.tsx
+++ b/apps/desktop/src/components/main/body/extensions/index.tsx
@@ -1,5 +1,11 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
-import { AlertTriangleIcon, BlocksIcon, PuzzleIcon, XIcon } from "lucide-react";
+import {
+  AlertTriangleIcon,
+  BlocksIcon,
+  PuzzleIcon,
+  StoreIcon,
+  XIcon,
+} from "lucide-react";
 import { Reorder, useDragControls } from "motion/react";
 import {
   Component,
@@ -26,6 +32,7 @@ import {
   ResizablePanel,
   ResizablePanelGroup,
 } from "@hypr/ui/components/ui/resizable";
+import { Tabs, TabsList, TabsTrigger } from "@hypr/ui/components/ui/tabs";
 import { cn } from "@hypr/utils";
 
 import { createIframeSynchronizer } from "../../../../store/tinybase/iframe-sync";
@@ -36,6 +43,7 @@ import { type TabItem, TabItemBase } from "../shared";
 import { ExtensionDetailsColumn } from "./details";
 import { ExtensionsListColumn } from "./list";
 import { getPanelInfoByExtensionId } from "./registry";
+import { ExtensionStoreColumn } from "./store";
 
 type ExtensionTab = Extract<Tab, { type: "extension" }>;
 type ExtensionsTab = Extract<Tab, { type: "extensions" }>;
@@ -74,6 +82,9 @@ function ExtensionsView({ tab }: { tab: ExtensionsTab }) {
   const updateExtensionsTabState = useTabs(
     (state) => state.updateExtensionsTabState,
   );
+  const [activeTab, setActiveTab] = useState<"installed" | "store">(
+    "installed",
+  );
 
   const { selectedExtension } = tab.state;
 
@@ -88,18 +99,46 @@ function ExtensionsView({ tab }: { tab: ExtensionsTab }) {
   );
 
   return (
-    <ResizablePanelGroup direction="horizontal" className="h-full">
-      <ResizablePanel defaultSize={30} minSize={20} maxSize={40}>
-        <ExtensionsListColumn
-          selectedExtension={selectedExtension}
-          setSelectedExtension={setSelectedExtension}
-        />
-      </ResizablePanel>
-      <ResizableHandle />
-      <ResizablePanel defaultSize={70} minSize={50}>
-        <ExtensionDetailsColumn selectedExtensionId={selectedExtension} />
-      </ResizablePanel>
-    </ResizablePanelGroup>
+    <div className="h-full flex flex-col">
+      <div className="border-b border-neutral-200 px-4 py-2">
+        <Tabs
+          value={activeTab}
+          onValueChange={(v) => setActiveTab(v as "installed" | "store")}
+        >
+          <TabsList className="h-8">
+            <TabsTrigger value="installed" className="text-xs px-3 h-6">
+              <BlocksIcon className="w-3 h-3 mr-1" />
+              Installed
+            </TabsTrigger>
+            <TabsTrigger value="store" className="text-xs px-3 h-6">
+              <StoreIcon className="w-3 h-3 mr-1" />
+              Store
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
+      <div className="flex-1 min-h-0">
+        <ResizablePanelGroup direction="horizontal" className="h-full">
+          <ResizablePanel defaultSize={30} minSize={20} maxSize={40}>
+            {activeTab === "installed" ? (
+              <ExtensionsListColumn
+                selectedExtension={selectedExtension}
+                setSelectedExtension={setSelectedExtension}
+              />
+            ) : (
+              <ExtensionStoreColumn
+                selectedExtension={selectedExtension}
+                setSelectedExtension={setSelectedExtension}
+              />
+            )}
+          </ResizablePanel>
+          <ResizableHandle />
+          <ResizablePanel defaultSize={70} minSize={50}>
+            <ExtensionDetailsColumn selectedExtensionId={selectedExtension} />
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
+    </div>
   );
 }
 

--- a/apps/desktop/src/components/main/body/extensions/store.tsx
+++ b/apps/desktop/src/components/main/body/extensions/store.tsx
@@ -1,0 +1,210 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Check, Download, Loader2, Store, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { commands, type RegistryEntry } from "@hypr/plugin-extensions";
+import { Button } from "@hypr/ui/components/ui/button";
+import { cn } from "@hypr/utils";
+
+import { listInstalledExtensions } from "./registry";
+
+export function ExtensionStoreColumn({
+  selectedExtension,
+  setSelectedExtension,
+}: {
+  selectedExtension: string | null;
+  setSelectedExtension: (id: string | null) => void;
+}) {
+  const queryClient = useQueryClient();
+
+  const { data: registry, isLoading: isLoadingRegistry } = useQuery({
+    queryKey: ["extensions", "registry"],
+    queryFn: async () => {
+      const result = await commands.fetchRegistry();
+      if (result.status === "ok") {
+        return result.data;
+      }
+      throw new Error(result.error as unknown as string);
+    },
+  });
+
+  const { data: installedExtensions = [] } = useQuery({
+    queryKey: ["extensions", "list"],
+    queryFn: listInstalledExtensions,
+  });
+
+  const installedIds = useMemo(
+    () => new Set(installedExtensions.map((ext) => ext.id)),
+    [installedExtensions],
+  );
+
+  const installMutation = useMutation({
+    mutationFn: async (entry: RegistryEntry) => {
+      const result = await commands.downloadExtension(
+        entry.id,
+        entry.download_url,
+        entry.checksum,
+      );
+      if (result.status === "error") {
+        throw new Error(result.error as unknown as string);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["extensions", "list"] });
+    },
+  });
+
+  const uninstallMutation = useMutation({
+    mutationFn: async (extensionId: string) => {
+      const result = await commands.uninstallExtension(extensionId);
+      if (result.status === "error") {
+        throw new Error(result.error as unknown as string);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["extensions", "list"] });
+    },
+  });
+
+  if (isLoadingRegistry) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-neutral-400" />
+      </div>
+    );
+  }
+
+  if (!registry) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <div className="text-center">
+          <Store size={32} className="mx-auto mb-2 text-neutral-300" />
+          <p className="text-sm text-neutral-500">
+            Unable to load extension store
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full flex flex-col">
+      <div className="@container border-b border-neutral-200">
+        <div className="py-2 pl-3 pr-1 flex items-center justify-between h-12 min-w-0">
+          <h3 className="text-sm font-medium">Available Extensions</h3>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        <div className="p-2">
+          {registry.extensions.length === 0 ? (
+            <div className="text-center py-8 text-neutral-500">
+              <Store size={32} className="mx-auto mb-2 text-neutral-300" />
+              <p className="text-sm">No extensions available</p>
+            </div>
+          ) : (
+            registry.extensions.map((entry) => (
+              <StoreExtensionItem
+                key={entry.id}
+                entry={entry}
+                isInstalled={installedIds.has(entry.id)}
+                isSelected={selectedExtension === entry.id}
+                isInstalling={
+                  installMutation.isPending &&
+                  installMutation.variables?.id === entry.id
+                }
+                isUninstalling={
+                  uninstallMutation.isPending &&
+                  uninstallMutation.variables === entry.id
+                }
+                onClick={() => setSelectedExtension(entry.id)}
+                onInstall={() => installMutation.mutate(entry)}
+                onUninstall={() => uninstallMutation.mutate(entry.id)}
+              />
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StoreExtensionItem({
+  entry,
+  isInstalled,
+  isSelected,
+  isInstalling,
+  isUninstalling,
+  onClick,
+  onInstall,
+  onUninstall,
+}: {
+  entry: RegistryEntry;
+  isInstalled: boolean;
+  isSelected: boolean;
+  isInstalling: boolean;
+  isUninstalling: boolean;
+  onClick: () => void;
+  onInstall: () => void;
+  onUninstall: () => void;
+}) {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const handleAction = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isInstalled) {
+      onUninstall();
+    } else {
+      onInstall();
+    }
+  };
+
+  return (
+    <div
+      onClick={onClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      className={cn([
+        "w-full text-left px-3 py-2 rounded-md text-sm border hover:bg-neutral-100 transition-colors cursor-pointer",
+        isSelected ? "border-neutral-500 bg-neutral-100" : "border-transparent",
+      ])}
+    >
+      <div className="flex items-center gap-2">
+        <Store className="h-4 w-4 text-neutral-500 shrink-0" />
+        <div className="flex-1 min-w-0">
+          <div className="font-medium truncate flex items-center gap-1">
+            {entry.name}
+            <span className="text-xs text-stone-400 font-mono">
+              v{entry.version}
+            </span>
+            {isInstalled && (
+              <Check className="h-3 w-3 text-green-500 shrink-0" />
+            )}
+          </div>
+          {entry.description && (
+            <div className="text-xs text-neutral-500 truncate">
+              {entry.description}
+            </div>
+          )}
+        </div>
+        {(isHovered || isInstalling || isUninstalling) && (
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-7 w-7 shrink-0"
+            onClick={handleAction}
+            disabled={isInstalling || isUninstalling}
+          >
+            {isInstalling || isUninstalling ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : isInstalled ? (
+              <Trash2 className="h-4 w-4 text-red-500" />
+            ) : (
+              <Download className="h-4 w-4" />
+            )}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/plugins/extensions/Cargo.toml
+++ b/plugins/extensions/Cargo.toml
@@ -19,9 +19,13 @@ hypr-extensions-runtime = { workspace = true }
 tauri = { workspace = true, features = ["test"] }
 tauri-specta = { workspace = true, features = ["derive", "typescript"] }
 
+hex = "0.4"
+reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+sha2 = "0.10"
 specta = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+zip = "2.2"

--- a/plugins/extensions/js/bindings.gen.ts
+++ b/plugins/extensions/js/bindings.gen.ts
@@ -54,6 +54,30 @@ async getExtension(extensionId: string) : Promise<Result<ExtensionInfo, Error>> 
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async fetchRegistry() : Promise<Result<RegistryResponse, Error>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:extensions|fetch_registry") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async downloadExtension(extensionId: string, downloadUrl: string, expectedChecksum: string) : Promise<Result<null, Error>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:extensions|download_extension", { extensionId, downloadUrl, expectedChecksum }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async uninstallExtension(extensionId: string) : Promise<Result<null, Error>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:extensions|uninstall_extension", { extensionId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 
@@ -67,9 +91,11 @@ async getExtension(extensionId: string) : Promise<Result<ExtensionInfo, Error>> 
 
 /** user-defined types **/
 
-export type Error = { ExtensionNotFound: string } | { RuntimeError: string } | { InvalidManifest: string } | { Io: string }
+export type Error = { ExtensionNotFound: string } | { RuntimeError: string } | { InvalidManifest: string } | { Io: string } | "RuntimeUnavailable" | { Network: string } | { ChecksumMismatch: { expected: string; actual: string } } | { ZipError: string }
 export type ExtensionInfo = { id: string; name: string; version: string; api_version: string; description: string | null; path: string; panels: PanelInfo[] }
 export type PanelInfo = { id: string; title: string; entry: string; entry_path: string | null; styles_path: string | null }
+export type RegistryEntry = { id: string; name: string; version: string; api_version: string; description: string; download_url: string; checksum: string; size: number }
+export type RegistryResponse = { version: number; extensions: RegistryEntry[] }
 
 /** tauri-specta globals **/
 

--- a/plugins/extensions/src/error.rs
+++ b/plugins/extensions/src/error.rs
@@ -12,6 +12,12 @@ pub enum Error {
     Io(String),
     #[error("Runtime unavailable: V8 engine failed to initialize")]
     RuntimeUnavailable,
+    #[error("Network error: {0}")]
+    Network(String),
+    #[error("Checksum mismatch: expected {expected}, got {actual}")]
+    ChecksumMismatch { expected: String, actual: String },
+    #[error("Zip extraction error: {0}")]
+    ZipError(String),
 }
 
 impl From<hypr_extensions_runtime::Error> for Error {

--- a/plugins/extensions/src/lib.rs
+++ b/plugins/extensions/src/lib.rs
@@ -32,6 +32,24 @@ pub struct PanelInfo {
     pub styles_path: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+pub struct RegistryResponse {
+    pub version: u32,
+    pub extensions: Vec<RegistryEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+pub struct RegistryEntry {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub api_version: String,
+    pub description: String,
+    pub download_url: String,
+    pub checksum: String,
+    pub size: u64,
+}
+
 pub struct State {
     pub runtime: hypr_extensions_runtime::ExtensionsRuntime,
 }
@@ -48,6 +66,9 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::list_extensions::<tauri::Wry>,
             commands::get_extensions_dir::<tauri::Wry>,
             commands::get_extension::<tauri::Wry>,
+            commands::fetch_registry,
+            commands::download_extension::<tauri::Wry>,
+            commands::uninstall_extension::<tauri::Wry>,
         ])
         .error_handling(tauri_specta::ErrorHandlingMode::Result)
 }


### PR DESCRIPTION
## Summary

This PR adds the ability to download and install extensions from a central registry hosted on Cloudflare R2. The implementation includes:

**CI/CD Changes:**
- Updated `extensions_cd.yaml` to package extensions into versioned zip archives
- Added registry.json generation with extension metadata (id, name, version, checksum, download URL)
- Added optional R2 upload step (triggered via `publish` input flag)

**Backend (Rust):**
- Added `fetch_registry` command to retrieve available extensions from R2
- Added `download_extension` command with SHA-256 checksum verification and zip extraction
- Added `uninstall_extension` command to remove installed extensions
- New error types for network, checksum mismatch, and zip extraction failures

**Frontend:**
- Added "Store" tab in Extensions view alongside "Installed" tab
- New `store.tsx` component showing available extensions with install/uninstall buttons
- Loading states and error handling for registry fetch and install operations

## Review & Testing Checklist for Human

- [ ] **Verify R2 bucket configuration**: The workflow expects `hyprnote-extensions` bucket and secrets (`CLOUDFLARE_R2_ENDPOINT_URL`, `CLOUDFLARE_R2_ACCESS_KEY_ID`, `CLOUDFLARE_R2_SECRET_ACCESS_KEY`). Confirm these exist or update accordingly.
- [ ] **Test the workflow manually**: Run `extensions_cd.yaml` with `publish: false` first to verify packaging and registry generation work correctly before enabling R2 uploads.
- [ ] **Test the Store UI in desktop app**: Run `ONBOARDING=0 pnpm -F desktop tauri dev` and navigate to Extensions to verify the Store tab loads and install/uninstall work.
- [ ] **Review zip extraction security**: The code uses `enclosed_name()` and skips the first path component - verify this handles all edge cases for path traversal protection.
- [ ] **Verify hardcoded registry URL**: `https://pub-hyprnote.r2.dev/extensions/registry.json` is hardcoded in `commands.rs:148` - confirm this matches your R2 public URL.

### Notes

- The registry URL will return a network error until the workflow is run with `publish: true` and extensions are uploaded to R2
- No version comparison logic yet - the UI only shows if an extension is installed, not if updates are available
- Link to Devin run: https://app.devin.ai/sessions/0838e846b501407b9dabf41088655300
- Requested by: yujonglee (@yujonglee)