### PR TITLE
feat(web): dismiss mobile drawer when clicking outside

### DIFF
--- a/apps/web/src/routes/_view/route.tsx
+++ b/apps/web/src/routes/_view/route.tsx
@@ -92,7 +92,7 @@ function MobileDocsDrawer({
     <>
       {isOpen && (
         <div
-          className="fixed inset-0 top-[69px] bg-black/20 z-40 md:hidden"
+          className="fixed inset-0 top-[69px] z-40 md:hidden"
           onClick={onClose}
         />
       )}
@@ -179,7 +179,7 @@ function MobileHandbookDrawer({
     <>
       {isOpen && (
         <div
-          className="fixed inset-0 top-[69px] bg-black/20 z-40 md:hidden"
+          className="fixed inset-0 top-[69px] z-40 md:hidden"
           onClick={onClose}
         />
       )}


### PR DESCRIPTION
## Summary

Adds click-outside-to-dismiss behavior for the mobile docs and company handbook navigation drawers. When the drawer is open, a transparent backdrop overlay appears behind it. Clicking on this backdrop dismisses the drawer.

The implementation adds an invisible overlay at z-40 (below the drawer at z-50) that covers the viewport below the header. Both `MobileDocsDrawer` and `MobileHandbookDrawer` components receive the same treatment.

## Updates since last revision

- Made the backdrop fully transparent (removed `bg-black/20`) per user request - the overlay is now invisible but still captures clicks to dismiss the drawer

## Review & Testing Checklist for Human

- [ ] Test on mobile viewport (or Chrome DevTools mobile emulation) that clicking outside the drawer dismisses it for both `/docs/*` and `/company-handbook/*` pages
- [ ] Verify the backdrop doesn't cover or interfere with the header navigation
- [ ] Confirm drawer navigation links still work correctly after this change

**Recommended test plan:** Open the site on a mobile viewport, navigate to `/docs` or `/company-handbook`, open the sidebar drawer via the hamburger menu, then tap anywhere outside the drawer panel to verify it closes.

### Notes

- Link to Devin run: https://app.devin.ai/sessions/54860a367c0f42118d62a185357a9f71
- Requested by: john@hyprnote.com (@ComputelessComputer)