### PR TITLE
Update file transcription page UI: file selection text and mock window titles

### DIFF
--- a/apps/web/src/components/transcription/upload-area.tsx
+++ b/apps/web/src/components/transcription/upload-area.tsx
@@ -64,7 +64,10 @@ export function UploadArea({
         <Upload className="text-neutral-400" size={48} />
         <div>
           <p className="text-lg font-medium text-neutral-700">
-            Drop audio file here or click to browse
+            Drop audio file or{" "}
+            <span className="text-stone-600 underline underline-offset-2 hover:text-stone-800">
+              click to upload
+            </span>
           </p>
           <p className="text-sm text-neutral-500 mt-2">
             Supports MP3, WAV, M4A, and other audio formats

--- a/apps/web/src/routes/_view/app/file-transcription.tsx
+++ b/apps/web/src/routes/_view/app/file-transcription.tsx
@@ -199,6 +199,9 @@ function Component() {
                   <div className="w-3 h-3 rounded-full bg-red-400" />
                   <div className="w-3 h-3 rounded-full bg-yellow-400" />
                   <div className="w-3 h-3 rounded-full bg-green-400" />
+                  <span className="ml-2 text-sm text-neutral-500">
+                    meeting content
+                  </span>
                 </div>
 
                 <div className="p-6 space-y-6">
@@ -248,6 +251,7 @@ function Component() {
                   <div className="w-3 h-3 rounded-full bg-red-400" />
                   <div className="w-3 h-3 rounded-full bg-yellow-400" />
                   <div className="w-3 h-3 rounded-full bg-green-400" />
+                  <span className="ml-2 text-sm text-neutral-500">summary</span>
                 </div>
 
                 <div className="p-6">

--- a/apps/web/src/routes/_view/file-transcription.tsx
+++ b/apps/web/src/routes/_view/file-transcription.tsx
@@ -110,6 +110,9 @@ function Component() {
                   <div className="w-3 h-3 rounded-full bg-red-400" />
                   <div className="w-3 h-3 rounded-full bg-yellow-400" />
                   <div className="w-3 h-3 rounded-full bg-green-400" />
+                  <span className="ml-2 text-sm text-neutral-500">
+                    meeting content
+                  </span>
                 </div>
 
                 <div className="p-6 space-y-6">
@@ -167,6 +170,7 @@ function Component() {
                   <div className="w-3 h-3 rounded-full bg-red-400" />
                   <div className="w-3 h-3 rounded-full bg-yellow-400" />
                   <div className="w-3 h-3 rounded-full bg-green-400" />
+                  <span className="ml-2 text-sm text-neutral-500">summary</span>
                 </div>
 
                 <div className="p-6">


### PR DESCRIPTION
## Summary

Updates the file transcription page UI with two changes:

1. **File selection area**: Changed text from "Drop audio file here or click to browse" to "Drop audio file or click to upload" with the "click to upload" portion styled as an underlined link (stone-600 color with hover state)

2. **Mock window headers**: Added titles to the macOS-style mock window headers:
   - First window: "meeting content"
   - Second window: "summary"

Changes applied consistently to both `/_view/file-transcription` (public) and `/_view/app/file-transcription` (authenticated) routes.

## Review & Testing Checklist for Human

- [ ] Verify the "click to upload" link styling looks correct (underlined, stone-600 color, hover state)
- [ ] Verify the mock window header titles ("meeting content" and "summary") are visible and properly positioned next to the traffic light dots
- [ ] Test both routes: `/file-transcription` and `/app/file-transcription`

### Notes

- Link to Devin run: https://app.devin.ai/sessions/42c42f119ac343838ab014d9d78ad40e
- Requested by: john@hyprnote.com (@ComputelessComputer)