### PR TITLE
feat(web): add Load More button to OSS friends page for efficient loading

### DIFF
--- a/apps/web/src/routes/_view/oss-friends.tsx
+++ b/apps/web/src/routes/_view/oss-friends.tsx
@@ -198,8 +198,9 @@ function FriendsSection({
             onClick={onLoadMore}
             className={cn([
               "inline-flex items-center justify-center gap-2 px-6 py-3 text-base font-medium rounded-full",
-              "border border-neutral-200 text-neutral-700 bg-white",
-              "hover:bg-stone-50 hover:border-stone-300 transition-colors",
+              "border border-neutral-200 text-neutral-700",
+              "bg-linear-to-t from-stone-100 to-white",
+              "hover:from-stone-200 hover:to-stone-50 hover:border-stone-300 transition-all",
             ])}
           >
             Load more


### PR DESCRIPTION
## Summary

Adds a "Load More" button to the OSS friends page for more efficient initial page loading. The page now shows 12 projects initially and loads 12 more each time the button is clicked. When the user starts searching, all matching results are shown immediately (pagination is bypassed).

## Updates since last revision

- Updated the Load More button styling to use a white-ish linear gradient (`from-stone-100 to-white`) with matching hover states

## Review & Testing Checklist for Human

- [ ] Verify the "Load more" button appears when there are more than 12 OSS friends
- [ ] Verify clicking "Load more" shows 12 additional projects
- [ ] Verify the button disappears when all projects are displayed
- [ ] Verify that typing in the search box shows all matching results (ignoring pagination)
- [ ] Verify the button gradient styling looks correct and hover state transitions smoothly
- [ ] **Note**: When clearing the search after loading more items, the `displayCount` state persists (user sees where they left off). Confirm this is the desired behavior vs. resetting to 12.

### Notes

- Link to Devin run: https://app.devin.ai/sessions/1ad403fa7ad64ca889047939337ff2eb
- Requested by: john@hyprnote.com (@ComputelessComputer)