### PR TITLE
fix(web): show homebrew section only on desktop macOS

### DIFF
--- a/apps/web/src/routes/_view/download/index.tsx
+++ b/apps/web/src/routes/_view/download/index.tsx
@@ -1,23 +1,21 @@
 import { Icon } from "@iconify-icon/react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Check, Copy } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { cn } from "@hypr/utils";
 
 import { Image } from "@/components/image";
 import { SlashSeparator } from "@/components/slash-separator";
+import { usePlatform } from "@/hooks/use-platform";
 
 export const Route = createFileRoute("/_view/download/")({
   component: Component,
 });
 
 function Component() {
-  const [isMac, setIsMac] = useState(false);
-
-  useEffect(() => {
-    setIsMac(navigator.userAgent.toLowerCase().includes("mac"));
-  }, []);
+  const platform = usePlatform();
+  const isMacDesktop = platform === "mac";
 
   return (
     <div
@@ -96,7 +94,7 @@ function Component() {
               </div>
             </div>
 
-            {isMac && (
+            {isMacDesktop && (
               <div className="mb-16">
                 <h2 className="text-2xl font-serif tracking-tight mb-6 text-center">
                   Homebrew


### PR DESCRIPTION
## Summary

The homebrew section on the download page was incorrectly showing on iOS devices because the previous implementation used `navigator.userAgent.toLowerCase().includes("mac")`, which matches iOS Safari's user agent string (which contains "Mac" on newer iOS versions).

This PR switches to using the existing `usePlatform` hook, which properly distinguishes desktop macOS from mobile devices by checking for mobile UA patterns first.

## Review & Testing Checklist for Human

- [ ] **Verify on iOS device**: Test the download page on an actual iPhone/iPad to confirm the homebrew section is hidden
- [ ] **Verify on macOS**: Test the download page on a Mac to confirm the homebrew section still appears
- [ ] **Review `usePlatform` hook logic**: The hook at `src/hooks/use-platform.ts` checks for mobile patterns before checking for "mac" - verify this logic is correct for all iOS UA strings

### Test Plan
1. Open https://hyprnote.com/download on a Mac browser → homebrew section should be visible
2. Open the same URL on an iPhone/iPad → homebrew section should NOT be visible
3. Open on Android/Windows → homebrew section should NOT be visible

### Notes

The user also reported a scroll snap issue on the download page's mobile view, but I couldn't find any `scroll-snap` CSS on the `/download` route (only on the home page carousels). I'll follow up to clarify whether this is referring to a different page or a browser-specific behavior.

---
**Requested by**: john@hyprnote.com (@ComputelessComputer)  
**Link to Devin run**: https://app.devin.ai/sessions/3dd9e7eb56b64c6eb674942b2e9fe6c4