### PR TITLE
fix(web): preserve scroll position in press-kit app sidebar

### DIFF
--- a/apps/web/src/routes/_view/press-kit/app.tsx
+++ b/apps/web/src/routes/_view/press-kit/app.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Menu, X, XIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import {
   ResizableHandle,
@@ -271,11 +271,29 @@ function AppDetailView({
   selectedItem: SelectedItem;
   setSelectedItem: (item: SelectedItem | null) => void;
 }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const scrollPosRef = useRef<number>(0);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    el.scrollTop = scrollPosRef.current;
+
+    const handleScroll = () => {
+      scrollPosRef.current = el.scrollTop;
+    };
+
+    el.addEventListener("scroll", handleScroll);
+    return () => el.removeEventListener("scroll", handleScroll);
+  }, [selectedItem]);
+
   return (
     <ResizablePanelGroup direction="horizontal" className="h-[480px]">
       <AppSidebar
         selectedItem={selectedItem}
         setSelectedItem={setSelectedItem}
+        scrollRef={scrollRef}
       />
       <ResizableHandle withHandle className="bg-neutral-200 w-px" />
       <AppDetailPanel
@@ -366,13 +384,15 @@ function AppDetailContent({
 function AppSidebar({
   selectedItem,
   setSelectedItem,
+  scrollRef,
 }: {
   selectedItem: SelectedItem;
   setSelectedItem: (item: SelectedItem) => void;
+  scrollRef: React.RefObject<HTMLDivElement | null>;
 }) {
   return (
     <ResizablePanel defaultSize={35} minSize={25} maxSize={45}>
-      <div className="p-4 h-full overflow-y-auto">
+      <div ref={scrollRef} className="p-4 h-full overflow-y-auto">
         <ScreenshotsSidebar
           selectedItem={selectedItem}
           setSelectedItem={setSelectedItem}


### PR DESCRIPTION
## Summary
Preserves the scroll position in the press-kit app sidebar when switching between screenshots. Previously, clicking on a different screenshot would reset the sidebar scroll position to the top.

The fix uses two refs:
- `scrollRef` - attached to the scrollable sidebar container
- `scrollPosRef` - stores the current scroll position

A `useEffect` hook restores the scroll position and sets up a scroll listener whenever the selected item changes.

## Review & Testing Checklist for Human
- [ ] Test on the press-kit app page: navigate to `/press-kit/app`, scroll down in the sidebar, click different screenshots, and verify scroll position is preserved
- [ ] Verify mobile drawer behavior is acceptable (scroll preservation was not added to the mobile drawer - confirm if this is desired)

### Notes
- Only the desktop sidebar (`AppDetailView` → `AppSidebar`) has scroll preservation. The mobile drawer (`MobileSidebarDrawer`) does not have this feature - let me know if it should be added.

Requested by: john@hyprnote.com (@ComputelessComputer)
Link to Devin run: https://app.devin.ai/sessions/cab0a37e9b8e44c29048b73e72dd05fc