### PR TITLE
feat(web): redesign opensource page with 5 new sections

### DIFF
--- a/apps/web/src/routes/_view/opensource.tsx
+++ b/apps/web/src/routes/_view/opensource.tsx
@@ -855,7 +855,6 @@ function JoinMovementSection() {
                   hasBorderB && "lg:border-b",
                   index % 2 === 0 && "sm:border-r lg:border-r-0",
                   index > 1 && "border-t sm:border-t-0 lg:border-t-0",
-                  hasBorderR && "lg:border-r",
                 ])}
               >
                 <div>


### PR DESCRIPTION
## Summary

Complete redesign of the `/opensource` page with a new 6-section structure:

1. **Hero Section** - Original hero with stargazers grid animation (preserved per user request)
2. **Letter Section** - A philosophical letter explaining why open source is necessary and inevitable in the age of AI
3. **Tech Stack Section** - Displays the tech stack (Rust, Tauri, React, Whisper, llama.cpp, SQLite) with sponsorship info (GitHub Sponsors, Open Collective)
4. **Progress Section** - GitHub stats (stars, forks, contributors, countries) with a milestone timeline
5. **Join Movement Section** - 6 contribution options (star, contribute code, report issues, translate, share, join community)
6. **CTA Section** - Simplified call-to-action with download button and GitHub link

Removed the previous `WhyOpenSourceSection`, `TransparencySection`, `GitHubOpenSource` component, and `ContributeSection` in favor of the new content-focused sections.

## Updates since last revision

- Restored the HeroSection with stargazers grid animation per user request
- Re-added `Stargazer` type and `useGitHubStargazers` imports

## Review & Testing Checklist for Human

- [ ] **Review letter content** - The philosophical letter about open source in AI should align with company messaging and tone. This is new marketing copy that needs approval.

- [ ] **Verify milestone dates and stats are accurate** - The timeline shows hardcoded dates (Jan 2024 first commit, Mar 2024 public beta, Jun 2024 1K stars, Sep 2024 v1.0, Dec 2024 5K stars, 2025 10K stars) and stats (50+ contributors, 30+ countries) that need verification

- [ ] **Verify sponsors list is accurate** - Lists Tauri, llama.cpp, and whisper.cpp as sponsored projects

- [ ] **Verify all external links work** - Several new links added:
  - `https://github.com/sponsors/fastrepl`
  - `https://opencollective.com/hyprnote`
  - `https://discord.gg/Hyprnote` (note: capitalization changed from previous `hyprnote`)
  - Tech stack URLs (rust-lang.org, tauri.app, react.dev, etc.)

- [ ] **Visual review on desktop and mobile** - Test responsive layouts at various breakpoints. Visit `/opensource` locally or on deploy preview to verify styling and layout

### Notes

- The `bg-linear-to-t` class was changed to `bg-gradient-to-t` per coderabbit review, but `bg-linear-to-b` was kept as it's a custom utility used throughout the codebase
- Removed unused imports: `Link` from tanstack router, `GitHubOpenSource` component
- Local visual testing was blocked by missing `RESTATE_INGRESS_URL` environment variable (unrelated to this PR)

**Link to Devin run:** https://app.devin.ai/sessions/48c01c87f11748819e789fea4a4b9b55
**Requested by:** john@hyprnote.com (@ComputelessComputer)