### PR TITLE
feat(web): change mobile CTA from Download to Get reminder

### DIFF
--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -392,6 +392,14 @@ function CTAButton({
     ? "px-4 h-8 flex items-center text-sm bg-linear-to-t from-stone-600 to-stone-500 text-white rounded-full shadow-md active:scale-[98%] transition-all"
     : "px-4 h-8 flex items-center text-sm bg-linear-to-t from-stone-600 to-stone-500 text-white rounded-full shadow-md hover:shadow-lg hover:scale-[102%] active:scale-[98%] transition-all";
 
+  if (mobile && platform === "mobile") {
+    return (
+      <Link to="/" hash="hero" onClick={scrollToHero} className={baseClass}>
+        Get reminder
+      </Link>
+    );
+  }
+
   if (platformCTA.action === "download") {
     return (
       <a href="/download/apple-silicon" download className={baseClass}>
@@ -402,7 +410,7 @@ function CTAButton({
 
   return (
     <Link to="/" hash="hero" onClick={scrollToHero} className={baseClass}>
-      {mobile && platform === "mobile" ? "Get reminder" : platformCTA.label}
+      {platformCTA.label}
     </Link>
   );
 }
@@ -604,7 +612,19 @@ function MobileMenuCTAs({
       >
         Get started
       </Link>
-      {platformCTA.action === "download" ? (
+      {platform === "mobile" ? (
+        <Link
+          to="/"
+          hash="hero"
+          onClick={() => {
+            setIsMenuOpen(false);
+            scrollToHero();
+          }}
+          className="block w-full px-4 py-3 text-center text-sm bg-linear-to-t from-stone-600 to-stone-500 text-white rounded-lg shadow-md active:scale-[98%] transition-all"
+        >
+          Get reminder
+        </Link>
+      ) : platformCTA.action === "download" ? (
         <a
           href="/download/apple-silicon"
           download
@@ -623,7 +643,7 @@ function MobileMenuCTAs({
           }}
           className="block w-full px-4 py-3 text-center text-sm bg-linear-to-t from-stone-600 to-stone-500 text-white rounded-lg shadow-md active:scale-[98%] transition-all"
         >
-          {platform === "mobile" ? "Get reminder" : platformCTA.label}
+          {platformCTA.label}
         </Link>
       )}
     </div>


### PR DESCRIPTION
## Summary

Updates the mobile header CTA buttons to always show "Get reminder" for mobile users, which redirects to the home page hero section with the email form. Previously, the mobile check happened after the download action check, which could result in mobile users seeing "Download" in certain cases.

Changes made:
- `CTAButton`: Added early return for mobile users to show "Get reminder" before checking download action
- `MobileMenuCTAs`: Restructured conditional to check `platform === "mobile"` first

## Review & Testing Checklist for Human

- [ ] **Test on actual mobile device**: Verify the header CTA shows "Get reminder" (not "Download") on iOS/Android browsers
- [ ] **Test the redirect**: Clicking "Get reminder" should scroll to the hero section with the email form
- [ ] **Test desktop behavior**: Verify Mac users still see "Download" button that links to `/download/apple-silicon`
- [ ] **Test mobile menu**: Open the hamburger menu on mobile and verify the CTA there also shows "Get reminder"

### Notes

Requested by: john@hyprnote.com (@ComputelessComputer)
Link to Devin run: https://app.devin.ai/sessions/6bc3d25c510c4fc684d184400759081c