### PR TITLE
refactor(api): reorganize STT providers into directory structure

### DIFF
--- a/apps/api/src/stt/assemblyai/batch.ts
+++ b/apps/api/src/stt/assemblyai/batch.ts
@@ -1,4 +1,4 @@
-import { env } from "../env";
+import { env } from "../../env";
 import type {
   BatchAlternatives,
   BatchChannel,
@@ -6,7 +6,7 @@ import type {
   BatchResponse,
   BatchResults,
   BatchWord,
-} from "./batch-types";
+} from "../batch-types";
 
 const ASSEMBLYAI_API_URL = "https://api.assemblyai.com/v2";
 const POLL_INTERVAL_MS = 3000;

--- a/apps/api/src/stt/assemblyai/index.ts
+++ b/apps/api/src/stt/assemblyai/index.ts
@@ -1,0 +1,2 @@
+export { buildAssemblyAIUrl, createAssemblyAIProxy } from "./live";
+export { transcribeWithAssemblyAI } from "./batch";

--- a/apps/api/src/stt/assemblyai/live.ts
+++ b/apps/api/src/stt/assemblyai/live.ts
@@ -1,5 +1,5 @@
-import { env } from "../env";
-import { WsProxyConnection } from "./connection";
+import { env } from "../../env";
+import { WsProxyConnection } from "../connection";
 
 const CONTROL_MESSAGE_TYPES = new Set(["Terminate"]);
 

--- a/apps/api/src/stt/deepgram/batch.ts
+++ b/apps/api/src/stt/deepgram/batch.ts
@@ -1,5 +1,5 @@
-import { env } from "../env";
-import type { BatchParams, BatchResponse } from "./batch-types";
+import { env } from "../../env";
+import type { BatchParams, BatchResponse } from "../batch-types";
 
 const DEEPGRAM_BATCH_URL = "https://api.deepgram.com/v1/listen";
 

--- a/apps/api/src/stt/deepgram/index.ts
+++ b/apps/api/src/stt/deepgram/index.ts
@@ -1,0 +1,2 @@
+export { buildDeepgramUrl, createDeepgramProxy } from "./live";
+export { transcribeWithDeepgram } from "./batch";

--- a/apps/api/src/stt/deepgram/live.ts
+++ b/apps/api/src/stt/deepgram/live.ts
@@ -1,5 +1,5 @@
-import { env } from "../env";
-import { WsProxyConnection } from "./connection";
+import { env } from "../../env";
+import { WsProxyConnection } from "../connection";
 
 const CONTROL_MESSAGE_TYPES = new Set(["KeepAlive", "CloseStream", "Finalize"]);
 

--- a/apps/api/src/stt/index.ts
+++ b/apps/api/src/stt/index.ts
@@ -1,21 +1,27 @@
-import { createAssemblyAIProxy } from "./assemblyai";
-import { transcribeWithAssemblyAI } from "./batch-assemblyai";
-import { transcribeWithDeepgram } from "./batch-deepgram";
-import { transcribeWithSoniox } from "./batch-soniox";
+import { createAssemblyAIProxy, transcribeWithAssemblyAI } from "./assemblyai";
 import type { BatchParams, BatchProvider, BatchResponse } from "./batch-types";
 import { WsProxyConnection } from "./connection";
-import { createDeepgramProxy } from "./deepgram";
-import { createSonioxProxy } from "./soniox";
+import { createDeepgramProxy, transcribeWithDeepgram } from "./deepgram";
+import { createSonioxProxy, transcribeWithSoniox } from "./soniox";
 
 export { WsProxyConnection, type WsProxyOptions } from "./connection";
 export { normalizeWsData, type WsPayload } from "./utils";
-export { buildDeepgramUrl, createDeepgramProxy } from "./deepgram";
-export { buildAssemblyAIUrl, createAssemblyAIProxy } from "./assemblyai";
-export { buildSonioxUrl, createSonioxProxy } from "./soniox";
+export {
+  buildDeepgramUrl,
+  createDeepgramProxy,
+  transcribeWithDeepgram,
+} from "./deepgram";
+export {
+  buildAssemblyAIUrl,
+  createAssemblyAIProxy,
+  transcribeWithAssemblyAI,
+} from "./assemblyai";
+export {
+  buildSonioxUrl,
+  createSonioxProxy,
+  transcribeWithSoniox,
+} from "./soniox";
 export type { BatchParams, BatchProvider, BatchResponse } from "./batch-types";
-export { transcribeWithDeepgram } from "./batch-deepgram";
-export { transcribeWithAssemblyAI } from "./batch-assemblyai";
-export { transcribeWithSoniox } from "./batch-soniox";
 
 export const UPSTREAM_URL_HEADER = "x-owh-upstream-url";
 export const UPSTREAM_AUTH_HEADER = "x-owh-upstream-auth";

--- a/apps/api/src/stt/soniox/batch.ts
+++ b/apps/api/src/stt/soniox/batch.ts
@@ -1,4 +1,4 @@
-import { env } from "../env";
+import { env } from "../../env";
 import type {
   BatchAlternatives,
   BatchChannel,
@@ -6,7 +6,7 @@ import type {
   BatchResponse,
   BatchResults,
   BatchWord,
-} from "./batch-types";
+} from "../batch-types";
 
 const SONIOX_API_HOST = "api.soniox.com";
 const POLL_INTERVAL_MS = 3000;

--- a/apps/api/src/stt/soniox/index.ts
+++ b/apps/api/src/stt/soniox/index.ts
@@ -1,0 +1,2 @@
+export { buildSonioxUrl, createSonioxProxy } from "./live";
+export { transcribeWithSoniox } from "./batch";

--- a/apps/api/src/stt/soniox/live.ts
+++ b/apps/api/src/stt/soniox/live.ts
@@ -1,5 +1,5 @@
-import { env } from "../env";
-import { WsProxyConnection } from "./connection";
+import { env } from "../../env";
+import { WsProxyConnection } from "../connection";
 
 const CONTROL_MESSAGE_TYPES = new Set(["keepalive", "finalize"]);
 


### PR DESCRIPTION
# refactor(api): reorganize STT providers into directory structure

## Summary
Restructures `apps/api/src/stt` to follow the pattern from `owhisper/owhisper-client/src/adapter`. Each STT provider now has its own directory with separate files for live streaming and batch transcription:

```
stt/
├── deepgram/
│   ├── index.ts    # re-exports
│   ├── live.ts     # WebSocket proxy
│   └── batch.ts    # batch transcription
├── assemblyai/
│   ├── index.ts
│   ├── live.ts
│   └── batch.ts
├── soniox/
│   ├── index.ts
│   ├── live.ts
│   └── batch.ts
├── index.ts        # main exports (unchanged API)
├── batch-types.ts  # shared types
├── connection.ts   # WsProxyConnection
└── utils.ts
```

No logic changes - purely file reorganization with updated import paths.

## Review & Testing Checklist for Human
- [ ] Verify import paths are correct (changed from `../env` to `../../env`, `./batch-types` to `../batch-types`, etc.)
- [ ] Confirm the public API exported from `apps/api/src/stt/index.ts` is unchanged

### Notes
- All 29 existing tests pass
- Requested by @yujonglee (yujonglee.dev@gmail.com)
- Devin session: https://app.devin.ai/sessions/95b5bfe6610f418a9f1a546124d83309