### PR TITLE
refactor(vad): unify VAD logic with StreamingVad

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,8 +225,7 @@ dependencies = [
  "data",
  "hound",
  "rodio",
- "vad3",
- "vvad",
+ "vad-ext",
 ]
 
 [[package]]

--- a/crates/agc/Cargo.toml
+++ b/crates/agc/Cargo.toml
@@ -10,7 +10,6 @@ rodio = { workspace = true }
 
 [dependencies]
 hypr-audio-utils = { workspace = true }
-hypr-vad3 = { workspace = true }
-hypr-vvad = { workspace = true }
+hypr-vad-ext = { workspace = true }
 
 dagc = "0.1.1"

--- a/crates/vad-ext/src/continuous2.rs
+++ b/crates/vad-ext/src/continuous2.rs
@@ -4,34 +4,31 @@ use std::{
 };
 
 use futures_util::Stream;
-use hypr_audio_utils::f32_to_i16_samples;
-use hypr_vvad::VoiceActivityDetector;
+
+use crate::{StreamingVad, VadConfig};
 
 pub struct ContinuousVadMaskStream<S> {
     inner: S,
-    vad: VoiceActivityDetector,
-    hangover_frames: usize,
-    trailing_non_speech: usize,
-    in_speech: bool,
-    scratch_frame: Vec<f32>,
-    amplitude_floor: f32,
+    vad: Option<StreamingVad>,
+    cfg: VadConfig,
 }
 
 impl<S> ContinuousVadMaskStream<S> {
     pub fn new(inner: S) -> Self {
         Self {
             inner,
-            vad: VoiceActivityDetector::new(),
-            hangover_frames: 3,
-            trailing_non_speech: 0,
-            in_speech: true,
-            scratch_frame: Vec::new(),
-            amplitude_floor: 0.001,
+            vad: None,
+            cfg: VadConfig::default(),
         }
     }
 
     pub fn with_hangover_frames(mut self, frames: usize) -> Self {
-        self.hangover_frames = frames;
+        self.cfg.hangover_frames = frames;
+        self
+    }
+
+    pub fn with_amplitude_floor(mut self, floor: f32) -> Self {
+        self.cfg.amplitude_floor = floor;
         self
     }
 
@@ -40,68 +37,15 @@ impl<S> ContinuousVadMaskStream<S> {
             return;
         }
 
-        let frame_size = hypr_vad3::choose_optimal_frame_size(chunk.len());
-        debug_assert!(frame_size > 0, "VAD frame size must be > 0");
+        let vad = self
+            .vad
+            .get_or_insert_with(|| StreamingVad::with_config(chunk.len(), self.cfg.clone()));
 
-        for frame in chunk.chunks_mut(frame_size) {
-            self.process_frame(frame, frame_size);
-        }
-    }
-
-    fn smooth_vad_decision(&mut self, raw_is_speech: bool) -> bool {
-        if raw_is_speech {
-            self.in_speech = true;
-            self.trailing_non_speech = 0;
-            true
-        } else if self.in_speech && self.trailing_non_speech < self.hangover_frames {
-            self.trailing_non_speech += 1;
-            true
-        } else {
-            self.in_speech = false;
-            self.trailing_non_speech = 0;
-            false
-        }
-    }
-
-    fn process_frame(&mut self, frame: &mut [f32], frame_size: usize) {
-        if frame.is_empty() {
-            return;
-        }
-
-        let rms = Self::calculate_rms(frame);
-        if rms < self.amplitude_floor {
-            let is_speech = self.smooth_vad_decision(false);
+        vad.process_in_place(chunk, |frame, is_speech| {
             if !is_speech {
                 frame.fill(0.0);
             }
-            return;
-        }
-
-        let raw_is_speech = if frame.len() == frame_size {
-            let i16_samples = f32_to_i16_samples(frame);
-            self.vad.predict_16khz(&i16_samples).unwrap_or(true)
-        } else {
-            self.scratch_frame.clear();
-            self.scratch_frame.extend_from_slice(frame);
-            self.scratch_frame.resize(frame_size, 0.0);
-
-            let i16_samples = f32_to_i16_samples(&self.scratch_frame);
-            self.vad.predict_16khz(&i16_samples).unwrap_or(true)
-        };
-
-        let is_speech = self.smooth_vad_decision(raw_is_speech);
-
-        if !is_speech {
-            frame.fill(0.0);
-        }
-    }
-
-    fn calculate_rms(samples: &[f32]) -> f32 {
-        if samples.is_empty() {
-            return 0.0;
-        }
-        let sum_sq: f32 = samples.iter().map(|&s| s * s).sum();
-        (sum_sq / samples.len() as f32).sqrt()
+        });
     }
 }
 
@@ -194,56 +138,12 @@ mod tests {
             }
         }
 
-        // We should not *introduce* any non-zero samples, and the vast majority
-        // of silence should stay zero.
         let non_zero_count = masked_samples.iter().filter(|&&s| s != 0.0).count();
         assert!(
             non_zero_count < 100,
             "Silence should be mostly masked (found {} non-zero samples)",
             non_zero_count
         );
-    }
-
-    #[test]
-    fn test_hangover_logic() {
-        // Use an empty inner stream; we only care about the internal state machine.
-        let mut vad_stream = ContinuousVadMaskStream::new(stream::empty::<Result<Vec<f32>, ()>>());
-        vad_stream.hangover_frames = 3;
-
-        // Initial state is conservative: in_speech = true
-        assert!(vad_stream.in_speech);
-        assert_eq!(vad_stream.trailing_non_speech, 0);
-
-        // Simulate raw VAD decisions: T, F, F, F, F
-        // First: raw speech
-        assert!(vad_stream.smooth_vad_decision(true));
-        assert!(vad_stream.in_speech);
-        assert_eq!(vad_stream.trailing_non_speech, 0);
-
-        // First false: still treated as speech (hangover 1/3)
-        assert!(vad_stream.smooth_vad_decision(false));
-        assert!(vad_stream.in_speech);
-        assert_eq!(vad_stream.trailing_non_speech, 1);
-
-        // Second false: still speech (hangover 2/3)
-        assert!(vad_stream.smooth_vad_decision(false));
-        assert!(vad_stream.in_speech);
-        assert_eq!(vad_stream.trailing_non_speech, 2);
-
-        // Third false: still speech (hangover 3/3)
-        assert!(vad_stream.smooth_vad_decision(false));
-        assert!(vad_stream.in_speech);
-        assert_eq!(vad_stream.trailing_non_speech, 3);
-
-        // Fourth false: now we finally flip to non-speech
-        assert!(!vad_stream.smooth_vad_decision(false));
-        assert!(!vad_stream.in_speech);
-        assert_eq!(vad_stream.trailing_non_speech, 0);
-
-        // More false: stays non-speech
-        assert!(!vad_stream.smooth_vad_decision(false));
-        assert!(!vad_stream.in_speech);
-        assert_eq!(vad_stream.trailing_non_speech, 0);
     }
 
     #[tokio::test]
@@ -316,7 +216,6 @@ mod tests {
 
     #[test]
     fn test_frame_size_selection() {
-        // Sanity-check assumptions about the VAD helper we're using.
         assert_eq!(hypr_vad3::choose_optimal_frame_size(160), 160);
         assert_eq!(hypr_vad3::choose_optimal_frame_size(320), 320);
         assert_eq!(hypr_vad3::choose_optimal_frame_size(480), 480);

--- a/crates/vad-ext/src/lib.rs
+++ b/crates/vad-ext/src/lib.rs
@@ -1,10 +1,12 @@
 mod continuous;
 mod continuous2;
 mod error;
+mod streaming;
 
 pub use continuous::*;
 pub use continuous2::*;
 pub use error::*;
+pub use streaming::*;
 
 #[cfg(test)]
 pub mod tests {

--- a/crates/vad-ext/src/streaming.rs
+++ b/crates/vad-ext/src/streaming.rs
@@ -1,0 +1,166 @@
+use hypr_audio_utils::f32_to_i16_samples;
+use hypr_vvad::VoiceActivityDetector;
+
+#[derive(Clone, Debug)]
+pub struct VadConfig {
+    pub hangover_frames: usize,
+    pub amplitude_floor: f32,
+    pub start_in_speech: bool,
+}
+
+impl Default for VadConfig {
+    fn default() -> Self {
+        Self {
+            hangover_frames: 3,
+            amplitude_floor: 0.001,
+            start_in_speech: true,
+        }
+    }
+}
+
+pub struct StreamingVad {
+    vad: VoiceActivityDetector,
+    cfg: VadConfig,
+    frame_size: usize,
+    in_speech: bool,
+    trailing_non_speech: usize,
+    scratch_frame: Vec<f32>,
+}
+
+impl StreamingVad {
+    pub fn new(frame_hint: usize) -> Self {
+        Self::with_config(frame_hint, VadConfig::default())
+    }
+
+    pub fn with_config(frame_hint: usize, cfg: VadConfig) -> Self {
+        let frame_size = hypr_vad3::choose_optimal_frame_size(frame_hint);
+        debug_assert!(frame_size > 0, "VAD frame size must be > 0");
+
+        Self {
+            vad: VoiceActivityDetector::new(),
+            frame_size,
+            in_speech: cfg.start_in_speech,
+            trailing_non_speech: 0,
+            scratch_frame: Vec::new(),
+            cfg,
+        }
+    }
+
+    pub fn frame_size(&self) -> usize {
+        self.frame_size
+    }
+
+    fn calculate_rms(samples: &[f32]) -> f32 {
+        if samples.is_empty() {
+            return 0.0;
+        }
+        let sum_sq: f32 = samples.iter().map(|&s| s * s).sum();
+        (sum_sq / samples.len() as f32).sqrt()
+    }
+
+    fn smooth_decision(&mut self, raw_is_speech: bool) -> bool {
+        if raw_is_speech {
+            self.in_speech = true;
+            self.trailing_non_speech = 0;
+            true
+        } else if self.in_speech && self.trailing_non_speech < self.cfg.hangover_frames {
+            self.trailing_non_speech += 1;
+            true
+        } else {
+            self.in_speech = false;
+            self.trailing_non_speech = 0;
+            false
+        }
+    }
+
+    fn classify_frame(&mut self, frame: &[f32]) -> bool {
+        if frame.is_empty() {
+            return false;
+        }
+
+        let rms = Self::calculate_rms(frame);
+        if rms < self.cfg.amplitude_floor {
+            return self.smooth_decision(false);
+        }
+
+        let raw_is_speech = if frame.len() == self.frame_size {
+            let i16_samples = f32_to_i16_samples(frame);
+            self.vad.predict_16khz(&i16_samples).unwrap_or(true)
+        } else {
+            self.scratch_frame.clear();
+            self.scratch_frame.extend_from_slice(frame);
+            self.scratch_frame.resize(self.frame_size, 0.0);
+            let i16_samples = f32_to_i16_samples(&self.scratch_frame);
+            self.vad.predict_16khz(&i16_samples).unwrap_or(true)
+        };
+
+        self.smooth_decision(raw_is_speech)
+    }
+
+    pub fn process_in_place<F>(&mut self, samples: &mut [f32], mut f: F)
+    where
+        F: FnMut(&mut [f32], bool),
+    {
+        if samples.is_empty() {
+            return;
+        }
+
+        for frame in samples.chunks_mut(self.frame_size) {
+            let is_speech = self.classify_frame(frame);
+            f(frame, is_speech);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hangover_logic() {
+        let mut vad = StreamingVad::with_config(
+            320,
+            VadConfig {
+                hangover_frames: 3,
+                ..Default::default()
+            },
+        );
+
+        assert!(vad.in_speech);
+        assert_eq!(vad.trailing_non_speech, 0);
+
+        assert!(vad.smooth_decision(true));
+        assert!(vad.in_speech);
+        assert_eq!(vad.trailing_non_speech, 0);
+
+        assert!(vad.smooth_decision(false));
+        assert!(vad.in_speech);
+        assert_eq!(vad.trailing_non_speech, 1);
+
+        assert!(vad.smooth_decision(false));
+        assert!(vad.in_speech);
+        assert_eq!(vad.trailing_non_speech, 2);
+
+        assert!(vad.smooth_decision(false));
+        assert!(vad.in_speech);
+        assert_eq!(vad.trailing_non_speech, 3);
+
+        assert!(!vad.smooth_decision(false));
+        assert!(!vad.in_speech);
+        assert_eq!(vad.trailing_non_speech, 0);
+
+        assert!(!vad.smooth_decision(false));
+        assert!(!vad.in_speech);
+        assert_eq!(vad.trailing_non_speech, 0);
+    }
+
+    #[test]
+    fn test_frame_size_selection() {
+        assert_eq!(StreamingVad::new(160).frame_size(), 160);
+        assert_eq!(StreamingVad::new(320).frame_size(), 320);
+        assert_eq!(StreamingVad::new(480).frame_size(), 480);
+        assert_eq!(StreamingVad::new(512).frame_size(), 320);
+        assert_eq!(StreamingVad::new(640).frame_size(), 320);
+        assert_eq!(StreamingVad::new(960).frame_size(), 480);
+    }
+}


### PR DESCRIPTION
## Summary

Consolidate VAD logic into a single `StreamingVad` struct and remove redundant double-VAD processing in the mic path.

## Changes

- **Introduce `StreamingVad`** in `vad-ext` to centralize VAD frame processing, hangover logic, and amplitude floor checks
- **Refactor `VadAgc`** to use `StreamingVad` with a new `with_masking(true)` option that enables zeroing non-speech frames
- **Refactor `ContinuousVadMaskStream`** to delegate to `StreamingVad` instead of duplicating the logic
- **Remove double VAD in mic path**: mic stream no longer goes through `.mask_with_vad()`, instead `VadAgc::with_masking(true)` handles both AGC gating and masking
- **Simplify dependencies**: `agc` crate now only depends on `vad-ext` instead of directly on `hypr-vad3` and `hypr-vvad`

## Behavior Notes

- VAD behavior is now consistent across AGC and masking (same hangover, amplitude floor, padding)
- Cross-call tail stitching is removed; each `process()` call is now independent (minor change for fixed chunk sizes)