### PR TITLE
show spinner in tabs or left side bar items when note is being enhanced

### DIFF
--- a/apps/desktop/src/components/main/body/sessions/index.tsx
+++ b/apps/desktop/src/components/main/body/sessions/index.tsx
@@ -6,6 +6,7 @@ import { commands as miscCommands } from "@hypr/plugin-misc";
 
 import AudioPlayer from "../../../../contexts/audio-player";
 import { useListener } from "../../../../contexts/listener";
+import { useIsSessionEnhancing } from "../../../../hooks/useEnhancedNotes";
 import * as main from "../../../../store/tinybase/main";
 import { rowIdfromTab, type Tab } from "../../../../store/zustand/tabs";
 import { StandardTabWrapper } from "../index";
@@ -36,7 +37,10 @@ export const TabItemNote: TabItem<Extract<Tab, { type: "sessions" }>> = ({
     main.STORE_ID,
   );
   const sessionMode = useListener((state) => state.getSessionMode(tab.id));
+  const isEnhancing = useIsSessionEnhancing(tab.id);
   const isActive = sessionMode === "active" || sessionMode === "finalizing";
+  const isFinalizing = sessionMode === "finalizing";
+  const showSpinner = isFinalizing || isEnhancing;
 
   return (
     <TabItemBase
@@ -44,6 +48,7 @@ export const TabItemNote: TabItem<Extract<Tab, { type: "sessions" }>> = ({
       title={title || "Untitled"}
       selected={tab.active}
       active={isActive}
+      finalizing={showSpinner}
       tabIndex={tabIndex}
       handleCloseThis={() => handleCloseThis(tab)}
       handleSelectThis={() => handleSelectThis(tab)}

--- a/apps/desktop/src/components/main/body/shared.tsx
+++ b/apps/desktop/src/components/main/body/shared.tsx
@@ -2,6 +2,7 @@ import { X } from "lucide-react";
 import { useState } from "react";
 
 import { Kbd } from "@hypr/ui/components/ui/kbd";
+import { Spinner } from "@hypr/ui/components/ui/spinner";
 import { cn } from "@hypr/utils";
 
 import { useCmdKeyPressed } from "../../../hooks/useCmdKeyPressed";
@@ -21,6 +22,7 @@ type TabItemBaseProps = {
   selected: boolean;
   active?: boolean;
   isEmptyTab?: boolean;
+  finalizing?: boolean;
   tabIndex?: number;
 } & {
   handleCloseThis: () => void;
@@ -39,6 +41,7 @@ export function TabItemBase({
   selected,
   active = false,
   isEmptyTab = false,
+  finalizing = false,
   tabIndex,
   handleCloseThis,
   handleSelectThis,
@@ -110,7 +113,9 @@ export function TabItemBase({
                 isHovered ? "opacity-0" : "opacity-100",
               ])}
             >
-              {active ? (
+              {finalizing ? (
+                <Spinner size={16} />
+              ) : active ? (
                 <div className="relative size-2">
                   <div className="absolute inset-0 rounded-full bg-red-600"></div>
                   <div className="absolute inset-0 rounded-full bg-red-300 animate-ping"></div>

--- a/apps/desktop/src/components/main/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/components/main/sidebar/timeline/item.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useMemo } from "react";
 
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
+import { Spinner } from "@hypr/ui/components/ui/spinner";
 import {
   Tooltip,
   TooltipContent,
@@ -8,6 +9,8 @@ import {
 } from "@hypr/ui/components/ui/tooltip";
 import { cn } from "@hypr/utils";
 
+import { useListener } from "../../../../contexts/listener";
+import { useIsSessionEnhancing } from "../../../../hooks/useEnhancedNotes";
 import { deleteSessionCascade } from "../../../../store/tinybase/deleteSession";
 import * as main from "../../../../store/tinybase/main";
 import { type TabInput, useTabs } from "../../../../store/zustand/tabs";
@@ -36,6 +39,14 @@ export const TimelineItemComponent = memo(
     const title = item.data.title || "Untitled";
     const timestamp =
       item.type === "event" ? item.data.started_at : item.data.created_at;
+
+    const sessionId = item.type === "session" ? item.id : null;
+    const sessionMode = useListener((state) =>
+      sessionId ? state.getSessionMode(sessionId) : "inactive",
+    );
+    const isEnhancing = useIsSessionEnhancing(sessionId ?? "");
+    const isFinalizing = sessionMode === "finalizing";
+    const showSpinner = isFinalizing || isEnhancing;
 
     const calendarId = useMemo(() => {
       if (!store || !eventId) {
@@ -79,6 +90,11 @@ export const TimelineItemComponent = memo(
         ])}
       >
         <div className="flex items-center gap-2">
+          {showSpinner && (
+            <div className="flex-shrink-0">
+              <Spinner size={14} />
+            </div>
+          )}
           <div className="flex flex-col gap-0.5 flex-1 min-w-0">
             <div className="text-sm font-normal truncate">{title}</div>
             {displayTime && (


### PR DESCRIPTION
show spinner in tabs or left side bar items when note is being enhanced

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack**:
- <kbd>&nbsp;3&nbsp;</kbd> #2445 
- <kbd>&nbsp;2&nbsp;</kbd> #2361 
- <kbd>&nbsp;1&nbsp;</kbd> #2359 👈 
<!-- GitButler Footer Boundary Bottom -->

