### PR TITLE
Add progress tracking for downloads and model states

### DIFF
--- a/apps/desktop/src/components/main/sidebar/banner/component.tsx
+++ b/apps/desktop/src/components/main/sidebar/banner/component.tsx
@@ -11,6 +11,8 @@ export function Banner({
   banner: BannerType;
   onDismiss?: () => void;
 }) {
+  const hasProgress = banner.progress !== undefined && banner.progress >= 0;
+
   return (
     <div className="overflow-hidden p-1">
       <div
@@ -50,12 +52,22 @@ export function Banner({
 
         <div className="flex flex-col gap-2 mt-1">
           {banner.primaryAction && (
-            <button
-              onClick={banner.primaryAction.onClick}
-              className="w-full py-2 rounded-full bg-gradient-to-t from-stone-600 to-stone-500 text-white text-sm font-medium duration-150 hover:scale-[1.01] active:scale-[0.99]"
-            >
-              {banner.primaryAction.label}
-            </button>
+            <div className="relative w-full overflow-hidden rounded-full">
+              <button
+                onClick={banner.primaryAction.onClick}
+                className="relative w-full py-2 rounded-full bg-gradient-to-t from-stone-600 to-stone-500 text-white text-sm font-medium duration-150 hover:scale-[1.01] active:scale-[0.99] z-10"
+              >
+                <span className="relative z-10">
+                  {banner.primaryAction.label}
+                </span>
+              </button>
+              {hasProgress && (
+                <div
+                  className="absolute inset-0 bg-gradient-to-t from-stone-700 to-stone-600 transition-all duration-300"
+                  style={{ width: `${banner.progress}%` }}
+                />
+              )}
+            </div>
           )}
           {banner.secondaryAction && (
             <button
@@ -64,6 +76,22 @@ export function Banner({
             >
               {banner.secondaryAction.label}
             </button>
+          )}
+          {!banner.primaryAction && !banner.secondaryAction && hasProgress && (
+            <div className="relative w-full h-9 rounded-full overflow-hidden bg-gradient-to-t from-stone-200 to-stone-100">
+              <div
+                className="absolute inset-0 bg-gradient-to-t from-stone-600 to-stone-500 transition-all duration-300"
+                style={{ width: `${banner.progress}%` }}
+              />
+              <div
+                className={cn([
+                  "absolute inset-0 flex items-center justify-center text-sm font-medium transition-colors duration-300",
+                  (banner.progress ?? 0) > 50 ? "text-white" : "text-stone-700",
+                ])}
+              >
+                {Math.round(banner.progress ?? 0)}%
+              </div>
+            </div>
           )}
         </div>
       </div>

--- a/apps/desktop/src/components/main/sidebar/banner/types.ts
+++ b/apps/desktop/src/components/main/sidebar/banner/types.ts
@@ -13,6 +13,7 @@ export type BannerType = {
   primaryAction?: BannerAction;
   secondaryAction?: BannerAction;
   dismissible: boolean;
+  progress?: number;
 };
 
 export type BannerCondition = () => boolean;


### PR DESCRIPTION
to show download progress in main app with inside a toast, after downloading ai models in onboarding
related: https://github.com/fastrepl/hyprnote/pull/2468

flow: download model in onboarding -> shows download progress toast in main window