### PR TITLE
fix native menu item panic and action handling

### DIFF
--- a/apps/desktop/src/hooks/useNativeContextMenu.ts
+++ b/apps/desktop/src/hooks/useNativeContextMenu.ts
@@ -1,6 +1,5 @@
-import { listen } from "@tauri-apps/api/event";
-import { Menu } from "@tauri-apps/api/menu";
-import { type MouseEvent, useCallback, useEffect, useRef } from "react";
+import { Menu, MenuItem } from "@tauri-apps/api/menu";
+import { type MouseEvent, useCallback } from "react";
 
 export type MenuItemDef = {
   id: string;
@@ -10,33 +9,22 @@ export type MenuItemDef = {
 };
 
 export function useNativeContextMenu(items: MenuItemDef[]) {
-  const actionsRef = useRef<Map<string, () => void>>(new Map());
-
-  useEffect(() => {
-    actionsRef.current.clear();
-    items.forEach((item) => actionsRef.current.set(item.id, item.action));
-  }, [items]);
-
-  useEffect(() => {
-    const unlisten = listen<string>("menu-event", (event) => {
-      const action = actionsRef.current.get(event.payload);
-      action?.();
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, []);
-
   const showMenu = useCallback(
     async (e: MouseEvent) => {
       e.preventDefault();
-      const menu = await Menu.new({
-        items: items.map((item) => ({
-          id: item.id,
-          text: item.text,
-          enabled: !item.disabled,
-        })),
-      });
+
+      const menuItems = await Promise.all(
+        items.map((item) =>
+          MenuItem.new({
+            id: item.id,
+            text: item.text,
+            enabled: !item.disabled,
+            action: item.action,
+          }),
+        ),
+      );
+
+      const menu = await Menu.new({ items: menuItems });
       await menu.popup();
     },
     [items],

--- a/plugins/tray/src/ext.rs
+++ b/plugins/tray/src/ext.rs
@@ -94,7 +94,11 @@ impl<'a, M: tauri::Manager<tauri::Wry>> Tray<'a, tauri::Wry, M> {
             .menu(&menu)
             .show_menu_on_left_click(true)
             .on_menu_event(move |app: &AppHandle, event| {
-                HyprMenuItem::from(event.id.clone()).handle(app);
+                // Tauri dispatches menu events globally, so we receive events from context menus
+                // created elsewhere. TryFrom gracefully ignores unknown menu IDs that don't belong to the tray menu.
+                if let Ok(item) = HyprMenuItem::try_from(event.id.clone()) {
+                    item.handle(app);
+                }
             })
             .build(app)?;
 

--- a/plugins/tray/src/menu_items/mod.rs
+++ b/plugins/tray/src/menu_items/mod.rs
@@ -40,12 +40,14 @@ macro_rules! menu_items {
             }
         }
 
-        impl From<tauri::menu::MenuId> for HyprMenuItem {
-            fn from(id: tauri::menu::MenuId) -> Self {
+        impl TryFrom<tauri::menu::MenuId> for HyprMenuItem {
+            type Error = ();
+
+            fn try_from(id: tauri::menu::MenuId) -> std::result::Result<Self, Self::Error> {
                 let id = id.0.as_str();
                 match id {
-                    $(<$item as MenuItemHandler>::ID => HyprMenuItem::$variant,)*
-                    _ => unreachable!("Unknown menu id: {}", id),
+                    $(<$item as MenuItemHandler>::ID => Ok(HyprMenuItem::$variant),)*
+                    _ => Err(()),
                 }
             }
         }


### PR DESCRIPTION
- Panic: Regression after https://github.com/fastrepl/hyprnote/commit/798e4cda62277b5ac6a0f18a73cdff5b93e60913. 
- Existing action handler syntax seems wrong: https://v2.tauri.app/ko/reference/javascript/api/namespacemenu/#properties-1

All fixed.