### PR TITLE
rust fmt

### DIFF
--- a/plugins/importer/src/types.rs
+++ b/plugins/importer/src/types.rs
@@ -115,4 +115,3 @@ pub struct ImportedSessionParticipant {
     pub human_id: String,
     pub source: String,
 }
-


### PR DESCRIPTION
• Applied `rustfmt` to format Rust code according to standard style guidelines