### PR TITLE
Preserve inner tab scroll; skip transcript restore during meetings

### DIFF
--- a/apps/desktop/src/components/main/body/sessions/note-input/index.tsx
+++ b/apps/desktop/src/components/main/body/sessions/note-input/index.tsx
@@ -13,6 +13,7 @@ import { useResizeObserver } from "usehooks-ts";
 import type { TiptapEditor } from "@hypr/tiptap/editor";
 import { cn } from "@hypr/utils";
 
+import { useListener } from "../../../../../contexts/listener";
 import { useAutoEnhance } from "../../../../../hooks/useAutoEnhance";
 import { useAutoTitle } from "../../../../../hooks/useAutoTitle";
 import { useScrollPreservation } from "../../../../../hooks/useScrollPreservation";
@@ -53,10 +54,19 @@ export const NoteInput = forwardRef<
     [currentTab],
   );
 
+  const sessionMode = useListener((state) => state.getSessionMode(sessionId));
+  const isMeetingInProgress =
+    sessionMode === "active" ||
+    sessionMode === "finalizing" ||
+    sessionMode === "running_batch";
+
   const { scrollRef, onBeforeTabChange } = useScrollPreservation(
     currentTab.type === "enhanced"
       ? `enhanced-${currentTab.id}`
       : currentTab.type,
+    {
+      skipRestoration: currentTab.type === "transcript" && isMeetingInProgress,
+    },
   );
 
   const { fadeRef, atStart, atEnd } = useScrollFade<HTMLDivElement>([

--- a/apps/desktop/src/hooks/useScrollPreservation.ts
+++ b/apps/desktop/src/hooks/useScrollPreservation.ts
@@ -1,6 +1,9 @@
 import { type RefObject, useCallback, useEffect, useRef } from "react";
 
-export function useScrollPreservation(key: string): {
+export function useScrollPreservation(
+  key: string,
+  options: { skipRestoration?: boolean } = {},
+): {
   scrollRef: RefObject<HTMLDivElement | null>;
   onBeforeTabChange: () => void;
 } {
@@ -23,6 +26,8 @@ export function useScrollPreservation(key: string): {
     const container = scrollRef.current;
     if (!container) return;
 
+    if (options.skipRestoration) return;
+
     const savedPosition = scrollPositions.current.get(key);
     if (savedPosition === undefined) return;
 
@@ -33,7 +38,7 @@ export function useScrollPreservation(key: string): {
     });
 
     return () => cancelAnimationFrame(rafId);
-  }, [key]);
+  }, [key, options.skipRestoration]);
 
   return { scrollRef, onBeforeTabChange };
 }


### PR DESCRIPTION
Keep scroll position for inner tabs (summary, memos, transcript, etc.) when switching tabs. When a session is in progress (active, finalizing, or running_batch), skip restoring the transcript tab's scroll position so the transcript opens at the bottom by default.

- Add listener-based session mode check in note input to determine meeting state.
- Pass skipRestoration option into useScrollPreservation for conditional restoration.
- Extend useScrollPreservation to accept options and early-return when skipRestoration is true, and include options in effect deps.