### PR TITLE
add tauri-plugin-notify initialization

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -107,6 +107,7 @@ pub async fn main() {
         .plugin(tauri_plugin_detect::init())
         .plugin(tauri_plugin_extensions::init())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_notify::init())
         .plugin(tauri_plugin_overlay::init())
         .plugin(tauri_plugin_pagefind::init())
         .plugin(tauri_plugin_clipboard_manager::init())


### PR DESCRIPTION
- Added Tauri notification plugin initialization to support system-level notifications in the application

---

to fix this:

```
@hypr/desktop:tauri:dev: 2026-01-02T10:54:06.939349Z ERROR tauri_plugin_tracing::ext: [String("[FolderWatcher] Failed to start:"), String("plugin notify not found")]
```