### PR TITLE
polished expandable profile menu

### DIFF
--- a/apps/desktop/src/components/main/sidebar/profile/index.tsx
+++ b/apps/desktop/src/components/main/sidebar/profile/index.tsx
@@ -256,8 +256,13 @@ export function ProfileSection({ onExpandChange }: ProfileSectionProps = {}) {
 
                       <div className="my-1 border-t border-neutral-100" />
 
-                      {menuItems.map((item) => (
-                        <MenuItem key={item.label} {...item} />
+                      {menuItems.map((item, index) => (
+                        <div key={item.label}>
+                          <MenuItem {...item} />
+                          {(index === 2 || index === 5) && (
+                            <div className="my-1 border-t border-neutral-100" />
+                          )}
+                        </div>
                       ))}
 
                       <AuthSection


### PR DESCRIPTION
## Changes

- Added Templates, Shortcuts, and Prompts entries to the expandable profile menu
- Registered keyboard shortcuts for new menu items (⌘ ⇧ T/S/P)
- Renamed sidebar labels to clarify settings:
  - "AI" → "AI Settings"
  - "Settings" → "App Settings"
- Added visual separators between menu sections in the sidebar