### PR TITLE
improve orphan removal error handling

### DIFF
--- a/apps/desktop/src/store/tinybase/persister/session/load.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/load.ts
@@ -8,7 +8,7 @@ import type {
   Tag,
 } from "@hypr/store";
 
-import { isUUID } from "../utils";
+import { isFileNotFoundError, isUUID } from "../utils";
 import type { SessionMetaJson } from "./collect";
 
 export type LoadedData = {
@@ -165,11 +165,14 @@ export async function cleanupOrphanSessionDirs(
   for (const dir of existingDirs) {
     if (isUUID(dir.name) && !validSessionIds.has(dir.name)) {
       try {
-        if (await exists(dir.path)) {
-          await remove(dir.path, { recursive: true });
+        await remove(dir.path, { recursive: true });
+      } catch (e) {
+        if (!isFileNotFoundError(e)) {
+          console.error(
+            `[SessionPersister] Failed to remove orphan dir ${dir.path}:`,
+            e,
+          );
         }
-      } catch {
-        // Ignore errors - directory may have been removed by another process
       }
     }
   }


### PR DESCRIPTION
## Summary
- Improved error handling for orphan directory removal in the persister
- Prevented concurrent save operations in the store using a reusable helper

## Details
- Use `isFileNotFoundError` helper for selective error logging in orphan cleanup (only logs actual errors, silently ignores "not found" which is expected in race conditions)
- Extract `createGuardedSave` helper to prevent concurrent save operations and reduce code duplication
- Removed TOCTOU-prone `exists()` checks that were added in earlier commits

## Review & Testing Checklist for Human
- [ ] Verify `isFileNotFoundError` in `utils.ts` correctly identifies file-not-found errors across platforms (check error string matching logic)
- [ ] Test that rapid window blur/close events don't cause data loss due to dropped saves (the guard drops concurrent requests rather than queueing them)
- [ ] Manually test orphan directory cleanup still works: create orphan chat/session dirs and verify they get cleaned up on save

### Notes
The `createGuardedSave` helper uses a simple boolean flag which drops save requests if one is in progress. This is acceptable because TinyBase retains data in memory, so the next save will include any pending changes. However, if the app crashes during a dropped save, that data could be lost.

Link to Devin run: https://app.devin.ai/sessions/09c51b1c49374b94bbcd3e239121ddf0
Requested by: yujonglee (@yujonglee)