### PR TITLE
Remove Kbd shortcuts from profile menu items

### DIFF
--- a/apps/desktop/src/components/main/sidebar/profile/index.tsx
+++ b/apps/desktop/src/components/main/sidebar/profile/index.tsx
@@ -195,19 +195,16 @@ export function ProfileSection({ onExpandChange }: ProfileSectionProps = {}) {
       icon: FileTextIcon,
       label: "Templates",
       onClick: handleClickTemplates,
-      badge: <Kbd className={kbdClass}>⌘ ⇧ T</Kbd>,
     },
     {
       icon: ZapIcon,
       label: "Shortcuts",
       onClick: handleClickShortcuts,
-      badge: <Kbd className={kbdClass}>⌘ ⇧ S</Kbd>,
     },
     {
       icon: MessageSquareIcon,
       label: "Prompts",
       onClick: handleClickPrompts,
-      badge: <Kbd className={kbdClass}>⌘ ⇧ P</Kbd>,
     },
     {
       icon: SparklesIcon,


### PR DESCRIPTION
Templates, Shortcuts, and Prompts entries in the expanding profile menu no longer display keyboard shortcut badges because there are no corresponding shortcuts to show. This cleans up the UI and removes misleading/unused Kbd elements from those menu items.