### PR TITLE
Update keyboard shortcuts: capitalize names and add Finder

### DIFF
--- a/apps/web/content/docs/faq/6.keyboard-shortcuts.mdx
+++ b/apps/web/content/docs/faq/6.keyboard-shortcuts.mdx
@@ -19,7 +19,7 @@ description: "Complete list of keyboard shortcuts in Hyprnote."
 
 | Shortcut                     | Action              |
 | ---------------------------- | ------------------- |
-| <kbd>⌘</kbd> + <kbd>\\</kbd> | Toggle left sidebar |
+| <kbd>⌘</kbd> + <kbd>\\</kbd> | Toggle Left Sidebar |
 | <kbd>⌘</kbd> + <kbd>J</kbd>  | Toggle AI assistant |
 
 ## Notes & Tabs
@@ -33,16 +33,17 @@ description: "Complete list of keyboard shortcuts in Hyprnote."
 
 ## Quick Access
 
-| Shortcut                                   | Action               |
-| ------------------------------------------ | -------------------- |
-| <kbd>⌘</kbd> + <kbd>K</kbd>                | Focus search         |
-| <kbd>⌘</kbd> + <kbd>F</kbd>                | Search inside editor |
-| <kbd>⌘</kbd> + <kbd>,</kbd>                | Open settings        |
-| <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>A</kbd> | Open AI              |
-| <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>C</kbd> | Open calendar        |
-| <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>D</kbd> | Open daily notes     |
-| <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>F</kbd> | Open advanced search |
-| <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>O</kbd> | Open contacts        |
+| Shortcut                                   | Action                         |
+| ------------------------------------------ | ------------------------------ |
+| <kbd>⌘</kbd> + <kbd>K</kbd>                | Focus Searchbar                |
+| <kbd>⌘</kbd> + <kbd>F</kbd>                | Search inside note or editor   |
+| <kbd>⌘</kbd> + <kbd>,</kbd>                | Open Settings                  |
+| <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>A</kbd> | Open AI                        |
+| <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>C</kbd> | Open Calendar                  |
+| <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>D</kbd> | Open Daily Notes               |
+| <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>F</kbd> | Open Advanced search           |
+| <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>L</kbd> | Open Folders                   |
+| <kbd>⌘</kbd> + <kbd>⇧</kbd> + <kbd>O</kbd> | Open Contacts                  |
 
 ## Application
 


### PR DESCRIPTION
Standardize shortcut labels by capitalizing "Calendar" and "Daily Notes" to match other entry styles, improving consistency in the FAQ. Also add a new shortcut binding (Cmd+Shift+I) to open Finder as requested.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #2796 
- <kbd>&nbsp;1&nbsp;</kbd> #2795 👈 
<!-- GitButler Footer Boundary Bottom -->

