### PR TITLE
feat(settings): store array fields as JSON instead of comma-separated strings

### DIFF
--- a/apps/desktop/src/store/tinybase/persister/settings/persister.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/settings/persister.test.ts
@@ -32,7 +32,7 @@ describe("settingsPersister roundtrip", () => {
         event: true,
         detect: false,
         respect_dnd: true,
-        ignored_platforms: "zoom,slack",
+        ignored_platforms: ["zoom", "slack"],
       },
       general: {
         autostart: true,
@@ -42,7 +42,7 @@ describe("settingsPersister roundtrip", () => {
       },
       language: {
         ai_language: "en",
-        spoken_languages: "en,ko",
+        spoken_languages: ["en", "ko"],
       },
     };
 
@@ -86,13 +86,13 @@ describe("settingsPersister roundtrip", () => {
       notification_event: true,
       notification_detect: false,
       respect_dnd: true,
-      ignored_platforms: "zoom",
+      ignored_platforms: '["zoom"]',
       autostart: true,
       save_recordings: false,
       quit_intercept: true,
       telemetry_consent: false,
       ai_language: "en",
-      spoken_languages: "en,ko",
+      spoken_languages: '["en","ko"]',
     };
 
     store.setTables(originalTables);
@@ -187,7 +187,7 @@ describe("settingsPersister roundtrip", () => {
     const original = {
       language: {
         ai_language: "ko",
-        spoken_languages: "ko,en",
+        spoken_languages: ["ko", "en"],
       },
     };
 
@@ -198,5 +198,121 @@ describe("settingsPersister roundtrip", () => {
     const result = storeToSettings(store);
 
     expect(result.language).toEqual(original.language);
+  });
+
+  test("handles migration from double-encoded JSON strings", () => {
+    const doubleEncoded = {
+      language: {
+        spoken_languages: '["en","ko"]',
+      },
+      notification: {
+        ignored_platforms: '["zoom"]',
+      },
+    };
+
+    const [tables, values] = settingsToContent(doubleEncoded);
+    const store = createMergeableStore();
+    store.setTables(tables);
+    store.setValues(values);
+    const result = storeToSettings(store);
+
+    expect(result.language).toEqual({
+      spoken_languages: ["en", "ko"],
+    });
+    expect(result.notification).toEqual({
+      ignored_platforms: ["zoom"],
+    });
+  });
+
+  test("handles migration from comma-separated strings (old format)", () => {
+    const oldFormat = {
+      language: {
+        spoken_languages: "en,ko,ja",
+      },
+      notification: {
+        ignored_platforms: "zoom,slack",
+      },
+    };
+
+    const [tables, values] = settingsToContent(oldFormat);
+    const store = createMergeableStore();
+    store.setTables(tables);
+    store.setValues(values);
+    const result = storeToSettings(store);
+
+    expect(result.language).toEqual({
+      spoken_languages: ["en", "ko", "ja"],
+    });
+    expect(result.notification).toEqual({
+      ignored_platforms: ["zoom", "slack"],
+    });
+  });
+
+  test("handles migration from general section to language section", () => {
+    const oldSettings = {
+      general: {
+        autostart: true,
+        ai_language: "ko",
+        spoken_languages: ["ko", "en"],
+      },
+    };
+
+    const [tables, values] = settingsToContent(oldSettings);
+    const store = createMergeableStore();
+    store.setTables(tables);
+    store.setValues(values);
+    const result = storeToSettings(store);
+
+    expect(result.language).toEqual({
+      ai_language: "ko",
+      spoken_languages: ["ko", "en"],
+    });
+    expect(result.general).toEqual({
+      autostart: true,
+    });
+  });
+
+  test("handles migration from general section with comma-separated spoken_languages", () => {
+    const oldSettings = {
+      general: {
+        ai_language: "ja",
+        spoken_languages: "ja,en,ko",
+      },
+    };
+
+    const [tables, values] = settingsToContent(oldSettings);
+    const store = createMergeableStore();
+    store.setTables(tables);
+    store.setValues(values);
+    const result = storeToSettings(store);
+
+    expect(result.language).toEqual({
+      ai_language: "ja",
+      spoken_languages: ["ja", "en", "ko"],
+    });
+  });
+
+  test("language section takes precedence over general section", () => {
+    const mixedSettings = {
+      general: {
+        ai_language: "en",
+        spoken_languages: ["en"],
+      },
+      language: {
+        ai_language: "ko",
+        spoken_languages: ["ko", "ja"],
+      },
+    };
+
+    const [tables, values] = settingsToContent(mixedSettings);
+    const store = createMergeableStore();
+    store.setTables(tables);
+    store.setValues(values);
+    const result = storeToSettings(store);
+
+    expect(result.language).toEqual({
+      ai_language: "ko",
+      spoken_languages: ["ko", "ja"],
+    });
   });
 });


### PR DESCRIPTION
## Summary

Migrate settings array fields (`spoken_languages`, `ignored_platforms`, `ignored_recurring_series`) to use JSON arrays instead of comma-separated strings.

## Changes

- Add `JSON_ARRAY_FIELDS` set to identify fields requiring transformation
- Implement `toStoreValue` and `fromStoreValue` for JSON serialization/deserialization
- Support backward compatibility with:
  - Old comma-separated format (`"en,ko"`)
  - Double-encoded JSON strings (`'["en","ko"]'`)
- Add comprehensive tests for migration scenarios