### PR TITLE
Restore focus to memos when switching tabs during meeting

### DIFF
--- a/apps/desktop/src/components/main/body/sessions/note-input/index.tsx
+++ b/apps/desktop/src/components/main/body/sessions/note-input/index.tsx
@@ -90,8 +90,12 @@ export const NoteInput = forwardRef<
     if (currentTab.type === "transcript") {
       internalEditorRef.current = { editor: null };
       setEditor(null);
+    } else if (currentTab.type === "raw" && isMeetingInProgress) {
+      requestAnimationFrame(() => {
+        internalEditorRef.current?.editor?.commands.focus();
+      });
     }
-  }, [currentTab]);
+  }, [currentTab, isMeetingInProgress]);
 
   useEffect(() => {
     const editorInstance = internalEditorRef.current?.editor ?? null;


### PR DESCRIPTION
When switching between inner tabs (memos and transcript) while listening to a meeting, focus was not returned to the memos editor when coming back into view. This change adds logic to focus the editor via requestAnimationFrame when the current tab is the raw memo tab and a meeting is in progress, and includes isMeetingInProgress in the effect dependencies to ensure the focus behavior runs correctly.