### PR TITLE
fade out consent banner

### DIFF
--- a/apps/desktop/src/components/main/body/sessions/index.tsx
+++ b/apps/desktop/src/components/main/body/sessions/index.tsx
@@ -282,12 +282,11 @@ function StatusBanner({
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          transition={{ duration: 0.3 }}
+          transition={{ duration: 0.3, ease: "easeOut" }}
           style={{ left: `calc(50% + ${totalOffset}px)` }}
           className={cn([
             "fixed -translate-x-1/2 bottom-6 z-50",
             "whitespace-nowrap text-center text-xs text-stone-300",
-            "transition-all duration-200 ease-out",
           ])}
         >
           {skipReason || "Ask for consent when using Hyprnote"}


### PR DESCRIPTION
• Implemented a brief consent banner that appears for 5 seconds when starting a listening session
• Fixed component exit animation to prevent visual flickering by adjusting transition easing