### PR TITLE
Prefer listener view when re-entering meeting

### DIFF
--- a/apps/desktop/src/components/main/body/sessions/shared.tsx
+++ b/apps/desktop/src/components/main/body/sessions/shared.tsx
@@ -41,12 +41,12 @@ export function useCurrentNoteTab(
       return { type: "raw" };
     }
 
-    if (tab.state.view) {
-      return tab.state.view;
-    }
-
     if (firstEnhancedNoteId) {
       return { type: "enhanced", id: firstEnhancedNoteId };
+    }
+
+    if (tab.state.view) {
+      return tab.state.view;
     }
 
     return { type: "raw" };


### PR DESCRIPTION
When re-entering a meeting as a listener, the UI should show the memos (editor) rather than leaving the old tab selection visible but missing its tab. This reorders the tab view selection logic so that an active listener forces the "raw" (memos) view first, preventing the summary tab from remaining selected when it no longer exists.