### PR TITLE
Normalize handbook section titles and UI ordering

### DIFF
--- a/apps/web/content/handbook/go-to-market/0.customers.mdx
+++ b/apps/web/content/handbook/go-to-market/0.customers.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Who our customers are"
-section: "Go-to-market"
+section: "Go To Market"
 summary: "Understanding who we build for and why."
 ---
 

--- a/apps/web/content/handbook/go-to-market/1.value-we-provide.mdx
+++ b/apps/web/content/handbook/go-to-market/1.value-we-provide.mdx
@@ -1,6 +1,6 @@
 ---
 title: "The value we provide"
-section: "Go-to-market"
+section: "Go To Market"
 summary: "What makes Hyprnote valuable to our customers."
 ---
 

--- a/apps/web/content/handbook/go-to-market/2.how-customers-find-us.mdx
+++ b/apps/web/content/handbook/go-to-market/2.how-customers-find-us.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How customers find us"
-section: "Go-to-market"
+section: "Go To Market"
 summary: "Our approach to reaching potential customers."
 ---
 

--- a/apps/web/content/handbook/go-to-market/3.how-we-talk-with-them.mdx
+++ b/apps/web/content/handbook/go-to-market/3.how-we-talk-with-them.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How we talk with them"
-section: "Go-to-market"
+section: "Go To Market"
 summary: "Our communication approach with customers."
 ---
 

--- a/apps/web/content/handbook/go-to-market/4.how-we-price.mdx
+++ b/apps/web/content/handbook/go-to-market/4.how-we-price.mdx
@@ -1,6 +1,6 @@
 ---
 title: "How we price our product"
-section: "Go-to-market"
+section: "Go To Market"
 summary: "Our pricing philosophy and approach."
 ---
 

--- a/apps/web/content/handbook/how-we-work/0.work-styles.mdx
+++ b/apps/web/content/handbook/how-we-work/0.work-styles.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Work styles"
-section: "How-we-work"
+section: "How We Work"
 summary: "At Hyprnote, our way of working is designed to maximize focus, creativity, and speed."
 ---
 

--- a/apps/web/content/handbook/how-we-work/1.communication-and-focus.mdx
+++ b/apps/web/content/handbook/how-we-work/1.communication-and-focus.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Communication and focus"
-section: "How-we-work"
+section: "How We Work"
 summary: "We balance independence with frequent sync to stay aligned and focused."
 ---
 

--- a/apps/web/content/handbook/how-we-work/2.customer-feedback.mdx
+++ b/apps/web/content/handbook/how-we-work/2.customer-feedback.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Customer feedback and issues"
-section: "How-we-work"
+section: "How We Work"
 summary: "GitHub Issues and Projects is our main channel for feedback and prioritization, keeping us open-source friendly and transparent."
 ---
 

--- a/apps/web/content/handbook/how-we-work/3.planning-and-sprints.mdx
+++ b/apps/web/content/handbook/how-we-work/3.planning-and-sprints.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Planning and sprints"
-section: "How-we-work"
+section: "How We Work"
 summary: "How we plan, execute, and ship in focused cycles."
 ---
 

--- a/apps/web/content/handbook/who-we-want/0.core-traits.mdx
+++ b/apps/web/content/handbook/who-we-want/0.core-traits.mdx
@@ -1,6 +1,6 @@
 ---
 title: "The Core Traits We Look For"
-section: "Who-we-want"
+section: "Who We Want"
 summary: "The core traits we value most in teammates: Grit, Intellectual honesty, Sharpness, and a Vivid vector."
 ---
 

--- a/apps/web/content/handbook/who-we-want/1.hard-skills.mdx
+++ b/apps/web/content/handbook/who-we-want/1.hard-skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Hard skills matter too"
-section: "Who-we-want"
+section: "Who We Want"
 summary: "While soft traits are essential, we also need people who are excellent at what they do."
 ---
 

--- a/apps/web/content/handbook/who-we-want/2.founders-example.mdx
+++ b/apps/web/content/handbook/who-we-want/2.founders-example.mdx
@@ -1,6 +1,6 @@
 ---
 title: "The example of our founders"
-section: "Who-we-want"
+section: "Who We Want"
 summary: "We hold ourselves to the same standards we expect from others."
 ---
 

--- a/apps/web/content/handbook/who-we-want/3.future-teammates.mdx
+++ b/apps/web/content/handbook/who-we-want/3.future-teammates.mdx
@@ -1,6 +1,6 @@
 ---
 title: "What this means for future teammates"
-section: "Who-we-want"
+section: "Who We Want"
 summary: "If you join Hyprnote, you'll be expected to own your work, move fast, and communicate openly."
 ---
 

--- a/apps/web/public/admin/config.yml
+++ b/apps/web/public/admin/config.yml
@@ -117,10 +117,11 @@ collections:
         widget: select
         options:
           - About
-          - Communication
-          - Go to Market
           - How We Work
           - Who We Want
+          - Go To Market
+          - Communication
+          - Beliefs
       - label: Summary
         name: summary
         widget: text

--- a/apps/web/src/routes/_view/company-handbook/-structure.ts
+++ b/apps/web/src/routes/_view/company-handbook/-structure.ts
@@ -5,12 +5,22 @@ export const handbookStructure = {
     "who-we-want",
     "go-to-market",
     "communication",
+    "beliefs",
   ],
+  sectionTitles: {
+    about: "About",
+    "how-we-work": "How We Work",
+    "who-we-want": "Who We Want",
+    "go-to-market": "Go To Market",
+    communication: "Communication",
+    beliefs: "Beliefs",
+  } as Record<string, string>,
   defaultPages: {
     about: "about/what-hyprnote-is",
     "how-we-work": "how-we-work/work-styles",
     "who-we-want": "who-we-want/core-traits",
     "go-to-market": "go-to-market/customers",
     communication: "communication/why-this-matters",
+    beliefs: "beliefs/what-we-believe",
   } as Record<string, string>,
 };

--- a/apps/web/src/routes/_view/company-handbook/route.tsx
+++ b/apps/web/src/routes/_view/company-handbook/route.tsx
@@ -60,8 +60,7 @@ function LeftSidebar() {
 
     const sections = handbookStructure.sections
       .map((sectionId) => {
-        const sectionName =
-          sectionId.charAt(0).toUpperCase() + sectionId.slice(1);
+        const sectionName = handbookStructure.sectionTitles[sectionId];
         return sectionGroups[sectionName];
       })
       .filter(Boolean);

--- a/apps/web/src/routes/_view/route.tsx
+++ b/apps/web/src/routes/_view/route.tsx
@@ -172,8 +172,7 @@ function MobileHandbookDrawer({
 
     const sections = handbookStructure.sections
       .map((sectionId) => {
-        const sectionName =
-          sectionId.charAt(0).toUpperCase() + sectionId.slice(1);
+        const sectionName = handbookStructure.sectionTitles[sectionId];
         return sectionGroups[sectionName];
       })
       .filter(Boolean);


### PR DESCRIPTION
Fix inconsistent section slugs and display names so sections render with human-friendly titles (e.g. "How We Work" instead of "How-we-work" / "How-we-work"). Update multiple handbook MDX frontmatter entries to use spaced section names, add new "Beliefs" and re-order items in the CMS config, and introduce a canonical sectionTitles mapping and defaultPages in the handbook structure so the UI shows the correct titles and navigation ordering.