### PR TITLE
Enable subfolder display for nested sidebar items

### DIFF
--- a/apps/web/public/admin/config.yml
+++ b/apps/web/public/admin/config.yml
@@ -107,7 +107,7 @@ collections:
     nested:
       depth: 10
       summary: "{{title}}"
-      subfolders: false
+      subfolders: true
     fields:
       - label: Title
         name: title


### PR DESCRIPTION
The sidebar currently lists several high-level sections (Core Traits, What Hyprnote is, What We Believe, Who our customers are, Why This Matters, Work styles). The nested block's subfolders option was disabled, preventing nested sub-items from appearing. Enable subfolders so deeper folder structures are shown in the admin sidebar, allowing those nested sections to display properly.