### PR TITLE
docs: add 1.0.1 stable changelog

### DIFF
--- a/apps/web/content/changelog/1.0.1.mdx
+++ b/apps/web/content/changelog/1.0.1.mdx
@@ -1,0 +1,117 @@
+---
+date: 2026-01-08T00:00:00.000Z
+---
+
+Hyprnote 1.0.1 brings significant improvements to plugin architecture, data management, and overall user experience.
+
+## Calendar Integration
+
+- Display calendar event info in metadata chip
+  - Show video icon and truncated event title
+  - Display event details including title, location, meeting link, and date/time
+  - Add Join button for meeting links
+
+## Auto-Enhancement & Title Generation
+
+- Automatically switch to summary tab and start summarizing when listening stops
+- Re-trigger summarization even if summary already exists
+- Require minimum words before auto-enhancement triggers
+- Show dismissible consent banner when listening starts (fades out after 5 seconds)
+- Display skip reason banner when auto-enhance is skipped
+- Prevent unnecessary title regeneration when switching tabs
+- Restore focus to memos editor when switching tabs during meeting
+
+## Plugins
+
+- Consolidate export, frontmatter, and folder plugins into unified fs-sync plugin
+  - Move folder operations to fs-sync plugin
+  - Move export functionality to fs-sync plugin
+  - Move frontmatter operations to fs-sync plugin
+  - Add audio operations (delete, exist, import, path) to fs-sync plugin
+  - Add chat directory, entity directory, and scan utilities to fs-sync plugin
+  - Add orphan cleanup commands (cleanup_orphan_dirs, cleanup_orphan_files)
+
+- Add apple-contacts plugin
+  - Implement Apple Contacts integration for importing contacts
+  - Add import command for batch importing contacts
+
+## Persistence & Storage
+
+- Major persister consolidation and refactoring
+  - Merge note and transcript persisters into single session persister
+  - Add chat shortcuts persister for storing chat shortcuts
+  - Remove memories feature and related code
+  - Refactor persister utilities into shared factories
+  - Add factory helpers for JSON file and markdown directory persistence
+  - Add generic transforms in human persister
+  - Add values persister for key-value pairs
+- Store transcript words inline instead of separate table
+- Store array fields as JSON instead of comma-separated strings
+- Move language settings to top-level 'language' key
+- Remove extension_state and ai_providers from main store
+
+## Search & Indexing
+
+- Tantivy search engine improvements
+  - Refactor to consolidate search args into SearchRequest struct
+  - Phase 1 foundation fixes for better search infrastructure
+  - Phase 2 feature parity with Orama search capabilities
+  - Add advanced search features including filters and sorting
+  - Improve batching, concurrency, and index versioning
+
+## Audio & Devices
+
+- Add DeviceListChanged event for device connect/disconnect detection
+- Fix wrong sample rate returned from audio buffer
+- Add `com.apple.Sound-Settings.extension` to microphone detection exclusion list
+- Add error propagation from STT adapters
+  - Improve error handling in Argmax, AssemblyAI, Fireworks, Gladia, OpenAI, and Soniox adapters
+  - Better error reporting in listener actor
+
+## Speech-to-Text
+
+- Fix Deepgram language configuration
+- Remove unsupported `detect_language` option from Deepgram streaming
+- Don't force accordion in STT config UI
+
+## Editor
+
+- Add resizable image extension to Tiptap editor
+  - Resize handles with hover effects
+  - Preserve custom attachmentId attribute
+
+## Data Import
+
+- Add Templates import to Hyprnote importer (supports v0 stable and nightly)
+- Refactor importer plugin with simplified import flow
+- Remove LIMIT in session queries for better import handling
+- Remove auto import on app startup
+- Remove data tab from main navigation (consolidated into settings)
+- Update data import UI in settings
+- Fix path display and reveal behavior for Hyprnote sources
+- Improve legacy HTML-to-markdown conversion
+- Use Tiptap native markdown conversion for better parsing
+
+## Performance
+
+- Implement incremental persister save optimization using content hashing
+- Optimize TinyBase store by inlining nested words
+
+## Meeting View
+
+- Prefer listener view when re-entering a meeting
+
+## macOS Notification
+
+- Improve progress bar animation with correct pause/resume behavior
+- Move progress bar to bottom of notification
+
+## Fixes
+
+- Fix edge-case for is_builtin_display_inactive on macOS
+- Compute Ollama Origin header from baseUrl to fix Forbidden error
+- Simplified error UI with single "Restart App" button
+- Read AI language from settings store instead of main store
+- Normalize bullet points (•) to dashes (-) in AI summaries
+- Better Sentry config with user-id tracking
+- Improve accessibility for tab button interaction


### PR DESCRIPTION
Consolidates all changes from 1.0.1-nightly.1 through 1.0.1-nightly.4 into a stable release changelog.