### PR TITLE
Normalize admin section option values

### DIFF
--- a/apps/web/public/admin/config.yml
+++ b/apps/web/public/admin/config.yml
@@ -116,12 +116,12 @@ collections:
         name: section
         widget: select
         options:
-          - About
-          - How We Work
-          - Who We Want
-          - Go To Market
-          - Communication
-          - Beliefs
+          - about
+          - how-we-work
+          - who-we-want
+          - go-to-market
+          - communication
+          - beliefs
       - label: Summary
         name: summary
         widget: text


### PR DESCRIPTION
Use lowercase, hyphen-separated identifiers for admin section options instead of title-cased words. This change ensures consistent, machine-friendly values (e.g. for routing, lookups, or config matching) while keeping labels displayed elsewhere unchanged.