### PR TITLE
feat(audio): increase speaker buffer size

### DIFF
--- a/crates/audio/src/speaker/linux.rs
+++ b/crates/audio/src/speaker/linux.rs
@@ -15,9 +15,9 @@ use ringbuf::{
     traits::{Consumer, Producer, Split},
 };
 
+use super::{BUFFER_SIZE, CHUNK_SIZE};
+
 const SAMPLE_RATE: u32 = 48000;
-const CHUNK_SIZE: usize = 256;
-const BUFFER_SIZE: usize = CHUNK_SIZE * 4;
 
 pub struct SpeakerInput {
     sample_rate: u32,

--- a/crates/audio/src/speaker/macos.rs
+++ b/crates/audio/src/speaker/macos.rs
@@ -47,7 +47,7 @@ struct Ctx {
     current_sample_rate: Arc<AtomicU32>,
 }
 
-const CHUNK_SIZE: usize = 256;
+use super::{BUFFER_SIZE, CHUNK_SIZE};
 
 impl SpeakerInput {
     pub fn new() -> Result<Self> {
@@ -167,8 +167,7 @@ impl SpeakerInput {
 
         let format = av::AudioFormat::with_asbd(&asbd).unwrap();
 
-        let buffer_size = CHUNK_SIZE * 4;
-        let rb = HeapRb::<f32>::new(buffer_size);
+        let rb = HeapRb::<f32>::new(BUFFER_SIZE);
         let (producer, consumer) = rb.split();
 
         let waker_state = Arc::new(Mutex::new(WakerState {

--- a/crates/audio/src/speaker/mod.rs
+++ b/crates/audio/src/speaker/mod.rs
@@ -1,6 +1,9 @@
 use anyhow::Result;
 use futures_util::{Stream, StreamExt};
 
+pub(super) const CHUNK_SIZE: usize = 256;
+pub(super) const BUFFER_SIZE: usize = CHUNK_SIZE * 64;
+
 #[cfg(target_os = "macos")]
 mod macos;
 #[cfg(target_os = "macos")]

--- a/crates/audio/src/speaker/windows.rs
+++ b/crates/audio/src/speaker/windows.rs
@@ -8,6 +8,8 @@ use std::time::Duration;
 use tracing::error;
 use wasapi::{Direction, SampleType, StreamMode, WaveFormat, get_default_device};
 
+use super::{BUFFER_SIZE, CHUNK_SIZE};
+
 pub struct SpeakerInput {}
 
 impl SpeakerInput {
@@ -41,7 +43,6 @@ impl SpeakerInput {
             error!("Audio initialization failed: {}", e);
         }
 
-        const CHUNK_SIZE: usize = 256;
         SpeakerStream {
             sample_queue,
             waker_state,
@@ -142,10 +143,10 @@ impl SpeakerStream {
                             queue.extend(samples);
 
                             let len = queue.len();
-                            if len > 8192 {
-                                let dropped = len - 8192;
+                            if len > BUFFER_SIZE {
+                                let dropped = len - BUFFER_SIZE;
                                 tracing::warn!(dropped, "samples_dropped");
-                                queue.drain(0..(len - 8192));
+                                queue.drain(0..(len - BUFFER_SIZE));
                             }
                         }
 


### PR DESCRIPTION
- Centralize `CHUNK_SIZE` and `BUFFER_SIZE` constants in `speaker/mod.rs`
- Increase buffer size from `CHUNK_SIZE * 4` (1024 samples) to `CHUNK_SIZE * 64` (16384 samples)
- Update linux, macos, and windows implementations to use shared constants