### PR TITLE
Handle Google Docs shared links and export fallback

### DIFF
--- a/apps/web/src/routes/admin/import/index.tsx
+++ b/apps/web/src/routes/admin/import/index.tsx
@@ -206,8 +206,9 @@ function ImportPage() {
           Step 1: Enter Google Docs URL
         </h2>
         <p className="text-sm text-neutral-600 mb-4">
-          The document must be published to the web. Go to File &gt; Share &gt;
-          Publish to web in Google Docs.
+          The document must be either published to the web (File &gt; Share &gt;
+          Publish to web) or shared with "Anyone with the link can view"
+          permissions (Share button).
         </p>
 
         <div className="space-y-4">

--- a/apps/web/src/routes/api/admin/import/google-docs.ts
+++ b/apps/web/src/routes/api/admin/import/google-docs.ts
@@ -204,21 +204,32 @@ export const Route = createFileRoute("/api/admin/import/google-docs")({
             );
           }
 
+          let html: string;
+          let response: Response;
+
           const publishedUrl = `https://docs.google.com/document/d/${docId}/pub`;
-          const response = await fetch(publishedUrl);
+          response = await fetch(publishedUrl);
 
           if (!response.ok) {
-            return new Response(
-              JSON.stringify({
-                success: false,
-                error:
-                  "Failed to fetch document. Make sure it is published to the web.",
-              }),
-              { status: 400, headers: { "Content-Type": "application/json" } },
-            );
+            const exportUrl = `https://docs.google.com/document/d/${docId}/export?format=html`;
+            response = await fetch(exportUrl);
+
+            if (!response.ok) {
+              return new Response(
+                JSON.stringify({
+                  success: false,
+                  error:
+                    "Failed to fetch document. Make sure it is either published to the web (File > Share > Publish to web) or shared with 'Anyone with the link can view' permissions.",
+                }),
+                {
+                  status: 400,
+                  headers: { "Content-Type": "application/json" },
+                },
+              );
+            }
           }
 
-          const html = await response.text();
+          html = await response.text();
           const extractedTitle = extractTitle(html) || "Untitled";
           const finalTitle = title || extractedTitle;
           const finalSlug = slug || generateSlug(finalTitle);


### PR DESCRIPTION
Allow importing Google Docs that are either published to the web or shared with "Anyone with the link can view". Previously we only attempted to fetch the /pub URL which returned 400 for shared (but not published) documents. The server now falls back to the /export?format=html endpoint when /pub fails, and returns a clearer error message if both attempts fail. The admin UI text was updated to inform users of both publishing and sharing options.