### PR TITLE
feat: add trial status and days remaining to billing UI

### DIFF
--- a/apps/desktop/src/billing.tsx
+++ b/apps/desktop/src/billing.tsx
@@ -11,18 +11,41 @@ import {
 import { useAuth } from "./auth";
 import { env } from "./env";
 
+type JwtClaims = {
+  entitlements?: string[];
+  subscription_status?: "trialing" | "active";
+  trial_end?: number;
+};
+
 export function getEntitlementsFromToken(accessToken: string): string[] {
   try {
-    const decoded = jwtDecode<{ entitlements?: string[] }>(accessToken);
+    const decoded = jwtDecode<JwtClaims>(accessToken);
     return decoded.entitlements ?? [];
   } catch {
     return [];
   }
 }
 
+export function getSubscriptionInfoFromToken(accessToken: string): {
+  status: "trialing" | "active" | null;
+  trialEnd: number | null;
+} {
+  try {
+    const decoded = jwtDecode<JwtClaims>(accessToken);
+    return {
+      status: decoded.subscription_status ?? null,
+      trialEnd: decoded.trial_end ?? null,
+    };
+  } catch {
+    return { status: null, trialEnd: null };
+  }
+}
+
 type BillingContextValue = {
   entitlements: string[];
   isPro: boolean;
+  isTrialing: boolean;
+  trialDaysRemaining: number | null;
   upgradeToPro: () => void;
 };
 
@@ -40,10 +63,34 @@ export function BillingProvider({ children }: { children: ReactNode }) {
     return getEntitlementsFromToken(auth.session.access_token);
   }, [auth?.session?.access_token]);
 
+  const subscriptionInfo = useMemo(() => {
+    if (!auth?.session?.access_token) {
+      return { status: null, trialEnd: null };
+    }
+    return getSubscriptionInfoFromToken(auth.session.access_token);
+  }, [auth?.session?.access_token]);
+
   const isPro = useMemo(
     () => entitlements.includes("hyprnote_pro"),
     [entitlements],
   );
+
+  const isTrialing = useMemo(
+    () => subscriptionInfo.status === "trialing",
+    [subscriptionInfo.status],
+  );
+
+  const trialDaysRemaining = useMemo(() => {
+    if (!subscriptionInfo.trialEnd) {
+      return null;
+    }
+    const now = Math.floor(Date.now() / 1000);
+    const secondsRemaining = subscriptionInfo.trialEnd - now;
+    if (secondsRemaining <= 0) {
+      return 0;
+    }
+    return Math.ceil(secondsRemaining / (24 * 60 * 60));
+  }, [subscriptionInfo.trialEnd]);
 
   const upgradeToPro = useCallback(() => {
     void openUrl(`${env.VITE_APP_URL}/app/checkout?period=monthly`);
@@ -53,9 +100,11 @@ export function BillingProvider({ children }: { children: ReactNode }) {
     () => ({
       entitlements,
       isPro,
+      isTrialing,
+      trialDaysRemaining,
       upgradeToPro,
     }),
-    [entitlements, isPro, upgradeToPro],
+    [entitlements, isPro, isTrialing, trialDaysRemaining, upgradeToPro],
   );
 
   return (

--- a/apps/desktop/src/components/settings/general/account.tsx
+++ b/apps/desktop/src/components/settings/general/account.tsx
@@ -24,9 +24,29 @@ import { useTrialBeginModal } from "../../devtool/trial-begin-modal";
 
 const WEB_APP_BASE_URL = env.VITE_APP_URL ?? "http://localhost:3000";
 
+function getPlanDescription(
+  isPro: boolean,
+  isTrialing: boolean,
+  trialDaysRemaining: number | null,
+): string {
+  if (!isPro) {
+    return "Your current plan is FREE.";
+  }
+  if (isTrialing && trialDaysRemaining !== null) {
+    if (trialDaysRemaining === 0) {
+      return "Your trial ends today. Add a payment method to continue.";
+    }
+    if (trialDaysRemaining === 1) {
+      return "Your trial ends tomorrow. Add a payment method to continue.";
+    }
+    return `Your trial ends in ${trialDaysRemaining} days.`;
+  }
+  return "Your current plan is PRO.";
+}
+
 export function AccountSettings() {
   const auth = useAuth();
-  const { isPro } = useBillingAccess();
+  const { isPro, isTrialing, trialDaysRemaining } = useBillingAccess();
 
   const isAuthenticated = !!auth?.session;
   const [isPending, setIsPending] = useState(false);
@@ -156,7 +176,7 @@ export function AccountSettings() {
 
       <Container
         title="Plan & Billing"
-        description={`Your current plan is ${isPro ? "PRO" : "FREE"}. `}
+        description={getPlanDescription(isPro, isTrialing, trialDaysRemaining)}
         action={<BillingButton />}
       >
         <p className="text-sm text-neutral-600">

--- a/apps/web/src/functions/billing-access.ts
+++ b/apps/web/src/functions/billing-access.ts
@@ -1,0 +1,72 @@
+import { createServerFn } from "@tanstack/react-start";
+
+import { getSupabaseServerClient } from "@/functions/supabase";
+
+const PRO_ENTITLEMENT = "hyprnote_pro";
+
+type JwtClaims = {
+  entitlements?: string[];
+  subscription_status?: "trialing" | "active";
+  trial_end?: number;
+};
+
+function decodeJwtPayload(accessToken: string): JwtClaims {
+  try {
+    const [, payloadBase64] = accessToken.split(".");
+    if (!payloadBase64) return {};
+
+    return JSON.parse(
+      Buffer.from(payloadBase64, "base64url").toString("utf-8"),
+    );
+  } catch {
+    return {};
+  }
+}
+
+export type BillingAccess = {
+  entitlements: string[];
+  isPro: boolean;
+  isTrialing: boolean;
+  trialDaysRemaining: number | null;
+};
+
+export const fetchBillingAccess = createServerFn({ method: "GET" }).handler(
+  async (): Promise<BillingAccess> => {
+    const supabase = getSupabaseServerClient();
+    const { data } = await supabase.auth.getSession();
+
+    if (!data.session?.access_token) {
+      return {
+        entitlements: [],
+        isPro: false,
+        isTrialing: false,
+        trialDaysRemaining: null,
+      };
+    }
+
+    const claims = decodeJwtPayload(data.session.access_token);
+    const entitlements = Array.isArray(claims.entitlements)
+      ? claims.entitlements
+      : [];
+    const isPro = entitlements.includes(PRO_ENTITLEMENT);
+    const isTrialing = claims.subscription_status === "trialing";
+
+    let trialDaysRemaining: number | null = null;
+    if (claims.trial_end) {
+      const now = Math.floor(Date.now() / 1000);
+      const secondsRemaining = claims.trial_end - now;
+      if (secondsRemaining <= 0) {
+        trialDaysRemaining = 0;
+      } else {
+        trialDaysRemaining = Math.ceil(secondsRemaining / (24 * 60 * 60));
+      }
+    }
+
+    return {
+      entitlements,
+      isPro,
+      isTrialing,
+      trialDaysRemaining,
+    };
+  },
+);

--- a/apps/web/src/hooks/use-billing-access.ts
+++ b/apps/web/src/hooks/use-billing-access.ts
@@ -1,0 +1,8 @@
+import { useMatch } from "@tanstack/react-router";
+
+import type { BillingAccess } from "@/functions/billing-access";
+
+export function useBillingAccess(): BillingAccess {
+  const match = useMatch({ from: "/_view/app", shouldThrow: true });
+  return match.context.billingAccess;
+}

--- a/apps/web/src/routes/_view/app/route.tsx
+++ b/apps/web/src/routes/_view/app/route.tsx
@@ -1,10 +1,15 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
 import { fetchUser } from "@/functions/auth";
+import { fetchBillingAccess } from "@/functions/billing-access";
 
 export const Route = createFileRoute("/_view/app")({
   beforeLoad: async ({ location }) => {
-    const user = await fetchUser();
+    const [user, billingAccess] = await Promise.all([
+      fetchUser(),
+      fetchBillingAccess(),
+    ]);
+
     if (!user) {
       const searchStr =
         Object.keys(location.search).length > 0
@@ -18,6 +23,7 @@ export const Route = createFileRoute("/_view/app")({
         },
       });
     }
-    return { user };
+
+    return { user, billingAccess };
   },
 });

--- a/supabase/migrations/20250101000006_auth_hook_add_subscription_claims.sql
+++ b/supabase/migrations/20250101000006_auth_hook_add_subscription_claims.sql
@@ -1,0 +1,56 @@
+CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+  claims jsonb;
+  entitlements jsonb := '[]'::jsonb;
+  v_customer_id text;
+  v_subscription_status text;
+  v_trial_end bigint;
+BEGIN
+  SELECT p.stripe_customer_id INTO v_customer_id
+  FROM public.profiles p
+  WHERE p.id = (event->>'user_id')::uuid;
+
+  SELECT
+    COALESCE(
+      jsonb_agg(ae.lookup_key ORDER BY ae.lookup_key)
+        FILTER (WHERE ae.lookup_key IS NOT NULL),
+      '[]'::jsonb
+    )
+  INTO entitlements
+  FROM public.profiles p
+  JOIN stripe.active_entitlements ae
+    ON ae.customer = p.stripe_customer_id
+  WHERE p.id = (event->>'user_id')::uuid;
+
+  IF v_customer_id IS NOT NULL THEN
+    SELECT
+      s.status::text,
+      (s.trial_end #>> '{}')::bigint
+    INTO v_subscription_status, v_trial_end
+    FROM stripe.subscriptions s
+    WHERE s.customer = v_customer_id
+      AND s.status IN ('trialing', 'active')
+    ORDER BY s.created DESC
+    LIMIT 1;
+  END IF;
+
+  claims := event->'claims';
+  claims := jsonb_set(claims, '{entitlements}', entitlements);
+
+  IF v_subscription_status IS NOT NULL THEN
+    claims := jsonb_set(claims, '{subscription_status}', to_jsonb(v_subscription_status));
+  END IF;
+
+  IF v_trial_end IS NOT NULL THEN
+    claims := jsonb_set(claims, '{trial_end}', to_jsonb(v_trial_end));
+  END IF;
+
+  event := jsonb_set(event, '{claims}', claims);
+
+  RETURN event;
+END;
+$$;


### PR DESCRIPTION
## Summary

- Add `subscription_status` and `trial_end` claims to JWT via Supabase auth hook
- Display trial days remaining in both desktop and web account settings
- Fetch billing access from JWT claims instead of additional API calls

## Test plan

- [ ] Verify trial status displays correctly in desktop settings
- [ ] Verify trial status displays correctly in web account page
- [ ] Confirm JWT claims are populated after Supabase migration