### PR TITLE
Use default MDX components instead of creating new ones

### DIFF
--- a/apps/web/src/components/mdx/mdx-components.tsx
+++ b/apps/web/src/components/mdx/mdx-components.tsx
@@ -1,9 +1,17 @@
+import { Columns, Info } from "lucide-react";
 import type { ComponentType } from "react";
 
+import { Accordion, Card, Note, Step, Steps, Tip } from "@hypr/ui/docs";
+
+import { CtaCard } from "@/components/cta-card";
 import { Image } from "@/components/image";
 
+import { DeeplinksList } from "../deeplinks-list";
+import { HooksList } from "../hooks-list";
+import { OpenAPIDocs } from "../openapi-docs";
 import { Callout } from "./callout";
 import { CodeBlock } from "./code-block";
+import { GithubEmbed } from "./github-embed";
 import { MDXLink } from "./link";
 import { Mermaid } from "./mermaid";
 import { Tweet } from "./tweet";
@@ -14,12 +22,25 @@ export type MDXComponents = {
 
 export const defaultMDXComponents: MDXComponents = {
   a: MDXLink,
+  Accordion,
+  Card,
   Callout,
+  Columns,
+  CtaCard,
+  DeeplinksList,
+  GithubEmbed,
+  HooksList,
   Image,
   img: Image,
+  Info,
   mermaid: Mermaid,
   Mermaid,
+  Note,
+  OpenAPIDocs,
   pre: CodeBlock,
+  Step,
+  Steps,
+  Tip,
   Tweet,
 };
 

--- a/apps/web/src/routes/_view/blog/$slug.tsx
+++ b/apps/web/src/routes/_view/blog/$slug.tsx
@@ -6,10 +6,9 @@ import { useEffect, useState } from "react";
 
 import { cn } from "@hypr/utils";
 
-import { CtaCard } from "@/components/cta-card";
 import { DownloadButton } from "@/components/download-button";
 import { Image } from "@/components/image";
-import { createMDXComponents } from "@/components/mdx";
+import { defaultMDXComponents } from "@/components/mdx";
 import { SlashSeparator } from "@/components/slash-separator";
 import { getPlatformCTA, usePlatform } from "@/hooks/use-platform";
 
@@ -170,10 +169,7 @@ function HeroSection({ article }: { article: any }) {
 function ArticleContent({ article }: { article: any }) {
   return (
     <article className="prose prose-stone prose-headings:font-serif prose-headings:font-semibold prose-h1:text-3xl prose-h1:mt-12 prose-h1:mb-6 prose-h2:text-2xl prose-h2:mt-10 prose-h2:mb-5 prose-h3:text-xl prose-h3:mt-8 prose-h3:mb-4 prose-h4:text-lg prose-h4:mt-6 prose-h4:mb-3 prose-a:text-stone-600 prose-a:underline prose-a:decoration-dotted hover:prose-a:text-stone-800 prose-headings:no-underline prose-headings:decoration-transparent prose-code:bg-stone-50 prose-code:border prose-code:border-neutral-200 prose-code:rounded prose-code:px-1.5 prose-code:py-0.5 prose-code:text-sm prose-code:font-mono prose-code:text-stone-700 prose-pre:bg-stone-50 prose-pre:border prose-pre:border-neutral-200 prose-pre:rounded-sm prose-pre:prose-code:bg-transparent prose-pre:prose-code:border-0 prose-pre:prose-code:p-0 prose-img:rounded-sm prose-img:border prose-img:border-neutral-200 prose-img:my-8 max-w-none">
-      <MDXContent
-        code={article.mdx}
-        components={createMDXComponents({ CtaCard })}
-      />
+      <MDXContent code={article.mdx} components={defaultMDXComponents} />
     </article>
   );
 }

--- a/apps/web/src/routes/_view/company-handbook/-components.tsx
+++ b/apps/web/src/routes/_view/company-handbook/-components.tsx
@@ -2,20 +2,9 @@ import { MDXContent } from "@content-collections/mdx/react";
 import { Link } from "@tanstack/react-router";
 import { allHandbooks } from "content-collections";
 
-import {
-  Accordion,
-  Card,
-  Columns,
-  Info,
-  Note,
-  Step,
-  Steps,
-  Tip,
-} from "@hypr/ui/docs";
 import { cn } from "@hypr/utils";
 
-import { Image } from "@/components/image";
-import { CodeBlock, MDXLink } from "@/components/mdx";
+import { defaultMDXComponents } from "@/components/mdx";
 
 export function HandbookLayout({
   doc,
@@ -102,23 +91,7 @@ function ArticleHeader({
 function ArticleContent({ doc }: { doc: any }) {
   return (
     <article className="prose prose-stone prose-headings:font-serif prose-headings:font-semibold prose-h1:text-3xl prose-h1:mt-12 prose-h1:mb-6 prose-h2:text-2xl prose-h2:mt-10 prose-h2:mb-5 prose-h3:text-xl prose-h3:mt-8 prose-h3:mb-4 prose-h4:text-lg prose-h4:mt-6 prose-h4:mb-3 prose-a:text-stone-600 prose-a:underline prose-a:decoration-dotted hover:prose-a:text-stone-800 prose-headings:no-underline prose-headings:decoration-transparent prose-code:bg-stone-50 prose-code:border prose-code:border-neutral-200 prose-code:rounded prose-code:px-1.5 prose-code:py-0.5 prose-code:text-sm prose-code:font-mono prose-code:text-stone-700 prose-pre:bg-stone-50 prose-pre:border prose-pre:border-neutral-200 prose-pre:rounded-sm prose-pre:prose-code:bg-transparent prose-pre:prose-code:border-0 prose-pre:prose-code:p-0 prose-img:rounded-sm prose-img:my-8 max-w-none">
-      <MDXContent
-        code={doc.mdx}
-        components={{
-          a: MDXLink,
-          Accordion,
-          Card,
-          Columns,
-          Image,
-          img: Image,
-          Info,
-          Note,
-          pre: CodeBlock,
-          Step,
-          Steps,
-          Tip,
-        }}
-      />
+      <MDXContent code={doc.mdx} components={defaultMDXComponents} />
     </article>
   );
 }
@@ -130,7 +103,7 @@ function RightSidebar({
 }) {
   return (
     <aside className="hidden lg:block w-64 shrink-0">
-      <div className="sticky top-[69px] max-h-[calc(100vh-69px)] overflow-y-auto space-y-6 px-4 py-6">
+      <div className="sticky top-17.25 max-h-[calc(100vh-69px)] overflow-y-auto space-y-6 px-4 py-6">
         {toc.length > 0 && (
           <nav className="space-y-1">
             <p className="text-xs font-medium text-neutral-500 uppercase tracking-wider mb-3">

--- a/apps/web/src/routes/_view/docs/-components.tsx
+++ b/apps/web/src/routes/_view/docs/-components.tsx
@@ -2,30 +2,9 @@ import { MDXContent } from "@content-collections/mdx/react";
 import { Link } from "@tanstack/react-router";
 import { allDocs } from "content-collections";
 
-import {
-  Accordion,
-  Card,
-  Columns,
-  Info,
-  Note,
-  Step,
-  Steps,
-  Tip,
-} from "@hypr/ui/docs";
 import { cn } from "@hypr/utils";
 
-import { CtaCard } from "@/components/cta-card";
-import { DeeplinksList } from "@/components/deeplinks-list";
-import { HooksList } from "@/components/hooks-list";
-import { Image } from "@/components/image";
-import {
-  CodeBlock,
-  GithubEmbed,
-  MDXLink,
-  Mermaid,
-  Tweet,
-} from "@/components/mdx";
-import { OpenAPIDocs } from "@/components/openapi-docs";
+import { defaultMDXComponents } from "@/components/mdx";
 
 export function DocLayout({
   doc,
@@ -112,31 +91,7 @@ function ArticleHeader({
 function ArticleContent({ doc }: { doc: any }) {
   return (
     <article className="prose prose-stone prose-headings:font-serif prose-headings:font-semibold prose-h1:text-3xl prose-h1:mt-12 prose-h1:mb-6 prose-h2:text-2xl prose-h2:mt-10 prose-h2:mb-5 prose-h3:text-xl prose-h3:mt-8 prose-h3:mb-4 prose-h4:text-lg prose-h4:mt-6 prose-h4:mb-3 prose-a:text-stone-600 prose-a:underline prose-a:decoration-dotted hover:prose-a:text-stone-800 prose-headings:no-underline prose-headings:decoration-transparent prose-code:bg-stone-50 prose-code:border prose-code:border-neutral-200 prose-code:rounded prose-code:px-1.5 prose-code:py-0.5 prose-code:text-sm prose-code:font-mono prose-code:text-stone-700 prose-pre:bg-stone-50 prose-pre:border prose-pre:border-neutral-200 prose-pre:rounded-sm prose-pre:prose-code:bg-transparent prose-pre:prose-code:border-0 prose-pre:prose-code:p-0 prose-img:rounded-sm prose-img:my-8 max-w-none">
-      <MDXContent
-        code={doc.mdx}
-        components={{
-          a: MDXLink,
-          Accordion,
-          Card,
-          Columns,
-          CtaCard,
-          DeeplinksList,
-          GithubEmbed,
-          HooksList,
-          Image,
-          img: Image,
-          Info,
-          mermaid: Mermaid,
-          Mermaid,
-          Note,
-          OpenAPIDocs,
-          pre: CodeBlock,
-          Step,
-          Steps,
-          Tip,
-          Tweet,
-        }}
-      />
+      <MDXContent code={doc.mdx} components={defaultMDXComponents} />
     </article>
   );
 }

--- a/apps/web/src/routes/admin/collections/index.tsx
+++ b/apps/web/src/routes/admin/collections/index.tsx
@@ -54,8 +54,7 @@ import {
 } from "@hypr/ui/components/ui/resizable";
 import { cn } from "@hypr/utils";
 
-import { CtaCard } from "@/components/cta-card";
-import { createMDXComponents } from "@/components/mdx";
+import { defaultMDXComponents } from "@/components/mdx";
 
 interface ContentItem {
   name: string;


### PR DESCRIPTION
Replace ad-hoc createMDXComponents usage and inline CtaCard components with the shared defaultMDXComponents. This simplifies MDX rendering by using a standard component set across blog article and admin collection pages, removing the need to pass CtaCard explicitly and reducing duplication.