### PR TITLE
perf(audio): make macOS speaker capture RT-safe and reuse conversion buffer

### DIFF
--- a/crates/audio-utils/src/lib.rs
+++ b/crates/audio-utils/src/lib.rs
@@ -5,10 +5,12 @@ use futures_util::{Stream, StreamExt};
 use hypr_audio_interface::AsyncSource;
 
 mod error;
+mod pcm;
 mod resampler;
 mod vorbis;
 
 pub use error::*;
+pub use pcm::*;
 pub use resampler::*;
 pub use vorbis::*;
 

--- a/crates/audio-utils/src/pcm.rs
+++ b/crates/audio-utils/src/pcm.rs
@@ -1,0 +1,29 @@
+#[inline]
+pub fn pcm_f32_to_f32(sample: f32) -> f32 {
+    sample
+}
+
+#[inline]
+pub fn pcm_f64_to_f32(sample: f64) -> f32 {
+    sample as f32
+}
+
+#[inline]
+pub fn pcm_i16_to_f32(sample: i16) -> f32 {
+    const SCALE: f32 = i16::MAX as f32;
+    if sample == i16::MIN {
+        -1.0
+    } else {
+        sample as f32 / SCALE
+    }
+}
+
+#[inline]
+pub fn pcm_i32_to_f32(sample: i32) -> f32 {
+    const SCALE: f32 = i32::MAX as f32;
+    if sample == i32::MIN {
+        -1.0
+    } else {
+        sample as f32 / SCALE
+    }
+}

--- a/crates/audio/Cargo.toml
+++ b/crates/audio/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+hypr-audio-interface = { workspace = true }
+hypr-audio-utils = { workspace = true }
+
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
@@ -21,7 +24,6 @@ dasp = { workspace = true }
 rodio = { workspace = true }
 
 ebur128 = "0.1.10"
-hypr-audio-interface = { workspace = true }
 ringbuf = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
Makes macOS speaker capture real-time safe by:
- Replacing Mutex-based waker state with AtomicWaker
- Reusing conversion buffer instead of allocating per sample
- Extracting PCM conversion functions to reusable module
- Using atomic counters for dropped samples tracking
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fastrepl/hyprnote/pull/3053">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
