### PR TITLE
Prevent active listening session tab from being replaced

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -31,11 +31,10 @@ import {
   StoreComponent as SettingsStoreComponent,
 } from "./store/tinybase/store/settings";
 import { createAITaskStore } from "./store/zustand/ai-task";
-import { createListenerStore } from "./store/zustand/listener";
+import { listenerStore } from "./store/zustand/listener/instance";
 import "./styles/globals.css";
 
 const toolRegistry = createToolRegistry();
-const listenerStore = createListenerStore();
 const queryClient = new QueryClient();
 
 const router = createRouter({

--- a/apps/desktop/src/store/zustand/listener/instance.ts
+++ b/apps/desktop/src/store/zustand/listener/instance.ts
@@ -1,0 +1,3 @@
+import { createListenerStore } from "./index";
+
+export const listenerStore = createListenerStore();

--- a/apps/desktop/src/store/zustand/tabs/basic.ts
+++ b/apps/desktop/src/store/zustand/tabs/basic.ts
@@ -3,6 +3,7 @@ import type { StoreApi } from "zustand";
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 
 import { id } from "../../../utils";
+import { listenerStore } from "../listener/instance";
 import type { LifecycleState } from "./lifecycle";
 import type { NavigationState, TabHistory } from "./navigation";
 import { pushHistory } from "./navigation";
@@ -38,7 +39,14 @@ export const createBasicSlice = <
   openCurrent: (tab) => {
     const { tabs, history } = get();
     const currentActiveTab = tabs.find((t) => t.active);
-    if (currentActiveTab?.pinned) {
+
+    const isCurrentTabListening =
+      currentActiveTab?.type === "sessions" &&
+      currentActiveTab.id === listenerStore.getState().live.sessionId &&
+      (listenerStore.getState().live.status === "active" ||
+        listenerStore.getState().live.status === "finalizing");
+
+    if (currentActiveTab?.pinned || isCurrentTabListening) {
       set(openTab(tabs, tab, history, false));
     } else {
       set(openTab(tabs, tab, history, true));


### PR DESCRIPTION
Ensure the tab representing a live listening session is treated like a pinned tab so it is never replaced when opening another note. The bug occurred when opening note A while note B was a listening session: B was being replaced even though it should remain visible (like tabs). To fix this, create a singleton listenerStore instance and consult its live state in the tabs open logic to detect when the current active tab is the active/finalizing listening session; treat that case the same as pinned tabs so openCurrent preserves it.