### PR TITLE
Initialize prevSessionMode to current session mode

### DIFF
--- a/apps/desktop/src/components/main/body/sessions/index.tsx
+++ b/apps/desktop/src/components/main/body/sessions/index.tsx
@@ -165,7 +165,7 @@ function TabContentNoteInner({
   const [showConsentBanner, setShowConsentBanner] = useState(false);
 
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
-  const prevSessionMode = useRef<string | null>(null);
+  const prevSessionMode = useRef<string | null>(sessionMode);
 
   useEffect(() => {
     const justStartedListening =


### PR DESCRIPTION
Prevent the consent banner from persisting incorrectly when switching tabs. The previous implementation initialized prevSessionMode to null which could make the UI think a session just started listening when returning to a tab, leaving the "Ask for consent when using Hyprnote" banner visible. Initializing prevSessionMode with the current sessionMode avoids that false-positive transition and stops the banner from sticking around unexpectedly.