### PR TITLE
Publish: What Are the Best AI Note-Taker Apps in 2026?

### DIFF
--- a/apps/web/content/articles/test.mdx
+++ b/apps/web/content/articles/test.mdx
@@ -95,7 +95,7 @@ Best for companies where cloud-based tools like Otter AI are banned, healthcare 
 
 #### Pricing:
 
-Char's core transcription and note-taking features are free forever. 
+Hyprnote's core transcription and note-taking features are free forever.
 
 Consider upgrading to Pro ($8/month or $59/year, save 65%) when you want cloud services included without managing API keys
 


### PR DESCRIPTION
## Article Ready for Publication

**Title:** What Are the Best AI Note-Taker Apps in 2026?
**Author:** John Jeong
**Date:** 2026-01-18
**Category:** Productivity Hack

**Branch:** blog/article-test
**File:** apps/web/content/articles/test.mdx

---
Auto-generated PR from admin panel.