### PR TITLE
fix(persister): restore MergeableChanges handling in extractChangedTables

### DIFF
--- a/apps/desktop/src/store/tinybase/persister/shared/utils.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/shared/utils.test.ts
@@ -20,6 +20,16 @@ describe("extractChangedTables", () => {
     test("returns null for null", () => {
       expect(extractChangedTables(null as any)).toBeNull();
     });
+
+    test("returns null for empty inner array (malformed MergeableChanges)", () => {
+      const malformed = [[], [{}, "hlc"], 1] as any;
+      expect(extractChangedTables(malformed)).toBeNull();
+    });
+
+    test("returns null for array as first element (not valid ChangedTables)", () => {
+      const malformed = [["not", "valid"], {}, 1] as any;
+      expect(extractChangedTables(malformed)).toBeNull();
+    });
   });
 
   describe("e2e: MergeableStore with persister", () => {

--- a/apps/desktop/src/store/tinybase/persister/shared/utils.ts
+++ b/apps/desktop/src/store/tinybase/persister/shared/utils.ts
@@ -63,7 +63,12 @@ export function extractChangedTables<Schemas extends OptionalSchemas>(
   }
 
   // Regular Changes: [changedTables, changedValues, 1]
-  if (tablesOrStamp && typeof tablesOrStamp === "object") {
+  // Exclude arrays - they would be MergeableChanges format handled above.
+  if (
+    tablesOrStamp &&
+    typeof tablesOrStamp === "object" &&
+    !Array.isArray(tablesOrStamp)
+  ) {
     return tablesOrStamp as ChangedTables;
   }
 


### PR DESCRIPTION
## Summary

- Fix session folder (`sessions/*.md`, `_meta.json`, etc.) not persisting since `nightly.8` release (worked in `nightly.7`)
- Restore MergeableChanges format handling in `extractChangedTables()`

## Root Cause Analysis

Commit `64922dfba` ("remove stamp repair that might cause dataloss") simplified `extractChangedTables()` too aggressively.

TinyBase sends changes in two different formats depending on the store type:

| Format | Structure | When Used |
|--------|-----------|-----------|
| Regular Changes | `[changedTables, changedValues, 1]` | Regular Store |
| MergeableChanges | `[[changedTables, hlc?], [changedValues, hlc?], 1]` | MergeableStore |

The app uses a **MergeableStore**, which sends changes in format #2.

### Before (nightly.7 - working)
```typescript
const tablesOrStamp = changes[0];

// MergeableChanges: [[changedTables, hlc?], [changedValues, hlc?], 1]
if (Array.isArray(tablesOrStamp) && tablesOrStamp.length >= 1) {
  const tables = tablesOrStamp[0];
  if (tables && typeof tables === "object") {
    return unwrapMergeableTables(tables);
  }
  return null;
}

// Regular Changes: [changedTables, changedValues, 1]
if (tablesOrStamp && typeof tablesOrStamp === "object") {
  return tablesOrStamp as ChangedTables;
}
```

### After (nightly.8 - broken)
```typescript
const tables = changes[0];
if (tables && typeof tables === "object") {
  return tables as ChangedTables;
}
```

### The Problem

With MergeableChanges, `changes[0]` is `[changedTables, hlc?]` (an array), not the tables object directly.

Since arrays are objects in JavaScript, `typeof tables === "object"` returns `true`, and the function returns `[changedTables, hlc]` instead of just `changedTables`.

When `getChangedSessionIds` receives this array:
- It tries to access `changedTables.sessions`
- Arrays don't have a `.sessions` property → returns `undefined`
- Function thinks nothing changed → returns `{ operations: [] }`
- **Nothing gets saved to disk**

## Test plan

- [x] All 304 persister tests pass
- [x] Added new test cases for MergeableChanges format
- [ ] Manual verification with nightly build
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fastrepl/hyprnote/pull/3240">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
