### PR TITLE
add functions to manage existing and new edit PRs

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -118,6 +118,7 @@ import { Route as ApiAdminImportGoogleDocsRouteImport } from './routes/api/admin
 import { Route as ApiAdminContentSaveRouteImport } from './routes/api/admin/content/save'
 import { Route as ApiAdminContentRenameRouteImport } from './routes/api/admin/content/rename'
 import { Route as ApiAdminContentPublishRouteImport } from './routes/api/admin/content/publish'
+import { Route as ApiAdminContentPendingPrRouteImport } from './routes/api/admin/content/pending-pr'
 import { Route as ApiAdminContentListDraftsRouteImport } from './routes/api/admin/content/list-drafts'
 import { Route as ApiAdminContentListRouteImport } from './routes/api/admin/content/list'
 import { Route as ApiAdminContentHistoryRouteImport } from './routes/api/admin/content/history'
@@ -684,6 +685,12 @@ const ApiAdminContentPublishRoute = ApiAdminContentPublishRouteImport.update({
   path: '/api/admin/content/publish',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiAdminContentPendingPrRoute =
+  ApiAdminContentPendingPrRouteImport.update({
+    id: '/api/admin/content/pending-pr',
+    path: '/api/admin/content/pending-pr',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiAdminContentListDraftsRoute =
   ApiAdminContentListDraftsRouteImport.update({
     id: '/api/admin/content/list-drafts',
@@ -848,6 +855,7 @@ export interface FileRoutesByFullPath {
   '/api/admin/content/history': typeof ApiAdminContentHistoryRoute
   '/api/admin/content/list': typeof ApiAdminContentListRoute
   '/api/admin/content/list-drafts': typeof ApiAdminContentListDraftsRoute
+  '/api/admin/content/pending-pr': typeof ApiAdminContentPendingPrRoute
   '/api/admin/content/publish': typeof ApiAdminContentPublishRoute
   '/api/admin/content/rename': typeof ApiAdminContentRenameRoute
   '/api/admin/content/save': typeof ApiAdminContentSaveRoute
@@ -964,6 +972,7 @@ export interface FileRoutesByTo {
   '/api/admin/content/history': typeof ApiAdminContentHistoryRoute
   '/api/admin/content/list': typeof ApiAdminContentListRoute
   '/api/admin/content/list-drafts': typeof ApiAdminContentListDraftsRoute
+  '/api/admin/content/pending-pr': typeof ApiAdminContentPendingPrRoute
   '/api/admin/content/publish': typeof ApiAdminContentPublishRoute
   '/api/admin/content/rename': typeof ApiAdminContentRenameRoute
   '/api/admin/content/save': typeof ApiAdminContentSaveRoute
@@ -1086,6 +1095,7 @@ export interface FileRoutesById {
   '/api/admin/content/history': typeof ApiAdminContentHistoryRoute
   '/api/admin/content/list': typeof ApiAdminContentListRoute
   '/api/admin/content/list-drafts': typeof ApiAdminContentListDraftsRoute
+  '/api/admin/content/pending-pr': typeof ApiAdminContentPendingPrRoute
   '/api/admin/content/publish': typeof ApiAdminContentPublishRoute
   '/api/admin/content/rename': typeof ApiAdminContentRenameRoute
   '/api/admin/content/save': typeof ApiAdminContentSaveRoute
@@ -1208,6 +1218,7 @@ export interface FileRouteTypes {
     | '/api/admin/content/history'
     | '/api/admin/content/list'
     | '/api/admin/content/list-drafts'
+    | '/api/admin/content/pending-pr'
     | '/api/admin/content/publish'
     | '/api/admin/content/rename'
     | '/api/admin/content/save'
@@ -1324,6 +1335,7 @@ export interface FileRouteTypes {
     | '/api/admin/content/history'
     | '/api/admin/content/list'
     | '/api/admin/content/list-drafts'
+    | '/api/admin/content/pending-pr'
     | '/api/admin/content/publish'
     | '/api/admin/content/rename'
     | '/api/admin/content/save'
@@ -1445,6 +1457,7 @@ export interface FileRouteTypes {
     | '/api/admin/content/history'
     | '/api/admin/content/list'
     | '/api/admin/content/list-drafts'
+    | '/api/admin/content/pending-pr'
     | '/api/admin/content/publish'
     | '/api/admin/content/rename'
     | '/api/admin/content/save'
@@ -1486,6 +1499,7 @@ export interface RootRouteChildren {
   ApiAdminContentHistoryRoute: typeof ApiAdminContentHistoryRoute
   ApiAdminContentListRoute: typeof ApiAdminContentListRoute
   ApiAdminContentListDraftsRoute: typeof ApiAdminContentListDraftsRoute
+  ApiAdminContentPendingPrRoute: typeof ApiAdminContentPendingPrRoute
   ApiAdminContentPublishRoute: typeof ApiAdminContentPublishRoute
   ApiAdminContentRenameRoute: typeof ApiAdminContentRenameRoute
   ApiAdminContentSaveRoute: typeof ApiAdminContentSaveRoute
@@ -2263,6 +2277,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAdminContentPublishRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/admin/content/pending-pr': {
+      id: '/api/admin/content/pending-pr'
+      path: '/api/admin/content/pending-pr'
+      fullPath: '/api/admin/content/pending-pr'
+      preLoaderRoute: typeof ApiAdminContentPendingPrRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/admin/content/list-drafts': {
       id: '/api/admin/content/list-drafts'
       path: '/api/admin/content/list-drafts'
@@ -2579,6 +2600,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiAdminContentHistoryRoute: ApiAdminContentHistoryRoute,
   ApiAdminContentListRoute: ApiAdminContentListRoute,
   ApiAdminContentListDraftsRoute: ApiAdminContentListDraftsRoute,
+  ApiAdminContentPendingPrRoute: ApiAdminContentPendingPrRoute,
   ApiAdminContentPublishRoute: ApiAdminContentPublishRoute,
   ApiAdminContentRenameRoute: ApiAdminContentRenameRoute,
   ApiAdminContentSaveRoute: ApiAdminContentSaveRoute,

--- a/apps/web/src/routes/api/admin/content/pending-pr.ts
+++ b/apps/web/src/routes/api/admin/content/pending-pr.ts
@@ -1,0 +1,55 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { fetchAdminUser } from "@/functions/admin";
+import { getExistingEditPRForArticle } from "@/functions/github-content";
+
+export const Route = createFileRoute("/api/admin/content/pending-pr")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const isDev = process.env.NODE_ENV === "development";
+        if (!isDev) {
+          const user = await fetchAdminUser();
+          if (!user?.isAdmin) {
+            return new Response(JSON.stringify({ error: "Unauthorized" }), {
+              status: 401,
+              headers: { "Content-Type": "application/json" },
+            });
+          }
+        }
+
+        const url = new URL(request.url);
+        const path = url.searchParams.get("path");
+
+        if (!path) {
+          return new Response(
+            JSON.stringify({ error: "Missing path parameter" }),
+            { status: 400, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        const result = await getExistingEditPRForArticle(path);
+
+        if (!result.success) {
+          return new Response(JSON.stringify({ error: result.error }), {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        return new Response(
+          JSON.stringify({
+            hasPendingPR: result.hasPendingPR,
+            prNumber: result.prNumber,
+            prUrl: result.prUrl,
+            branchName: result.branchName,
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Adds utility functions for managing pull requests in the content editing workflow — including logic to detect whether an edit PR already exists for a given article and to create new edit PRs when needed.

## Review & Testing Checklist for Human

- [ ] **Existing PR detection accuracy**: Verify the lookup correctly distinguishes between open, closed, and merged PRs for the same article — a false negative would create duplicate PRs, while a false positive would skip creating a needed one
- [ ] **New PR creation**: Confirm that newly created PRs have the correct base branch, title, and body — inspect at least one created PR on GitHub to verify fields are populated as expected
- [ ] **Error handling on API failures**: Test behavior when the GitHub API is unreachable or returns an auth error — confirm failures surface clearly rather than silently proceeding

**Suggested test plan:** Trigger the edit flow for an article that already has an open PR and confirm the existing PR is reused. Then trigger for an article with no existing PR and confirm a new one is created correctly. Finally, simulate an API failure (e.g., revoke token temporarily) and verify the error is handled gracefully.

### Notes

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer