### PR TITLE
Make buttons use pointer cursor by default

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -155,3 +155,13 @@
     animation: fade-in-out 3s ease-in-out infinite;
   }
 }
+
+@layer base {
+  button,
+  [role="button"],
+  [type="button"],
+  [type="submit"],
+  [type="reset"] {
+    cursor: pointer;
+  }
+}

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -218,4 +218,11 @@
   body {
     @apply bg-background text-foreground;
   }
+  button,
+  [role="button"],
+  [type="button"],
+  [type="submit"],
+  [type="reset"] {
+    cursor: pointer;
+  }
 }


### PR DESCRIPTION
## Summary

Ensure all interactive button elements show the pointer cursor by default on both the web app and shared UI package. This adds a base CSS rule that targets `button`, `[role="button"]`, and `input[type="button"]` to apply `cursor: pointer` so desktop app and website controls consistently indicate clickability.

## Review & Testing Checklist for Human

- [ ] Verify that disabled buttons (`disabled`, `aria-disabled="true"`) still behave correctly — a blanket `cursor: pointer` rule may override the expected `cursor: not-allowed` or `cursor: default` on disabled states
- [ ] Spot-check interactive elements across the web app and desktop app (modals, dropdowns, toolbars, settings) to confirm no non-clickable elements styled as `<button>` now incorrectly show a pointer cursor
- [ ] Check CSS specificity: confirm the new base rule doesn't override intentional `cursor` overrides elsewhere in the codebase (e.g., drag handles using `cursor: grab`)

**Suggested test plan:** Open the deploy preview and navigate through key pages (landing, blog, settings, editor). Hover over buttons, icon buttons, and form controls to confirm pointer cursor appears. Then check disabled buttons and drag handles to confirm they retain their expected cursor styles.

### Notes

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer