### PR TITLE
refactor(contacts): unified selection model, org pinning, and new list component

### DIFF
--- a/packages/tiptap/src/blog-editor/toolbar.tsx
+++ b/packages/tiptap/src/blog-editor/toolbar.tsx
@@ -137,10 +137,20 @@ export function Toolbar({
   }, [showSearch, editor]);
 
   useEffect(() => {
-    if (showSearch && searchInputRef.current) {
-      searchInputRef.current.focus();
+    if (showSearch && editor) {
+      const { from, to } = editor.state.selection;
+      if (from !== to) {
+        const selectedText = editor.state.doc.textBetween(from, to, " ");
+        if (selectedText.trim()) {
+          setSearchTerm(selectedText);
+        }
+      }
+      if (searchInputRef.current) {
+        searchInputRef.current.focus();
+        searchInputRef.current.select();
+      }
     }
-  }, [showSearch]);
+  }, [showSearch, editor]);
 
   useEffect(() => {
     if (showReplace && replaceInputRef.current) {


### PR DESCRIPTION
## Summary

Refactors the contacts system with three main changes:

1. **Unified selection model** — Replaces separate `selectedPerson` / `selectedOrganization` nullable fields with a single tagged-union `ContactsSelection` (`{ type: "person"; id } | { type: "organization"; id }`). Updated across Rust plugin state, TS bindings, Zustand tab schema, advanced search, and tests.

2. **Organization pinning** — Extends `pinned` and `pin_order` support (previously humans-only) to organizations. Adds fields to the Zod schema, TinyBase table schema, persister transforms (with tests), and query definitions.

3. **New unified contacts list** — Adds `contacts-list.tsx` (~657 lines) rendering pinned items (people + orgs interleaved by `pin_order`) above unpinned items, with drag-to-reorder (`motion/react` `Reorder`), inline search, sort options, and inline new-person/org forms.

Also adds `created_at` to both human and organization schemas, and removes the contacts-permission check from the calendar sidebar.

## Review & Testing Checklist for Human

- [ ] **Persisted state migration**: Existing Zustand-persisted tabs carry the old `{ selectedOrganization, selectedPerson }` shape. Open the app after upgrading and confirm the contacts tab doesn't crash or render blank due to deserialization mismatch — this is the highest-risk item since it affects every existing user on first launch.
- [ ] **Selection model completeness**: Search the codebase for any remaining references to `selectedPerson` or `selectedOrganization` that may have been missed — a stale reference will compile but silently produce `undefined` selections at runtime.
- [ ] **Organization pin persistence round-trip**: Pin an organization, reorder it among pinned people, restart the app, and confirm `pinned` + `pin_order` values survive the persist → reload cycle without resetting or corrupting human pin orders.
- [ ] **`created_at` backward compat**: Open the app with existing contacts that lack a `created_at` field — confirm no parse errors and sorting by "newest"/"oldest" handles `undefined` gracefully (no `NaN` comparisons or crashes).
- [ ] **Calendar sidebar contacts permission removal**: Confirm this is intentional — the Apple calendar accordion no longer checks or prompts for macOS contacts permission. Verify contacts permission is requested elsewhere if still needed.

**Suggested test plan:** Open Contacts tab → pin a person and an organization → drag to reorder → search to filter → add a new person and org inline → select each and verify detail panel loads → restart app and confirm all state persisted. Then open Calendar sidebar on macOS and confirm no contacts-permission prompt appears (verify this is desired).

### Notes

- `contacts-list.tsx` is ~657 lines with no dedicated unit tests — visual/manual testing is especially important.
- `pin_order` defaults to `0` in `storeToFrontmatter` for both humans and orgs, meaning all unpinned items serialize `pin_order: 0` — confirm this doesn't interfere with sort stability when items are later pinned.
- Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
- Requested by: @ComputelessComputer