### PR TITLE
refactor(contacts): unified list with organization pinning and selection model

### DIFF
--- a/apps/web/content/articles/best-ai-notetaker.mdx
+++ b/apps/web/content/articles/best-ai-notetaker.mdx
@@ -27,16 +27,17 @@ If you are in the market for an AI note taking app, I have done the research for
 
 ## What Are the Best AI Note Taker Apps? A Quick Comparison
 
-| Tool | Platform | Best For | Pricing |
-|------|----------|----------|---------|
-| Hyprnote | macOS | local-first processing, data control | Free (Pro $8/mo) |
-| Obsidian + AI | Windows, macOS, Linux, iOS, Android | Knowledge management | Free (Sync $5/mo, Publish $10/mo) |
-| Granola | macOS, iPhone | Active note takers during meetings | Free trial, then $14/mo |
-| Notion | Web, Windows, macOS, iOS, Android | Teams already using Notion | Free (Business $24/mo for AI) |
-| Fathom | Web, Chrome | Sales teams needing CRM integration | Free (Business $28/mo) |
-| Reflect | Web, iOS | Daily notes with networked thinking | $10/mo ($120/year only) |
-| Otter AI | Web, iOS, Android | Teams needing a feature-rich solution | Free 300 min (Pro $17/mo, Business $30/mo) |
-| Mem.ai | Mac, Windows, iOS, web | Self-organizing notes with AI | Free 25 notes (Pro $12/mo) |
+
+| Tool          | Platform                            | Best For                              | Pricing                                    |
+| ------------- | ----------------------------------- | ------------------------------------- | ------------------------------------------ |
+| Hyprnote      | macOS                               | local-first processing, data control  | Free (Pro $8/mo)                           |
+| Obsidian + AI | Windows, macOS, Linux, iOS, Android | Knowledge management                  | Free (Sync $5/mo, Publish $10/mo)          |
+| Granola       | macOS, iPhone                       | Active note takers during meetings    | Free trial, then $14/mo                    |
+| Notion        | Web, Windows, macOS, iOS, Android   | Teams already using Notion            | Free (Business $24/mo for AI)              |
+| Fathom        | Web, Chrome                         | Sales teams needing CRM integration   | Free (Business $28/mo)                     |
+| Reflect       | Web, iOS                            | Daily notes with networked thinking   | $10/mo ($120/year only)                    |
+| Otter AI      | Web, iOS, Android                   | Teams needing a feature-rich solution | Free 300 min (Pro $17/mo, Business $30/mo) |
+| Mem.ai        | Mac, Windows, iOS, web              | Self-organizing notes with AI         | Free 25 notes (Pro $12/mo)                 |
 
 
 ## What Is an AI Note Taker?
@@ -252,7 +253,7 @@ You'll need Notion's $24/month Business Plan to be able to use its AI features.
 - Bot presence in the calls may feel intrusive
 - Advanced AI features require paid plans
 
-#### Pricing: 
+#### Pricing:
 
 Has a generous free tier with basic CRM sync. Team $18/month/user (min 2 users) adds collaboration. Business $28/month/user unlocks full CRM field sync, Deal View, and coaching metrics.
 


### PR DESCRIPTION
## Summary

Refactors the contacts system with three main changes:

1. **Unified selection model** — Replaces the separate `selectedPerson` / `selectedOrganization` nullable fields with a single tagged-union `ContactsSelection` (`{ type: "person"; id } | { type: "organization"; id }`), enforcing that only one entity can be selected at a time. Updated across Rust plugin state, TS bindings, Zustand tab schema, advanced search, and tests.

2. **Organization pinning** — Extends `pinned` and `pin_order` support (previously humans-only) to organizations. Adds fields to the Zod schema, TinyBase table schema, persister transforms (with tests), and query definitions.

3. **New unified contacts list** — Adds `contacts-list.tsx` (~657 lines) rendering pinned items (people + orgs interleaved by `pin_order`) above unpinned items, with drag-to-reorder (motion/react `Reorder`), inline search, sort options, and inline new-person/org forms. Adds `contacts-organization.tsx` for org detail view with member management.

Also adds `created_at` to both human and organization schemas, and removes the contacts-permission check from the calendar sidebar.

## Review & Testing Checklist for Human

- [ ] **Selection model migration**: Verify no runtime errors from stale `selectedPerson`/`selectedOrganization` references — search the codebase for any remaining uses of the old field names that may have been missed (especially in serialized Zustand state or persisted tabs that could carry the old shape)
- [ ] **Organization pin persistence round-trip**: Pin an organization, reorder it among pinned people, restart the app, and confirm `pinned` + `pin_order` values survive the persist → reload cycle without resetting or corrupting human pin orders
- [ ] **Drag-to-reorder across types**: Reorder a mixed list of pinned people and pinned orgs — confirm `pin_order` values are written correctly for both entity types and no items jump or disappear after drop
- [ ] **`created_at` backward compat**: Open the app with existing contacts that lack a `created_at` field in their frontmatter — confirm no parse errors and sorting by "newest"/"oldest" handles `undefined` gracefully (no NaN comparisons or crashes)
- [ ] **Calendar sidebar contacts permission removal**: Confirm this is intentional — the Apple calendar accordion no longer checks or prompts for macOS contacts permission. If contacts permission is still needed elsewhere, verify it's requested at the right point in the flow

**Suggested test plan:** Open Contacts tab → pin a person and an organization → drag to reorder → search to filter → add a new person and a new org inline → select each and verify the detail panel loads correctly → restart the app and confirm all state (pins, order, new entries) persisted. Then open Calendar sidebar on macOS and confirm no contacts-permission prompt appears (verify this is desired).

### Notes

- The new `contacts-list.tsx` is substantial (~657 lines) and has no dedicated unit tests — visual/manual testing is especially important here.
- `pin_order` defaults to `0` in `storeToFrontmatter` for both humans and orgs, which means all unpinned items serialize `pin_order: 0` — confirm this doesn't interfere with sort stability if items are later pinned.

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer