### PR TITLE
ci: optimize dprint formatting to scope MDX changes to articles directory

### DIFF
--- a/.github/workflows/blog-auto-format.yml
+++ b/.github/workflows/blog-auto-format.yml
@@ -20,21 +20,25 @@ jobs:
       - name: Get changed MDX files
         id: changed-files
         run: |
-          FILES=$(git diff --name-only HEAD~1 HEAD -- 'apps/web/content/articles/*.mdx' 2>/dev/null | tr '\n' ' ' || echo "")
-          echo "files=$FILES" >> $GITHUB_OUTPUT
+          git diff --name-only -z HEAD~1 HEAD -- 'apps/web/content/articles/*.mdx' > /tmp/changed-files.txt 2>/dev/null || true
+          if [ -s /tmp/changed-files.txt ]; then
+            echo "has_files=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_files=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Setup dprint
-        if: steps.changed-files.outputs.files != ''
+        if: steps.changed-files.outputs.has_files == 'true'
         run: |
           curl -fsSL https://dprint.dev/install.sh | sh
           echo "$HOME/.dprint/bin" >> $GITHUB_PATH
 
       - name: Run dprint fmt on changed MDX file
-        if: steps.changed-files.outputs.files != ''
-        run: dprint fmt ${{ steps.changed-files.outputs.files }}
+        if: steps.changed-files.outputs.has_files == 'true'
+        run: xargs -0 -r dprint fmt < /tmp/changed-files.txt
 
       - name: Commit and push formatting changes
-        if: steps.changed-files.outputs.files != ''
+        if: steps.changed-files.outputs.has_files == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary

- Optimized dprint formatting workflow for changed MDX files
- Restricted MDX file detection to articles directory

## Review & Testing Checklist for Human

- [ ] Verify the file path filter correctly matches all MDX files under the articles directory — a too-narrow glob could silently skip files that should be formatted
- [ ] Confirm that MDX files outside the articles directory (e.g., docs, changelog) are intentionally excluded and don't need dprint formatting in this workflow

### Notes

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer