### PR TITLE
Enhance Slack notification for article updates

### DIFF
--- a/.github/workflows/blog-grammar-check.yml
+++ b/.github/workflows/blog-grammar-check.yml
@@ -142,6 +142,7 @@ jobs:
           payload: |
             {
               "channel": "${{ secrets.SLACK_BLOG_CHANNEL_ID }}",
+              "text": "${{ steps.article-info.outputs.is_edit == 'true' && format('{0} made changes to {1}', steps.article-info.outputs.slack_user, steps.article-info.outputs.title) || format('{0} is ready to publish: {1}', steps.article-info.outputs.slack_user, steps.article-info.outputs.title) }}",
               "blocks": [
                 {
                   "type": "section",


### PR DESCRIPTION
## Summary

Conditionally generate Slack message text based on whether an article is being edited or published, improving communication clarity in the blog workflow.

## Review & Testing Checklist for Human

- [ ] **Condition field accuracy**: Verify the field/value used to distinguish "edit" from "publish" matches what the admin UI actually sends — a mismatch will silently produce the wrong message variant for every notification
- [ ] **Slack message rendering**: Trigger both an edit and a publish action and confirm the Slack message text is correct for each case — CI cannot validate external webhook output
- [ ] **Fallback behavior**: Confirm that if the condition field is missing or unexpected, the notification still sends a reasonable default message rather than failing or sending a blank payload

**Suggested test plan:** Open the content admin, edit an existing published article and save — verify the Slack notification says "edited." Then publish a new article and verify the notification says "published." Inspect the Slack message formatting in both cases.

### Notes

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer