### PR TITLE
improve image alt text input interaction

### DIFF
--- a/packages/tiptap/src/blog-editor/image-with-alt.tsx
+++ b/packages/tiptap/src/blog-editor/image-with-alt.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 function ImageNodeView({ node, updateAttributes, selected }: NodeViewProps) {
   const [isHovered, setIsHovered] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
   const [altText, setAltText] = useState(node.attrs.alt || "");
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -28,6 +29,8 @@ function ImageNodeView({ node, updateAttributes, selected }: NodeViewProps) {
     }
   }, []);
 
+  const showAltField = isHovered || isFocused;
+
   return (
     <NodeViewWrapper className="relative">
       <div
@@ -46,7 +49,7 @@ function ImageNodeView({ node, updateAttributes, selected }: NodeViewProps) {
           ].join(" ")}
           draggable={false}
         />
-        {isHovered && (
+        {showAltField && (
           <div className="absolute bottom-2 left-2 right-2 bg-white/95 backdrop-blur-sm rounded-md shadow-lg border border-neutral-200 p-2">
             <label className="flex items-center gap-2">
               <span className="text-xs text-neutral-500 whitespace-nowrap">
@@ -58,6 +61,8 @@ function ImageNodeView({ node, updateAttributes, selected }: NodeViewProps) {
                 value={altText}
                 onChange={handleAltChange}
                 onKeyDown={handleKeyDown}
+                onFocus={() => setIsFocused(true)}
+                onBlur={() => setIsFocused(false)}
                 placeholder="Describe this image..."
                 className="flex-1 text-sm bg-transparent border-none outline-none text-neutral-700 placeholder:text-neutral-400"
               />


### PR DESCRIPTION
## Summary

Enhance image alt text field visibility by showing on hover or focus, and add focus/blur state tracking for better user experience.

## Review & Testing Checklist for Human

- [ ] **Keyboard accessibility**: Tab to an image block and verify the alt text input becomes visible on focus — then tab away and confirm it hides correctly. Screen reader users rely on this path exclusively.
- [ ] **Hover vs. focus interplay**: Hover over the image to reveal the alt text field, click into it (focus), then move the mouse away — the field should remain visible while focused and only hide after blur.
- [ ] **Cross-browser check**: Verify hover/focus behavior in Safari and Firefox — CSS `:hover`/`:focus-within` interactions can differ subtly.

**Suggested test plan:** Insert an image block in the editor. Hover to reveal the alt text input, type a value, click elsewhere to blur, and confirm the input hides. Repeat using only the keyboard (Tab/Shift+Tab). Verify the entered alt text persists after blur.

### Notes

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer