### PR TITLE
add ui build step before web build

### DIFF
--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -1,7 +1,7 @@
 # https://docs.netlify.com/build/configure-builds/overview/#definitions
 # We must set package="apps/web" in the UI
 [build]
-command = "VITE_APP_VERSION=$COMMIT_REF pnpm -F @hypr/web build"
+command = "pnpm -F @hypr/ui build && VITE_APP_VERSION=$COMMIT_REF pnpm -F @hypr/web build"
 publish = "apps/web/dist/client"
 ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF apps/web packages/api-client packages/tiptap packages/ui packages/utils package.json pnpm-lock.yaml"
 


### PR DESCRIPTION
## Summary

Adds an explicit UI package build step that runs before the web app build, ensuring `@hypr/ui` artifacts are available when `apps/web` compiles.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #3392 
- <kbd>&nbsp;1&nbsp;</kbd> #3391 👈 
<!-- GitButler Footer Boundary Bottom -->

## Review & Testing Checklist for Human

- [ ] Run a clean build (`pnpm install && pnpm -F web build`) from scratch and verify it succeeds without missing `@hypr/ui` artifacts
- [ ] Confirm CI passes — the build ordering change could surface issues if other packages also depend on `@hypr/ui` and expect a different build sequence

### Notes

- Low-risk build configuration change scoped to build ordering.

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer