### PR TITLE
add new blog article link to related articles sections

### DIFF
--- a/apps/web/content/articles/building-editorial-workflow-github-slack.mdx
+++ b/apps/web/content/articles/building-editorial-workflow-github-slack.mdx
@@ -1,0 +1,247 @@
+---
+meta_title: "Building an Editorial Workflow with GitHub Draft PRs and Slack"
+display_title: "Building an Editorial Workflow with GitHub and Slack"
+meta_description: "Why we built a complete editorial workflow using draft PRs, auto-save, and Slack notifications instead of using existing CMS products—and why we're open sourcing it."
+author: "John Jeong"
+published: false
+category: "Engineering"
+date: "2026-01-26"
+---
+
+We recently rebuilt our entire editorial workflow from scratch.
+
+Not a tweak. A complete rebuild.
+
+And the question we kept getting was: "Why didn't you just use Payload? Or Sanity? Or any of the existing CMS products?"
+
+The answer goes deeper than "we wanted more control." It connects to something we've been thinking about since we started Hyprnote: the belief that content should live as files, not database rows.
+
+This is Part 7 of our publishing series, and it's probably the most philosophical one. We'll explain the "why" first, then break down exactly what we built.
+
+## The Filesystem Is the Cortex
+
+We wrote about this in [The Filesystem Is the Cortex](/blog/filesystem-is-coretex), but the core thesis is simple:
+
+**Files are a human interface, not a technical detail.**
+
+Humans have organized information spatially for centuries. Drawers. Cabinets. Folders. We remember where something is. Location is recall. Structure is memory.
+
+When notes—or blog posts—live as files, they feel like part of you. When they live as opaque blobs behind an API, they feel like someone else's product.
+
+This isn't nostalgia for "old-school files." It's a belief about the future:
+
+> If AI is going to help humans think, it needs access to artifacts humans can own, inspect, move, and understand.
+
+Markdown. Plain text. Files.
+
+The filesystem is the cortex—and in the AI era, it becomes even more important, not less.
+
+## Why Not Payload, Sanity, or Other CMS Products?
+
+We evaluated them all. Payload is excellent. Sanity is powerful. But every CMS we looked at had the same fundamental issue:
+
+**They want your content to live in their system.**
+
+Even the "open source" ones. Even the "self-hosted" ones. Your content becomes structured JSON in a database, mediated through schemas, accessed via APIs.
+
+That's fine for some use cases. But for us, it violated the core principle:
+
+> Content should be files. Files in a repo. Diffable. Portable. Ownable forever.
+
+We already wrote about this in [Why Our CMS Is GitHub](/blog/why-our-cms-is-github). GitHub gives us everything a CMS promises—versioning, collaboration, review workflows, rollback—without the lock-in.
+
+But there was one gap: **editorial workflows for non-engineers.**
+
+## The Gap We Needed to Fill
+
+Our stack was simple: MDX files in GitHub. Engineers write in IDEs. PRs are drafts, merges are publish.
+
+But we hit friction:
+
+1. **Accidental publishes** — No review gate. Click merge, it's live.
+2. **Lost work** — Writers forgot to save. Changes disappeared.
+3. **No visibility** — What's pending? What's been reviewed? Nobody knew.
+4. **Context switching** — Reviewers had to check GitHub constantly.
+5. **No unified actions** — Approve in GitHub, notify in Slack, merge somewhere else.
+
+We needed an editorial workflow. But we didn't want to abandon our file-first principles.
+
+So we built one.
+
+## What We Built
+
+The system has three layers:
+
+### 1. Draft PRs by Default
+
+Every change—new post, edit, unpublish—creates a **draft pull request**.
+
+Draft PRs are GitHub's best-kept secret. They:
+
+- Don't notify reviewers
+- Don't show up in review queues
+- Signal "I'm still working on this"
+- Can be converted to "ready for review" with one API call
+
+When a writer creates a new post, it lives on a draft PR. They can edit, save, walk away, come back. The PR stays invisible until they're ready.
+
+### 2. Auto-Save with Visible Countdown
+
+Writers shouldn't lose work. But they also shouldn't be interrupted.
+
+We added a 60-second auto-save countdown:
+
+```
+[ Save (52s) ]
+```
+
+When the countdown reaches zero:
+- Content auto-saves to the draft PR branch
+- No tab opens. No notification. Silent.
+- The countdown resets if more changes are made
+
+Manual save (button or Cmd+S):
+- Saves immediately
+- Countdown disappears
+- Still no tab opens—saving is silent
+
+The PR URL only opens when submitting for review. This keeps writers focused on writing, not on managing PRs.
+
+### 3. Slack as the Review Interface
+
+Reviewers live in Slack. So Slack became our review interface.
+
+When a writer clicks "Submit for Review":
+
+1. Content saves with `published: true`
+2. Draft PR converts to ready-for-review
+3. Reviewer is automatically assigned
+4. Slack receives a notification with three buttons:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Article submitted for review                                │
+│ @john please review                                         │
+│                                                             │
+│ > "Building an Editorial Workflow with GitHub and Slack"    │
+│                                                             │
+│ [ Preview ]  [ View PR ]  [ Merge ]                         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- **Preview** — Opens the Netlify deploy preview
+- **View PR** — Opens GitHub for detailed review
+- **Merge** — Merges the PR directly from Slack
+
+One click. Article goes live.
+
+For unpublishing, we send a yellow warning message:
+
+```
+⚠️ @jane wants to unpublish "Article Title"
+```
+
+Destructive actions deserve visual distinction.
+
+## The Technical Stack
+
+Everything is built on primitives that already exist:
+
+| Component | Implementation |
+|-----------|----------------|
+| Content storage | MDX files in GitHub repo |
+| Draft workflow | GitHub draft PRs |
+| Auto-save | React state + interval + GitHub API |
+| PR conversion | GitHub REST API (`PATCH /pulls/{id}`) |
+| Notifications | GitHub Actions + Slack API |
+| Merge from Slack | Slack interactive webhook → GitHub API |
+| Preview | Netlify deploy previews (automatic) |
+
+No database. No CMS backend. No proprietary schemas.
+
+Just GitHub, Slack, and a few hundred lines of glue code.
+
+## Button States: Small Details Matter
+
+Getting button states right is crucial for clarity:
+
+| Scenario | Save | Submit for Review | Status |
+|----------|------|-------------------|--------|
+| No unsaved changes | Disabled | Disabled | Current state |
+| Has unsaved changes | **Enabled** + countdown | **Enabled** | Current state |
+| Currently saving | Spinner | Disabled | Current state |
+| Unpublished article | — | — | Gray "Not Published" |
+| Published article | — | — | Green "Published" (hover: "Unpublish") |
+
+Writers don't need a "Publish" button. They need to know if something is published. Make state visible; make actions secondary.
+
+## Why This Matters for Open Source
+
+Here's where it gets interesting.
+
+We're an open source company. Hyprnote is open source. And we believe this editorial workflow should be open source too.
+
+Not just "source available." Actually usable by other teams.
+
+The vision:
+
+> **Bring your own repository. Bring your own S3. Get a complete editorial workflow.**
+
+Imagine a world where:
+
+- Your content lives in your GitHub repo (not ours)
+- Your images live in your S3 bucket (not ours)
+- You get draft PRs, auto-save, Slack notifications, one-click merge
+- Zero vendor lock-in. Zero data migration. Forever portable.
+
+This is the opposite of what CMS products offer. They want you to put content in their system. We want to give you tools that work with the systems you already have.
+
+We're not there yet. But the architecture is designed for it. The code is written to be extractable. And we're committed to open sourcing it when it's ready.
+
+## What We Learned
+
+### 1. Draft PRs are criminally underused
+
+Most teams create regular PRs immediately. Draft PRs are better for work-in-progress because they don't spam reviewers with notifications.
+
+### 2. Auto-save needs visibility
+
+Silent auto-save creates anxiety. "Did it save? Should I save manually?" A visible countdown removes uncertainty.
+
+### 3. Slack is a legitimate review interface
+
+For simple approve/reject workflows, Slack buttons are faster than GitHub's UI. Save GitHub for complex reviews with inline comments.
+
+### 4. Status indicators matter more than action buttons
+
+Writers don't need a "Publish" button. They need to know if something is published. Make state visible; make actions secondary.
+
+### 5. Files are the foundation
+
+Every design decision was easier because we started with files. No schema migrations. No content lake. No API rate limits. Just files.
+
+## The Philosophy Behind It
+
+We built this because we believe:
+
+1. **Content should be owned, not rented.** Your words should live in your repo, not in a SaaS database.
+
+2. **Tools should compose, not capture.** GitHub + Slack + Netlify already exist. We connected them instead of replacing them.
+
+3. **Simplicity survives.** Markdown files will outlive every CMS platform launched this decade.
+
+4. **Open source means open data.** If the software is open, the content should be portable.
+
+This editorial workflow is one piece of that vision. It's how we publish our blog, our docs, our changelog. And eventually, it's something we want to share with every team that believes content should be files.
+
+---
+
+**This is Part 7 of our publishing series.**
+
+1. [Why We Write Our Blog in an IDE](/blog/using-ide-for-writing)
+2. [Why Our CMS Is GitHub](/blog/why-our-cms-is-github)
+3. [Choosing a CMS in 2025](/blog/choosing-a-cms)
+4. [Don't Use a CMS Until You Absolutely Need One](/blog/dont-use-a-cms)
+5. [Docs Edition: What to Use for Developer Documentation](/blog/developer-documentation-tools)
+6. [How We Built Hyprnote's Publishing Stack](/blog/hyprnote-publishing-stack)
+7. [Building an Editorial Workflow with GitHub and Slack](/blog/building-editorial-workflow-github-slack) (You are here)

--- a/apps/web/content/articles/choosing-a-cms.mdx
+++ b/apps/web/content/articles/choosing-a-cms.mdx
@@ -30,6 +30,7 @@ I'll show you **what each category is good at**, what it quietly locks you into,
 4. [Don't Use a CMS Until You Absolutely Need One](/blog/dont-use-a-cms)
 5. [Docs Edition: What to Use for Developer Documentation](/blog/developer-documentation-tools)
 6. [How We Built Hyprnote's Publishing Stack](/blog/hyprnote-publishing-stack)
+7. [Building an Editorial Workflow with GitHub and Slack](/blog/building-editorial-workflow-github-slack)
 
 ## Step 0: Decide What Problem You're Actually Solving
 
@@ -318,3 +319,4 @@ Your content shouldn't have to.
 4. [Don't Use a CMS Until You Absolutely Need One](/blog/dont-use-a-cms)
 5. [Docs Edition: What to Use for Developer Documentation](/blog/developer-documentation-tools)
 6. [How We Built Hyprnote's Publishing Stack](/blog/hyprnote-publishing-stack)
+7. [Building an Editorial Workflow with GitHub and Slack](/blog/building-editorial-workflow-github-slack)

--- a/apps/web/content/articles/developer-documentation-tools.mdx
+++ b/apps/web/content/articles/developer-documentation-tools.mdx
@@ -299,3 +299,4 @@ This is Part 5 of our publishing series.
 4. [Don't Use a CMS Until You Absolutely Need One](/blog/dont-use-a-cms)
 5. [Docs Edition: What to Use for Developer Documentation](/blog/developer-documentation-tools) (You are here)
 6. [How We Built Hyprnote's Publishing Stack](/blog/hyprnote-publishing-stack)
+7. [Building an Editorial Workflow with GitHub and Slack](/blog/building-editorial-workflow-github-slack)

--- a/apps/web/content/articles/dont-use-a-cms.mdx
+++ b/apps/web/content/articles/dont-use-a-cms.mdx
@@ -213,3 +213,4 @@ You cannot subtract it.
 4. [Don't Use a CMS Until You Absolutely Need One](/blog/dont-use-a-cms) (You are here)
 5. [Docs Edition: What to Use for Developer Documentation](/blog/developer-documentation-tools)
 6. [How We Built Hyprnote's Publishing Stack](/blog/hyprnote-publishing-stack)
+7. [Building an Editorial Workflow with GitHub and Slack](/blog/building-editorial-workflow-github-slack)

--- a/apps/web/content/articles/hyprnote-publishing-stack.mdx
+++ b/apps/web/content/articles/hyprnote-publishing-stack.mdx
@@ -19,7 +19,7 @@ So we did the simplest thing: we built our publishing system the same way we bui
 
 This post breaks down exactly how it works, why it works, and why I expect it to outlive most CMS platforms people are betting on today.
 
-This is Part 6 of our publishing series — the final one.
+This is Part 6 of our publishing series.
 
 ## 1. Start With the Root: MDX + Git
 
@@ -268,7 +268,7 @@ Our publishing system isn't static. It's a foundation for the next decade of how
 
 ---
 
-**This concludes the publishing series!**
+**This is Part 6 of our publishing series.**
 
 1. [Why We Write Our Blog in an IDE](/blog/using-ide-for-writing)
 2. [Why Our CMS Is GitHub](/blog/why-our-cms-is-github)
@@ -276,3 +276,4 @@ Our publishing system isn't static. It's a foundation for the next decade of how
 4. [Don't Use a CMS Until You Absolutely Need One](/blog/dont-use-a-cms)
 5. [Docs Edition: What to Use for Developer Documentation](/blog/developer-documentation-tools)
 6. [How We Built Hyprnote's Publishing Stack](/blog/hyprnote-publishing-stack) (You are here)
+7. [Building an Editorial Workflow with GitHub and Slack](/blog/building-editorial-workflow-github-slack)

--- a/apps/web/content/articles/using-ide-for-writing.mdx
+++ b/apps/web/content/articles/using-ide-for-writing.mdx
@@ -130,3 +130,4 @@ Once you experience that kind of writing, it's hard to go back.
 4. [Don't Use a CMS Until You Absolutely Need One](/blog/dont-use-a-cms)
 5. [Docs Edition: What to Use for Developer Documentation](/blog/developer-documentation-tools)
 6. [How We Built Hyprnote's Publishing Stack](/blog/hyprnote-publishing-stack)
+7. [Building an Editorial Workflow with GitHub and Slack](/blog/building-editorial-workflow-github-slack)

--- a/apps/web/content/articles/why-our-cms-is-github.mdx
+++ b/apps/web/content/articles/why-our-cms-is-github.mdx
@@ -152,3 +152,4 @@ This is Part 2 of our publishing series.
 4. [Don't Use a CMS Until You Absolutely Need One](/blog/dont-use-a-cms)
 5. [Docs Edition: What to Use for Developer Documentation](/blog/developer-documentation-tools)
 6. [How We Built Hyprnote's Publishing Stack](/blog/hyprnote-publishing-stack)
+7. [Building an Editorial Workflow with GitHub and Slack](/blog/building-editorial-workflow-github-slack)


### PR DESCRIPTION
## Summary

Adds a link to a new blog article in the related articles sections of existing blog posts.

## Review & Testing Checklist for Human

- [ ] Verify the linked article slug resolves correctly on the deploy preview — a typo in the slug will produce a broken link or 404
- [ ] Spot-check that the related articles section renders correctly on the affected pages (no duplicate entries, correct ordering)

**Suggested test plan:** Open the deploy preview, navigate to each blog post that was modified, scroll to the related articles section, and click the new link to confirm it resolves.

### Notes

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer