### PR TITLE
automatically start trial on first app launch

### DIFF
--- a/apps/desktop/src/components/main-app-layout.tsx
+++ b/apps/desktop/src/components/main-app-layout.tsx
@@ -10,6 +10,7 @@ import { NetworkProvider } from "../contexts/network";
 import { useProModelAutoConfig } from "../hooks/useProModelAutoConfig";
 import { useProSettingsReset } from "../hooks/useProSettingsReset";
 import { useTrialExpiredModalTrigger } from "../hooks/useTrialExpiredModalTrigger";
+import { useTrialStartOnFirstLaunch } from "../hooks/useTrialStartOnFirstLaunch";
 import { useTabs } from "../store/zustand/tabs";
 import { TrialBeginModal } from "./devtool/trial-begin-modal";
 import { TrialExpiredModal } from "./devtool/trial-expired-modal";
@@ -35,6 +36,7 @@ function MainAppContent() {
   useProSettingsReset();
   useTrialExpiredModalTrigger();
   useProModelAutoConfig();
+  useTrialStartOnFirstLaunch();
 
   return (
     <>

--- a/apps/desktop/src/hooks/useTrialStartOnFirstLaunch.ts
+++ b/apps/desktop/src/hooks/useTrialStartOnFirstLaunch.ts
@@ -1,0 +1,81 @@
+import { useMutation } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+
+import { postBillingStartTrial } from "@hypr/api-client";
+import { createClient } from "@hypr/api-client/client";
+import { commands as analyticsCommands } from "@hypr/plugin-analytics";
+
+import { useAuth } from "../auth";
+import { getEntitlementsFromToken, useBillingAccess } from "../billing";
+import { useTrialBeginModal } from "../components/devtool/trial-begin-modal";
+import { env } from "../env";
+import * as settings from "../store/tinybase/store/settings";
+
+export function useTrialStartOnFirstLaunch() {
+  const auth = useAuth();
+  const { canStartTrial } = useBillingAccess();
+  const { open: openTrialBeginModal } = useTrialBeginModal();
+  const store = settings.UI.useStore(settings.STORE_ID);
+  const hasCheckedRef = useRef(false);
+
+  const startTrialMutation = useMutation({
+    mutationFn: async () => {
+      const headers = auth?.getHeaders();
+      if (!headers) {
+        throw new Error("No auth headers");
+      }
+      const client = createClient({ baseUrl: env.VITE_API_URL, headers });
+      await postBillingStartTrial({ client, query: { interval: "monthly" } });
+
+      const newSession = await auth!.refreshSession();
+      const isPro = newSession
+        ? getEntitlementsFromToken(newSession.access_token).includes(
+            "hyprnote_pro",
+          )
+        : false;
+
+      return { isPro };
+    },
+    onSuccess: ({ isPro }) => {
+      if (isPro) {
+        void analyticsCommands.event({
+          event: "trial_started",
+          plan: "pro",
+        });
+        const trialEndDate = new Date();
+        trialEndDate.setDate(trialEndDate.getDate() + 14);
+        void analyticsCommands.setProperties({
+          set: {
+            plan: "pro",
+            trial_end_date: trialEndDate.toISOString(),
+          },
+        });
+        openTrialBeginModal();
+      }
+    },
+    onError: (e) => {
+      console.error("Failed to start trial:", e);
+    },
+  });
+
+  const isAuthenticated = !!auth?.session;
+
+  useEffect(() => {
+    if (hasCheckedRef.current || !store || !isAuthenticated) {
+      return;
+    }
+
+    const checkedAt = store.getValue("trial_start_checked_at");
+    if (checkedAt) {
+      hasCheckedRef.current = true;
+      return;
+    }
+
+    store.setValue("trial_start_checked_at", Date.now());
+    hasCheckedRef.current = true;
+
+    if (canStartTrial) {
+      startTrialMutation.mutate();
+    }
+  }, [isAuthenticated, canStartTrial, store, startTrialMutation]);
+}

--- a/apps/desktop/src/store/tinybase/store/settings.ts
+++ b/apps/desktop/src/store/tinybase/store/settings.ts
@@ -69,6 +69,10 @@ export const SETTINGS_MAPPING = {
       type: "number",
       path: ["billing", "trial_expired_modal_dismissed_at"],
     },
+    trial_start_checked_at: {
+      type: "number",
+      path: ["billing", "trial_start_checked_at"],
+    },
   },
   tables: {
     ai_providers: {


### PR DESCRIPTION
## Summary

Automatically starts a trial for new users on their first app launch, removing the need for manual trial activation.

## Review & Testing Checklist for Human

- [ ] **Duplicate trial prevention**: Reinstall the app or log in on a second device and confirm a second trial is NOT started if one is already active — this is the highest-risk edge case since it could reset or extend trial periods unintentionally
- [ ] **Race with onboarding**: Walk through the full first-launch flow (onboarding screens → app ready) and verify the trial starts at the correct point without conflicting with other initialization steps
- [ ] **Trial state visibility**: After first launch, confirm the user can see that a trial is active (e.g., in settings or a banner) — a silently started trial with no UI indication would confuse users when it expires
- [ ] **Failure path**: Disconnect network before first launch and verify the app handles a failed trial-start gracefully (no crash, no stuck state, retries on next launch or reconnect)

**Suggested test plan:** Fresh install → first launch → verify trial is active in settings. Then log out and back in (or reinstall) → confirm no duplicate trial is created. Finally, test with network disabled on first launch to verify error handling.

### Notes

- [Link to Devin run](https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6)
- Requested by @ComputelessComputer