### PR TITLE
fix: support multi-word transcript search queries

### DIFF
--- a/apps/desktop/src/components/main/body/sessions/note-input/transcript/search-context.tsx
+++ b/apps/desktop/src/components/main/body/sessions/note-input/transcript/search-context.tsx
@@ -35,12 +35,21 @@ function getMatchingElements(
     return [];
   }
 
+  const queryTerms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((term) => term.length > 0);
+
+  if (queryTerms.length === 0) {
+    return [];
+  }
+
   const allSpans = Array.from(
     container.querySelectorAll<HTMLElement>("[data-word-id]"),
   );
   return allSpans.filter((span) => {
-    const text = span.textContent || "";
-    return text.toLowerCase().includes(query.toLowerCase());
+    const text = (span.textContent || "").toLowerCase();
+    return queryTerms.some((term) => text.includes(term));
   });
 }
 


### PR DESCRIPTION
 fix: support multi-word transcript search queries                                                                                                           
                                                                                                                                                              
  PR Description                                                                                                                                              
                                                                                                                                                              
  ## Summary                                                                                                                                                  
  - Fixes #3351                                                                                                                                               
  - In-transcript search (Ctrl+F) now supports multi-word queries for Korean and English                                                                      
                                                                                                                                                              
  ## Problem                                                                                                                                                  
  The search was checking if the **entire query** existed within each individual word span. Since each word is stored in a separate `<span>` element,         
  multi-word queries like `김철수 프로젝트` or `meeting transcript` would return 0 results.                                                                   
                                                                                                                                                              
  ## Solution                                                                                                                                                 
  - Split the search query by spaces into separate terms                                                                                                      
  - Match spans containing **any** of the search terms                                                                                                        
  - Highlight all matching terms correctly with overlapping range support                                                                                     
                                                                                                                                                              
  ## Test                                                                                                                                                     
  1. Open a session with transcript                                                                                                                           
  2. Press Ctrl+F to open search                                                                                                                              
  3. Search for multiple words                                                                                     
  4. Both words are now found and highlighted           