### PR TITLE
change markdown heading level for hiring section

### DIFF
--- a/apps/web/content/jobs/designteer.mdx
+++ b/apps/web/content/jobs/designteer.mdx
@@ -69,7 +69,7 @@ Click on the apply button and tell me three things:
 
 But really the above is just a guideline - feel free to surprise us with your unique format!
 
-### How we hire
+## How we hire
 
 1. Apply by email: We'll review your application and reply within 48 hours ONLY if we think you're interesting.
 2. 20-min intro: An introductory chat about our team and getting to know each other. You'll get a reply within 24 hours with follow-up questions. You can answer via video call or _email_ (which we prefer so we can make the most of our time together).


### PR DESCRIPTION
## Summary

Adjusts the markdown heading level in the hiring section for correct document hierarchy.

## Review & Testing Checklist for Human

- [ ] Verify the rendered heading hierarchy looks correct on the deploy preview — confirm the hiring section heading is at the appropriate level relative to surrounding sections

### Notes

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer