### PR TITLE
Show formatted changelog date in views

### DIFF
--- a/apps/web/src/routes/_view/changelog/$slug.tsx
+++ b/apps/web/src/routes/_view/changelog/$slug.tsx
@@ -99,9 +99,21 @@ function Component() {
                 alt="Hyprnote"
                 className="size-32 rounded-2xl"
               />
-              <h1 className="text-3xl sm:text-4xl font-mono font-medium text-stone-600">
-                {changelog.version}
-              </h1>
+              <div className="flex flex-col items-center gap-2">
+                <h1 className="text-3xl sm:text-4xl font-mono font-medium text-stone-600">
+                  {changelog.version}
+                </h1>
+                <time
+                  className="text-sm text-neutral-500"
+                  dateTime={changelog.date}
+                >
+                  {new Date(changelog.date).toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </time>
+              </div>
             </div>
 
             <DownloadLinksHero version={changelog.version} />
@@ -118,9 +130,21 @@ function Component() {
                 alt="Hyprnote"
                 className="size-16 rounded-2xl"
               />
-              <h1 className="text-3xl font-mono font-medium text-stone-600">
-                {changelog.version}
-              </h1>
+              <div className="flex flex-col items-center gap-2">
+                <h1 className="text-3xl font-mono font-medium text-stone-600">
+                  {changelog.version}
+                </h1>
+                <time
+                  className="text-sm text-neutral-500"
+                  dateTime={changelog.date}
+                >
+                  {new Date(changelog.date).toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                  })}
+                </time>
+              </div>
             </div>
 
             <DownloadLinksHeroMobile version={changelog.version} />

--- a/apps/web/src/routes/_view/changelog/index.tsx
+++ b/apps/web/src/routes/_view/changelog/index.tsx
@@ -113,6 +113,16 @@ function ChangelogSection({ changelog }: { changelog: ChangelogWithMeta }) {
               ? `${currentVersion.major}.${currentVersion.minor}.${currentVersion.patch}`
               : changelog.version}
           </h2>
+          <time
+            className="text-sm text-neutral-500 mt-1"
+            dateTime={changelog.date}
+          >
+            {new Date(changelog.date).toLocaleDateString("en-US", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            })}
+          </time>
         </div>
 
         <DownloadLinks version={changelog.version} />


### PR DESCRIPTION
## Summary

Display the changelog date alongside the version in the changelog views
so users can see when a release was published. Add `<time>` elements with
a machine-readable `dateTime` and a human-friendly formatted date (e.g.
"January 1, 2023") in `apps/web/src/routes/_view/changelog/$slug.tsx` and
`apps/web/src/routes/_view/changelog/index.tsx`.

- Insert a small, neutral-colored date under the version header in the individual changelog page (`$slug.tsx`) in both desktop and mobile header areas.
- Add a date below the version heading on the changelog index page (`index.tsx`).

This improves usability by making release dates explicit and accessible
while preserving semantic markup.

## Review & Testing Checklist for Human

- [ ] Verify date rendering on the individual changelog page (`/changelog/<slug>`) — confirm the date appears correctly under the version header in both desktop and mobile layouts
- [ ] Verify date rendering on the changelog index page (`/changelog/`) — confirm each entry shows a date below the version heading
- [ ] Spot-check a changelog entry with no date or an unusual date format to confirm it doesn't render broken or empty `<time>` elements

**Suggested test plan:** Open the deploy preview, navigate to `/changelog/`, and visually inspect a few entries for correct date display. Click into an individual changelog page and verify the date appears in both desktop and mobile viewport sizes.

### Notes

- Low-risk cosmetic change scoped to two view files with no business logic modifications.
- [Link to Devin run](https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6)
- Requested by @ComputelessComputer