### PR TITLE
feat: identify website visitors on OAuth callback

### DIFF
--- a/apps/web/src/routes/_view/callback/auth.tsx
+++ b/apps/web/src/routes/_view/callback/auth.tsx
@@ -100,7 +100,7 @@ function Component() {
       const email = payload.email;
       const userId = payload.sub;
 
-      if (email) {
+      if (email && userId) {
         identify({
           email,
           userId,


### PR DESCRIPTION
## Summary
Link anonymous website visitors to authenticated users when they complete sign-in. This enables attribution of marketing channels → signups → feature usage -> revenue

## Changes
- Import `useOutlit` hook from `@outlit/browser/react` in the auth callback page
- Decode JWT from `access_token` URL parameter to extract `email`, `userId`, and `auth_provider`
- Call `identify()` to link the browser's `visitor_id` cookie to the authenticated user
- Wait for SDK initialization (`isInitialized`) before calling identify to avoid race condition

## How it works
```
Website visit → visitor_id cookie created
       ↓
OAuth callback → JWT contains email/userId
       ↓
identify({ email, userId }) → links visitor_id to user
       ↓
Deeplink to desktop app
```

## Coverage
- ✅ Google OAuth
- ✅ GitHub OAuth  
- ✅ Email magic link

## Test plan
- [x] Verified visitor_id exists in localStorage before identify
- [x] Verified identify call fires with correct payload
- [x] Verified SDK waits for initialization before calling identify
- [x] TypeScript typecheck passes