### PR TITLE
feat(feedback): add feedback submission with GitHub issue creation

### DIFF
--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -31,6 +31,7 @@ export const env = createEnv({
     SLACK_SIGNING_SECRET: z.string().optional(),
     LOOPS_API_KEY: z.string().optional(),
     LOOPS_SLACK_CHANNEL_ID: z.string().optional(),
+    YUJONGLEE_GITHUB_TOKEN_REPO: z.string().optional(),
   },
   runtimeEnv: Bun.env,
   emptyStringAsUndefined: true,

--- a/apps/api/src/routes/feedback.ts
+++ b/apps/api/src/routes/feedback.ts
@@ -1,0 +1,202 @@
+import { Hono } from "hono";
+import { describeRoute } from "hono-openapi";
+import { resolver, validator } from "hono-openapi/zod";
+import { z } from "zod";
+
+import { env } from "../env";
+import type { AppBindings } from "../hono-bindings";
+import { API_TAGS } from "./constants";
+
+const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1/chat/completions";
+
+const FeedbackRequestSchema = z.object({
+  type: z.enum(["bug", "feature"]),
+  description: z.string().min(10),
+  logs: z.string().optional(),
+  deviceInfo: z.object({
+    platform: z.string(),
+    arch: z.string(),
+    osVersion: z.string(),
+    appVersion: z.string(),
+    gitHash: z.string(),
+  }),
+});
+
+const FeedbackResponseSchema = z.object({
+  success: z.boolean(),
+  issueUrl: z.string().optional(),
+  error: z.string().optional(),
+});
+
+async function analyzeLogsWithAI(logs: string): Promise<string | null> {
+  try {
+    const response = await fetch(OPENROUTER_BASE_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${env.OPENROUTER_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: "google/gemini-2.0-flash-001",
+        max_tokens: 300,
+        messages: [
+          {
+            role: "user",
+            content: `Extract only ERROR and WARNING entries from these logs. Output max 800 chars, no explanation:\n\n${logs.slice(-10000)}`,
+          },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const content = data.choices?.[0]?.message?.content;
+    return content ? content.slice(0, 800) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function createGitHubIssue(
+  title: string,
+  body: string,
+  labels: string[],
+): Promise<{ url: string } | { error: string }> {
+  if (!env.YUJONGLEE_GITHUB_TOKEN_REPO) {
+    return { error: "GitHub bot token not configured" };
+  }
+
+  const response = await fetch(
+    "https://api.github.com/repos/fastrepl/hyprnote/issues",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.YUJONGLEE_GITHUB_TOKEN_REPO}`,
+        Accept: "application/vnd.github.v3+json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        title,
+        body,
+        labels,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    return { error: `GitHub API error: ${response.status} - ${errorText}` };
+  }
+
+  const data = (await response.json()) as { html_url?: string };
+  if (!data.html_url) {
+    return { error: "GitHub API did not return issue URL" };
+  }
+
+  return { url: data.html_url };
+}
+
+export const feedback = new Hono<AppBindings>();
+
+feedback.post(
+  "/submit",
+  describeRoute({
+    tags: [API_TAGS.PRIVATE_SKIP_OPENAPI],
+    responses: {
+      200: {
+        description: "Feedback submitted successfully",
+        content: {
+          "application/json": {
+            schema: resolver(FeedbackResponseSchema),
+          },
+        },
+      },
+      400: {
+        description: "Invalid request",
+        content: {
+          "application/json": {
+            schema: resolver(FeedbackResponseSchema),
+          },
+        },
+      },
+      500: {
+        description: "Server error",
+        content: {
+          "application/json": {
+            schema: resolver(FeedbackResponseSchema),
+          },
+        },
+      },
+    },
+  }),
+  validator("json", FeedbackRequestSchema),
+  async (c) => {
+    const { type, description, logs, deviceInfo } = c.req.valid("json");
+
+    const trimmedDescription = description.trim();
+    const firstLine = trimmedDescription.split("\n")[0].slice(0, 100).trim();
+    const title =
+      firstLine || (type === "bug" ? "Bug Report" : "Feature Request");
+
+    const deviceInfoSection = [
+      `**Platform:** ${deviceInfo.platform}`,
+      `**Architecture:** ${deviceInfo.arch}`,
+      `**OS Version:** ${deviceInfo.osVersion}`,
+      `**App Version:** ${deviceInfo.appVersion}`,
+      `**Git Hash:** ${deviceInfo.gitHash}`,
+    ].join("\n");
+
+    let logSection = "";
+    if (type === "bug" && logs) {
+      const logSummary = await analyzeLogsWithAI(logs);
+      if (logSummary?.trim()) {
+        logSection = `
+
+## Log Summary
+\`\`\`
+${logSummary}
+\`\`\`
+`;
+      }
+    }
+
+    const body =
+      type === "bug"
+        ? `## Description
+${trimmedDescription}
+
+## Device Information
+${deviceInfoSection}
+${logSection}
+---
+*This issue was submitted from the Hyprnote desktop app.*
+`
+        : `## Feature Request
+${trimmedDescription}
+
+## Submitted From
+${deviceInfoSection}
+
+---
+*This feature request was submitted from the Hyprnote desktop app.*
+`;
+
+    const labels =
+      type === "bug"
+        ? ["bug", "user-reported"]
+        : ["enhancement", "user-reported"];
+
+    const result = await createGitHubIssue(title, body, labels);
+
+    if ("error" in result) {
+      return c.json({ success: false, error: result.error }, 500);
+    }
+
+    return c.json({ success: true, issueUrl: result.url }, 200);
+  },
+);

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 
 import type { AppBindings } from "../hono-bindings";
 import { billing } from "./billing";
+import { feedback } from "./feedback";
 import { fileTranscription } from "./file-transcription";
 import { health } from "./health";
 import { rpc } from "./rpc";
@@ -13,6 +14,7 @@ export const routes = new Hono<AppBindings>();
 
 routes.route("/health", health);
 routes.route("/billing", billing);
+routes.route("/feedback", feedback);
 routes.route("/file-transcription", fileTranscription);
 routes.route("/rpc", rpc);
 routes.route("/webhook", webhook);


### PR DESCRIPTION
## Summary

Adds a feedback submission flow that creates GitHub issues from user-submitted feedback, including device info and log analysis. This lays the foundation for the improved log analysis in #3485.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #3485 
- <kbd>&nbsp;1&nbsp;</kbd> #3484 👈 
<!-- GitButler Footer Boundary Bottom -->

## Review & Testing Checklist for Human

- [ ] **GitHub API auth & permissions**: Verify the API token/app used for issue creation has `issues: write` permission on the target repository — a misconfigured token will silently fail or return a 403 that may not surface clearly to the user
- [ ] **Payload correctness**: Submit feedback from the app and inspect the created GitHub issue — confirm the title, body (description, device info, logs), and any labels are correctly populated with no missing or garbled fields
- [ ] **Error handling**: Test with an invalid API key or unreachable GitHub API endpoint and verify the user sees a meaningful error instead of a silent failure or unhandled exception

**Suggested test plan:** Submit feedback from the desktop app with a description and logs attached. Check the GitHub repo's issues list to confirm an issue was created with the correct content. Then simulate a failure (e.g., disconnect network or use an invalid token) and verify the error path is handled gracefully.

### Notes

- Part 1 of 2 in a stack — review #3485 next for log analysis improvements built on top of this.
- [Link to Devin run](https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6)
- Requested by @ComputelessComputer