### PR TITLE
feat(feedback): add issue type for GitHub issue creation

### DIFF
--- a/apps/api/src/routes/feedback.ts
+++ b/apps/api/src/routes/feedback.ts
@@ -66,6 +66,7 @@ async function createGitHubIssue(
   title: string,
   body: string,
   labels: string[],
+  issueType: string,
 ): Promise<{ url: string; number: number } | { error: string }> {
   if (!env.YUJONGLEE_GITHUB_TOKEN_REPO) {
     return { error: "GitHub bot token not configured" };
@@ -84,6 +85,7 @@ async function createGitHubIssue(
         title,
         body,
         labels,
+        type: issueType,
       }),
     },
   );
@@ -197,12 +199,10 @@ ${deviceInfoSection}
 *This feature request was submitted from the Hyprnote desktop app.*
 `;
 
-    const labels =
-      type === "bug"
-        ? ["bug", "user-reported"]
-        : ["enhancement", "user-reported"];
+    const labels = ["product/desktop"];
+    const issueType = type === "bug" ? "Bug" : "Feature";
 
-    const result = await createGitHubIssue(title, body, labels);
+    const result = await createGitHubIssue(title, body, labels, issueType);
 
     if ("error" in result) {
       return c.json({ success: false, error: result.error }, 500);


### PR DESCRIPTION
## Summary

Adds an issue type field to the GitHub issue creation flow in the feedback submission system, allowing submitted issues to be categorized (e.g., bug report, feature request) when created on GitHub.

## Review & Testing Checklist for Human

- [ ] Verify the issue type value is correctly passed through the full pipeline: UI selection → API request → GitHub issue label/title prefix — confirm no silent fallback to a default when a type is explicitly selected
- [ ] Submit feedback with each available issue type and check the created GitHub issue has the correct categorization applied
- [ ] Submit feedback without selecting an issue type (if optional) and confirm it still creates an issue successfully without errors

### Notes

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer