### PR TITLE
Fix/duplicate sidebar after reschedule

### DIFF
--- a/apps/desktop/src/components/main/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/components/main/sidebar/timeline/item.tsx
@@ -318,21 +318,22 @@ const SessionItem = memo(
     const isFinalizing = sessionMode === "finalizing";
     const showSpinner = !selected && (isFinalizing || isEnhancing);
 
-    const calendarId = useMemo(() => {
-      if (!store || !item.data.event_id) {
-        return null;
-      }
-      const event = store.getRow("events", item.data.event_id);
-      return event?.calendar_id ? String(event.calendar_id) : null;
-    }, [store, item.data.event_id]);
+    const eventIdStr = item.data.event_id ? String(item.data.event_id) : "";
 
-    const eventStartedAt = useMemo(() => {
-      if (!store || !item.data.event_id) {
-        return null;
-      }
-      const event = store.getRow("events", item.data.event_id);
-      return event?.started_at ? String(event.started_at) : null;
-    }, [store, item.data.event_id]);
+    const eventCalendarId = main.UI.useCell(
+      "events",
+      eventIdStr,
+      "calendar_id",
+      main.STORE_ID,
+    ) as string | undefined;
+    const calendarId = eventCalendarId ?? null;
+
+    const eventStartedAt = main.UI.useCell(
+      "events",
+      eventIdStr,
+      "started_at",
+      main.STORE_ID,
+    ) as string | undefined;
 
     const displayTime = useMemo(
       () =>

--- a/apps/desktop/src/services/apple-calendar/process/events/sync.ts
+++ b/apps/desktop/src/services/apple-calendar/process/events/sync.ts
@@ -95,10 +95,6 @@ export function syncEvents(
       }
     }
 
-    if (hasNonEmptySession) {
-      continue;
-    }
-
     const rescheduledEvent = findRescheduledEvent(ctx, storeEvent, incoming);
     const rescheduledEventKey = rescheduledEvent
       ? getEventKey(
@@ -122,6 +118,10 @@ export function syncEvents(
         calendar_id: storeEvent.calendar_id,
       });
       handledEventKeys.add(rescheduledEventKey);
+      continue;
+    }
+
+    if (hasNonEmptySession) {
       continue;
     }
 


### PR DESCRIPTION
### Fix stale sidebar datetime after sequential reschedules

- Replaced `useMemo([store, event_id])` with TinyBase’s reactive `useCell` hook in `SessionItem` for both `eventStartedAt` and `calendarId`.
  - The displayed time now updates immediately on **every** reschedule, not just the first one.

- Moved the `hasNonEmptySession` guard from **before** `findRescheduledEvent` to **after** it.
  - This allows events with notes to still be matched by the heuristic when Apple Calendar changes the tracking ID on reschedule.
  - The guard now only prevents deletion, not matching.

- Added tests covering:
  - Reschedule with a different tracking ID and a non-empty session
  - Sequential forward → backward reschedules
  - Sequential reschedules with a non-empty session
#3258 