### PR TITLE
fix(ui): adjust profile dropdown padding

### DIFF
--- a/apps/desktop/src/components/main/sidebar/profile/index.tsx
+++ b/apps/desktop/src/components/main/sidebar/profile/index.tsx
@@ -244,7 +244,7 @@ export function ProfileSection({ onExpandChange }: ProfileSectionProps = {}) {
             className="absolute bottom-full left-0 right-0 mb-1"
           >
             <div className="bg-neutral-50 rounded-xl overflow-hidden shadow-xs border">
-              <div className="pt-1">
+              <div className="py-1">
                 <AnimatePresence mode="wait">
                   {currentView === "main" ? (
                     <motion.div


### PR DESCRIPTION
## Summary

- Adjusted padding on the profile dropdown component for improved visual consistency

## Review & Testing Checklist for Human

- [ ] Open the profile dropdown and verify spacing looks correct at various window sizes — confirm no content is clipped or misaligned

### Notes

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer