### PR TITLE
make whisper-cpp optional and remove quantized models from UI

### DIFF
--- a/apps/desktop/src/components/settings/ai/stt/configure.tsx
+++ b/apps/desktop/src/components/settings/ai/stt/configure.tsx
@@ -151,39 +151,6 @@ function HyprProviderCard({
                 displayName="Whisper Large v3"
                 description="Broad coverage of languages."
               />
-
-              <details className="flex flex-col gap-4 pt-2">
-                <summary className="text-xs cursor-pointer text-neutral-600 hover:text-neutral-900 hover:underline">
-                  Advanced
-                </summary>
-                <div className="mt-4 flex flex-col gap-3">
-                  <HyprProviderLocalRow
-                    model="QuantizedTinyEn"
-                    displayName="whisper-tiny-en-q8"
-                    description="Only for experiment & development purposes."
-                  />
-                  <HyprProviderLocalRow
-                    model="QuantizedSmallEn"
-                    displayName="whisper-small-en-q8"
-                    description="Only for experiment & development purposes."
-                  />
-                </div>
-              </details>
-            </>
-          )}
-
-          {!isAppleSilicon && (
-            <>
-              <HyprProviderLocalRow
-                model="QuantizedTinyEn"
-                displayName="whisper-tiny-en-q8"
-                description="Powered by Whisper.cpp. English only."
-              />
-              <HyprProviderLocalRow
-                model="QuantizedSmallEn"
-                displayName="whisper-small-en-q8"
-                description="Powered by Whisper.cpp. English only."
-              />
             </>
           )}
         </div>

--- a/apps/desktop/src/components/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/components/settings/ai/stt/select.tsx
@@ -332,13 +332,11 @@ function useConfiguredMapping(): Record<
 
   const isAppleSilicon = targetArch.data === "aarch64";
 
-  const [p2, p3, whisperLargeV3, tinyEn, smallEn] = useQueries({
+  const [p2, p3, whisperLargeV3] = useQueries({
     queries: [
       sttModelQueries.isDownloaded("am-parakeet-v2"),
       sttModelQueries.isDownloaded("am-parakeet-v3"),
       sttModelQueries.isDownloaded("am-whisper-large-v3"),
-      sttModelQueries.isDownloaded("QuantizedTinyEn"),
-      sttModelQueries.isDownloaded("QuantizedSmallEn"),
     ],
   });
 
@@ -362,16 +360,8 @@ function useConfiguredMapping(): Record<
       }
 
       if (provider.id === "hyprnote") {
-        const models = [
+        const models: Array<{ id: string; isDownloaded: boolean }> = [
           { id: "cloud", isDownloaded: billing.isPro },
-          {
-            id: "QuantizedTinyEn",
-            isDownloaded: tinyEn.data ?? false,
-          },
-          {
-            id: "QuantizedSmallEn",
-            isDownloaded: smallEn.data ?? false,
-          },
         ];
 
         if (isAppleSilicon) {

--- a/apps/desktop/src/components/settings/ai/stt/shared.tsx
+++ b/apps/desktop/src/components/settings/ai/stt/shared.tsx
@@ -2,11 +2,7 @@ import { Icon } from "@iconify-icon/react";
 import { AssemblyAI, ElevenLabs, Fireworks, OpenAI } from "@lobehub/icons";
 import type { ReactNode } from "react";
 
-import type {
-  AmModel,
-  SupportedSttModel,
-  WhisperModel,
-} from "@hypr/plugin-local-stt";
+import type { AmModel, SupportedSttModel } from "@hypr/plugin-local-stt";
 
 import { env } from "../../../../env";
 import { localSttQueries } from "../../../../hooks/useLocalSttModel";
@@ -75,16 +71,6 @@ export const displayModelId = (model: string) => {
     }
   }
 
-  if (model.startsWith("Quantized")) {
-    const whisper = model as WhisperModel;
-    if (whisper == "QuantizedTinyEn") {
-      return "Whisper Tiny (English)";
-    }
-    if (whisper == "QuantizedSmallEn") {
-      return "Whisper Small (English)";
-    }
-  }
-
   return model;
 };
 
@@ -101,8 +87,6 @@ const _PROVIDERS = [
       "am-parakeet-v2",
       "am-parakeet-v3",
       "am-whisper-large-v3",
-      "QuantizedTinyEn",
-      "QuantizedSmallEn",
     ],
     requirements: [],
   },

--- a/plugins/local-stt/Cargo.toml
+++ b/plugins/local-stt/Cargo.toml
@@ -9,15 +9,16 @@ description = ""
 
 [features]
 default = []
-coreml = ["hypr-transcribe-whisper-local/coreml", "hypr-transcribe-moonshine/coreml"]
-directml = ["hypr-transcribe-whisper-local/directml", "hypr-transcribe-moonshine/directml"]
-cuda = ["hypr-transcribe-whisper-local/cuda", "hypr-transcribe-moonshine/cuda"]
-hipblas = ["hypr-transcribe-whisper-local/hipblas"]
-openblas = ["hypr-transcribe-whisper-local/openblas"]
-metal = ["hypr-transcribe-whisper-local/metal"]
-vulkan = ["hypr-transcribe-whisper-local/vulkan"]
-openmp = ["hypr-transcribe-whisper-local/openmp"]
-load-dynamic = ["hypr-transcribe-whisper-local/load-dynamic"]
+whisper-cpp = ["dep:hypr-transcribe-whisper-local", "dep:hypr-whisper-local"]
+coreml = ["whisper-cpp", "hypr-transcribe-whisper-local/coreml", "hypr-transcribe-moonshine/coreml"]
+directml = ["whisper-cpp", "hypr-transcribe-whisper-local/directml", "hypr-transcribe-moonshine/directml"]
+cuda = ["whisper-cpp", "hypr-transcribe-whisper-local/cuda", "hypr-transcribe-moonshine/cuda"]
+hipblas = ["whisper-cpp", "hypr-transcribe-whisper-local/hipblas"]
+openblas = ["whisper-cpp", "hypr-transcribe-whisper-local/openblas"]
+metal = ["whisper-cpp", "hypr-transcribe-whisper-local/metal"]
+vulkan = ["whisper-cpp", "hypr-transcribe-whisper-local/vulkan"]
+openmp = ["whisper-cpp", "hypr-transcribe-whisper-local/openmp"]
+load-dynamic = ["whisper-cpp", "hypr-transcribe-whisper-local/load-dynamic"]
 
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
@@ -43,8 +44,9 @@ hypr-file = { workspace = true }
 hypr-host = { workspace = true }
 hypr-language = { workspace = true, features = ["whisper"] }
 hypr-transcribe-moonshine = { workspace = true }
-hypr-transcribe-whisper-local = { workspace = true }
-hypr-whisper-local = { workspace = true }
+
+hypr-transcribe-whisper-local = { workspace = true, optional = true }
+hypr-whisper-local = { workspace = true, optional = true }
 hypr-whisper-local-model = { workspace = true }
 
 owhisper-client = { workspace = true }

--- a/plugins/local-stt/src/ext.rs
+++ b/plugins/local-stt/src/ext.rs
@@ -10,9 +10,11 @@ use tauri_plugin_sidecar2::Sidecar2PluginExt;
 use hypr_download_interface::DownloadProgress;
 use hypr_file::download_file_parallel_cancellable;
 
+#[cfg(feature = "whisper-cpp")]
+use crate::server::internal;
 use crate::{
     model::SupportedSttModel,
-    server::{ServerInfo, ServerStatus, ServerType, external, internal, supervisor},
+    server::{ServerInfo, ServerStatus, ServerType, external, supervisor},
     types::DownloadProgressPayload,
 };
 
@@ -78,8 +80,16 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
             SupportedSttModel::Whisper(_) => ServerType::Internal,
         };
 
+        #[cfg(not(feature = "whisper-cpp"))]
+        if matches!(server_type, ServerType::Internal) {
+            return Err(crate::Error::UnsupportedModelType);
+        }
+
         let current_info = match server_type {
+            #[cfg(feature = "whisper-cpp")]
             ServerType::Internal => internal_health().await,
+            #[cfg(not(feature = "whisper-cpp"))]
+            ServerType::Internal => None,
             ServerType::External => external_health().await,
         };
 
@@ -106,6 +116,7 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
             .map_err(|e| crate::Error::ServerStopFailed(e.to_string()))?;
 
         match server_type {
+            #[cfg(feature = "whisper-cpp")]
             ServerType::Internal => {
                 let cache_dir = self.models_dir();
                 let whisper_model = match model {
@@ -115,6 +126,8 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
 
                 start_internal_server(&supervisor, cache_dir, whisper_model).await
             }
+            #[cfg(not(feature = "whisper-cpp"))]
+            ServerType::Internal => Err(crate::Error::UnsupportedModelType),
             ServerType::External => {
                 let data_dir = self.models_dir();
                 let am_model = match model {
@@ -149,11 +162,18 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
 
     #[tracing::instrument(skip_all)]
     pub async fn get_servers(&self) -> Result<HashMap<ServerType, ServerInfo>, crate::Error> {
+        #[cfg(feature = "whisper-cpp")]
         let internal_info = internal_health().await.unwrap_or(ServerInfo {
             url: None,
             status: ServerStatus::Unreachable,
             model: None,
         });
+        #[cfg(not(feature = "whisper-cpp"))]
+        let internal_info = ServerInfo {
+            url: None,
+            status: ServerStatus::Unreachable,
+            model: None,
+        };
 
         let external_info = external_health().await.unwrap_or(ServerInfo {
             url: None,
@@ -457,6 +477,7 @@ impl<R: Runtime, T: Manager<R>> LocalSttPluginExt<R> for T {
     }
 }
 
+#[cfg(feature = "whisper-cpp")]
 async fn start_internal_server(
     supervisor: &supervisor::SupervisorRef,
     cache_dir: PathBuf,
@@ -526,6 +547,7 @@ async fn start_external_server<R: Runtime, T: Manager<R>>(
         .ok_or_else(|| crate::Error::ServerStartFailed("empty_health".to_string()))
 }
 
+#[cfg(feature = "whisper-cpp")]
 async fn internal_health() -> Option<ServerInfo> {
     match registry::where_is(internal::InternalSTTActor::name()) {
         Some(cell) => {

--- a/plugins/local-stt/src/server/mod.rs
+++ b/plugins/local-stt/src/server/mod.rs
@@ -1,4 +1,5 @@
 pub mod external;
+#[cfg(feature = "whisper-cpp")]
 pub mod internal;
 pub mod supervisor;
 


### PR DESCRIPTION
## Summary
- Make `whisper-cpp` dependency optional via feature flag in `local-stt` plugin
- Remove quantized whisper models (QuantizedTinyEn, QuantizedSmallEn) from the settings UI
- Add conditional compilation throughout the codebase for whisper-cpp features

## Test plan
- [ ] Verify build without whisper-cpp feature
- [ ] Verify build with whisper-cpp feature enabled
- [ ] Check settings UI shows only supported models
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fastrepl/hyprnote/pull/3562">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
