### PR TITLE
Render changelog without extra empty paragraphs

### DIFF
--- a/apps/desktop/src/components/main/body/changelog/index.tsx
+++ b/apps/desktop/src/components/main/body/changelog/index.tsx
@@ -69,23 +69,6 @@ function fixImageUrls(content: string): string {
   );
 }
 
-function addEmptyParagraphsBeforeHeaders(
-  json: ReturnType<typeof md2json>,
-): ReturnType<typeof md2json> {
-  if (!json.content) return json;
-
-  const newContent: typeof json.content = [];
-  for (let i = 0; i < json.content.length; i++) {
-    const node = json.content[i];
-    if (node.type === "heading" && i > 0) {
-      newContent.push({ type: "paragraph" });
-    }
-    newContent.push(node);
-  }
-
-  return { ...json, content: newContent };
-}
-
 export const TabItemChangelog: TabItem<Extract<Tab, { type: "changelog" }>> = ({
   tab,
   tabIndex,


### PR DESCRIPTION
## Summary

Remove automatic insertion of empty paragraphs before headers when converting changelog markdown to JSON for the desktop app. This avoids introducing unwanted blank lines between sections in the rendered changelog UI and preserves the original markdown structure.

## Review & Testing Checklist for Human

- [ ] Open the changelog view in the desktop app and verify spacing between sections looks correct — removing the empty paragraphs could make sections appear too tightly packed if the original spacing relied on them
- [ ] Spot-check a few changelog entries with multiple headers in sequence (e.g., `## v1.2.0` immediately followed by `### Features`) to confirm no content collapses or merges unexpectedly

**Suggested test plan:** Run the desktop app locally (`ONBOARDING=0 pnpm -F desktop tauri dev`), open the changelog, and scroll through several releases comparing the rendered output against the raw markdown source.

### Notes

- [Link to Devin run](https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6)
- Requested by @ComputelessComputer