### PR TITLE
fix: add handler to remove empty session on tab close

### DIFF
--- a/apps/desktop/src/services/apple-calendar/process/utils.ts
+++ b/apps/desktop/src/services/apple-calendar/process/utils.ts
@@ -1,50 +1,6 @@
-import { json2md } from "@hypr/tiptap/shared";
-
 import type { Store } from "../../../store/tinybase/store/main";
 
-export function isSessionEmpty(store: Store, sessionId: string): boolean {
-  const session = store.getRow("sessions", sessionId);
-  if (!session) {
-    return true;
-  }
-
-  if (session.raw_md) {
-    let raw_md: string;
-    try {
-      raw_md = json2md(JSON.parse(session.raw_md));
-    } catch {
-      raw_md = session.raw_md;
-    }
-    if (raw_md.trim()) {
-      return false;
-    }
-  }
-
-  let hasEnhancedNotes = false;
-  store.forEachRow("enhanced_notes", (rowId, _forEachCell) => {
-    const note = store.getRow("enhanced_notes", rowId);
-    if (note?.session_id === sessionId) {
-      const content = note.content;
-      if (typeof content === "string" && content.trim()) {
-        hasEnhancedNotes = true;
-      }
-    }
-  });
-
-  if (hasEnhancedNotes) {
-    return false;
-  }
-
-  let hasTranscript = false;
-  store.forEachRow("transcripts", (rowId, _forEachCell) => {
-    const transcript = store.getRow("transcripts", rowId);
-    if (transcript?.session_id === sessionId) {
-      hasTranscript = true;
-    }
-  });
-
-  return !hasTranscript;
-}
+export { isSessionEmpty } from "../../../store/tinybase/store/sessions";
 
 export function getSessionForEvent(
   store: Store,

--- a/apps/desktop/src/store/tinybase/store/deleteSession.ts
+++ b/apps/desktop/src/store/tinybase/store/deleteSession.ts
@@ -1,5 +1,3 @@
-import { useCallback } from "react";
-
 import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 
 import type { DeletedSessionData } from "../../zustand/undo-delete";
@@ -234,17 +232,4 @@ export function deleteSessionCascade(
   }
 
   void fsSyncCommands.audioDelete(sessionId);
-}
-
-export function useDeleteSession() {
-  const store = main.UI.useStore(main.STORE_ID);
-  const indexes = main.UI.useIndexes(main.STORE_ID);
-
-  return useCallback(
-    (sessionId: string) => {
-      if (!store) return;
-      void deleteSessionCascade(store, indexes, sessionId);
-    },
-    [store, indexes],
-  );
 }

--- a/apps/desktop/src/store/tinybase/store/sessions.ts
+++ b/apps/desktop/src/store/tinybase/store/sessions.ts
@@ -1,4 +1,5 @@
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
+import { json2md } from "@hypr/tiptap/shared";
 
 import { DEFAULT_USER_ID } from "../../../utils";
 import { id } from "../../../utils";
@@ -52,4 +53,54 @@ export function getOrCreateSessionForEventId(
     has_event_id: true,
   });
   return sessionId;
+}
+
+export function isSessionEmpty(store: Store, sessionId: string): boolean {
+  const session = store.getRow("sessions", sessionId);
+  if (!session) {
+    return true;
+  }
+
+  // event sessions automatically have a title
+  // only consider titles if it does not have an event
+  if (session.title && session.title.trim() && !session.event_id) {
+    return false;
+  }
+
+  if (session.raw_md) {
+    let raw_md: string;
+    try {
+      raw_md = json2md(JSON.parse(session.raw_md));
+    } catch {
+      raw_md = session.raw_md;
+    }
+    if (raw_md.trim()) {
+      return false;
+    }
+  }
+
+  let hasEnhancedNotes = false;
+  store.forEachRow("enhanced_notes", (rowId, _forEachCell) => {
+    const note = store.getRow("enhanced_notes", rowId);
+    if (note?.session_id === sessionId) {
+      const content = note.content;
+      if (typeof content === "string" && content.trim()) {
+        hasEnhancedNotes = true;
+      }
+    }
+  });
+
+  if (hasEnhancedNotes) {
+    return false;
+  }
+
+  let hasTranscript = false;
+  store.forEachRow("transcripts", (rowId, _forEachCell) => {
+    const transcript = store.getRow("transcripts", rowId);
+    if (transcript?.session_id === sessionId) {
+      hasTranscript = true;
+    }
+  });
+
+  return !hasTranscript;
 }

--- a/apps/desktop/src/store/zustand/tabs/lifecycle.ts
+++ b/apps/desktop/src/store/zustand/tabs/lifecycle.ts
@@ -10,9 +10,9 @@ export type LifecycleState = {
 };
 
 export type LifecycleActions = {
-  registerOnClose: (handler: (tab: Tab) => void) => void;
-  registerOnEmpty: (handler: () => void) => void;
-  registerCanClose: (handler: (tab: Tab) => boolean) => void;
+  registerOnClose: (handler: ((tab: Tab) => void) | null) => void;
+  registerOnEmpty: (handler: (() => void) | null) => void;
+  registerCanClose: (handler: ((tab: Tab) => boolean) | null) => void;
   setPendingCloseConfirmationTab: (tab: Tab | null) => void;
 };
 


### PR DESCRIPTION
This is a follow up on #3559 and #3564.

The issue is that once the user open a event, without doing anything else, a session is automatically created.
To ignore such event, the user has to do a Remove Attached Note and then an Ignore Event, which is very confusing.

To fix this, this basically registers an onClose callback to the tab system, checks if the session is empty, and removes it on tab close.

I'm not satisfied with the solution: loading the main tinybase store and the index in `_layout` feels ugly. I wanted the `TabItemNote` or a `TabContentNote` to register a `onClose` callback to the tab system, so that it's responsible for cleaning up it's own session.

But for now, the tab zustand store doesn't have a method to register multiple callbacks, and I was not comfortable in overhauling the whole tab store into supporting those (I'm thinking of having an array of callbacks with ids ala addEventListener and so on) without asking you guys (and it's probably going to be a whole bunch of merge conflicts mess).

Open to feedback. btw, I removed `useDeleteSession` since it's not used anywhere.