### PR TITLE
feat(handbook): add new "Teams" section to company handbook

### DIFF
--- a/apps/web/content/handbook/teams/0.one-team.mdx
+++ b/apps/web/content/handbook/teams/0.one-team.mdx
@@ -1,0 +1,15 @@
+---
+title: "One Team"
+section: "Teams"
+summary: "We have many functions but one team — everyone works across boundaries."
+---
+
+We don't have separate departments. We have one team with many functions.
+
+Everyone at Hyprnote works cross-functionally. Engineers think about the user journey. Product people read the code. Marketers use the product daily. Growth is everyone's job.
+
+The pages in this section describe the mindset for each function — not separate teams, but different lenses through which the same team looks at the same problems. You'll wear multiple hats. That's the point.
+
+When you're writing code, think like the [Engineering](/company-handbook/teams/engineering/) page describes. When you're thinking about what to build next, think like the [Product](/company-handbook/teams/product/) page. When you're writing a blog post, think like [Content and Marketing](/company-handbook/teams/content-and-marketing/). When you're looking at the funnel, think like [Growth](/company-handbook/teams/growth/).
+
+One team. Many lenses. No silos.

--- a/apps/web/content/handbook/teams/1.engineering.mdx
+++ b/apps/web/content/handbook/teams/1.engineering.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Engineering"
-section: "How We Work"
+section: "Teams"
 summary: "Ship fast, own the full stack, use AI as a multiplier."
 ---
 

--- a/apps/web/content/handbook/teams/2.product.mdx
+++ b/apps/web/content/handbook/teams/2.product.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Product"
-section: "How We Work"
+section: "Teams"
 summary: "Obsess over the user journey, have strong taste, reduce cognitive load."
 ---
 

--- a/apps/web/content/handbook/teams/3.content-and-marketing.mdx
+++ b/apps/web/content/handbook/teams/3.content-and-marketing.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Content and Marketing"
-section: "How We Work"
+section: "Teams"
 summary: "Be genuinely helpful, build in public, own the channels."
 ---
 

--- a/apps/web/content/handbook/teams/4.growth.mdx
+++ b/apps/web/content/handbook/teams/4.growth.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Growth"
-section: "How We Work"
+section: "Teams"
 summary: "Product-led, bottoms-up — reduce friction everywhere in the user journey."
 ---
 

--- a/apps/web/src/routes/_view/company-handbook/-structure.ts
+++ b/apps/web/src/routes/_view/company-handbook/-structure.ts
@@ -2,6 +2,7 @@ export const handbookStructure = {
   sections: [
     "about",
     "how-we-work",
+    "teams",
     "who-we-want",
     "go-to-market",
     "communication",
@@ -9,6 +10,7 @@ export const handbookStructure = {
   sectionTitles: {
     about: "About",
     "how-we-work": "How We Work",
+    teams: "Teams",
     "who-we-want": "Who We Want",
     "go-to-market": "Go To Market",
     communication: "Communication",
@@ -16,6 +18,7 @@ export const handbookStructure = {
   defaultPages: {
     about: "about/what-hyprnote-is",
     "how-we-work": "how-we-work/work-styles",
+    teams: "teams/one-team",
     "who-we-want": "who-we-want/core-traits",
     "go-to-market": "go-to-market/customers",
     communication: "communication/how-we-communicate",


### PR DESCRIPTION
## Summary

Adds a new "Teams" section to the company handbook, documenting team structure and organization for reference by current and new team members.

## Review & Testing Checklist for Human

- [ ] Read through the Teams content for factual accuracy — confirm the described teams, roles, and responsibilities match the current org structure
- [ ] Verify the handbook page renders correctly in the web app (heading hierarchy, formatting, no broken markdown)
- [ ] Check that all links within the new section resolve correctly (no 404s)

**Suggested test plan:** Open the handbook in the web app deploy preview and navigate to the new Teams section. Verify all content renders correctly and is factually accurate.

### Notes

- Content-only change — no logic or functional modifications.
- [Link to Devin run](https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6)
- Requested by @ComputelessComputer