### PR TITLE
feat(ui): center align content in github open source section

### DIFF
--- a/apps/web/src/components/github-open-source.tsx
+++ b/apps/web/src/components/github-open-source.tsx
@@ -251,7 +251,7 @@ function OpenSourceButton({
     n > 1000 ? `${(n / 1000).toFixed(1)}k` : n;
 
   return (
-    <div className="text-center flex flex-col gap-4 w-full max-w-md mx-auto">
+    <div className="text-center flex flex-col items-center gap-4 w-full max-w-md mx-auto">
       <h2 className="text-2xl font-serif text-stone-600">Open source</h2>
       <p className="text-neutral-600">
         {


### PR DESCRIPTION
## Summary

Centers the content alignment in the GitHub open source section of the web landing page for improved visual consistency.

## Review & Testing Checklist for Human

- [ ] Check the GitHub open source section on the landing page at various viewport widths (mobile, tablet, desktop) to confirm content is properly centered with no overflow or clipping

### Notes

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer