### PR TITLE
feat(footer): add line break for better readability in meetings text

### DIFF
--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -59,7 +59,8 @@ function BrandSection({ currentYear }: { currentYear: number }) {
       </Link>
       <p className="text-sm text-neutral-500 mb-4">Fastrepl © {currentYear}</p>
       <p className="text-sm text-neutral-600 mb-3">
-        Are you in back-to-back meetings?{" "}
+        Are you in back-to-back meetings?
+        <br />
         <Link
           to="/auth/"
           className="text-neutral-600 hover:text-stone-600 transition-colors underline decoration-solid"


### PR DESCRIPTION
## Summary

Adds a line break in the footer's meetings-related text to improve readability and visual flow.

## Review & Testing Checklist for Human

- [ ] Check the footer text on both desktop and mobile viewports to confirm the line break doesn't cause awkward wrapping or layout issues at various screen widths

### Notes

- Cosmetic-only change; no logic or functional impact.

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer