### PR TITLE
fix: add missing timelineEvents query types

### DIFF
--- a/apps/desktop/src/store/tinybase/store/main.ts
+++ b/apps/desktop/src/store/tinybase/store/main.ts
@@ -398,6 +398,8 @@ interface _QueryResultRows {
     ended_at: string;
     calendar_id: string;
     recurrence_series_id: string;
+    ignored: boolean;
+    is_all_day: boolean;
   };
   timelineSessions: {
     title: string;


### PR DESCRIPTION
## Summary
- Add missing `ignored` and `is_all_day` fields to `timelineEvents` query result type
- These fields were selected in the query definition but not included in the `_QueryResultRows` type, causing typecheck failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)