### PR TITLE
fix: apply timestamp offset when exporting multi-transcript sessions

### DIFF
--- a/apps/desktop/src/components/main/body/sessions/outer-header/overflow/export-pdf.tsx
+++ b/apps/desktop/src/components/main/body/sessions/outer-header/overflow/export-pdf.tsx
@@ -150,13 +150,22 @@ export function ExportPDF({
       channel: number;
     }> = [];
 
-    const firstStartedAt = store.getCell("transcripts", transcriptIds[0], "started_at");
+    const firstStartedAt = store.getCell(
+      "transcripts",
+      transcriptIds[0],
+      "started_at",
+    );
 
     for (const transcriptId of transcriptIds) {
-      const startedAt = store.getCell("transcripts", transcriptId, "started_at");
-      const offset = typeof startedAt === "number" && typeof firstStartedAt === "number"
-        ? startedAt - firstStartedAt
-        : 0;
+      const startedAt = store.getCell(
+        "transcripts",
+        transcriptId,
+        "started_at",
+      );
+      const offset =
+        typeof startedAt === "number" && typeof firstStartedAt === "number"
+          ? startedAt - firstStartedAt
+          : 0;
 
       const words = parseTranscriptWords(store, transcriptId);
       for (const word of words) {

--- a/apps/desktop/src/components/main/body/sessions/outer-header/overflow/export-transcript.tsx
+++ b/apps/desktop/src/components/main/body/sessions/outer-header/overflow/export-transcript.tsx
@@ -45,13 +45,22 @@ export function ExportTranscript({ sessionId }: { sessionId: string }) {
       channel: number;
     }> = [];
 
-    const firstStartedAt = store.getCell("transcripts", transcriptIds[0], "started_at");
+    const firstStartedAt = store.getCell(
+      "transcripts",
+      transcriptIds[0],
+      "started_at",
+    );
 
     for (const transcriptId of transcriptIds) {
-      const startedAt = store.getCell("transcripts", transcriptId, "started_at");
-      const offset = typeof startedAt === "number" && typeof firstStartedAt === "number"
-        ? startedAt - firstStartedAt
-        : 0;
+      const startedAt = store.getCell(
+        "transcripts",
+        transcriptId,
+        "started_at",
+      );
+      const offset =
+        typeof startedAt === "number" && typeof firstStartedAt === "number"
+          ? startedAt - firstStartedAt
+          : 0;
 
       const words = parseTranscriptWords(store, transcriptId);
       for (const word of words) {


### PR DESCRIPTION
## Problem

When a recording is interrupted and resumed within the same session (e.g., due to network issues or manual stop/start), each new "Start Listening" creates a separate transcript with word timestamps relative to its own start time (both starting near 0ms).

When exporting (VTT or PDF), all words from all transcripts are merged into a single array and sorted by `start_ms`. Since multiple transcripts share the same timestamp range (0ms → duration), words from different recordings get **interleaved** rather than appearing sequentially.

**Example with real data:**
- Transcript 1: 8,388 words, timestamps 0–34.5 min
- Transcript 2: 3,911 words, timestamps 0–17.3 min (recorded ~57 min after T1)
- Exported VTT: all 12,299 words present, but T2 words mixed into T1's first 17 minutes

The in-app transcript display is **not affected** because it renders each transcript independently via `transcriptIds.map()`.

## Solution

Before merging words from multiple transcripts, calculate a timestamp offset for each transcript based on:
```
offset = transcript.started_at - firstTranscript.started_at
```

Apply this offset to each word's `start_ms` and `end_ms` before sorting. This ensures words from later recordings appear after words from earlier recordings, matching their actual chronological order.

The fix is applied to both export paths:
- `export-transcript.tsx` (VTT export)
- `export-pdf.tsx` (PDF export)

For single-transcript sessions, offset = 0 (no behavior change).

## Testing

Tested with a real session containing two transcripts (34.5 min + 17.3 min, 57 min gap between recordings):

| | Before | After |
|---|---|---|
| T1 range | 00:00 – 34:25 | 00:00 – 34:25 |
| T2 range | 00:00 – 17:19 (interleaved with T1) | 57:19 – 01:14:38 |
| Last word | "да" (T1) | "собираюсь." (T2) |
| Duplicates | Words from both sessions in first 17 min | None |

**Environment:** App Version 1.0.5-nightly.1, macOS (Apple Silicon)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fastrepl/hyprnote/pull/3800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
