### PR TITLE
Add dev docs link to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,7 @@ alwaysApply: true
 - Do not create summary docs or example code file if not requested. Plan is ok.
 - If there are many classNames and they have conditional logic, use `cn` (import it with `import { cn } from "@hypr/utils"`). It is similar to `clsx`. Always pass an array. Split by logical grouping.
 - Use `motion/react` instead of `framer-motion`.
+
+# Dev Docs
+
+https://hyprnote.com/docs/developers


### PR DESCRIPTION
## Summary
- Add a link to the developer docs (https://hyprnote.com/docs/developers) in AGENTS.md

## Rationale
Without this reference, AI agents have no way to discover setup instructions and fail to build the project. For example, the `@hypr/ui` package requires a build step (`pnpm -F ui build`) before the desktop app can run, but nothing in AGENTS.md or CLAUDE.md pointed to the docs where this is documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)