### PR TITLE
refactor(tiptap): simplify first block selection check

### DIFF
--- a/packages/tiptap/src/editor/index.tsx
+++ b/packages/tiptap/src/editor/index.tsx
@@ -93,17 +93,17 @@ const Editor = forwardRef<{ editor: TiptapEditor | null }, EditorProps>(
           const isAtStart = state.selection.$head.pos === 0;
 
           const $head = state.selection.$head;
-          const depth = $head.depth;
           let isInFirstBlock = false;
 
-          for (let d = depth; d > 0; d--) {
-            const node = $head.node(d);
-            if (node.type.name === "doc") continue;
-            const parentNode = $head.node(d - 1);
-            if (parentNode.type.name === "doc") {
-              isInFirstBlock = parentNode.firstChild === node;
-              break;
-            }
+          let node = state.doc.firstChild;
+          let firstTextBlockPos = 0;
+          while (node && !node.isTextblock) {
+            firstTextBlockPos += 1;
+            node = node.firstChild;
+          }
+
+          if (node) {
+            isInFirstBlock = $head.start($head.depth) === firstTextBlockPos + 1;
           }
 
           if (


### PR DESCRIPTION
## Summary

- Simplified the first block selection check in the Tiptap extension
- Improved code readability and reduced complexity of block selection logic

## Review & Testing Checklist for Human

- [ ] Verify text selection behavior in the editor still works correctly — click to place cursor, drag to select text, and shift-click to extend selection across multiple blocks
- [ ] Confirm that selecting the very first block in the editor (empty and non-empty documents) behaves as expected with no regressions

### Notes

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fastrepl/hyprnote/pull/3842" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->