### PR TITLE
Notify Slack only on review submission and remove Merge button

### DIFF
--- a/.github/workflows/blog-slack-notify.yml
+++ b/.github/workflows/blog-slack-notify.yml
@@ -160,7 +160,7 @@ jobs:
             }
 
       - name: Notify Slack (Regular)
-        if: steps.changed-files.outputs.has_files == 'true' && steps.unpublish-check.outputs.is_unpublish != 'true'
+        if: steps.changed-files.outputs.has_files == 'true' && steps.unpublish-check.outputs.is_unpublish != 'true' && steps.review-status.outputs.ready_for_review == 'true'
         uses: slackapi/slack-github-action@v2.0.0
         with:
           method: chat.postMessage
@@ -168,16 +168,16 @@ jobs:
           payload: |
             {
               "channel": "${{ secrets.SLACK_BLOG_CHANNEL_ID }}",
-              "text": "${{ steps.review-status.outputs.ready_for_review == 'true' && format('Article submitted for review: {0}', steps.article-info.outputs.title) || (steps.article-info.outputs.is_edit == 'true' && format('{0} made changes to {1}', steps.article-info.outputs.slack_user, steps.article-info.outputs.title) || format('{0} is ready to publish: {1}', steps.article-info.outputs.slack_user, steps.article-info.outputs.title)) }}",
+              "text": "Article submitted for review: ${{ steps.article-info.outputs.title }}",
               "attachments": [
                 {
-                  "color": "${{ steps.review-status.outputs.ready_for_review == 'true' && '#3b82f6' || '#2eb886' }}",
+                  "color": "#3b82f6",
                   "blocks": [
                     {
                       "type": "section",
                       "text": {
                         "type": "mrkdwn",
-                        "text": "${{ steps.review-status.outputs.ready_for_review == 'true' && format('👀 *Article submitted for review*\n<@U08PVBSGL31> please review\n\n>*{0}*', steps.article-info.outputs.title) || (steps.article-info.outputs.is_edit == 'true' && format('✏️ {0} made changes to *{1}*', steps.article-info.outputs.slack_user, steps.article-info.outputs.title) || format('🚀 {0} is ready to publish a new article: *{1}*', steps.article-info.outputs.slack_user, steps.article-info.outputs.title)) }}"
+                        "text": "👀 *Article submitted for review*\n<@U08PVBSGL31> please review\n\n>*${{ steps.article-info.outputs.title }}*"
                       }
                     },
                     {
@@ -209,17 +209,6 @@ jobs:
                             "emoji": true
                           },
                           "url": "${{ github.event.pull_request.html_url }}",
-                          "style": "primary"
-                        },
-                        {
-                          "type": "button",
-                          "text": {
-                            "type": "plain_text",
-                            "text": "Merge",
-                            "emoji": true
-                          },
-                          "action_id": "merge_pr",
-                          "value": "${{ github.event.pull_request.number }}",
                           "style": "primary"
                         }
                       ]

--- a/apps/web/src/routes/admin/README.md
+++ b/apps/web/src/routes/admin/README.md
@@ -60,10 +60,7 @@ Complete flow from editing to publication:
 
 **3. GitHub Actions Trigger**
 - `blog-grammar-check.yml` - Runs AI grammar check, posts suggestions as PR comment
-- `blog-slack-notify.yml` - Sends Slack notification (green border):
-  ```
-  ✏️ @user made changes to *Article Title*
-  ```
+- `blog-slack-notify.yml` - No notification sent (waiting for review submission)
 
 **4. User Continues Editing (Optional)**
 - Each "Save" updates the same PR branch
@@ -74,11 +71,13 @@ Complete flow from editing to publication:
 - Adds `ComputelessComputer` as PR reviewer
 
 **6. GitHub Actions Trigger Again**
-- Slack notification changes to (blue border):
+- Slack notification sent (blue border):
   ```
   👀 *Article submitted for review*
   @john please review
   ```
+  - Includes "Preview" and "View PR" buttons
+  - No "Merge" button (merge through GitHub interface)
 
 **7. Reviewer Merges PR**
 - Article goes live on the website
@@ -87,7 +86,7 @@ Complete flow from editing to publication:
 
 | Action | `ready_for_review` | Slack Message | Border |
 |--------|-------------------|---------------|--------|
-| Save | `false` | "✏️ made changes" | Green |
+| Save | `false` | No notification | - |
 | Submit for Review | `true` | "👀 submitted for review" @john | Blue |
 
 ## API Endpoints


### PR DESCRIPTION
## Summary

Only send Slack notifications when an article is submitted for review (`ready_for_review == true`) and remove the "Merge" button from the Slack message. This avoids noisy notifications on every save/edit and prevents offering a merge action from Slack — merging should be done via the GitHub UI.

Changes:
- Added review-status check to the Notify Slack step condition so messages are only sent on submission for review.
- Replaced dynamic message text with a fixed "Article submitted for review" message and adjusted attachment color to the review color.
- Removed the "Merge" button from the Slack message attachments.
- Updated admin README to reflect that no notification is sent on save and to document the new review notification behavior and removed merge action.

## Review & Testing Checklist for Human

- [ ] Verify the `ready_for_review` field name and expected value (`true`) match what the admin UI actually sends — if the field name or shape differs, notifications will be silently suppressed for all submissions
- [ ] Test the end-to-end flow: save a draft (should NOT trigger Slack), then submit for review (should trigger Slack with the new fixed message and no Merge button)
- [ ] Confirm the Slack message renders correctly (attachment color, text, and absence of Merge button)

### Notes

- Low-risk change: scoped to notification filtering and message formatting. No data model or business logic changes.

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fastrepl/hyprnote/pull/3872" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->