### PR TITLE
feat: granular notification controls

### DIFF
--- a/apps/desktop/src/components/settings/general/notification.tsx
+++ b/apps/desktop/src/components/settings/general/notification.tsx
@@ -11,6 +11,7 @@ import {
 import { commands as notificationCommands } from "@hypr/plugin-notification";
 import { Badge } from "@hypr/ui/components/ui/badge";
 import { Button } from "@hypr/ui/components/ui/button";
+import { Input } from "@hypr/ui/components/ui/input";
 import { Switch } from "@hypr/ui/components/ui/switch";
 import { cn } from "@hypr/utils";
 
@@ -29,6 +30,10 @@ export function NotificationSettingsView() {
     "notification_detect",
     "respect_dnd",
     "ignored_platforms",
+    "event_notify_before_minutes",
+    "event_notification_timeout_secs",
+    "mic_detection_delay_secs",
+    "mic_notification_timeout_secs",
   ] as const);
 
   useEffect(() => {
@@ -101,12 +106,44 @@ export function NotificationSettingsView() {
     settings.STORE_ID,
   );
 
+  const handleSetEventNotifyBeforeMinutes = settings.UI.useSetValueCallback(
+    "event_notify_before_minutes",
+    (value: number) => value,
+    [],
+    settings.STORE_ID,
+  );
+
+  const handleSetEventNotificationTimeoutSecs = settings.UI.useSetValueCallback(
+    "event_notification_timeout_secs",
+    (value: number) => value,
+    [],
+    settings.STORE_ID,
+  );
+
+  const handleSetMicDetectionDelaySecs = settings.UI.useSetValueCallback(
+    "mic_detection_delay_secs",
+    (value: number) => value,
+    [],
+    settings.STORE_ID,
+  );
+
+  const handleSetMicNotificationTimeoutSecs = settings.UI.useSetValueCallback(
+    "mic_notification_timeout_secs",
+    (value: number) => value,
+    [],
+    settings.STORE_ID,
+  );
+
   const form = useForm({
     defaultValues: {
       notification_event: configs.notification_event,
       notification_detect: configs.notification_detect,
       respect_dnd: configs.respect_dnd,
       ignored_platforms: configs.ignored_platforms.map(bundleIdToName),
+      event_notify_before_minutes: configs.event_notify_before_minutes,
+      event_notification_timeout_secs: configs.event_notification_timeout_secs,
+      mic_detection_delay_secs: configs.mic_detection_delay_secs,
+      mic_notification_timeout_secs: configs.mic_notification_timeout_secs,
     },
     listeners: {
       onChange: async ({ formApi }) => {
@@ -120,6 +157,12 @@ export function NotificationSettingsView() {
       handleSetIgnoredPlatforms(
         JSON.stringify(value.ignored_platforms.map(nameToBundleId)),
       );
+      handleSetEventNotifyBeforeMinutes(value.event_notify_before_minutes);
+      handleSetEventNotificationTimeoutSecs(
+        value.event_notification_timeout_secs,
+      );
+      handleSetMicDetectionDelaySecs(value.mic_detection_delay_secs);
+      handleSetMicNotificationTimeoutSecs(value.mic_notification_timeout_secs);
     },
   });
 
@@ -220,17 +263,68 @@ export function NotificationSettingsView() {
     <div className="flex flex-col gap-6">
       <form.Field name="notification_event">
         {(field) => (
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex-1">
-              <h3 className="mb-1 text-sm font-medium">Event notifications</h3>
-              <p className="text-xs text-neutral-600">
-                Get notified 5 minutes before calendar events start
-              </p>
+          <div className="flex flex-col gap-4">
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex-1">
+                <h3 className="mb-1 text-sm font-medium">
+                  Event notifications
+                </h3>
+                <p className="text-xs text-neutral-600">
+                  Get notified before calendar events start
+                </p>
+              </div>
+              <Switch
+                checked={field.state.value}
+                onCheckedChange={field.handleChange}
+              />
             </div>
-            <Switch
-              checked={field.state.value}
-              onCheckedChange={field.handleChange}
-            />
+
+            {field.state.value && (
+              <div
+                className={cn([
+                  "ml-6 border-l-2 border-muted pl-6 flex flex-col gap-3",
+                ])}
+              >
+                <form.Field name="event_notify_before_minutes">
+                  {(subField) => (
+                    <div className="flex items-center justify-between gap-4">
+                      <span className="text-xs text-neutral-600">
+                        Minutes before event
+                      </span>
+                      <Input
+                        type="number"
+                        min={1}
+                        max={60}
+                        className="w-20 h-7 text-xs"
+                        value={subField.state.value}
+                        onChange={(e) =>
+                          subField.handleChange(Number(e.target.value))
+                        }
+                      />
+                    </div>
+                  )}
+                </form.Field>
+                <form.Field name="event_notification_timeout_secs">
+                  {(subField) => (
+                    <div className="flex items-center justify-between gap-4">
+                      <span className="text-xs text-neutral-600">
+                        Auto-dismiss after (seconds)
+                      </span>
+                      <Input
+                        type="number"
+                        min={0}
+                        max={300}
+                        className="w-20 h-7 text-xs"
+                        value={subField.state.value}
+                        onChange={(e) =>
+                          subField.handleChange(Number(e.target.value))
+                        }
+                      />
+                    </div>
+                  )}
+                </form.Field>
+              </div>
+            )}
           </div>
         )}
       </form.Field>
@@ -255,7 +349,51 @@ export function NotificationSettingsView() {
             </div>
 
             {field.state.value && (
-              <div className={cn(["ml-6 border-l-2 border-muted pl-6 pt-2"])}>
+              <div
+                className={cn([
+                  "ml-6 border-l-2 border-muted pl-6 pt-2 flex flex-col gap-4",
+                ])}
+              >
+                <div className="flex flex-col gap-3">
+                  <form.Field name="mic_detection_delay_secs">
+                    {(subField) => (
+                      <div className="flex items-center justify-between gap-4">
+                        <span className="text-xs text-neutral-600">
+                          Detection delay (seconds)
+                        </span>
+                        <Input
+                          type="number"
+                          min={0}
+                          max={600}
+                          className="w-20 h-7 text-xs"
+                          value={subField.state.value}
+                          onChange={(e) =>
+                            subField.handleChange(Number(e.target.value))
+                          }
+                        />
+                      </div>
+                    )}
+                  </form.Field>
+                  <form.Field name="mic_notification_timeout_secs">
+                    {(subField) => (
+                      <div className="flex items-center justify-between gap-4">
+                        <span className="text-xs text-neutral-600">
+                          Auto-dismiss after (seconds)
+                        </span>
+                        <Input
+                          type="number"
+                          min={0}
+                          max={300}
+                          className="w-20 h-7 text-xs"
+                          value={subField.state.value}
+                          onChange={(e) =>
+                            subField.handleChange(Number(e.target.value))
+                          }
+                        />
+                      </div>
+                    )}
+                  </form.Field>
+                </div>
                 <div className="mb-3 flex flex-col gap-1">
                   <h4 className="text-sm font-medium">
                     Exclude apps from detection

--- a/apps/desktop/src/components/settings/lab/index.tsx
+++ b/apps/desktop/src/components/settings/lab/index.tsx
@@ -5,11 +5,7 @@ import { arch, platform } from "@tauri-apps/plugin-os";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
 import { commands as windowsCommands } from "@hypr/plugin-windows";
 import { Button } from "@hypr/ui/components/ui/button";
-import { Switch } from "@hypr/ui/components/ui/switch";
 import { cn } from "@hypr/utils";
-
-import { useConfigValue } from "../../../config/use-config";
-import * as settings from "../../../store/tinybase/store/settings";
 
 export function SettingsLab() {
   const handleOpenControlWindow = async () => {
@@ -30,35 +26,7 @@ export function SettingsLab() {
         </Button>
       </div>
 
-      <MeetingReminderToggle />
-
       <DownloadButtons />
-    </div>
-  );
-}
-
-function MeetingReminderToggle() {
-  const value = useConfigValue("notification_in_meeting_reminder");
-  const setValue = settings.UI.useSetValueCallback(
-    "notification_in_meeting_reminder",
-    (value: boolean) => value,
-    [],
-    settings.STORE_ID,
-  );
-
-  return (
-    <div className="flex items-center justify-between gap-4">
-      <div className="flex-1">
-        <h3 className="text-sm font-medium mb-1">In-Meeting Reminder</h3>
-        <p className="text-xs text-neutral-600">
-          Get nudged when a meeting app is using your mic without Hyprnote
-          recording.
-        </p>
-      </div>
-      <Switch
-        checked={value}
-        onCheckedChange={(checked) => setValue(checked)}
-      />
     </div>
   );
 }

--- a/apps/desktop/src/config/registry.ts
+++ b/apps/desktop/src/config/registry.ts
@@ -22,7 +22,10 @@ export type ConfigKey =
   | "current_llm_model"
   | "timezone"
   | "week_start"
-  | "notification_in_meeting_reminder";
+  | "event_notify_before_minutes"
+  | "event_notification_timeout_secs"
+  | "mic_detection_delay_secs"
+  | "mic_notification_timeout_secs";
 
 type ConfigValueType<K extends ConfigKey> =
   (typeof CONFIG_REGISTRY)[K]["default"];
@@ -153,8 +156,26 @@ export const CONFIG_REGISTRY = {
     default: undefined as "sunday" | "monday" | undefined,
   },
 
-  notification_in_meeting_reminder: {
-    key: "notification_in_meeting_reminder",
-    default: true,
+  event_notify_before_minutes: {
+    key: "event_notify_before_minutes",
+    default: 5,
+  },
+
+  event_notification_timeout_secs: {
+    key: "event_notification_timeout_secs",
+    default: 30,
+  },
+
+  mic_detection_delay_secs: {
+    key: "mic_detection_delay_secs",
+    default: 0,
+    sideEffect: async (value: number, _) => {
+      await detectCommands.setMicDetectionDelay(value);
+    },
+  },
+
+  mic_notification_timeout_secs: {
+    key: "mic_notification_timeout_secs",
+    default: 8,
   },
 } satisfies Record<ConfigKey, ConfigDefinition>;

--- a/apps/desktop/src/store/tinybase/persister/settings/transform.ts
+++ b/apps/desktop/src/store/tinybase/persister/settings/transform.ts
@@ -77,6 +77,14 @@ function settingsToStoreValues(settings: unknown): Record<string, unknown> {
         value = getByPath(settings, ["general", "ai_language"]);
       } else if (key === "spoken_languages") {
         value = getByPath(settings, ["general", "spoken_languages"]);
+      } else if (key === "mic_detection_delay_secs") {
+        const legacy = getByPath(settings, [
+          "notification",
+          "in_meeting_reminder",
+        ]);
+        if (legacy === true) {
+          value = 180;
+        }
       }
     }
 

--- a/apps/desktop/src/store/tinybase/store/settings.ts
+++ b/apps/desktop/src/store/tinybase/store/settings.ts
@@ -69,9 +69,21 @@ export const SETTINGS_MAPPING = {
       type: "string",
       path: ["general", "week_start"],
     },
-    notification_in_meeting_reminder: {
-      type: "boolean",
-      path: ["notification", "in_meeting_reminder"],
+    event_notify_before_minutes: {
+      type: "number",
+      path: ["notification", "event_notify_before_minutes"],
+    },
+    event_notification_timeout_secs: {
+      type: "number",
+      path: ["notification", "event_notification_timeout_secs"],
+    },
+    mic_detection_delay_secs: {
+      type: "number",
+      path: ["notification", "mic_detection_delay_secs"],
+    },
+    mic_notification_timeout_secs: {
+      type: "number",
+      path: ["notification", "mic_notification_timeout_secs"],
     },
   },
   tables: {

--- a/plugins/detect/js/bindings.gen.ts
+++ b/plugins/detect/js/bindings.gen.ts
@@ -61,6 +61,14 @@ async getCurrentLocaleIdentifier() : Promise<Result<string, string>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async setMicDetectionDelay(secs: number) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:detect|set_mic_detection_delay", { secs }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 
@@ -79,7 +87,7 @@ detectEvent: "plugin:detect:detect-event"
 
 /** user-defined types **/
 
-export type DetectEvent = { type: "micStarted"; key: string; apps: InstalledApp[] } | { type: "micStopped"; apps: InstalledApp[] } | { type: "micMuted"; value: boolean } | { type: "sleepStateChanged"; value: boolean } | { type: "micProlongedUsage"; key: string; app: InstalledApp; duration_secs: number }
+export type DetectEvent = { type: "micDetected"; key: string; apps: InstalledApp[]; duration_secs: number } | { type: "micStopped"; apps: InstalledApp[] } | { type: "micMuted"; value: boolean } | { type: "sleepStateChanged"; value: boolean }
 export type InstalledApp = { id: string; name: string }
 
 /** tauri-specta globals **/

--- a/plugins/detect/permissions/autogenerated/commands/set_mic_detection_delay.toml
+++ b/plugins/detect/permissions/autogenerated/commands/set_mic_detection_delay.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-set-mic-detection-delay"
+description = "Enables the set_mic_detection_delay command without any pre-configured scope."
+commands.allow = ["set_mic_detection_delay"]
+
+[[permission]]
+identifier = "deny-set-mic-detection-delay"
+description = "Denies the set_mic_detection_delay command without any pre-configured scope."
+commands.deny = ["set_mic_detection_delay"]

--- a/plugins/detect/permissions/autogenerated/reference.md
+++ b/plugins/detect/permissions/autogenerated/reference.md
@@ -11,6 +11,7 @@ Default permissions for the plugin
 - `allow-list-default-ignored-bundle-ids`
 - `allow-get-preferred-languages`
 - `allow-get-current-locale-identifier`
+- `allow-set-mic-detection-delay`
 
 ## Permission Table
 
@@ -199,6 +200,32 @@ Enables the set_ignored_bundle_ids command without any pre-configured scope.
 <td>
 
 Denies the set_ignored_bundle_ids command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`detect:allow-set-mic-detection-delay`
+
+</td>
+<td>
+
+Enables the set_mic_detection_delay command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`detect:deny-set-mic-detection-delay`
+
+</td>
+<td>
+
+Denies the set_mic_detection_delay command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/detect/permissions/default.toml
+++ b/plugins/detect/permissions/default.toml
@@ -8,4 +8,5 @@ permissions = [
     "allow-list-default-ignored-bundle-ids",
     "allow-get-preferred-languages",
     "allow-get-current-locale-identifier",
+    "allow-set-mic-detection-delay",
 ]

--- a/plugins/detect/permissions/schemas/schema.json
+++ b/plugins/detect/permissions/schemas/schema.json
@@ -379,6 +379,18 @@
           "markdownDescription": "Denies the set_ignored_bundle_ids command without any pre-configured scope."
         },
         {
+          "description": "Enables the set_mic_detection_delay command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-set-mic-detection-delay",
+          "markdownDescription": "Enables the set_mic_detection_delay command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_mic_detection_delay command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-set-mic-detection-delay",
+          "markdownDescription": "Denies the set_mic_detection_delay command without any pre-configured scope."
+        },
+        {
           "description": "Enables the set_quit_handler command without any pre-configured scope.",
           "type": "string",
           "const": "allow-set-quit-handler",
@@ -403,10 +415,10 @@
           "markdownDescription": "Denies the set_respect_do_not_disturb command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-list-installed-applications`\n- `allow-list-mic-using-applications`\n- `allow-set-respect-do-not-disturb`\n- `allow-set-ignored-bundle-ids`\n- `allow-list-default-ignored-bundle-ids`\n- `allow-get-preferred-languages`\n- `allow-get-current-locale-identifier`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-list-installed-applications`\n- `allow-list-mic-using-applications`\n- `allow-set-respect-do-not-disturb`\n- `allow-set-ignored-bundle-ids`\n- `allow-list-default-ignored-bundle-ids`\n- `allow-get-preferred-languages`\n- `allow-get-current-locale-identifier`\n- `allow-set-mic-detection-delay`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-list-installed-applications`\n- `allow-list-mic-using-applications`\n- `allow-set-respect-do-not-disturb`\n- `allow-set-ignored-bundle-ids`\n- `allow-list-default-ignored-bundle-ids`\n- `allow-get-preferred-languages`\n- `allow-get-current-locale-identifier`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-list-installed-applications`\n- `allow-list-mic-using-applications`\n- `allow-set-respect-do-not-disturb`\n- `allow-set-ignored-bundle-ids`\n- `allow-list-default-ignored-bundle-ids`\n- `allow-get-preferred-languages`\n- `allow-get-current-locale-identifier`\n- `allow-set-mic-detection-delay`"
         }
       ]
     }

--- a/plugins/detect/src/commands.rs
+++ b/plugins/detect/src/commands.rs
@@ -44,6 +44,16 @@ pub(crate) async fn set_respect_do_not_disturb<R: tauri::Runtime>(
     Ok(())
 }
 
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn set_mic_detection_delay<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    secs: u64,
+) -> Result<(), String> {
+    app.detect().set_mic_detection_delay(secs);
+    Ok(())
+}
+
 #[cfg(target_os = "macos")]
 #[tauri::command]
 #[specta::specta]

--- a/plugins/detect/src/events.rs
+++ b/plugins/detect/src/events.rs
@@ -9,10 +9,11 @@ macro_rules! common_event_derives {
 common_event_derives! {
     #[serde(tag = "type")]
     pub enum DetectEvent {
-        #[serde(rename = "micStarted")]
-        MicStarted {
+        #[serde(rename = "micDetected")]
+        MicDetected {
             key: String,
             apps: Vec<hypr_detect::InstalledApp>,
+            duration_secs: u64,
         },
         #[serde(rename = "micStopped")]
         MicStopped {
@@ -22,11 +23,5 @@ common_event_derives! {
         MicMuteStateChanged { value: bool },
         #[serde(rename = "sleepStateChanged")]
         SleepStateChanged { value: bool },
-        #[serde(rename = "micProlongedUsage")]
-        MicProlongedUsage {
-            key: String,
-            app: hypr_detect::InstalledApp,
-            duration_secs: u64,
-        },
     }
 }

--- a/plugins/detect/src/ext.rs
+++ b/plugins/detect/src/ext.rs
@@ -30,6 +30,12 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Detect<'a, R, M> {
         let mut state_guard = state.lock().unwrap_or_else(|e| e.into_inner());
         state_guard.policy.respect_dnd = enabled;
     }
+
+    pub fn set_mic_detection_delay(&self, secs: u64) {
+        let state = self.manager.state::<crate::ProcessorState>();
+        let mut state_guard = state.lock().unwrap_or_else(|e| e.into_inner());
+        state_guard.mic_detection_delay = std::time::Duration::from_secs(secs);
+    }
 }
 
 pub trait DetectPluginExt<R: tauri::Runtime> {

--- a/plugins/detect/src/lib.rs
+++ b/plugins/detect/src/lib.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use tauri::Manager;
 
@@ -27,6 +28,7 @@ pub(crate) type ProcessorState = Arc<Mutex<Processor>>;
 pub(crate) struct Processor {
     pub(crate) policy: policy::MicNotificationPolicy,
     pub(crate) mic_usage_tracker: mic_usage_tracker::MicUsageTracker,
+    pub(crate) mic_detection_delay: Duration,
 }
 
 fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
@@ -40,6 +42,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::list_default_ignored_bundle_ids::<tauri::Wry>,
             commands::get_preferred_languages::<tauri::Wry>,
             commands::get_current_locale_identifier::<tauri::Wry>,
+            commands::set_mic_detection_delay::<tauri::Wry>,
         ])
         .events(tauri_specta::collect_events![DetectEvent])
         .error_handling(tauri_specta::ErrorHandlingMode::Result)


### PR DESCRIPTION
## Summary

Configurable notification behavior for both event-based and mic detection-based notifications.

### Event notifications
- **Minutes before event** – when to notify (default: 5)
- **Auto-dismiss after** – notification timeout in seconds (default: 30)

### Mic detection notifications
- **Detection delay** – 0 = instant (basic mic detection), N secs = prolonged usage (default: 0)
- **Auto-dismiss after** – notification timeout in seconds (default: 8)

### Behavioral harmonization
- Unified `MicStarted` / `MicProlongedUsage` into `MicDetected` with `duration_secs`
- DnD symmetry: both immediate and delayed paths respect policy at emit time
- Cooldown for immediate path (1hr, same as delayed)
- isFocused guard for both paths
- Removed 2000ms debounce (Rust cooldown handles dedup)

### Migration
- `in_meeting_reminder: true` → `mic_detection_delay_secs: 180`

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fastrepl/hyprnote/pull/3898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
