### PR TITLE
fix(collections): handle draftArticles query invalidation conditionally

### DIFF
--- a/apps/web/src/routes/admin/collections/index.tsx
+++ b/apps/web/src/routes/admin/collections/index.tsx
@@ -308,8 +308,9 @@ function CollectionsPage() {
             },
           ],
         );
+      } else {
+        queryClient.invalidateQueries({ queryKey: ["draftArticles"] });
       }
-      queryClient.invalidateQueries({ queryKey: ["draftArticles"] });
     },
   });
 


### PR DESCRIPTION
## Summary

- Added conditional logic to draftArticles query invalidation to prevent unnecessary or incorrect cache invalidation
- Ensures query invalidation only triggers when the relevant conditions are met, avoiding redundant refetches

## Review & Testing Checklist for Human

- [ ] Verify that draft articles update correctly after creating, editing, or deleting a draft
- [ ] Confirm that unrelated operations no longer trigger unnecessary draftArticles query refetches
- [ ] Check for stale data edge cases — e.g., switching between views or tabs after modifying a draft

### Notes

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fastrepl/hyprnote/pull/3902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->