### PR TITLE
fix(web): invalidate draft articles with delayed query update

### DIFF
--- a/apps/web/src/routes/admin/collections/index.tsx
+++ b/apps/web/src/routes/admin/collections/index.tsx
@@ -275,6 +275,18 @@ function CollectionsPage() {
   const [deleteConfirmation, setDeleteConfirmation] =
     useState<DeleteConfirmation | null>(null);
 
+  const draftSyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const scheduleDraftSync = useCallback(() => {
+    if (draftSyncTimerRef.current) {
+      clearTimeout(draftSyncTimerRef.current);
+    }
+    draftSyncTimerRef.current = setTimeout(() => {
+      draftSyncTimerRef.current = null;
+      queryClient.invalidateQueries({ queryKey: ["draftArticles"] });
+    }, 5000);
+  }, [queryClient]);
+
   const createMutation = useMutation({
     mutationFn: async (params: {
       folder: string;
@@ -308,9 +320,7 @@ function CollectionsPage() {
             },
           ],
         );
-        setTimeout(() => {
-          queryClient.invalidateQueries({ queryKey: ["draftArticles"] });
-        }, 5000);
+        scheduleDraftSync();
       } else {
         queryClient.invalidateQueries({ queryKey: ["draftArticles"] });
       }


### PR DESCRIPTION
## Summary

- Adds a delayed query invalidation for draft articles to avoid stale cache after mutations
- Ensures the draft article list refreshes correctly after content changes

## Review & Testing Checklist for Human

- [ ] Verify that after creating/updating a draft article, the draft list updates correctly after the delay
- [ ] Check for race conditions: rapidly creating or editing multiple drafts should not cause stale or missing entries
- [ ] Confirm the delay duration feels appropriate — not so short that it fires before the mutation settles, not so long that the UI feels unresponsive

### Notes

Link to Devin run: https://app.devin.ai/sessions/1b9ae9acc87349e393883ca54ed961c6
Requested by: @ComputelessComputer

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fastrepl/hyprnote/pull/3904" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->