### PR TITLE
feat: update category from Hyprnote to Char Weekly

### DIFF
--- a/apps/web/content/articles/hyprnote-weekly-2026-02-08.mdx
+++ b/apps/web/content/articles/hyprnote-weekly-2026-02-08.mdx
@@ -3,7 +3,7 @@ meta_title: "Hyprnote Weekly: Calendar Redesign, Backlink Mentions, and Undo Del
 display_title: "Hyprnote Weekly: February 8, 2026"
 meta_description: "This week we shipped v1.0.4 and v1.0.5 stable with a full calendar redesign, backlink mentions for notes and people, undo delete for notes, and a new hold-to-quit shortcut inspired by Chrome."
 author: "John Jeong"
-category: "Hyprnote Weekly"
+category: "Char Weekly"
 date: "2026-02-08"
 ---
 


### PR DESCRIPTION
Changes the category metadata in the February 8, 2026 weekly
article from "Hyprnote Weekly" to "Char Weekly" to reflect the
new branding or publication name for the weekly content series.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fastrepl/hyprnote/pull/3936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
