### PR TITLE
Publish: 7 Best AI Notetakers for Google Meet in 2026

### DIFF
--- a/apps/web/content/articles/best-ai-notetakers-google-meet.mdx
+++ b/apps/web/content/articles/best-ai-notetakers-google-meet.mdx
@@ -68,8 +68,6 @@ During meetings, Char transcribes your conversations in real-time, and when the 
 - macOS and Linux only; Windows version coming soon
 - No Video recordings
 
-&nbsp;
-
 #### Pricing
 
 An unlimited free plan with local transcription or bring-your-own-key. Pro is $8/month for managed cloud service.
@@ -105,8 +103,6 @@ Fireflies joins your Google Meet as a bot participant called "Fred." You can inv
 - **Storage limitations** on lower-tier plans create pressure to upgrade
 - **May spam** all participants with meeting notes
 
-&nbsp;
-
 #### Pricing
 
 Free forever with unlimited transcription but limited AI features. Paid plans start at $18/user/month.
@@ -136,8 +132,6 @@ You can invite a Sembly agent to your meeting from the Google Chrome Extension o
 - **Flexible attendance model** allowing the bot to capture meetings even when you're not present
 - **Unified meeting intelligence** consolidating summaries, transcripts, and analytics in one interface
 - **Comprehensive integrations** with popular CRMs and project management tools like Trello, ClickUp, Asana, etc.
-
-  
 
 #### Considerations
 


### PR DESCRIPTION
## Article Ready for Publication

**Title:** 7 Best AI Notetakers for Google Meet in 2026
**Author:** John Jeong
**Date:** 2026-02-11
**Category:** Uncategorized

**Branch:** blog/best-ai-notetakers-google-meet-1770999186702
**File:** apps/web/content/articles/best-ai-notetakers-google-meet.mdx

---
Auto-generated PR from admin panel.