### PR TITLE
Adopt pin-project for safe pin projections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,7 @@ dependencies = [
  "futures-util",
  "hound",
  "libpulse-binding",
+ "pin-project",
  "ringbuf",
  "rodio",
  "serde",
@@ -1317,6 +1318,7 @@ dependencies = [
  "data",
  "futures-util",
  "hound",
+ "pin-project",
  "rodio",
  "rubato",
  "thiserror 2.0.18",
@@ -2772,6 +2774,28 @@ name = "cached_proc_macro_types"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
+
+[[package]]
+name = "cactus"
+version = "0.2.0"
+source = "git+https://github.com/mrsarac/cactus-rs#dd82beae35c97acc283acd839860184ff5e29571"
+dependencies = [
+ "cactus-sys",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cactus-sys"
+version = "0.2.0"
+source = "git+https://github.com/mrsarac/cactus-rs#dd82beae35c97acc283acd839860184ff5e29571"
+dependencies = [
+ "bindgen 0.70.1",
+ "cmake",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cairo-rs"
@@ -9406,6 +9430,16 @@ name = "hypher"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74e25026c579b170c59f8d3ddfc523d7dab0abe079f09eb8edaebd2417044f60"
+
+[[package]]
+name = "hypr-cactus"
+version = "0.1.0"
+dependencies = [
+ "cactus",
+ "data",
+ "hound",
+ "serde_json",
+]
 
 [[package]]
 name = "hypr-http-utils"
@@ -22057,6 +22091,7 @@ dependencies = [
  "data",
  "futures-util",
  "hound",
+ "pin-project",
  "rodio",
  "serde",
  "silero",
@@ -23708,6 +23743,7 @@ dependencies = [
  "axum 0.8.8",
  "futures-util",
  "owhisper-interface",
+ "pin-project",
  "serde_json",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,7 @@ futures-channel = "0.3.31"
 futures-core = "0.3.31"
 futures-util = "0.3.31"
 hypr-supervisor = { path = "crates/supervisor", package = "supervisor" }
+pin-project = "1"
 ractor = "0.15.10"
 rayon = "1.11"
 reqwest = "0.13"

--- a/crates/audio-utils/Cargo.toml
+++ b/crates/audio-utils/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 bytes = { workspace = true }
 futures-util = { workspace = true }
 hypr-audio-interface = { workspace = true }
+pin-project = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/audio-utils/src/resampler/dynamic_old.rs
+++ b/crates/audio-utils/src/resampler/dynamic_old.rs
@@ -4,7 +4,9 @@ use std::task::{Context, Poll};
 use dasp::interpolate::Interpolator;
 use futures_util::{Stream, pin_mut};
 use hypr_audio_interface::AsyncSource;
+use pin_project::pin_project;
 
+#[pin_project]
 pub struct ResamplerDynamicOld<S: AsyncSource> {
     source: S,
     target_sample_rate: u32,
@@ -51,7 +53,7 @@ impl<S: AsyncSource> ResamplerDynamicOld<S> {
     }
 }
 
-impl<S: AsyncSource + Unpin> Stream for ResamplerDynamicOld<S> {
+impl<S: AsyncSource> Stream for ResamplerDynamicOld<S> {
     type Item = f32;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -96,7 +98,7 @@ impl<S: AsyncSource + Unpin> Stream for ResamplerDynamicOld<S> {
     }
 }
 
-impl<S: AsyncSource + Unpin> AsyncSource for ResamplerDynamicOld<S> {
+impl<S: AsyncSource> AsyncSource for ResamplerDynamicOld<S> {
     fn as_stream(&mut self) -> impl Stream<Item = f32> + '_ {
         self
     }

--- a/crates/audio/Cargo.toml
+++ b/crates/audio/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = { workspace = true }
 
 futures-channel = { workspace = true }
 futures-util = { workspace = true }
+pin-project = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 
 cpal = { workspace = true }

--- a/crates/audio/src/norm.rs
+++ b/crates/audio/src/norm.rs
@@ -3,6 +3,7 @@ use std::task::{Context, Poll};
 
 use ebur128::{EbuR128, Mode};
 use futures_util::Stream;
+use pin_project::pin_project;
 
 const CHANNELS: u32 = 1;
 const TARGET_LUFS: f64 = -23.0;
@@ -10,6 +11,7 @@ const TRUE_PEAK_LIMIT: f64 = -1.0;
 const LIMITER_LOOKAHEAD_MS: usize = 10;
 const ANALYZE_CHUNK_SIZE: usize = 512;
 
+#[pin_project]
 pub struct NormalizedSource<S: hypr_audio_interface::AsyncSource> {
     source: S,
     gain_linear: f32,
@@ -80,7 +82,7 @@ impl<S: hypr_audio_interface::AsyncSource> NormalizeExt<S> for S {
     }
 }
 
-impl<S: hypr_audio_interface::AsyncSource + Unpin> Stream for NormalizedSource<S> {
+impl<S: hypr_audio_interface::AsyncSource> Stream for NormalizedSource<S> {
     type Item = f32;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -115,7 +117,7 @@ impl<S: hypr_audio_interface::AsyncSource + Unpin> Stream for NormalizedSource<S
     }
 }
 
-impl<S: hypr_audio_interface::AsyncSource + Unpin> hypr_audio_interface::AsyncSource
+impl<S: hypr_audio_interface::AsyncSource> hypr_audio_interface::AsyncSource
     for NormalizedSource<S>
 {
     fn sample_rate(&self) -> u32 {

--- a/crates/vad-ext/Cargo.toml
+++ b/crates/vad-ext/Cargo.toml
@@ -22,5 +22,6 @@ hypr-vvad = { workspace = true }
 silero-rs = { workspace = true }
 
 futures-util = { workspace = true }
+pin-project = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing = { workspace = true }

--- a/crates/ws-utils/Cargo.toml
+++ b/crates/ws-utils/Cargo.toml
@@ -12,6 +12,7 @@ hypr-audio-interface = { workspace = true }
 serde_json = { workspace = true }
 
 futures-util = { workspace = true }
+pin-project = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
## Summary

- Add `pin-project` crate to replace manual pin projection patterns (`get_mut`, `Pin::new`, `Pin::into_inner`) with compile-time verified safe projections across audio, vad-ext, audio-utils, and ws-utils crates.
- For generic stream wrappers (`ContinuousVadMaskStream`, `ContinuousVadStream`, `NormalizedSource`, `ResamplerDynamicOld`/`New`, `ResamplerStaticNew`), this **removes the `Unpin` bound from public APIs**, allowing non-`Unpin` streams (e.g. from `async_stream::stream!`) to be used as inner sources.
- For concrete-type wrappers (`SpeakerStream` on macOS/Linux/Windows, `MicStream`, `WebSocketAudioSource`, `ChannelAudioSource`), the change is stylistic consistency with the pin-project pattern.

### Motivation

All custom `Stream` implementations in these crates were doing manual pin projection via `self.get_mut()` + `Pin::new()`, which requires an `S: Unpin` escape hatch on all generic parameters. `pin-project` generates the same unsafe projection code but **verifies structural pinning invariants at compile time**, and makes the `Unpin` bound unnecessary for types that don't structurally pin their fields.

Reference: [pin-project docs](https://docs.rs/pin-project/1.1.10/pin_project/), [std::pin projections](https://doc.rust-lang.org/std/pin/index.html#projections-and-structural-pinning)

### Why `pin-project` over `pin-project-lite`

This workspace already pulls in `syn`/`quote`/`proc-macro2` many times over (serde, tauri, specta, tokio-macros, etc.), so the only reason to use `-lite` (avoiding proc-macro deps) [does not apply](https://github.com/rust-lang/futures-rs/issues/2170). `pin-project` provides better error messages and supports tuple structs.

## Test plan

- [x] `cargo check -p audio -p audio-utils -p ws-utils -p vad-ext` passes
- [ ] Existing tests for affected crates still pass


Made with [Cursor](https://cursor.com)