### PR TITLE
feat: remove code block pseudo-element quotes

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -264,6 +264,11 @@
   }
 }
 
+.prose :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *))::before,
+.prose :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *))::after {
+  content: none;
+}
+
 @layer base {
   button,
   [role="button"],


### PR DESCRIPTION
Remove ::before and ::after content from prose code elements to
prevent unwanted quotation marks or backticks from appearing
around inline code blocks in markdown content.