### PR TITLE
style: format prose code selector for readability

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -264,8 +264,12 @@
   }
 }
 
-.prose :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *))::before,
-.prose :where(code):not(:where([class~="not-prose"], [class~="not-prose"] *))::after {
+.prose
+  :where(code):not(:where([class~="not-prose"], [class~="not-prose"]
+    *))::before,
+.prose
+  :where(code):not(:where([class~="not-prose"], [class~="not-prose"]
+    *))::after {
   content: none;
 }
 


### PR DESCRIPTION
Break long CSS selector into multiple lines to improve code
readability and maintainability. The selector targets pseudo-elements
of code elements within prose sections that are not marked as
not-prose.