### PR TITLE
fix: remove overflow-y-auto from metadata container

### DIFF
--- a/apps/desktop/src/components/main/body/sessions/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/components/main/body/sessions/outer-header/metadata/index.tsx
@@ -97,7 +97,7 @@ function ContentInner({ sessionId }: { sessionId: string }) {
     : null;
 
   return (
-    <div className="flex flex-col gap-4 p-4 overflow-y-auto">
+    <div className="flex flex-col gap-4 p-4">
       {!eventDisplayData && <DateDisplay sessionId={sessionId} />}
       {eventDisplayData && (
         <EventDisplay event={eventDisplayData}>


### PR DESCRIPTION
Removes overflow-y-auto CSS class from the session metadata
container div to fix scrolling behavior. The overflow handling
is now managed by parent components for better layout control.