### PR TITLE
feat: Improve calendar visual hierarchy and styling

### DIFF
--- a/apps/desktop/src/components/main/body/calendar/calendar-view.tsx
+++ b/apps/desktop/src/components/main/body/calendar/calendar-view.tsx
@@ -145,7 +145,7 @@ export function CalendarView() {
         <div
           className={cn([
             "flex items-center justify-between",
-            "px-2 pt-1 pb-1 border-b border-neutral-200",
+            "py-2 pl-3 pr-1 h-12 border-b border-neutral-200",
           ])}
         >
           <div className="flex items-center gap-2">
@@ -158,7 +158,7 @@ export function CalendarView() {
                 <CalendarCogIcon className="h-4 w-4" />
               </Button>
             )}
-            <h2 className="text-lg font-semibold text-neutral-900">
+            <h2 className="text-sm font-medium text-neutral-900">
               {isMonthView
                 ? format(currentMonth, "MMMM yyyy")
                 : days.length > 0
@@ -202,8 +202,11 @@ export function CalendarView() {
             <div
               key={`${day}-${i}`}
               className={cn([
-                "text-center text-xs font-medium text-neutral-500",
+                "text-center text-xs font-medium",
                 "py-2",
+                day === "Sat" || day === "Sun"
+                  ? "text-neutral-400"
+                  : "text-neutral-900",
               ])}
             >
               {day}

--- a/apps/desktop/src/components/main/body/calendar/day-cell.tsx
+++ b/apps/desktop/src/components/main/body/calendar/day-cell.tsx
@@ -103,8 +103,16 @@ export function DayCell({
           className={cn([
             "text-sm font-medium mb-1 w-7 h-7 flex items-center justify-center rounded-full",
             today && "bg-neutral-900 text-white",
-            !today && isCurrentMonth && "text-neutral-900",
-            !today && !isCurrentMonth && "text-neutral-400",
+            !today && !isCurrentMonth && "text-neutral-300",
+            !today &&
+              isCurrentMonth &&
+              (day.getDay() === 0 || day.getDay() === 6) &&
+              "text-neutral-400",
+            !today &&
+              isCurrentMonth &&
+              day.getDay() !== 0 &&
+              day.getDay() !== 6 &&
+              "text-neutral-900",
           ])}
         >
           {format(day, "d")}


### PR DESCRIPTION
Update calendar day cell text colors to distinguish weekends from
weekdays with lighter colors. Modify header spacing and typography
for better proportions. Apply consistent weekend styling to both
day headers and individual day cells to improve visual clarity.