### PR TITLE
Publish: The Best Markdown Note-Taking Apps in 2026

### DIFF
--- a/apps/web/content/articles/markdown-note-taking-apps.mdx
+++ b/apps/web/content/articles/markdown-note-taking-apps.mdx
@@ -33,7 +33,7 @@ This list cuts through the noise. We picked five apps, each the clear best for a
 
 ![](https://auth.hyprnote.com/storage/v1/object/public/blog/articles/markdown-note-taking-apps/image-1.png)
 
-++[Char](https://char.com/)++ (formerly Hypernote) is an open-source AI notepad built specifically for meetings. It transcribes your conversations in real-time, and when the meeting ends, it combines the transcript with your manual notes to create the perfect summary. No bots join your calls, data stays on your device, and you get to choose your preferred STT and LLM provider. 
+**[Char](https://char.com/)** (formerly Hypernote) is an open-source AI notepad built specifically for meetings. It transcribes your conversations in real-time, and when the meeting ends, it combines the transcript with your manual notes to create the perfect summary. No bots join your calls, data stays on your device, and you get to choose your preferred STT and LLM provider. 
 
 #### Key Features:
 
@@ -70,7 +70,7 @@ Free plan with local transcription or bring-your-own-key. Pro is $8/month for th
 
 ![](https://auth.hyprnote.com/storage/v1/object/public/blog/articles/markdown-note-taking-apps/image-2.png)
 
-Most note apps make you forget what you wrote six months ago. ++[Obsidian](https://obsidian.md/)++ doesn't - because everything is linked. 
+Most note apps make you forget what you wrote six months ago. **[Obsidian](https://obsidian.md/)** doesn't - because everything is linked. 
 
 Once you're deep enough in a vault, opening one note pulls you into three others you forgot existed but suddenly need. 
 
@@ -112,7 +112,7 @@ Free for personal use, no limits, no sign-up. Obsidian Sync is $4/user/month bil
 
 ![](https://auth.hyprnote.com/storage/v1/object/public/blog/articles/markdown-note-taking-apps/image-3.png)
 
-++[Logseq](https://logseq.com/)++ clicked for me the moment I stopped trying to organize it and just started writing. You open it, land on today's journal page, and go. No deciding where a note lives. No folder structure to maintain. 
+**[Logseq](https://logseq.com/)** clicked for me the moment I stopped trying to organize it and just started writing. You open it, land on today's journal page, and go. No deciding where a note lives. No folder structure to maintain. 
 
 Every bullet point is a block that can be linked, referenced, and surfaced anywhere else in your graph - so the organization happens as a byproduct of writing, not before it.
 
@@ -156,7 +156,7 @@ Free for personal use. Logseq Sync is in beta. No paid tiers beyond sync.
 
 ![](https://auth.hyprnote.com/storage/v1/object/public/blog/articles/markdown-note-taking-apps/image-4.png)
 
-++[Joplin](https://joplinapp.org/)++ doesn't try to be your second brain or your writing tool. It does one thing exceptionally well: keeping your notes encrypted, portable, and in sync across every device you own - using whatever cloud storage you already pay for. No vendor lock-in on sync, no paywall surprises, no compromise on privacy.
+**[Joplin](https://joplinapp.org/)** doesn't try to be your second brain or your writing tool. It does one thing exceptionally well: keeping your notes encrypted, portable, and in sync across every device you own - using whatever cloud storage you already pay for. No vendor lock-in on sync, no paywall surprises, no compromise on privacy.
 
 #### Key Features:
 
@@ -197,7 +197,7 @@ Completely free with self-managed sync. Joplin Cloud starts at 2.99€/month for
 
 ![](https://auth.hyprnote.com/storage/v1/object/public/blog/articles/markdown-note-taking-apps/image-5.png)
 
-Most note apps tolerate developers. ++[Inkdrop](https://www.inkdrop.app/)++ is built for them. Vim keybindings, multi-language code highlighting, Mermaid diagrams, KaTeX math, multi-cursor editing - it's all there without hunting for plugins. The whole thing is built by a single developer, Takuya Matsuyama, who clearly uses it himself, and that shows in how deliberate every feature decision feels.
+Most note apps tolerate developers. **[Inkdrop](https://www.inkdrop.app/)** is built for them. Vim keybindings, multi-language code highlighting, Mermaid diagrams, KaTeX math, multi-cursor editing - it's all there without hunting for plugins. The whole thing is built by a single developer, Takuya Matsuyama, who clearly uses it himself, and that shows in how deliberate every feature decision feels.
 
 Where Obsidian gives you a blank canvas to build whatever system you want, Inkdrop gives you a clean, opinionated workflow that gets out of your way. Less tinkering, more writing.
 
@@ -238,7 +238,7 @@ $8.31/month billed annually. 30-day free trial, no credit card required.
 
 ### 1. Zettlr
 
-++[Zettlr](https://www.zettlr.com/)++ is a strong app with a specific audience: academics and researchers doing citation-heavy writing. 
+**[Zettlr](https://www.zettlr.com/)** is a strong app with a specific audience: academics and researchers doing citation-heavy writing. 
 
 The Zotero integration, reference manager support, and export pipeline to LaTeX and PDF are genuinely best-in-class for that workflow. 
 
@@ -246,7 +246,7 @@ If you're writing papers with footnotes and bibliographies, Zettlr deserves a se
 
 ### 2. MarkText
 
-++[MarkText](https://github.com/marktext/marktext)++ has one of the cleanest writing experiences in this list - distraction-free, real-time preview, good theme selection. The problem is that development has gone quiet. 
+**[MarkText](https://github.com/marktext/marktext)** has one of the cleanest writing experiences in this list - distraction-free, real-time preview, good theme selection. The problem is that development has gone quiet. 
 
 For a tool you're trusting with long-term notes, an uncertain maintenance trajectory is a real concern. 
 
@@ -254,13 +254,13 @@ Worth trying if you need a focused writing editor, but not somewhere to plant yo
 
 ### 3. Notable
 
-++[Notable](https://github.com/notable/notable)++ is deliberately minimal: tag-based organization, split-pane editor, no frills. For users who find Obsidian overwhelming and just want a clean place to write and find notes quickly, that simplicity is genuinely appealing. 
+**[Notable](https://github.com/notable/notable)** is deliberately minimal: tag-based organization, split-pane editor, no frills. For users who find Obsidian overwhelming and just want a clean place to write and find notes quickly, that simplicity is genuinely appealing. 
 
 It didn't make the cut because the feature set hasn't kept pace with the alternatives, and the development has been sparse in recent years.
 
 ### 4. Zim
 
-++[Zim](https://zim-wiki.org/)++ is the oldest app on this list and, quietly, one of the most reliable. It's been described by long-time users as bulletproof - fast, stable, and does exactly what it claims. 
+**[Zim](https://zim-wiki.org/)** is the oldest app on this list and, quietly, one of the most reliable. It's been described by long-time users as bulletproof - fast, stable, and does exactly what it claims. 
 
 The interface looks like it was built in 2008 because it was, and that puts off a lot of people. But if you run Linux and want a desktop wiki that just works forever without surprises, Zim has a loyal following for good reason.
 


### PR DESCRIPTION
## Article Ready for Publication

**Title:** The Best Markdown Note-Taking Apps in 2026
**Author:** John Jeong
**Date:** 2026-02-18
**Category:** Comparisons

**Branch:** blog/markdown-note-taking-apps
**File:** apps/web/content/articles/markdown-note-taking-apps.mdx

---
Auto-generated PR from admin panel.