### PR TITLE
feat: Update site URL from hyprnote.com to char.com

### DIFF
--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -41,4 +41,4 @@ Disallow: /vs/
 # AI crawlers can find detailed content at /llms.txt
 
 # Sitemap location
-Sitemap: https://hyprnote.com/sitemap.xml
+Sitemap: https://char.com/sitemap.xml

--- a/apps/web/src/utils/sitemap.ts
+++ b/apps/web/src/utils/sitemap.ts
@@ -6,7 +6,7 @@ export type TRoutes = FileRouteTypes["fullPaths"];
 
 export function getSitemap(): Sitemap<TRoutes> {
   return {
-    siteUrl: "https://hyprnote.com",
+    siteUrl: "https://char.com",
     defaultPriority: 0.5,
     defaultChangeFreq: "monthly",
     routes: {


### PR DESCRIPTION
Change site URL configuration in sitemap utility and robots.txt
to reflect new domain. Updates both the sitemap generator and
robots.txt sitemap reference for consistency across the site.