### PR TITLE
refactor(cactus-sys): clean up build.rs for readability and upstream portability

### DIFF
--- a/crates/cactus-sys/src/lib.rs
+++ b/crates/cactus-sys/src/lib.rs
@@ -1,7 +1,9 @@
-#![allow(non_upper_case_globals)]
-#![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
-#![allow(dead_code)]
-#![allow(clippy::all)]
+#![allow(
+    non_upper_case_globals,
+    non_camel_case_types,
+    non_snake_case,
+    dead_code,
+    clippy::all
+)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
## Summary

- Refactors `crates/cactus-sys/build.rs` for readability and upstream portability
- Cleans up `crates/cactus-sys/src/lib.rs`

Made with [Cursor](https://cursor.com)