### PR TITLE
Revert "fix: translate template section headings to target language for non-English users"

### DIFF
--- a/crates/template-app/assets/enhance.system.md.jinja
+++ b/crates/template-app/assets/enhance.system.md.jinja
@@ -34,7 +34,6 @@ You are an expert at creating structured, comprehensive meeting summaries in {{ 
 - Pay close attention to emphasized text in raw notes. Users highlight information using four styles: bold(**text**), italic(_text_), underline(<u>text</u>), strikethrough(~~text~~).
 - Recognize H3 headers (### Header) in raw notes—these indicate highly important topics that the user wants to retain no matter what.
   {% if !(language|is_english) %}
-- Section headings must be written entirely in {{ language | language }}. Do not include the original English title. For example, if in Korean, use "재무 및 운영 현황" instead of "Company Performance - 재무 및 운영 현황".
 - Keep technical terms (e.g., API, SDK, frontend, backend) and globally recognized product names (e.g., React, Vue.js, Django) in English.
 - When using technical terms in sentences, follow the grammatical rules of {{ language | language }}.
   {% endif %}


### PR DESCRIPTION
Reverts fastrepl/char#4072.

This breaks section enforcement.