### PR TITLE
feat: redesign button styles with enhanced visuals

### DIFF
--- a/apps/desktop/src/components/main/sidebar/toast/component.tsx
+++ b/apps/desktop/src/components/main/sidebar/toast/component.tsx
@@ -65,7 +65,7 @@ export function Toast({
           {toast.primaryAction && (
             <button
               onClick={toast.primaryAction.onClick}
-              className="w-full py-2 rounded-full bg-stone-600 text-white text-sm font-medium duration-150 hover:scale-[1.01] active:scale-[0.99]"
+              className="w-full py-2 rounded-full bg-stone-800 hover:bg-stone-700 text-white text-sm font-medium border-2 border-stone-600 shadow-[0_4px_14px_rgba(87,83,78,0.4)] transition-all duration-200"
             >
               {toast.primaryAction.label}
             </button>

--- a/apps/desktop/src/components/onboarding/shared.tsx
+++ b/apps/desktop/src/components/onboarding/shared.tsx
@@ -129,7 +129,7 @@ export function OnboardingButton(
   return (
     <button
       {...props}
-      className="w-fit px-6 py-2.5 rounded-full bg-stone-600 text-white text-sm font-medium duration-150 hover:scale-[1.01] active:scale-[0.99]"
+      className="w-fit px-6 py-2.5 rounded-full bg-stone-800 hover:bg-stone-700 text-white text-sm font-medium border-2 border-stone-600 shadow-[0_4px_14px_rgba(87,83,78,0.4)] transition-all duration-200"
     />
   );
 }


### PR DESCRIPTION
Update button styling from stone-600 to stone-800 background with stone-700 hover state. Add border, shadow effects and smooth transitions to improve visual hierarchy and user interaction feedback across onboarding and toast components.