### PR TITLE
feat: add extension to clear inline marks on enter

### DIFF
--- a/packages/tiptap/src/shared/clear-marks-on-enter.ts
+++ b/packages/tiptap/src/shared/clear-marks-on-enter.ts
@@ -1,0 +1,43 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+
+const INLINE_MARK_NAMES = ["bold", "italic", "underline"];
+
+export const ClearMarksOnEnter = Extension.create({
+  name: "clearMarksOnEnter",
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("clearMarksOnEnter"),
+        appendTransaction(transactions, oldState, newState) {
+          if (!transactions.some((tr) => tr.docChanged)) return null;
+          if (newState.doc.content.size <= oldState.doc.content.size)
+            return null;
+
+          const { $head } = newState.selection;
+          const currentNode = $head.parent;
+
+          if (
+            currentNode.type.name !== "paragraph" ||
+            currentNode.content.size !== 0 ||
+            $head.parentOffset !== 0
+          ) {
+            return null;
+          }
+
+          const storedMarks = newState.storedMarks;
+          if (!storedMarks || storedMarks.length === 0) return null;
+
+          const filtered = storedMarks.filter(
+            (mark) => !INLINE_MARK_NAMES.includes(mark.type.name),
+          );
+
+          if (filtered.length === storedMarks.length) return null;
+
+          return newState.tr.setStoredMarks(filtered);
+        },
+      }),
+    ];
+  },
+});

--- a/packages/tiptap/src/shared/extensions/index.ts
+++ b/packages/tiptap/src/shared/extensions/index.ts
@@ -16,6 +16,7 @@ import StarterKit from "@tiptap/starter-kit";
 
 import { AIHighlight } from "../ai-highlight";
 import { StreamingAnimation } from "../animation";
+import { ClearMarksOnEnter } from "../clear-marks-on-enter";
 import { ClipboardTextSerializer } from "../clipboard";
 import CustomListKeymap from "../custom-list-keymap";
 import { Hashtag } from "../hashtag";
@@ -218,6 +219,7 @@ export const getExtensions = (
   Highlight,
   AIHighlight,
   CustomListKeymap,
+  ClearMarksOnEnter,
   StreamingAnimation,
   ClipboardTextSerializer,
   SearchAndReplace.configure({


### PR DESCRIPTION
Create ClearMarksOnEnter extension that removes bold, italic, and
underline marks when pressing enter in empty paragraphs. This prevents
unwanted formatting persistence when starting new lines after
formatted text.

The extension uses a ProseMirror plugin to detect document changes
and automatically clears stored inline marks when the cursor is at
the beginning of an empty paragraph, improving the typing experience.