### PR TITLE
feat: improve link handling and auto-update behavior

### DIFF
--- a/packages/tiptap/package.json
+++ b/packages/tiptap/package.json
@@ -46,6 +46,7 @@
     "prosemirror-model": "^1.25.4",
     "prosemirror-state": "^1.4.4",
     "requestidlecallback-polyfill": "^1.0.2",
+    "tlds": "^1.261.0",
     "usehooks-ts": "^3.1.1"
   },
   "devDependencies": {

--- a/packages/tiptap/src/shared/extensions/index.ts
+++ b/packages/tiptap/src/shared/extensions/index.ts
@@ -11,8 +11,10 @@ import {
 import TaskItem from "@tiptap/extension-task-item";
 import TaskList from "@tiptap/extension-task-list";
 import Underline from "@tiptap/extension-underline";
+import { Mark } from "@tiptap/pm/model";
 import { Plugin, PluginKey, Transaction } from "@tiptap/pm/state";
 import StarterKit from "@tiptap/starter-kit";
+import tldList from "tlds";
 
 import { AIHighlight } from "../ai-highlight";
 import { StreamingAnimation } from "../animation";
@@ -80,48 +82,7 @@ const AttachmentImage = Image.extend({
   },
 });
 
-const COMMON_TLDS = new Set([
-  "com",
-  "org",
-  "net",
-  "edu",
-  "gov",
-  "mil",
-  "int",
-  "info",
-  "biz",
-  "name",
-  "pro",
-  "app",
-  "dev",
-  "tech",
-  "xyz",
-  "online",
-  "site",
-  "store",
-  "cloud",
-  "design",
-  "studio",
-  "agency",
-  "blog",
-  "shop",
-  "media",
-  "news",
-  "world",
-  "global",
-  "digital",
-  "network",
-  "museum",
-  "aero",
-  "coop",
-  "travel",
-  "jobs",
-  "mobi",
-  "asia",
-  "tel",
-  "cat",
-  "post",
-]);
+const VALID_TLDS = new Set(tldList.map((t: string) => t.toLowerCase()));
 
 function isValidUrl(url: string): boolean {
   try {
@@ -131,8 +92,7 @@ function isValidUrl(url: string): boolean {
     const parts = parsed.hostname.split(".");
     if (parts.length < 2) return false;
     const tld = parts[parts.length - 1].toLowerCase();
-    if (tld.length === 2 && /^[a-z]{2}$/.test(tld)) return true;
-    return COMMON_TLDS.has(tld);
+    return VALID_TLDS.has(tld);
   } catch {
     return false;
   }
@@ -186,7 +146,7 @@ export const getExtensions = (
             let prevLink: {
               startPos: number;
               endPos: number;
-              mark: InstanceType<typeof linkType>;
+              mark: Mark;
             } | null = null;
             newState.doc.descendants((node, pos) => {
               if (!node.isText || !node.text) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1426,6 +1426,9 @@ importers:
       requestidlecallback-polyfill:
         specifier: ^1.0.2
         version: 1.0.2
+      tlds:
+        specifier: ^1.261.0
+        version: 1.261.0
       usehooks-ts:
         specifier: ^3.1.1
         version: 3.1.1(react@19.2.4)
@@ -15571,6 +15574,10 @@ packages:
 
   tinytick@1.2.8:
     resolution: {integrity: sha512-tT7/2EIfUcQN4yjREOx7xwL85pooPYg9vahoPcY9/sGdfurR/cp/bgfxlAAKQnIoXjcD8peYhqa6NS3em2PioA==}
+
+  tlds@1.261.0:
+    resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
+    hasBin: true
 
   tldts-core@7.0.23:
     resolution: {integrity: sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==}
@@ -33097,6 +33104,8 @@ snapshots:
   tinyspy@4.0.4: {}
 
   tinytick@1.2.8: {}
+
+  tlds@1.261.0: {}
 
   tldts-core@7.0.23: {}
 


### PR DESCRIPTION
Make Link extension non-inclusive to prevent accidental expansion
and enhance link boundary guard plugin to automatically update
href attributes when users edit link text. The plugin now detects
URL patterns and syncs the href with modified text content, while
also extending links when users type adjacent characters without
whitespace separation.