### PR TITLE
fix(auth): isolate desktop/web sessions across sign-in and sign-out

### DIFF
--- a/apps/web/src/functions/auth.ts
+++ b/apps/web/src/functions/auth.ts
@@ -1,3 +1,4 @@
+import type { Session, SupabaseClient } from "@supabase/supabase-js";
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 
@@ -15,6 +16,148 @@ const shared = z.object({
   redirect: z.string().optional(),
 });
 
+type Flow = z.infer<typeof shared>["flow"];
+
+type FlowTokenResult =
+  | { ok: true; access_token: string; refresh_token: string }
+  | { ok: false; error: string };
+
+function buildAuthCallbackParams(data: {
+  flow: Flow;
+  scheme?: string;
+  redirect?: string;
+}) {
+  const params = new URLSearchParams({ flow: data.flow });
+  if (data.scheme) params.set("scheme", data.scheme);
+  if (data.redirect) params.set("redirect", data.redirect);
+  return params;
+}
+
+function tokenSuccess(session: {
+  access_token: string;
+  refresh_token: string;
+}): FlowTokenResult {
+  return {
+    ok: true,
+    access_token: session.access_token,
+    refresh_token: session.refresh_token,
+  };
+}
+
+function tokenError(error: string): FlowTokenResult {
+  return { ok: false, error };
+}
+
+async function resolveTokensForFlow({
+  flow,
+  session,
+  email,
+}: {
+  flow: Flow;
+  session: Session;
+  email?: string;
+}): Promise<FlowTokenResult> {
+  if (flow === "web") {
+    return tokenSuccess(session);
+  }
+
+  const resolvedEmail = email ?? session.user.email;
+  if (!resolvedEmail) {
+    return tokenError("No email returned");
+  }
+
+  const desktopSession = await mintDesktopSessionFromEmail(resolvedEmail);
+  if (!desktopSession) {
+    return tokenError("Failed to create desktop session");
+  }
+
+  return tokenSuccess(desktopSession);
+}
+
+function toSuccessTokenResponse(result: FlowTokenResult) {
+  if (!result.ok) {
+    return { success: false as const, error: result.error };
+  }
+  return {
+    success: true as const,
+    access_token: result.access_token,
+    refresh_token: result.refresh_token,
+  };
+}
+
+function toMutationTokenResponse(result: FlowTokenResult) {
+  if (!result.ok) {
+    return { error: true as const, message: result.error };
+  }
+  return {
+    success: true as const,
+    access_token: result.access_token,
+    refresh_token: result.refresh_token,
+  };
+}
+
+async function upsertAdminGithubTokenIfNeeded(
+  supabase: SupabaseClient,
+  session: Session,
+) {
+  const email = session.user.email;
+  if (!session.provider_token || !email || !isAdminEmail(email)) {
+    return;
+  }
+
+  const githubUsername =
+    session.user.user_metadata?.user_name ||
+    session.user.user_metadata?.preferred_username;
+
+  await supabase.from("admins").upsert({
+    id: session.user.id,
+    github_token: session.provider_token,
+    github_username: githubUsername,
+    updated_at: new Date().toISOString(),
+  });
+}
+
+async function mintDesktopSessionFromEmail(email: string) {
+  try {
+    const admin = getSupabaseAdminClient();
+    const { data: linkData, error: linkError } =
+      await admin.auth.admin.generateLink({
+        type: "magiclink",
+        email,
+      });
+
+    if (linkError || !linkData.properties?.hashed_token) {
+      console.error(
+        "[mintDesktopSessionFromEmail] generateLink failed:",
+        linkError?.message ?? "no hashed_token",
+      );
+      return null;
+    }
+
+    const supabase = getSupabaseDesktopFlowClient();
+    const { data: authData, error } = await supabase.auth.verifyOtp({
+      token_hash: linkData.properties.hashed_token,
+      type: "email",
+    });
+
+    if (error || !authData.session) {
+      console.error(
+        "[mintDesktopSessionFromEmail] verifyOtp failed:",
+        error?.message ?? "no session",
+      );
+      return null;
+    }
+
+    return {
+      access_token: authData.session.access_token,
+      refresh_token: authData.session.refresh_token,
+    };
+  } catch (e) {
+    console.error("[mintDesktopSessionFromEmail] unexpected error:", e);
+    return null;
+  }
+}
+
 export const doAuth = createServerFn({ method: "POST" })
   .inputValidator(
     shared.extend({
@@ -24,10 +167,7 @@ export const doAuth = createServerFn({ method: "POST" })
   )
   .handler(async ({ data }) => {
     const supabase = getSupabaseServerClient();
-
-    const params = new URLSearchParams({ flow: data.flow });
-    if (data.scheme) params.set("scheme", data.scheme);
-    if (data.redirect) params.set("redirect", data.redirect);
+    const params = buildAuthCallbackParams(data);
 
     const scopes = data.provider === "github" && data.rra ? "repo" : undefined;
 
@@ -54,10 +194,7 @@ export const doMagicLinkAuth = createServerFn({ method: "POST" })
   )
   .handler(async ({ data }) => {
     const supabase = getSupabaseServerClient();
-
-    const params = new URLSearchParams({ flow: data.flow });
-    if (data.scheme) params.set("scheme", data.scheme);
-    if (data.redirect) params.set("redirect", data.redirect);
+    const params = buildAuthCallbackParams(data);
 
     const { error } = await supabase.auth.signInWithOtp({
       email: data.email,
@@ -90,7 +227,7 @@ export const fetchUser = createServerFn({ method: "GET" }).handler(async () => {
 export const signOutFn = createServerFn({ method: "POST" }).handler(
   async () => {
     const supabase = getSupabaseServerClient();
-    const { error } = await supabase.auth.signOut();
+    const { error } = await supabase.auth.signOut({ scope: "local" });
 
     if (error) {
       return { success: false, message: error.message };
@@ -108,10 +245,7 @@ export const exchangeOAuthCode = createServerFn({ method: "POST" })
     }),
   )
   .handler(async ({ data }) => {
-    const supabase =
-      data.flow === "desktop"
-        ? getSupabaseDesktopFlowClient()
-        : getSupabaseServerClient();
+    const supabase = getSupabaseServerClient();
     const { data: authData, error } =
       await supabase.auth.exchangeCodeForSession(data.code);
 
@@ -119,24 +253,12 @@ export const exchangeOAuthCode = createServerFn({ method: "POST" })
       return { success: false, error: error?.message || "Unknown error" };
     }
 
-    const email = authData.session.user.email;
-    if (authData.session.provider_token && email && isAdminEmail(email)) {
-      const githubUsername =
-        authData.session.user.user_metadata?.user_name ||
-        authData.session.user.user_metadata?.preferred_username;
-      await supabase.from("admins").upsert({
-        id: authData.session.user.id,
-        github_token: authData.session.provider_token,
-        github_username: githubUsername,
-        updated_at: new Date().toISOString(),
-      });
-    }
-
-    return {
-      success: true,
-      access_token: authData.session.access_token,
-      refresh_token: authData.session.refresh_token,
-    };
+    await upsertAdminGithubTokenIfNeeded(supabase, authData.session);
+    const tokens = await resolveTokensForFlow({
+      flow: data.flow,
+      session: authData.session,
+    });
+    return toSuccessTokenResponse(tokens);
   });
 
 export const doPasswordSignUp = createServerFn({ method: "POST" })
@@ -147,14 +269,8 @@ export const doPasswordSignUp = createServerFn({ method: "POST" })
     }),
   )
   .handler(async ({ data }) => {
-    const supabase =
-      data.flow === "desktop"
-        ? getSupabaseDesktopFlowClient()
-        : getSupabaseServerClient();
-
-    const params = new URLSearchParams({ flow: data.flow });
-    if (data.scheme) params.set("scheme", data.scheme);
-    if (data.redirect) params.set("redirect", data.redirect);
+    const supabase = getSupabaseServerClient();
+    const params = buildAuthCallbackParams(data);
 
     const { data: authData, error } = await supabase.auth.signUp({
       email: data.email,
@@ -169,11 +285,12 @@ export const doPasswordSignUp = createServerFn({ method: "POST" })
     }
 
     if (authData.session) {
-      return {
-        success: true,
-        access_token: authData.session.access_token,
-        refresh_token: authData.session.refresh_token,
-      };
+      const tokens = await resolveTokensForFlow({
+        flow: data.flow,
+        session: authData.session,
+        email: data.email,
+      });
+      return toMutationTokenResponse(tokens);
     }
 
     return { success: true, needsConfirmation: true };
@@ -187,10 +304,7 @@ export const doPasswordSignIn = createServerFn({ method: "POST" })
     }),
   )
   .handler(async ({ data }) => {
-    const supabase =
-      data.flow === "desktop"
-        ? getSupabaseDesktopFlowClient()
-        : getSupabaseServerClient();
+    const supabase = getSupabaseServerClient();
 
     const { data: authData, error } = await supabase.auth.signInWithPassword({
       email: data.email,
@@ -205,11 +319,12 @@ export const doPasswordSignIn = createServerFn({ method: "POST" })
       return { error: true, message: "No session returned" };
     }
 
-    return {
-      success: true,
-      access_token: authData.session.access_token,
-      refresh_token: authData.session.refresh_token,
-    };
+    const tokens = await resolveTokensForFlow({
+      flow: data.flow,
+      session: authData.session,
+      email: data.email,
+    });
+    return toMutationTokenResponse(tokens);
   });
 
 export const exchangeOtpToken = createServerFn({ method: "POST" })
@@ -221,10 +336,7 @@ export const exchangeOtpToken = createServerFn({ method: "POST" })
     }),
   )
   .handler(async ({ data }) => {
-    const supabase =
-      data.flow === "desktop"
-        ? getSupabaseDesktopFlowClient()
-        : getSupabaseServerClient();
+    const supabase = getSupabaseServerClient();
     const { data: authData, error } = await supabase.auth.verifyOtp({
       token_hash: data.token_hash,
       type: data.type,
@@ -234,55 +346,18 @@ export const exchangeOtpToken = createServerFn({ method: "POST" })
       return { success: false, error: error?.message || "Unknown error" };
     }
 
-    return {
-      success: true,
-      access_token: authData.session.access_token,
-      refresh_token: authData.session.refresh_token,
-    };
+    const flow: Flow =
+      data.flow === "desktop" && data.type === "email" ? "desktop" : "web";
+    const tokens = await resolveTokensForFlow({
+      flow,
+      session: authData.session,
+    });
+    return toSuccessTokenResponse(tokens);
   });
 
 export const createDesktopSession = createServerFn({ method: "POST" })
   .inputValidator(z.object({ email: z.string().email() }))
-  .handler(async ({ data }) => {
-    try {
-      const admin = getSupabaseAdminClient();
-      const { data: linkData, error: linkError } =
-        await admin.auth.admin.generateLink({
-          type: "magiclink",
-          email: data.email,
-        });
-
-      if (linkError || !linkData.properties?.hashed_token) {
-        console.error(
-          "[createDesktopSession] generateLink failed:",
-          linkError?.message ?? "no hashed_token",
-        );
-        return null;
-      }
-
-      const supabase = getSupabaseDesktopFlowClient();
-      const { data: authData, error } = await supabase.auth.verifyOtp({
-        token_hash: linkData.properties.hashed_token,
-        type: "email",
-      });
-
-      if (error || !authData.session) {
-        console.error(
-          "[createDesktopSession] verifyOtp failed:",
-          error?.message ?? "no session",
-        );
-        return null;
-      }
-
-      return {
-        access_token: authData.session.access_token,
-        refresh_token: authData.session.refresh_token,
-      };
-    } catch (e) {
-      console.error("[createDesktopSession] unexpected error:", e);
-      return null;
-    }
-  });
+  .handler(async ({ data }) => mintDesktopSessionFromEmail(data.email));
 
 export const doPasswordResetRequest = createServerFn({ method: "POST" })
   .inputValidator(
@@ -325,11 +400,7 @@ export const doUpdatePassword = createServerFn({ method: "POST" })
   });
 
 export const updateUserEmail = createServerFn({ method: "POST" })
-  .inputValidator(
-    z.object({
-      email: z.string().email(),
-    }),
-  )
+  .inputValidator(z.object({ email: z.email() }))
   .handler(async ({ data }) => {
     const supabase = getSupabaseServerClient();
 


### PR DESCRIPTION
## Summary
- keep desktop auth default behavior user-friendly by establishing web login while still minting a separate desktop session token set
- refactor `apps/web/src/functions/auth.ts` to centralize flow/token resolution logic and remove duplicated branching across OAuth/password/OTP handlers
- change web sign-out to `scope: \"local\"` so signing out on web no longer revokes desktop session

## Test plan
- [x] `dprint fmt`
- [x] `pnpm -r typecheck`

Made with [Cursor](https://cursor.com)