### PR TITLE
feat: Replace search with direct new note creation

### DIFF
--- a/apps/desktop/src/components/main/body/index.tsx
+++ b/apps/desktop/src/components/main/body/index.tsx
@@ -25,7 +25,6 @@ import { cn } from "@hypr/utils";
 import { useListener } from "../../../contexts/listener";
 import { useNotifications } from "../../../contexts/notifications";
 import { useShell } from "../../../contexts/shell";
-import { useNativeContextMenu } from "../../../hooks/useNativeContextMenu";
 import {
   type Tab,
   uniqueIdfromTab,
@@ -53,7 +52,6 @@ import { loadExtensionPanels } from "./extensions/registry";
 import { TabContentFolder, TabItemFolder } from "./folders";
 import { TabContentHuman, TabItemHuman } from "./humans";
 import { TabContentOnboarding, TabItemOnboarding } from "./onboarding";
-import { Search } from "./search";
 import { TabContentNote, TabItemNote } from "./sessions";
 import { useCaretPosition } from "./sessions/caret-position-context";
 import { TabContentSettings, TabItemSettings } from "./settings";
@@ -146,19 +144,7 @@ function Header({ tabs }: { tabs: Tab[] }) {
 
   const tabsScrollContainerRef = useRef<HTMLDivElement>(null);
   const handleNewEmptyTab = useNewEmptyTab();
-  const handleNewNote = useNewNote({ behavior: "new" });
   const handleNewNoteAndListen = useNewNoteAndListen();
-  const showNewTabMenu = useNativeContextMenu([
-    { id: "empty-tab", text: "Open Empty Tab", action: handleNewEmptyTab },
-    { id: "new-note", text: "Create New Note", action: handleNewNote },
-    {
-      id: "new-note-listen",
-      text: "Create and Start Listening",
-      action: handleNewNoteAndListen,
-    },
-  ]);
-  const [isSearchManuallyExpanded, setIsSearchManuallyExpanded] =
-    useState(false);
   const scrollState = useScrollState(
     tabsScrollContainerRef,
     regularTabs.length,
@@ -308,26 +294,31 @@ function Header({ tabs }: { tabs: Tab[] }) {
         data-tauri-drag-region
         className="flex-1 flex h-full items-center justify-between"
       >
-        {!isSearchManuallyExpanded && (
-          <Button
-            onClick={isOnboarding ? undefined : handleNewEmptyTab}
-            onContextMenu={isOnboarding ? undefined : showNewTabMenu}
-            disabled={isOnboarding}
-            variant="ghost"
-            size="icon"
-            className={cn([
-              "text-neutral-600",
-              isOnboarding && "opacity-40 cursor-not-allowed",
-            ])}
-          >
-            <PlusIcon size={16} />
-          </Button>
-        )}
+        <Button
+          onClick={isOnboarding ? undefined : handleNewEmptyTab}
+          disabled={isOnboarding}
+          variant="ghost"
+          size="icon"
+          className={cn([
+            "text-neutral-600",
+            isOnboarding && "opacity-40 cursor-not-allowed",
+          ])}
+        >
+          <PlusIcon size={16} />
+        </Button>
 
         <div className="flex items-center gap-1 h-full ml-auto">
           <Update />
           {!isOnboarding && (
-            <Search onManualExpandChange={setIsSearchManuallyExpanded} />
+            <Button
+              onClick={handleNewNoteAndListen}
+              variant="ghost"
+              size="sm"
+              className="gap-1 text-neutral-600 shrink-0"
+            >
+              <PlusIcon size={14} />
+              <span className="text-sm">New Note</span>
+            </Button>
           )}
         </div>
       </div>

--- a/apps/desktop/src/components/main/sidebar/index.tsx
+++ b/apps/desktop/src/components/main/sidebar/index.tsx
@@ -1,7 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import { platform } from "@tauri-apps/plugin-os";
-import { AxeIcon, PanelLeftCloseIcon } from "lucide-react";
-import { lazy, Suspense, useState } from "react";
+import {
+  AxeIcon,
+  Loader2Icon,
+  PanelLeftCloseIcon,
+  SearchIcon,
+  XIcon,
+} from "lucide-react";
+import { lazy, Suspense, useEffect, useState } from "react";
 
 import { Button } from "@hypr/ui/components/ui/button";
 import { Kbd } from "@hypr/ui/components/ui/kbd";
@@ -10,6 +16,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@hypr/ui/components/ui/tooltip";
+import { useCmdKeyPressed } from "@hypr/ui/hooks/use-cmd-key-pressed";
 import { cn } from "@hypr/utils";
 
 import { useSearch } from "../../../contexts/search/ui";
@@ -27,8 +34,19 @@ const DevtoolView = lazy(() =>
 
 export function LeftSidebar() {
   const { leftsidebar } = useShell();
-  const { query } = useSearch();
+  const {
+    query,
+    setQuery,
+    inputRef,
+    setFocusImpl,
+    isSearching,
+    isIndexing,
+    selectedIndex,
+    setSelectedIndex,
+    results,
+  } = useSearch();
   const [isProfileExpanded, setIsProfileExpanded] = useState(false);
+  const isCmdPressed = useCmdKeyPressed();
   const isLinux = platform() === "linux";
 
   const { data: showDevtoolButton = false } = useQuery({
@@ -37,6 +55,14 @@ export function LeftSidebar() {
   });
 
   const showSearchResults = query.trim() !== "";
+  const showLoading = isSearching || isIndexing;
+  const showShortcut = isCmdPressed && !query;
+
+  useEffect(() => {
+    setFocusImpl(() => {
+      inputRef.current?.focus();
+    });
+  }, [setFocusImpl, inputRef]);
 
   return (
     <div className="h-full w-70 flex flex-col overflow-hidden shrink-0 gap-1">
@@ -78,6 +104,80 @@ export function LeftSidebar() {
           </Tooltip>
         </div>
       </header>
+
+      <div className="px-2 shrink-0">
+        <div className="relative flex items-center w-full">
+          {showLoading ? (
+            <Loader2Icon
+              className={cn([
+                "h-4 w-4 absolute left-2.5 text-neutral-400 animate-spin",
+              ])}
+            />
+          ) : (
+            <SearchIcon
+              className={cn(["h-4 w-4 absolute left-2.5 text-neutral-400"])}
+            />
+          )}
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder="Search anything..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                if (query.trim()) {
+                  setQuery("");
+                  setSelectedIndex(-1);
+                } else {
+                  e.currentTarget.blur();
+                }
+              }
+              const flatResults =
+                results?.groups.flatMap((g) => g.results) ?? [];
+              if (e.key === "ArrowDown" && flatResults.length > 0) {
+                e.preventDefault();
+                setSelectedIndex(
+                  Math.min(selectedIndex + 1, flatResults.length - 1),
+                );
+              }
+              if (e.key === "ArrowUp" && flatResults.length > 0) {
+                e.preventDefault();
+                setSelectedIndex(Math.max(selectedIndex - 1, -1));
+              }
+            }}
+            className={cn([
+              "text-sm placeholder:text-sm placeholder:text-neutral-400",
+              "w-full pl-8 pr-8 py-1.5",
+              "rounded-lg bg-neutral-100",
+              "focus:outline-hidden focus:bg-neutral-200",
+              "transition-colors",
+            ])}
+          />
+          {query && (
+            <button
+              onClick={() => {
+                setQuery("");
+                setSelectedIndex(-1);
+              }}
+              className={cn([
+                "absolute right-2.5",
+                "h-4 w-4",
+                "text-neutral-400 hover:text-neutral-600",
+                "transition-colors",
+              ])}
+              aria-label="Clear search"
+            >
+              <XIcon className="h-4 w-4" />
+            </button>
+          )}
+          {showShortcut && (
+            <div className="absolute right-2 flex items-center">
+              <Kbd>⌘ K</Kbd>
+            </div>
+          )}
+        </div>
+      </div>
 
       <div className="flex flex-col flex-1 overflow-hidden gap-1">
         <div className="flex-1 min-h-0 overflow-hidden relative">


### PR DESCRIPTION
Remove native context menu and search components from body header.
Replace search functionality with direct "New Note" button that
creates and starts listening immediately. Simplify plus button by
removing context menu options and conditional display based on
search state.

Move search functionality to sidebar with improved keyboard
shortcuts and search state management. Add command key detection
and focus handling for better user experience.