### PR TITLE
feat: add Chrome extension and Google Meet detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2968,6 +2968,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58b52a9840ffff5d4d0058ae529fa066a75e794e3125546acfc61c23ad755e49"
 
 [[package]]
+name = "chrome-native-host"
+version = "0.1.0"
+dependencies = [
+ "dirs 6.0.0",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4656,6 +4666,7 @@ dependencies = [
  "plist",
  "regex",
  "serde",
+ "serde_json",
  "specta",
  "sysinfo",
  "thiserror 2.0.18",
@@ -17566,9 +17577,11 @@ name = "tauri-plugin-detect"
 version = "0.1.0"
 dependencies = [
  "detect",
+ "dirs 6.0.0",
  "host",
  "notification-interface",
  "serde",
+ "serde_json",
  "specta",
  "specta-typescript",
  "tauri",

--- a/apps/chrome-extension/background.js
+++ b/apps/chrome-extension/background.js
@@ -1,0 +1,31 @@
+const HOST_NAME = "com.hyprnote.chrome";
+let port = null;
+
+function connect() {
+  try {
+    port = chrome.runtime.connectNative(HOST_NAME);
+
+    port.onDisconnect.addListener(() => {
+      port = null;
+      chrome.action.setBadgeText({ text: "!" });
+      chrome.action.setBadgeBackgroundColor({ color: "#E53E3E" });
+      setTimeout(connect, 5000);
+    });
+
+    chrome.action.setBadgeText({ text: "" });
+  } catch {
+    port = null;
+    chrome.action.setBadgeText({ text: "!" });
+    chrome.action.setBadgeBackgroundColor({ color: "#E53E3E" });
+    setTimeout(connect, 5000);
+  }
+}
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (port) {
+    port.postMessage(message);
+  }
+});
+
+chrome.runtime.onInstalled.addListener(() => connect());
+chrome.runtime.onStartup.addListener(() => connect());

--- a/apps/chrome-extension/content.js
+++ b/apps/chrome-extension/content.js
@@ -1,0 +1,77 @@
+(() => {
+  let lastState = null;
+
+  function getMuteState() {
+    const btn = document.querySelector("[data-is-muted]");
+    if (btn) {
+      return btn.getAttribute("data-is-muted") === "true";
+    }
+
+    const muteBtn = document.querySelector(
+      'button[aria-label*="microphone" i], button[aria-label*="mic" i]',
+    );
+    if (muteBtn) {
+      const label = muteBtn.getAttribute("aria-label") || "";
+      if (/unmute|turn on/i.test(label)) return true;
+      if (/mute|turn off/i.test(label)) return false;
+    }
+    return null;
+  }
+
+  function getParticipants() {
+    const participants = [];
+
+    const nameElements = document.querySelectorAll(
+      "[data-self-name], [data-participant-id]",
+    );
+    nameElements.forEach((el) => {
+      const name = el.textContent?.trim();
+      if (name) {
+        participants.push({
+          name,
+          is_self: el.hasAttribute("data-self-name"),
+        });
+      }
+    });
+
+    return participants;
+  }
+
+  function sendState() {
+    const muted = getMuteState();
+    if (muted === null) return;
+
+    const state = {
+      type: "meeting_state",
+      url: window.location.href,
+      is_active: true,
+      muted,
+      participants: getParticipants(),
+    };
+
+    const stateStr = JSON.stringify(state);
+    if (stateStr === lastState) return;
+    lastState = stateStr;
+
+    chrome.runtime.sendMessage(state);
+  }
+
+  const observer = new MutationObserver(() => sendState());
+
+  observer.observe(document.body, {
+    attributes: true,
+    attributeFilter: ["data-is-muted", "aria-label"],
+    subtree: true,
+    childList: true,
+  });
+
+  sendState();
+
+  window.addEventListener("beforeunload", () => {
+    chrome.runtime.sendMessage({
+      type: "meeting_ended",
+      url: window.location.href,
+      is_active: false,
+    });
+  });
+})();

--- a/apps/chrome-extension/manifest.json
+++ b/apps/chrome-extension/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 3,
+  "name": "Hyprnote",
+  "version": "0.1.0",
+  "description": "Google Meet integration for Hyprnote",
+  "permissions": ["nativeMessaging"],
+  "content_scripts": [
+    {
+      "matches": ["https://meet.google.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "background": {
+    "service_worker": "background.js"
+  }
+}

--- a/apps/desktop/src/contexts/listener.tsx
+++ b/apps/desktop/src/contexts/listener.tsx
@@ -80,6 +80,10 @@ function getNearbyEvents(
 const useHandleDetectEvents = (store: ListenerStore) => {
   const stop = useStore(store, (state) => state.stop);
   const setMuted = useStore(store, (state) => state.setMuted);
+  const setMeetParticipants = useStore(
+    store,
+    (state) => state.setMeetParticipants,
+  );
   const notificationDetectEnabled = useConfigValue("notification_detect");
   const tinybaseStore = main.UI.useStore(main.STORE_ID);
 
@@ -141,6 +145,8 @@ const useHandleDetectEvents = (store: ListenerStore) => {
           }
         } else if (payload.type === "micMuted") {
           setMuted(payload.value);
+        } else if (payload.type === "googleMeetParticipants") {
+          setMeetParticipants(payload.participants);
         }
       })
       .then((fn) => {
@@ -158,5 +164,5 @@ const useHandleDetectEvents = (store: ListenerStore) => {
       cancelled = true;
       unlisten?.();
     };
-  }, [stop, setMuted]);
+  }, [stop, setMuted, setMeetParticipants]);
 };

--- a/apps/desktop/src/store/zustand/listener/general.ts
+++ b/apps/desktop/src/store/zustand/listener/general.ts
@@ -39,6 +39,11 @@ export type LoadingPhase =
   | "connecting"
   | "connected";
 
+export type MeetParticipant = {
+  name: string;
+  is_self: boolean;
+};
+
 export type GeneralState = {
   live: {
     eventUnlisteners?: (() => void)[];
@@ -53,6 +58,7 @@ export type GeneralState = {
     lastError: string | null;
     device: string | null;
     degraded: DegradedError | null;
+    meetParticipants: MeetParticipant[];
   };
 };
 
@@ -63,6 +69,7 @@ export type GeneralActions = {
   ) => void;
   stop: () => void;
   setMuted: (value: boolean) => void;
+  setMeetParticipants: (participants: MeetParticipant[]) => void;
   runBatch: (
     params: BatchParams,
     options?: { handlePersist?: HandlePersistCallback; sessionId?: string },
@@ -82,6 +89,7 @@ const initialState: GeneralState = {
     lastError: null,
     device: null,
     degraded: null,
+    meetParticipants: [],
   },
 };
 
@@ -233,6 +241,7 @@ export const createGeneralSlice = <
             draft.live.device = null;
             draft.live.degraded = null;
             draft.live.muted = initialState.live.muted;
+            draft.live.meetParticipants = [];
           }),
         );
 
@@ -406,6 +415,7 @@ export const createGeneralSlice = <
               draft.live.seconds = 0;
               draft.live.sessionId = null;
               draft.live.muted = initialState.live.muted;
+              draft.live.meetParticipants = [];
               draft.live.lastError = null;
               draft.live.device = null;
               draft.live.degraded = null;
@@ -467,6 +477,13 @@ export const createGeneralSlice = <
       mutate(state, (draft) => {
         draft.live.muted = value;
         void listenerCommands.setMicMuted(value);
+      }),
+    );
+  },
+  setMeetParticipants: (participants) => {
+    set((state) =>
+      mutate(state, (draft) => {
+        draft.live.meetParticipants = participants;
       }),
     );
   },

--- a/crates/chrome-native-host/Cargo.toml
+++ b/crates/chrome-native-host/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "chrome-native-host"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "hyprnote-chrome-native-host"
+path = "src/main.rs"
+
+[dependencies]
+dirs = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/chrome-native-host/src/main.rs
+++ b/crates/chrome-native-host/src/main.rs
@@ -1,0 +1,119 @@
+use std::io::{self, Read, Write};
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+struct IncomingMessage {
+    #[serde(rename = "type")]
+    msg_type: String,
+    url: Option<String>,
+    is_active: Option<bool>,
+    muted: Option<bool>,
+    participants: Option<Vec<Participant>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Participant {
+    pub name: String,
+    pub is_self: bool,
+}
+
+#[derive(Serialize)]
+struct ChromeState {
+    version: u32,
+    timestamp_ms: u64,
+    meeting: Option<MeetingState>,
+}
+
+#[derive(Serialize)]
+struct MeetingState {
+    url: String,
+    is_active: bool,
+    muted: bool,
+    participants: Vec<Participant>,
+}
+
+fn state_file_path() -> PathBuf {
+    let data_dir = dirs::data_dir().expect("failed to resolve data directory");
+    data_dir.join("hyprnote").join("chrome_state.json")
+}
+
+fn read_message(stdin: &mut impl Read) -> io::Result<Option<Vec<u8>>> {
+    let mut len_buf = [0u8; 4];
+    match stdin.read_exact(&mut len_buf) {
+        Ok(()) => {}
+        Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e),
+    }
+    let len = u32::from_le_bytes(len_buf) as usize;
+    let mut buf = vec![0u8; len];
+    stdin.read_exact(&mut buf)?;
+    Ok(Some(buf))
+}
+
+fn write_state(state: &ChromeState) -> io::Result<()> {
+    let path = state_file_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let dir = path.parent().unwrap();
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)?;
+    serde_json::to_writer(&mut tmp, state)?;
+    tmp.as_file_mut().flush()?;
+    tmp.persist(&path).map_err(|e| e.error)?;
+    Ok(())
+}
+
+fn timestamp_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}
+
+fn main() {
+    let mut stdin = io::stdin().lock();
+
+    loop {
+        match read_message(&mut stdin) {
+            Ok(Some(data)) => {
+                let msg: IncomingMessage = match serde_json::from_slice(&data) {
+                    Ok(m) => m,
+                    Err(_) => continue,
+                };
+
+                let meeting = if msg.msg_type == "meeting_state" && msg.is_active.unwrap_or(false) {
+                    Some(MeetingState {
+                        url: msg.url.unwrap_or_default(),
+                        is_active: true,
+                        muted: msg.muted.unwrap_or(false),
+                        participants: msg.participants.unwrap_or_default(),
+                    })
+                } else {
+                    None
+                };
+
+                let state = ChromeState {
+                    version: 1,
+                    timestamp_ms: timestamp_ms(),
+                    meeting,
+                };
+
+                if let Err(e) = write_state(&state) {
+                    eprintln!("failed to write state: {e}");
+                }
+            }
+            Ok(None) => break,
+            Err(_) => break,
+        }
+    }
+
+    let state = ChromeState {
+        version: 1,
+        timestamp_ms: timestamp_ms(),
+        meeting: None,
+    };
+    let _ = write_state(&state);
+}

--- a/crates/detect/Cargo.toml
+++ b/crates/detect/Cargo.toml
@@ -11,6 +11,7 @@ list = []
 app = []
 zoom = []
 sleep = []
+google-meet = []
 
 [dependencies]
 isolang = { workspace = true }
@@ -24,6 +25,7 @@ tokio = { workspace = true, features = ["rt", "sync", "time", "macros"] }
 tracing = { workspace = true }
 
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 specta = { workspace = true, features = ["derive"] }
 
 [target."cfg(target_os = \"macos\")".dependencies]

--- a/crates/detect/src/google_meet.rs
+++ b/crates/detect/src/google_meet.rs
@@ -1,0 +1,242 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use crate::{BackgroundTask, DetectCallback, DetectEvent};
+
+pub trait GoogleMeetRuntime: Send + Sync + 'static {
+    fn chrome_state_path(&self) -> PathBuf;
+    fn native_host_binary_path(&self) -> Option<PathBuf>;
+    fn chrome_native_messaging_hosts_dir(&self) -> Option<PathBuf>;
+
+    fn register_chrome_native_host(&self) {
+        let Some(dir) = self.chrome_native_messaging_hosts_dir() else {
+            tracing::warn!("could not determine Chrome NativeMessagingHosts directory");
+            return;
+        };
+
+        let Some(binary_path) = self.native_host_binary_path() else {
+            tracing::warn!("could not resolve native messaging host binary path");
+            return;
+        };
+
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            tracing::warn!("failed to create NativeMessagingHosts dir: {e}");
+            return;
+        }
+
+        let manifest = NativeMessagingManifest {
+            name: "com.hyprnote.chrome".to_string(),
+            description: "Hyprnote Chrome integration".to_string(),
+            path: binary_path.to_string_lossy().into_owned(),
+            host_type: "stdio".to_string(),
+            allowed_origins: vec!["chrome-extension://hyprnote/".to_string()],
+        };
+
+        let manifest_path = dir.join("com.hyprnote.chrome.json");
+
+        match serde_json::to_string_pretty(&manifest) {
+            Ok(json) => {
+                if let Err(e) = std::fs::write(&manifest_path, json) {
+                    tracing::warn!("failed to write native messaging manifest: {e}");
+                } else {
+                    tracing::info!(
+                        "registered Chrome native messaging host at {}",
+                        manifest_path.display()
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!("failed to serialize native messaging manifest: {e}");
+            }
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct NativeMessagingManifest {
+    name: String,
+    description: String,
+    path: String,
+    #[serde(rename = "type")]
+    host_type: String,
+    allowed_origins: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ChromeState {
+    #[allow(dead_code)]
+    version: u32,
+    timestamp_ms: u64,
+    meeting: Option<MeetingState>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct MeetingState {
+    #[allow(dead_code)]
+    url: String,
+    is_active: bool,
+    muted: bool,
+    participants: Vec<MeetParticipant>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, serde::Serialize, specta::Type)]
+pub struct MeetParticipant {
+    pub name: String,
+    pub is_self: bool,
+}
+
+pub struct GoogleMeetWatcher {
+    background: BackgroundTask,
+    runtime: Option<Arc<dyn GoogleMeetRuntime>>,
+}
+
+impl Default for GoogleMeetWatcher {
+    fn default() -> Self {
+        Self {
+            background: BackgroundTask::default(),
+            runtime: None,
+        }
+    }
+}
+
+impl GoogleMeetWatcher {
+    pub fn set_runtime(&mut self, runtime: Arc<dyn GoogleMeetRuntime>) {
+        self.runtime = Some(runtime);
+    }
+}
+
+struct WatcherState {
+    last_mute_state: Option<bool>,
+    last_participants: Option<Vec<MeetParticipant>>,
+    poll_interval: Duration,
+}
+
+impl WatcherState {
+    fn new() -> Self {
+        Self {
+            last_mute_state: None,
+            last_participants: None,
+            poll_interval: Duration::from_millis(500),
+        }
+    }
+}
+
+const STALENESS_THRESHOLD_MS: u64 = 30_000;
+
+fn read_chrome_state(path: &PathBuf) -> Option<ChromeState> {
+    let data = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+fn is_stale(timestamp_ms: u64) -> bool {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64;
+    now.saturating_sub(timestamp_ms) > STALENESS_THRESHOLD_MS
+}
+
+impl crate::Observer for GoogleMeetWatcher {
+    fn start(&mut self, f: DetectCallback) {
+        if self.background.is_running() {
+            return;
+        }
+
+        let Some(runtime) = self.runtime.clone() else {
+            tracing::debug!("google meet watcher has no runtime, skipping start");
+            return;
+        };
+
+        let chrome_state_path = runtime.chrome_state_path();
+
+        self.background.start(|running, mut rx| async move {
+            let mut state = WatcherState::new();
+
+            loop {
+                tokio::select! {
+                    _ = &mut rx => {
+                        break;
+                    }
+                    _ = tokio::time::sleep(state.poll_interval) => {
+                        if !running.load(std::sync::atomic::Ordering::SeqCst) {
+                            break;
+                        }
+
+                        let chrome_state = match read_chrome_state(&chrome_state_path) {
+                            Some(s) => s,
+                            None => {
+                                if state.last_mute_state.is_some() {
+                                    tracing::debug!("chrome state file gone, clearing state");
+                                    state.last_mute_state = None;
+                                    state.last_participants = None;
+                                }
+                                continue;
+                            }
+                        };
+
+                        if is_stale(chrome_state.timestamp_ms) {
+                            if state.last_mute_state.is_some() {
+                                tracing::debug!("chrome state stale, clearing");
+                                state.last_mute_state = None;
+                                state.last_participants = None;
+                            }
+                            continue;
+                        }
+
+                        match chrome_state.meeting {
+                            Some(meeting) if meeting.is_active => {
+                                if state.last_mute_state != Some(meeting.muted) {
+                                    tracing::info!(muted = meeting.muted, "google meet mute state changed");
+                                    state.last_mute_state = Some(meeting.muted);
+                                    f(DetectEvent::GoogleMeetMuteStateChanged { value: meeting.muted });
+                                }
+
+                                if state.last_participants.as_ref() != Some(&meeting.participants) {
+                                    tracing::info!(count = meeting.participants.len(), "google meet participants changed");
+                                    state.last_participants = Some(meeting.participants.clone());
+                                    f(DetectEvent::GoogleMeetParticipantsChanged { participants: meeting.participants });
+                                }
+                            }
+                            _ => {
+                                if state.last_mute_state.is_some() {
+                                    tracing::debug!("google meet meeting ended, clearing state");
+                                    state.last_mute_state = None;
+                                    state.last_participants = None;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            tracing::info!("google meet watcher stopped");
+        });
+    }
+
+    fn stop(&mut self) {
+        self.background.stop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Observer, new_callback};
+    use std::time::Duration;
+
+    // cargo test --package detect --lib --features mic,list,google-meet -- google_meet::tests::test_watcher --exact --nocapture --ignored
+    #[tokio::test]
+    #[ignore]
+    async fn test_watcher() {
+        let mut watcher = GoogleMeetWatcher::default();
+        watcher.start(new_callback(|v| {
+            println!("{:?}", v);
+        }));
+
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        watcher.stop();
+    }
+}

--- a/plugins/detect/Cargo.toml
+++ b/plugins/detect/Cargo.toml
@@ -8,10 +8,11 @@ links = "tauri-plugin-detect"
 description = ""
 
 [features]
-default = ["zoom", "sleep"]
+default = ["zoom", "sleep", "google-meet"]
 zoom = ["hypr-detect/zoom"]
 language = ["hypr-detect/language"]
 sleep = ["hypr-detect/sleep"]
+google-meet = ["hypr-detect/google-meet"]
 
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }
@@ -21,7 +22,7 @@ specta-typescript = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 
 [dependencies]
-hypr-detect = { workspace = true, features = ["mic", "list", "language", "sleep"] }
+hypr-detect = { workspace = true, features = ["mic", "list", "language", "sleep", "google-meet"] }
 hypr-host = { workspace = true }
 hypr-notification-interface = { workspace = true }
 
@@ -31,7 +32,9 @@ tauri-plugin-windows = { workspace = true }
 specta = { workspace = true }
 tauri-specta = { workspace = true, features = ["derive", "typescript"] }
 
+dirs = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 

--- a/plugins/detect/js/bindings.gen.ts
+++ b/plugins/detect/js/bindings.gen.ts
@@ -87,8 +87,9 @@ detectEvent: "plugin:detect:detect-event"
 
 /** user-defined types **/
 
-export type DetectEvent = { type: "micDetected"; key: string; apps: InstalledApp[]; duration_secs: number } | { type: "micStopped"; apps: InstalledApp[] } | { type: "micMuted"; value: boolean } | { type: "sleepStateChanged"; value: boolean }
+export type DetectEvent = { type: "micDetected"; key: string; apps: InstalledApp[]; duration_secs: number } | { type: "micStopped"; apps: InstalledApp[] } | { type: "micMuted"; value: boolean } | { type: "sleepStateChanged"; value: boolean } | { type: "googleMeetParticipants"; participants: MeetParticipant[] }
 export type InstalledApp = { id: string; name: string }
+export type MeetParticipant = { name: string; is_self: boolean }
 
 /** tauri-specta globals **/
 

--- a/plugins/detect/src/events.rs
+++ b/plugins/detect/src/events.rs
@@ -23,5 +23,15 @@ common_event_derives! {
         MicMuteStateChanged { value: bool },
         #[serde(rename = "sleepStateChanged")]
         SleepStateChanged { value: bool },
+        #[serde(rename = "googleMeetParticipants")]
+        GoogleMeetParticipantsChanged {
+            participants: Vec<MeetParticipant>,
+        },
     }
+}
+
+#[derive(serde::Serialize, Clone, specta::Type)]
+pub struct MeetParticipant {
+    pub name: String,
+    pub is_self: bool,
 }

--- a/plugins/detect/src/google_meet_runtime.rs
+++ b/plugins/detect/src/google_meet_runtime.rs
@@ -1,0 +1,56 @@
+use std::path::PathBuf;
+
+pub(crate) struct TauriGoogleMeetRuntime;
+
+impl hypr_detect::GoogleMeetRuntime for TauriGoogleMeetRuntime {
+    fn chrome_state_path(&self) -> PathBuf {
+        dirs::data_dir()
+            .unwrap()
+            .join("hyprnote")
+            .join("chrome_state.json")
+    }
+
+    fn native_host_binary_path(&self) -> Option<PathBuf> {
+        if cfg!(debug_assertions) {
+            let workspace_dir = std::env::var("CARGO_MANIFEST_DIR").ok()?;
+            let workspace_root = PathBuf::from(workspace_dir)
+                .parent()?
+                .parent()?
+                .to_path_buf();
+            Some(workspace_root.join("target/debug/hyprnote-chrome-native-host"))
+        } else {
+            #[cfg(target_os = "macos")]
+            {
+                let exe = std::env::current_exe().ok()?;
+                let macos_dir = exe.parent()?;
+                Some(macos_dir.join("hyprnote-chrome-native-host"))
+            }
+
+            #[cfg(not(target_os = "macos"))]
+            {
+                let exe = std::env::current_exe().ok()?;
+                let bin_dir = exe.parent()?;
+                Some(bin_dir.join("hyprnote-chrome-native-host"))
+            }
+        }
+    }
+
+    fn chrome_native_messaging_hosts_dir(&self) -> Option<PathBuf> {
+        #[cfg(target_os = "macos")]
+        {
+            let home = dirs::home_dir()?;
+            Some(home.join("Library/Application Support/Google/Chrome/NativeMessagingHosts"))
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let home = dirs::home_dir()?;
+            Some(home.join(".config/google-chrome/NativeMessagingHosts"))
+        }
+
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        {
+            None
+        }
+    }
+}

--- a/plugins/detect/src/handler.rs
+++ b/plugins/detect/src/handler.rs
@@ -50,6 +50,21 @@ pub(crate) fn handle_detect_event<E: Env>(
         hypr_detect::DetectEvent::SleepStateChanged { value } => {
             env.emit(DetectEvent::SleepStateChanged { value });
         }
+        #[cfg(feature = "google-meet")]
+        hypr_detect::DetectEvent::GoogleMeetMuteStateChanged { value } => {
+            env.emit(DetectEvent::MicMuteStateChanged { value });
+        }
+        #[cfg(feature = "google-meet")]
+        hypr_detect::DetectEvent::GoogleMeetParticipantsChanged { participants } => {
+            let participants = participants
+                .into_iter()
+                .map(|p| crate::events::MeetParticipant {
+                    name: p.name,
+                    is_self: p.is_self,
+                })
+                .collect();
+            env.emit(DetectEvent::GoogleMeetParticipantsChanged { participants });
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Add Chrome extension (background, content scripts, manifest)
- Add chrome-native-host crate for native messaging
- Add Google Meet detection in detect crate and plugin
- Update desktop listener for Google Meet runtime

Made with [Cursor](https://cursor.com)