### PR TITLE
fix: update domain from hyprnote.com to char.com

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -13,7 +13,6 @@ import { Route as YoutubeRouteImport } from './routes/youtube'
 import { Route as XRouteImport } from './routes/x'
 import { Route as UpdatePasswordRouteImport } from './routes/update-password'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
-import { Route as RedditRouteImport } from './routes/reddit'
 import { Route as LinkedinRouteImport } from './routes/linkedin'
 import { Route as GithubRouteImport } from './routes/github'
 import { Route as FoundersRouteImport } from './routes/founders'
@@ -31,7 +30,7 @@ import { Route as ApiTemplatesRouteImport } from './routes/api/templates'
 import { Route as ApiShortcutsRouteImport } from './routes/api/shortcuts'
 import { Route as ApiMediaUploadRouteImport } from './routes/api/media-upload'
 import { Route as ApiK6ReportsRouteImport } from './routes/api/k6-reports'
-import { Route as ViewWhyHyprnoteRouteImport } from './routes/_view/why-hyprnote'
+import { Route as ViewWhyCharRouteImport } from './routes/_view/why-char'
 import { Route as ViewSecurityRouteImport } from './routes/_view/security'
 import { Route as ViewPrivacyRouteImport } from './routes/_view/privacy'
 import { Route as ViewPricingRouteImport } from './routes/_view/pricing'
@@ -176,11 +175,6 @@ const ResetPasswordRoute = ResetPasswordRouteImport.update({
   path: '/reset-password',
   getParentRoute: () => rootRouteImport,
 } as any)
-const RedditRoute = RedditRouteImport.update({
-  id: '/reddit',
-  path: '/reddit',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const LinkedinRoute = LinkedinRouteImport.update({
   id: '/linkedin',
   path: '/linkedin',
@@ -265,9 +259,9 @@ const ApiK6ReportsRoute = ApiK6ReportsRouteImport.update({
   path: '/api/k6-reports',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ViewWhyHyprnoteRoute = ViewWhyHyprnoteRouteImport.update({
-  id: '/why-hyprnote',
-  path: '/why-hyprnote',
+const ViewWhyCharRoute = ViewWhyCharRouteImport.update({
+  id: '/why-char',
+  path: '/why-char',
   getParentRoute: () => ViewRouteRoute,
 } as any)
 const ViewSecurityRoute = ViewSecurityRouteImport.update({
@@ -922,7 +916,6 @@ export interface FileRoutesByFullPath {
   '/founders': typeof FoundersRoute
   '/github': typeof GithubRoute
   '/linkedin': typeof LinkedinRoute
-  '/reddit': typeof RedditRoute
   '/reset-password': typeof ResetPasswordRoute
   '/update-password': typeof UpdatePasswordRoute
   '/x': typeof XRoute
@@ -941,7 +934,7 @@ export interface FileRoutesByFullPath {
   '/pricing': typeof ViewPricingRoute
   '/privacy': typeof ViewPrivacyRoute
   '/security': typeof ViewSecurityRoute
-  '/why-hyprnote': typeof ViewWhyHyprnoteRoute
+  '/why-char': typeof ViewWhyCharRoute
   '/api/k6-reports': typeof ApiK6ReportsRoute
   '/api/media-upload': typeof ApiMediaUploadRoute
   '/api/shortcuts': typeof ApiShortcutsRoute
@@ -1067,7 +1060,6 @@ export interface FileRoutesByTo {
   '/founders': typeof FoundersRoute
   '/github': typeof GithubRoute
   '/linkedin': typeof LinkedinRoute
-  '/reddit': typeof RedditRoute
   '/reset-password': typeof ResetPasswordRoute
   '/update-password': typeof UpdatePasswordRoute
   '/x': typeof XRoute
@@ -1083,7 +1075,7 @@ export interface FileRoutesByTo {
   '/pricing': typeof ViewPricingRoute
   '/privacy': typeof ViewPrivacyRoute
   '/security': typeof ViewSecurityRoute
-  '/why-hyprnote': typeof ViewWhyHyprnoteRoute
+  '/why-char': typeof ViewWhyCharRoute
   '/api/k6-reports': typeof ApiK6ReportsRoute
   '/api/media-upload': typeof ApiMediaUploadRoute
   '/api/shortcuts': typeof ApiShortcutsRoute
@@ -1213,7 +1205,6 @@ export interface FileRoutesById {
   '/founders': typeof FoundersRoute
   '/github': typeof GithubRoute
   '/linkedin': typeof LinkedinRoute
-  '/reddit': typeof RedditRoute
   '/reset-password': typeof ResetPasswordRoute
   '/update-password': typeof UpdatePasswordRoute
   '/x': typeof XRoute
@@ -1232,7 +1223,7 @@ export interface FileRoutesById {
   '/_view/pricing': typeof ViewPricingRoute
   '/_view/privacy': typeof ViewPrivacyRoute
   '/_view/security': typeof ViewSecurityRoute
-  '/_view/why-hyprnote': typeof ViewWhyHyprnoteRoute
+  '/_view/why-char': typeof ViewWhyCharRoute
   '/api/k6-reports': typeof ApiK6ReportsRoute
   '/api/media-upload': typeof ApiMediaUploadRoute
   '/api/shortcuts': typeof ApiShortcutsRoute
@@ -1363,7 +1354,6 @@ export interface FileRouteTypes {
     | '/founders'
     | '/github'
     | '/linkedin'
-    | '/reddit'
     | '/reset-password'
     | '/update-password'
     | '/x'
@@ -1382,7 +1372,7 @@ export interface FileRouteTypes {
     | '/pricing'
     | '/privacy'
     | '/security'
-    | '/why-hyprnote'
+    | '/why-char'
     | '/api/k6-reports'
     | '/api/media-upload'
     | '/api/shortcuts'
@@ -1508,7 +1498,6 @@ export interface FileRouteTypes {
     | '/founders'
     | '/github'
     | '/linkedin'
-    | '/reddit'
     | '/reset-password'
     | '/update-password'
     | '/x'
@@ -1524,7 +1513,7 @@ export interface FileRouteTypes {
     | '/pricing'
     | '/privacy'
     | '/security'
-    | '/why-hyprnote'
+    | '/why-char'
     | '/api/k6-reports'
     | '/api/media-upload'
     | '/api/shortcuts'
@@ -1653,7 +1642,6 @@ export interface FileRouteTypes {
     | '/founders'
     | '/github'
     | '/linkedin'
-    | '/reddit'
     | '/reset-password'
     | '/update-password'
     | '/x'
@@ -1672,7 +1660,7 @@ export interface FileRouteTypes {
     | '/_view/pricing'
     | '/_view/privacy'
     | '/_view/security'
-    | '/_view/why-hyprnote'
+    | '/_view/why-char'
     | '/api/k6-reports'
     | '/api/media-upload'
     | '/api/shortcuts'
@@ -1802,7 +1790,6 @@ export interface RootRouteChildren {
   FoundersRoute: typeof FoundersRoute
   GithubRoute: typeof GithubRoute
   LinkedinRoute: typeof LinkedinRoute
-  RedditRoute: typeof RedditRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
   UpdatePasswordRoute: typeof UpdatePasswordRoute
   XRoute: typeof XRoute
@@ -1871,13 +1858,6 @@ declare module '@tanstack/react-router' {
       path: '/reset-password'
       fullPath: '/reset-password'
       preLoaderRoute: typeof ResetPasswordRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/reddit': {
-      id: '/reddit'
-      path: '/reddit'
-      fullPath: '/reddit'
-      preLoaderRoute: typeof RedditRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/linkedin': {
@@ -1999,11 +1979,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiK6ReportsRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/_view/why-hyprnote': {
-      id: '/_view/why-hyprnote'
-      path: '/why-hyprnote'
-      fullPath: '/why-hyprnote'
-      preLoaderRoute: typeof ViewWhyHyprnoteRouteImport
+    '/_view/why-char': {
+      id: '/_view/why-char'
+      path: '/why-char'
+      fullPath: '/why-char'
+      preLoaderRoute: typeof ViewWhyCharRouteImport
       parentRoute: typeof ViewRouteRoute
     }
     '/_view/security': {
@@ -2935,7 +2915,7 @@ interface ViewRouteRouteChildren {
   ViewPricingRoute: typeof ViewPricingRoute
   ViewPrivacyRoute: typeof ViewPrivacyRoute
   ViewSecurityRoute: typeof ViewSecurityRoute
-  ViewWhyHyprnoteRoute: typeof ViewWhyHyprnoteRoute
+  ViewWhyCharRoute: typeof ViewWhyCharRoute
   ViewIndexRoute: typeof ViewIndexRoute
   ViewBlogSlugRoute: typeof ViewBlogSlugRoute
   ViewCallbackAuthRoute: typeof ViewCallbackAuthRoute
@@ -3019,7 +2999,7 @@ const ViewRouteRouteChildren: ViewRouteRouteChildren = {
   ViewPricingRoute: ViewPricingRoute,
   ViewPrivacyRoute: ViewPrivacyRoute,
   ViewSecurityRoute: ViewSecurityRoute,
-  ViewWhyHyprnoteRoute: ViewWhyHyprnoteRoute,
+  ViewWhyCharRoute: ViewWhyCharRoute,
   ViewIndexRoute: ViewIndexRoute,
   ViewBlogSlugRoute: ViewBlogSlugRoute,
   ViewCallbackAuthRoute: ViewCallbackAuthRoute,
@@ -3129,7 +3109,6 @@ const rootRouteChildren: RootRouteChildren = {
   FoundersRoute: FoundersRoute,
   GithubRoute: GithubRoute,
   LinkedinRoute: LinkedinRoute,
-  RedditRoute: RedditRoute,
   ResetPasswordRoute: ResetPasswordRoute,
   UpdatePasswordRoute: UpdatePasswordRoute,
   XRoute: XRoute,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -31,12 +31,12 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       { title: TITLE },
       { name: "description", content: DESCRIPTION },
       { name: "keywords", content: KEYWORDS },
-      { name: "ai-sitemap", content: "https://hyprnote.com/llms.txt" },
+      { name: "ai-sitemap", content: "https://char.com/llms.txt" },
       { name: "ai-content", content: "public" },
       { property: "og:type", content: "website" },
       { property: "og:title", content: TITLE },
       { property: "og:description", content: DESCRIPTION },
-      { property: "og:url", content: "https://hyprnote.com" },
+      { property: "og:url", content: "https://char.com" },
       {
         property: "og:image",
         content: "/api/images/hyprnote/og-image.jpg",
@@ -48,7 +48,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       { name: "twitter:creator", content: "@getcharnotes" },
       { name: "twitter:title", content: TITLE },
       { name: "twitter:description", content: DESCRIPTION },
-      { name: "twitter:url", content: "https://hyprnote.com" },
+      { name: "twitter:url", content: "https://char.com" },
       {
         name: "twitter:image",
         content: "/api/images/hyprnote/og-image.jpg",

--- a/apps/web/src/routes/_view/docs/$.tsx
+++ b/apps/web/src/routes/_view/docs/$.tsx
@@ -49,8 +49,8 @@ export const Route = createFileRoute("/_view/docs/$")({
     }
 
     const { doc } = loaderData;
-    const url = `https://hyprnote.com/docs/${doc.slug}`;
-    const ogImageUrl = `https://hyprnote.com/og?type=docs&title=${encodeURIComponent(doc.title)}&section=${encodeURIComponent(doc.section)}${doc.summary ? `&description=${encodeURIComponent(doc.summary)}` : ""}&v=1`;
+    const url = `https://char.com/docs/${doc.slug}`;
+    const ogImageUrl = `https://char.com/og?type=docs&title=${encodeURIComponent(doc.title)}&section=${encodeURIComponent(doc.section)}${doc.summary ? `&description=${encodeURIComponent(doc.summary)}` : ""}&v=1`;
 
     return {
       meta: [

--- a/apps/web/src/routes/_view/enterprise.tsx
+++ b/apps/web/src/routes/_view/enterprise.tsx
@@ -25,7 +25,7 @@ export const Route = createFileRoute("/_view/enterprise")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/enterprise",
+        content: "https://char.com/enterprise",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/eval/index.tsx
+++ b/apps/web/src/routes/_view/eval/index.tsx
@@ -33,7 +33,7 @@ export const Route = createFileRoute("/_view/eval/")({
           "Interactive comparison of AI models for meeting transcription tasks. Benchmark results for summarization, Q&A, action items, and speaker identification.",
       },
       { property: "og:type", content: "website" },
-      { property: "og:url", content: "https://hyprnote.com/eval" },
+      { property: "og:url", content: "https://char.com/eval" },
     ],
   }),
 });

--- a/apps/web/src/routes/_view/free.tsx
+++ b/apps/web/src/routes/_view/free.tsx
@@ -23,7 +23,7 @@ export const Route = createFileRoute("/_view/free")({
           "Char offers free AI-powered meeting transcription and notes. Local processing, unlimited recordings, and no usage limits. Download now.",
       },
       { property: "og:type", content: "website" },
-      { property: "og:url", content: "https://hyprnote.com/free" },
+      { property: "og:url", content: "https://char.com/free" },
     ],
   }),
 });

--- a/apps/web/src/routes/_view/gallery/$type.$slug.tsx
+++ b/apps/web/src/routes/_view/gallery/$type.$slug.tsx
@@ -38,10 +38,10 @@ export const Route = createFileRoute("/_view/gallery/$type/$slug")({
 
     const { type, item } = loaderData;
     const typeLabel = type === "template" ? "Template" : "Shortcut";
-    const url = `https://hyprnote.com/gallery/${type}/${item.slug}`;
+    const url = `https://char.com/gallery/${type}/${item.slug}`;
 
     const ogType = type === "template" ? "templates" : "shortcuts";
-    const ogImageUrl = `https://hyprnote.com/og?type=${ogType}&title=${encodeURIComponent(item.title)}&category=${encodeURIComponent(item.category)}${item.description ? `&description=${encodeURIComponent(item.description)}` : ""}&v=1`;
+    const ogImageUrl = `https://char.com/og?type=${ogType}&title=${encodeURIComponent(item.title)}&category=${encodeURIComponent(item.category)}${item.description ? `&description=${encodeURIComponent(item.description)}` : ""}&v=1`;
 
     return {
       meta: [

--- a/apps/web/src/routes/_view/gallery/index.tsx
+++ b/apps/web/src/routes/_view/gallery/index.tsx
@@ -45,7 +45,7 @@ export const Route = createFileRoute("/_view/gallery/")({
           "Browse our collection of AI meeting templates and shortcuts. From engineering standups to sales discovery calls, find the perfect tool for your workflow.",
       },
       { property: "og:type", content: "website" },
-      { property: "og:url", content: "https://hyprnote.com/gallery" },
+      { property: "og:url", content: "https://char.com/gallery" },
     ],
   }),
 });

--- a/apps/web/src/routes/_view/index.tsx
+++ b/apps/web/src/routes/_view/index.tsx
@@ -119,7 +119,7 @@ function Component() {
       style={{ backgroundImage: "url(/patterns/dots.svg)" }}
     >
       <div className="max-w-6xl mx-auto border-x border-neutral-100 bg-white">
-        <YCombinatorBanner />
+        <AnnouncementBanner />
         <HeroSection
           onVideoExpand={setExpandedVideo}
           heroInputRef={heroInputRef}
@@ -159,7 +159,7 @@ function Component() {
   );
 }
 
-function YCombinatorBanner() {
+function AnnouncementBanner() {
   return (
     <Link
       to="/blog/$slug/"
@@ -475,7 +475,7 @@ Cheers!"
         author="Flavius Catalin Miron"
         role="Product Engineer"
         company="Waveful"
-        body="Guys at Hyprnote (YC S25) are wild.
+        body="Guys at Char are wild.
 
 Had a call with John Jeong about their product (privacy-first AI notepad).
 
@@ -555,7 +555,7 @@ Cheers!"
           author="Flavius Catalin Miron"
           role="Product Engineer"
           company="Waveful"
-          body="Guys at Hyprnote (YC S25) are wild.
+          body="Guys at Char are wild.
 
 Had a call with John Jeong about their product (privacy-first AI notepad).
 
@@ -1737,7 +1737,7 @@ function BlogSection() {
         {sortedArticles.map((article) => {
           const ogImage =
             article.coverImage ||
-            `https://hyprnote.com/og?type=blog&title=${encodeURIComponent(article.title ?? "")}${article.author.length > 0 ? `&author=${encodeURIComponent(article.author.join(", "))}` : ""}${article.date ? `&date=${encodeURIComponent(new Date(article.date).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" }))}` : ""}&v=1`;
+            `https://char.com/og?type=blog&title=${encodeURIComponent(article.title ?? "")}${article.author.length > 0 ? `&author=${encodeURIComponent(article.author.join(", "))}` : ""}${article.date ? `&date=${encodeURIComponent(new Date(article.date).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" }))}` : ""}&v=1`;
 
           return (
             <Link

--- a/apps/web/src/routes/_view/integrations/$category.$slug.tsx
+++ b/apps/web/src/routes/_view/integrations/$category.$slug.tsx
@@ -44,7 +44,7 @@ export const Route = createFileRoute("/_view/integrations/$category/$slug")({
         { property: "og:type", content: "website" },
         {
           property: "og:url",
-          content: `https://hyprnote.com/integrations/${doc.category}/${doc.slug}`,
+          content: `https://char.com/integrations/${doc.category}/${doc.slug}`,
         },
         { name: "twitter:card", content: "summary" },
         { name: "twitter:title", content: metaTitle },

--- a/apps/web/src/routes/_view/jobs/$slug.tsx
+++ b/apps/web/src/routes/_view/jobs/$slug.tsx
@@ -76,7 +76,7 @@ function JobPage() {
 function getApplyUrl(job: (typeof allJobs)[0]) {
   return (
     job.applyUrl ||
-    `mailto:founders@hyprnote.com?subject=Application for ${job.title}`
+    `mailto:founders@char.com?subject=Application for ${job.title}`
   );
 }
 

--- a/apps/web/src/routes/_view/jobs/index.tsx
+++ b/apps/web/src/routes/_view/jobs/index.tsx
@@ -141,7 +141,7 @@ function CTASection() {
         </p>
         <div className="pt-6">
           <a
-            href="mailto:founders@hyprnote.com"
+            href="mailto:founders@char.com"
             className="px-6 h-12 flex items-center justify-center text-base sm:text-lg bg-linear-to-t from-stone-600 to-stone-500 text-white rounded-full shadow-md hover:shadow-lg hover:scale-[102%] active:scale-[98%] transition-all"
           >
             Contact us

--- a/apps/web/src/routes/_view/legal/$slug.tsx
+++ b/apps/web/src/routes/_view/legal/$slug.tsx
@@ -20,7 +20,7 @@ export const Route = createFileRoute("/_view/legal/$slug")({
     }
 
     const { doc } = loaderData;
-    const url = `https://hyprnote.com/legal/${doc.slug}`;
+    const url = `https://char.com/legal/${doc.slug}`;
 
     return {
       meta: [

--- a/apps/web/src/routes/_view/legal/index.tsx
+++ b/apps/web/src/routes/_view/legal/index.tsx
@@ -17,7 +17,7 @@ export const Route = createFileRoute("/_view/legal/")({
         content: "Terms, privacy policy, and other legal documents for Char",
       },
       { property: "og:type", content: "website" },
-      { property: "og:url", content: "https://hyprnote.com/legal" },
+      { property: "og:url", content: "https://char.com/legal" },
       { name: "twitter:card", content: "summary" },
       { name: "twitter:title", content: "Legal - Char" },
       {

--- a/apps/web/src/routes/_view/opensource.tsx
+++ b/apps/web/src/routes/_view/opensource.tsx
@@ -36,7 +36,7 @@ export const Route = createFileRoute("/_view/opensource")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/opensource",
+        content: "https://char.com/opensource",
       },
       { name: "twitter:card", content: "summary_large_image" },
       { name: "twitter:title", content: "Open Source - Char" },
@@ -820,14 +820,14 @@ const contributions = [
     title: "Spread the Word",
     description: "Share Char with your network and community",
     icon: "mdi:share-variant",
-    link: "https://twitter.com/intent/tweet?text=Check%20out%20Hyprnote%20-%20open%20source%20AI%20meeting%20notes%20that%20run%20locally!%20https://hyprnote.com",
+    link: "https://twitter.com/intent/tweet?text=Check%20out%Char%20-%20open%20source%20AI%20meeting%20notes%20that%20run%20locally!%20https://char.com",
     linkText: "Share on X",
   },
   {
     title: "Join Community",
     description: "Connect with other users and contributors",
     icon: "mdi:forum",
-    link: "https://discord.gg/Hyprnote",
+    link: "/discord",
     linkText: "Join Discord",
   },
 ];

--- a/apps/web/src/routes/_view/oss-friends.tsx
+++ b/apps/web/src/routes/_view/oss-friends.tsx
@@ -27,7 +27,7 @@ export const Route = createFileRoute("/_view/oss-friends")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/oss-friends",
+        content: "https://char.com/oss-friends",
       },
       { name: "twitter:card", content: "summary_large_image" },
       { name: "twitter:title", content: "OSS Friends - Char" },

--- a/apps/web/src/routes/_view/press-kit/index.tsx
+++ b/apps/web/src/routes/_view/press-kit/index.tsx
@@ -54,10 +54,10 @@ function Component() {
               Download press materials, logos, screenshots, and learn more about
               Char. For press inquiries, contact us at{" "}
               <a
-                href="mailto:founders@hyprnote.com"
+                href="mailto:founders@char.com"
                 className="text-stone-600 underline hover:text-stone-700"
               >
-                founders@hyprnote.com
+                founders@char.com
               </a>
             </p>
           </div>
@@ -108,7 +108,7 @@ function Component() {
                       appIcon
                     />
                     <FinderAction
-                      href="mailto:founders@hyprnote.com"
+                      href="mailto:founders@char.com"
                       iconImage="/api/images/icons/macos-mail.png"
                       label="Contact"
                     />

--- a/apps/web/src/routes/_view/privacy.tsx
+++ b/apps/web/src/routes/_view/privacy.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute("/_view/privacy")({
           "We believe your conversations belong to you, not to us or anyone else. Discover how Char puts your privacy first.",
       },
       { property: "og:type", content: "website" },
-      { property: "og:url", content: "https://hyprnote.com/privacy" },
+      { property: "og:url", content: "https://char.com/privacy" },
       { name: "twitter:card", content: "summary_large_image" },
       { name: "twitter:title", content: "Privacy - Char" },
       {

--- a/apps/web/src/routes/_view/product/ai-notetaking.tsx
+++ b/apps/web/src/routes/_view/product/ai-notetaking.tsx
@@ -31,7 +31,7 @@ export const Route = createFileRoute("/_view/product/ai-notetaking")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/product/ai-notetaking",
+        content: "https://char.com/product/ai-notetaking",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/product/flexible-ai.tsx
+++ b/apps/web/src/routes/_view/product/flexible-ai.tsx
@@ -89,7 +89,7 @@ function AISetupSection() {
         <div className="p-8 border-r border-b border-neutral-100 md:border-b-0">
           <Icon icon="mdi:cloud" className="text-3xl text-stone-600 mb-4" />
           <h3 className="text-xl font-serif text-stone-600 mb-1">
-            Hyprnote Cloud ($8/month)
+            Char Cloud ($8/month)
           </h3>
           <p className="text-neutral-600">
             Managed service that works out of the box. No setup, no API keys, no
@@ -176,7 +176,7 @@ function SwitchSection() {
             Start with Cloud
           </h3>
           <p className="text-neutral-600">
-            Try Hyprnote's managed service free for 14 days.
+            Try Char's managed service free for 14 days.
           </p>
         </div>
         <div className="p-8 border-b border-neutral-100 md:border-b-0">
@@ -246,8 +246,8 @@ function FAQSection() {
           </h2>
         </div>
         <FAQ>
-          <FAQItem question="Which AI models does Hyprnote use?">
-            Hyprnote Cloud routes requests to the best models for each task.
+          <FAQItem question="Which AI models does Char use?">
+            Char Cloud routes requests to the best models for each task.
           </FAQItem>
           <FAQItem question="Can I use different models for different meetings?">
             Yes. You can switch providers before any meeting or re-process
@@ -260,11 +260,11 @@ function FAQSection() {
           <FAQItem question="Is local AI good enough?">
             Local models are improving rapidly. For most meetings, local Whisper
             + Llama 3 works well. For complex summaries or technical
-            discussions, cloud models (Hyprnote Cloud or BYOK) tend to perform
+            discussions, cloud models (Char Cloud or BYOK) tend to perform
             better.
           </FAQItem>
-          <FAQItem question="Does Hyprnote train AI models on my data?">
-            No. Hyprnote does not use your recordings, transcripts, or notes to
+          <FAQItem question="Does Char train AI models on my data?">
+            No. Char does not use your recordings, transcripts, or notes to
             train AI models. When using cloud providers, your data is processed
             according to their privacy policies.
           </FAQItem>

--- a/apps/web/src/routes/_view/product/local-ai.tsx
+++ b/apps/web/src/routes/_view/product/local-ai.tsx
@@ -27,7 +27,7 @@ export const Route = createFileRoute("/_view/product/local-ai")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/product/local-ai",
+        content: "https://char.com/product/local-ai",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/roadmap/$slug.tsx
+++ b/apps/web/src/routes/_view/roadmap/$slug.tsx
@@ -23,7 +23,7 @@ export const Route = createFileRoute("/_view/roadmap/$slug")({
     }
 
     const { item } = loaderData;
-    const url = `https://hyprnote.com/roadmap/${item.slug}`;
+    const url = `https://char.com/roadmap/${item.slug}`;
 
     return {
       meta: [

--- a/apps/web/src/routes/_view/security.tsx
+++ b/apps/web/src/routes/_view/security.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute("/_view/security")({
           "Your meeting data deserves the highest level of protection. Learn how Char's security-first architecture keeps your conversations safe.",
       },
       { property: "og:type", content: "website" },
-      { property: "og:url", content: "https://hyprnote.com/security" },
+      { property: "og:url", content: "https://char.com/security" },
       { name: "twitter:card", content: "summary_large_image" },
       { name: "twitter:title", content: "Security - Char" },
       {

--- a/apps/web/src/routes/_view/solution/coaching.tsx
+++ b/apps/web/src/routes/_view/solution/coaching.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/_view/solution/coaching")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/solution/coaching",
+        content: "https://char.com/solution/coaching",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/solution/consulting.tsx
+++ b/apps/web/src/routes/_view/solution/consulting.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/_view/solution/consulting")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/solution/consulting",
+        content: "https://char.com/solution/consulting",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/solution/customer-success.tsx
+++ b/apps/web/src/routes/_view/solution/customer-success.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/_view/solution/customer-success")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/solution/customer-success",
+        content: "https://char.com/solution/customer-success",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/solution/engineering.tsx
+++ b/apps/web/src/routes/_view/solution/engineering.tsx
@@ -37,7 +37,7 @@ export const Route = createFileRoute("/_view/solution/engineering")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/solution/engineering",
+        content: "https://char.com/solution/engineering",
       },
       { name: "twitter:card", content: "summary_large_image" },
       {

--- a/apps/web/src/routes/_view/solution/field-engineering.tsx
+++ b/apps/web/src/routes/_view/solution/field-engineering.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/_view/solution/field-engineering")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/solution/field-engineering",
+        content: "https://char.com/solution/field-engineering",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/solution/government.tsx
+++ b/apps/web/src/routes/_view/solution/government.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/_view/solution/government")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/solution/government",
+        content: "https://char.com/solution/government",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/solution/healthcare.tsx
+++ b/apps/web/src/routes/_view/solution/healthcare.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/_view/solution/healthcare")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/solution/healthcare",
+        content: "https://char.com/solution/healthcare",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/solution/journalism.tsx
+++ b/apps/web/src/routes/_view/solution/journalism.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/_view/solution/journalism")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/solution/journalism",
+        content: "https://char.com/solution/journalism",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/solution/knowledge-workers.tsx
+++ b/apps/web/src/routes/_view/solution/knowledge-workers.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/_view/solution/knowledge-workers")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/solution/knowledge-workers",
+        content: "https://char.com/solution/knowledge-workers",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/solution/legal.tsx
+++ b/apps/web/src/routes/_view/solution/legal.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/_view/solution/legal")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/solution/legal",
+        content: "https://char.com/solution/legal",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/solution/media.tsx
+++ b/apps/web/src/routes/_view/solution/media.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/_view/solution/media")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/solution/media",
+        content: "https://char.com/solution/media",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/solution/meeting.tsx
+++ b/apps/web/src/routes/_view/solution/meeting.tsx
@@ -33,7 +33,7 @@ export const Route = createFileRoute("/_view/solution/meeting")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/solution/meeting",
+        content: "https://char.com/solution/meeting",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/solution/project-management.tsx
+++ b/apps/web/src/routes/_view/solution/project-management.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/_view/solution/project-management")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/solution/project-management",
+        content: "https://char.com/solution/project-management",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/solution/recruiting.tsx
+++ b/apps/web/src/routes/_view/solution/recruiting.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/_view/solution/recruiting")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/solution/recruiting",
+        content: "https://char.com/solution/recruiting",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/solution/research.tsx
+++ b/apps/web/src/routes/_view/solution/research.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/_view/solution/research")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/solution/research",
+        content: "https://char.com/solution/research",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/solution/sales.tsx
+++ b/apps/web/src/routes/_view/solution/sales.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/_view/solution/sales")({
       { property: "og:type", content: "website" },
       {
         property: "og:url",
-        content: "https://hyprnote.com/solution/sales",
+        content: "https://char.com/solution/sales",
       },
     ],
   }),

--- a/apps/web/src/routes/_view/vs/$slug.tsx
+++ b/apps/web/src/routes/_view/vs/$slug.tsx
@@ -42,7 +42,7 @@ export const Route = createFileRoute("/_view/vs/$slug")({
         { property: "og:type", content: "website" },
         {
           property: "og:url",
-          content: `https://hyprnote.com/vs/${doc.slug}`,
+          content: `https://char.com/vs/${doc.slug}`,
         },
         { name: "twitter:card", content: "summary" },
         { name: "twitter:title", content: metaTitle },

--- a/apps/web/src/routes/_view/why-char.tsx
+++ b/apps/web/src/routes/_view/why-char.tsx
@@ -6,7 +6,7 @@ import { Image } from "@/components/image";
 import { SlashSeparator } from "@/components/slash-separator";
 import { CTASection } from "@/routes/_view/index";
 
-export const Route = createFileRoute("/_view/why-hyprnote")({
+export const Route = createFileRoute("/_view/why-char")({
   component: Component,
   head: () => ({
     meta: [
@@ -23,7 +23,7 @@ export const Route = createFileRoute("/_view/why-hyprnote")({
           "Most AI note-takers lock your data in their database. We thought that was bullshit. So we built Char differently.",
       },
       { property: "og:type", content: "website" },
-      { property: "og:url", content: "https://hyprnote.com/why-hyprnote" },
+      { property: "og:url", content: "https://char.com/why-char" },
       { name: "twitter:card", content: "summary_large_image" },
       { name: "twitter:title", content: "Why Char" },
       {

--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -237,14 +237,14 @@ function LegalText() {
     <p className="text-xs text-neutral-500 mt-4 text-center">
       By signing up, you agree to our{" "}
       <a
-        href="https://hyprnote.com/legal/terms"
+        href="https://char.com/legal/terms"
         className="underline hover:text-neutral-700"
       >
         Terms of Service
       </a>{" "}
       and{" "}
       <a
-        href="https://hyprnote.com/legal/privacy"
+        href="https://char.com/legal/privacy"
         className="underline hover:text-neutral-700"
       >
         Privacy Policy

--- a/apps/web/src/routes/contact.tsx
+++ b/apps/web/src/routes/contact.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 export const Route = createFileRoute("/contact")({
   beforeLoad: () => {
     throw redirect({
-      href: "mailto:support@hyprnote.com",
+      href: "mailto:support@char.com",
     } as any);
   },
 });

--- a/apps/web/src/routes/founders.tsx
+++ b/apps/web/src/routes/founders.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute("/founders")({
     };
   },
   beforeLoad: ({ search }) => {
-    const baseUrl = "https://cal.com/team/hyprnote/welcome?duration=20";
+    const baseUrl = "https://cal.com/team/char/welcome?duration=20";
     const url = search.source ? `${baseUrl}&source=${search.source}` : baseUrl;
     throw redirect({
       href: url,

--- a/apps/web/src/routes/reddit.tsx
+++ b/apps/web/src/routes/reddit.tsx
@@ -1,9 +1,0 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
-
-export const Route = createFileRoute("/reddit")({
-  beforeLoad: () => {
-    throw redirect({
-      href: "https://www.reddit.com/r/Hyprnote/",
-    } as any);
-  },
-});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -16,7 +16,7 @@ const config = defineConfig(() => ({
     tailwindcss(),
     tanstackStart({
       sitemap: {
-        host: "https://hyprnote.com",
+        host: "https://char.com",
       },
       prerender: {
         enabled: true,


### PR DESCRIPTION
Replace all occurrences of hyprnote.com domain with char.com across meta tags, OpenGraph URLs, and external links to reflect
the new brand identity. Also update product name references from "Hyprnote" to "Char" in user-facing content.