### PR TITLE
feat: Replace static poster with dynamic Mux thumbnail

### DIFF
--- a/apps/web/src/components/video-thumbnail.tsx
+++ b/apps/web/src/components/video-thumbnail.tsx
@@ -24,7 +24,7 @@ export function VideoThumbnail({
     >
       <MuxPlayer
         playbackId={playbackId}
-        poster="/api/images/hyprnote/poster-image.png"
+        poster="https://image.mux.com/bpcBHf4Qv5FbhwWD02zyFDb24EBuEuTPHKFUrZEktULQ/thumbnail.png?width=1152&height=648&time=58"
         muted
         playsInline
         className="w-full h-full object-cover pointer-events-none aspect-video"


### PR DESCRIPTION
Update VideoThumbnail component to use Mux's dynamic thumbnail API instead of static poster image. This provides video-specific
thumbnails with configurable dimensions and timestamp for better user experience and more accurate video previews.