### PR TITLE
feat: Rebrand from Hyprnote to Char

### DIFF
--- a/apps/desktop/src/components/main/body/calendar/shared.tsx
+++ b/apps/desktop/src/components/main/body/calendar/shared.tsx
@@ -22,7 +22,7 @@ const _PROVIDERS = [
     badge: "Beta",
     icon: <Icon icon="logos:apple" width={20} height={20} />,
     platform: "macos",
-    docsPath: "https://hyprnote.com/docs/calendar/apple",
+    docsPath: "https://char.com/docs/calendar/apple",
     nangoIntegrationId: undefined,
   },
   {
@@ -32,7 +32,7 @@ const _PROVIDERS = [
     badge: "Beta",
     icon: <Icon icon="logos:google-calendar" width={20} height={20} />,
     platform: "all",
-    docsPath: "https://hyprnote.com/docs/calendar/gcal",
+    docsPath: "https://char.com/docs/calendar/gcal",
     nangoIntegrationId: "google-calendar",
   },
   {
@@ -42,7 +42,7 @@ const _PROVIDERS = [
     badge: "Coming soon",
     icon: <OutlookIcon size={20} />,
     platform: "all",
-    docsPath: "https://hyprnote.com/docs/calendar/outlook",
+    docsPath: "https://char.com/docs/calendar/outlook",
     nangoIntegrationId: undefined,
   },
 ] as const satisfies readonly CalendarProvider[];

--- a/apps/desktop/src/components/main/body/changelog/index.tsx
+++ b/apps/desktop/src/components/main/body/changelog/index.tsx
@@ -194,7 +194,7 @@ function ChangelogHeader({
             className="gap-1.5 text-neutral-600 hover:text-black"
             onClick={() =>
               openerCommands.openUrl(
-                `https://hyprnote.com/changelog/${version}`,
+                `https://char.com/changelog/${version}`,
                 null,
               )
             }
@@ -211,7 +211,7 @@ function ChangelogHeader({
 async function fetchChangelogFromGitHub(
   version: string,
 ): Promise<string | null> {
-  const url = `https://raw.githubusercontent.com/fastrepl/hyprnote/main/apps/web/content/changelog/${version}.mdx`;
+  const url = `https://raw.githubusercontent.com/fastrepl/char/main/apps/web/content/changelog/${version}.mdx`;
   try {
     const response = await fetch(url);
     if (!response.ok) {

--- a/apps/desktop/src/components/main/body/sessions/index.tsx
+++ b/apps/desktop/src/components/main/body/sessions/index.tsx
@@ -335,7 +335,7 @@ function StatusBanner({
             showTimeline ? "bottom-[76px]" : "bottom-6",
           ])}
         >
-          {skipReason || "Ask for consent when using Hyprnote"}
+          {skipReason || "Ask for consent when using Char"}
         </motion.div>
       )}
     </AnimatePresence>,

--- a/apps/desktop/src/components/main/body/sessions/note-input/enhanced/config-error.tsx
+++ b/apps/desktop/src/components/main/body/sessions/note-input/enhanced/config-error.tsx
@@ -41,7 +41,7 @@ function getMessageForStatus(status: LLMConnectionStatus): string {
   }
 
   if (status.status === "error" && status.reason === "unauthenticated") {
-    return "You need to sign in to use Hyprnote's language model";
+    return "You need to sign in to use Char's language model";
   }
 
   if (status.status === "error" && status.reason === "missing_config") {

--- a/apps/desktop/src/components/main/body/shared.tsx
+++ b/apps/desktop/src/components/main/body/shared.tsx
@@ -309,8 +309,8 @@ export function TabItemBase({
         >
           <div className="flex flex-col gap-2">
             <p className="text-sm text-neutral-700">
-              Are you sure you want to close this tab? This will stop Hyprnote
-              from listening.
+              Are you sure you want to close this tab? This will stop Char from
+              listening.
             </p>
             <Button
               variant="destructive"

--- a/apps/desktop/src/components/main/sidebar/toast/registry.tsx
+++ b/apps/desktop/src/components/main/sidebar/toast/registry.tsx
@@ -146,7 +146,7 @@ export function createToastRegistry({
         ),
         title: "Sign in required",
         description:
-          "You have Hyprnote Pro models configured. Please sign in to use them.",
+          "You have Char Pro models configured. Please sign in to use them.",
         primaryAction: {
           label: "Sign in",
           onClick: onSignIn,

--- a/apps/desktop/src/components/onboarding/final.tsx
+++ b/apps/desktop/src/components/onboarding/final.tsx
@@ -18,7 +18,7 @@ const SOCIALS = [
     label: "GitHub",
     icon: "simple-icons:github",
     size: 14,
-    url: "https://github.com/fastrepl/hyprnote",
+    url: "https://github.com/fastrepl/char",
   },
   {
     label: "X",

--- a/apps/desktop/src/components/settings/ai/llm/configure.tsx
+++ b/apps/desktop/src/components/settings/ai/llm/configure.tsx
@@ -35,7 +35,7 @@ export function ConfigureProviders() {
       >
         <HyprProviderCard
           providerId="hyprnote"
-          providerName="Hyprnote"
+          providerName="Char"
           icon={<img src="/assets/icon.png" alt="Char" className="size-5" />}
           badge={PROVIDERS.find((p) => p.id === "hyprnote")?.badge}
         />
@@ -129,9 +129,9 @@ function HyprProviderAutoRow({ highlight }: { highlight?: boolean }) {
   return (
     <HyprProviderRow>
       <div className="flex-1">
-        <span className="text-sm font-medium">Hyprnote Cloud</span>
+        <span className="text-sm font-medium">Char Cloud</span>
         <p className="text-xs text-neutral-500">
-          Use the Hyprnote Cloud API for AI assistance.
+          Use the Char Cloud API for AI assistance.
         </p>
       </div>
       <HyprCloudCTAButton

--- a/apps/desktop/src/components/settings/ai/llm/select.tsx
+++ b/apps/desktop/src/components/settings/ai/llm/select.tsx
@@ -193,7 +193,7 @@ export function SelectProviderAndModel() {
           <div className="flex items-center gap-2 pt-2 border-t border-red-200">
             <span className="text-sm text-red-600">
               <strong className="font-medium">Language model</strong> is needed
-              to make Hyprnote summarize and chat about your conversations.
+              to make Char summarize and chat about your conversations.
             </span>
           </div>
         )}

--- a/apps/desktop/src/components/settings/ai/llm/shared.tsx
+++ b/apps/desktop/src/components/settings/ai/llm/shared.tsx
@@ -36,7 +36,7 @@ type Provider = {
 const _PROVIDERS = [
   {
     id: "hyprnote",
-    displayName: "Hyprnote",
+    displayName: "Char",
     badge: "Recommended",
     icon: <img src="/assets/icon.png" alt="Char" className="size-5" />,
     baseUrl: new URL("/llm", env.VITE_API_URL).toString(),
@@ -57,7 +57,7 @@ const _PROVIDERS = [
       models: { label: "Available models", url: "https://lmstudio.ai/models" },
       setup: {
         label: "Setup guide",
-        url: "https://hyprnote.com/docs/faq/local-llm-setup/#lm-studio-setup",
+        url: "https://char.com/docs/faq/local-llm-setup/#lm-studio-setup",
       },
     },
   },
@@ -76,7 +76,7 @@ const _PROVIDERS = [
       models: { label: "Available models", url: "https://ollama.com/library" },
       setup: {
         label: "Setup guide",
-        url: "https://hyprnote.com/docs/faq/local-llm-setup/#ollama-setup",
+        url: "https://char.com/docs/faq/local-llm-setup/#ollama-setup",
       },
     },
   },

--- a/apps/desktop/src/components/settings/ai/stt/configure.tsx
+++ b/apps/desktop/src/components/settings/ai/stt/configure.tsx
@@ -57,7 +57,7 @@ export function ConfigureProviders() {
         <HyprProviderCard
           ref={hyprAccordionRef}
           providerId="hyprnote"
-          providerName="Hyprnote"
+          providerName="Char"
           icon={<img src="/assets/icon.png" alt="Char" className="size-5" />}
           badge={PROVIDERS.find((p) => p.id === "hyprnote")?.badge}
         />
@@ -157,7 +157,7 @@ function HyprProviderCard({
               <div className="flex items-center gap-3 py-2">
                 <div className="flex-1 border-t border-dashed border-neutral-300" />
                 <a
-                  href="https://hyprnote.com/docs/developers/local-models"
+                  href="https://char.com/docs/developers/local-models"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-xs text-neutral-400 hover:underline flex items-center gap-1"
@@ -363,9 +363,9 @@ function HyprProviderCloudRow() {
   return (
     <HyprProviderRow>
       <div className="flex-1">
-        <span className="text-sm font-medium">Hyprnote Cloud</span>
+        <span className="text-sm font-medium">Char Cloud</span>
         <p className="text-xs text-neutral-500">
-          Use the Hyprnote Cloud API to transcribe your audio.
+          Use the Char Cloud API to transcribe your audio.
         </p>
       </div>
       <HyprCloudCTAButton
@@ -562,7 +562,7 @@ function HyprProviderLocalRow({
 function ProviderContext({ providerId }: { providerId: ProviderId }) {
   const content =
     providerId === "hyprnote"
-      ? "Hyprnote curates list of on-device models and also cloud models with high-availability and performance."
+      ? "Char curates list of on-device models and also cloud models with high-availability and performance."
       : providerId === "deepgram"
         ? `Use [Deepgram](https://deepgram.com) for transcriptions. \
     If you want to use a [Dedicated](https://developers.deepgram.com/reference/custom-endpoints#deepgram-dedicated-endpoints)

--- a/apps/desktop/src/components/settings/data/index.tsx
+++ b/apps/desktop/src/components/settings/data/index.tsx
@@ -101,7 +101,7 @@ export function Data() {
     <div>
       <StyledStreamdown className="text-neutral-500">
         {
-          "Import data from other apps. Read more about [import](https://hyprnote.com/docs/data/#import) and [export](https://hyprnote.com/docs/data/#export)."
+          "Import data from other apps. Read more about [import](https://char.com/docs/data/#import) and [export](https://char.com/docs/data/#export)."
         }
       </StyledStreamdown>
 

--- a/apps/desktop/src/components/settings/general/account.tsx
+++ b/apps/desktop/src/components/settings/general/account.tsx
@@ -200,9 +200,7 @@ export function AccountSettings() {
     return (
       <div className="flex flex-col items-center gap-6 text-center">
         <div className="flex flex-col gap-2">
-          <h2 className="text-2xl font-semibold font-serif">
-            Sign in to Hyprnote
-          </h2>
+          <h2 className="text-2xl font-semibold font-serif">Sign in to Char</h2>
           <p className="text-base text-neutral-500">
             Get started without an account. Sign in to unlock more.
           </p>

--- a/apps/desktop/src/components/settings/integrations.tsx
+++ b/apps/desktop/src/components/settings/integrations.tsx
@@ -36,7 +36,7 @@ const MOCK_INTEGRATIONS: Integration[] = [
     description: "Send meeting notes and updates to Slack channels",
     connected: true,
     connectedAt: "2024-10-10T09:00:00Z",
-    accountInfo: "Hyprnote Workspace",
+    accountInfo: "Char Workspace",
   },
   {
     id: "2",
@@ -45,7 +45,7 @@ const MOCK_INTEGRATIONS: Integration[] = [
     description: "Sync your notes and transcripts with Notion databases",
     connected: true,
     connectedAt: "2024-09-15T14:30:00Z",
-    accountInfo: "john@hyprnote.com",
+    accountInfo: "john@char.com",
   },
   {
     id: "3",
@@ -290,7 +290,7 @@ function IntegrationCard({
         <>
           Are you sure you want to disconnect {integration.name}
           {integration.accountInfo && ` (${integration.accountInfo})`}? This
-          integration will no longer sync with Hyprnote.
+          integration will no longer sync with Char.
         </>
       }
     >


### PR DESCRIPTION
Update product name from "Hyprnote" to "Char" throughout the desktop application components. Change provider names, cloud
service references, documentation URLs, and user-facing text to reflect the new branding.

Update documentation links from hyprnote.com to char.com for calendar integrations and data import/export guides.