### PR TITLE
docs: Update URLs and branding from hyprnote to char

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-https://hyprnote.com/docs/developers
+https://char.com/docs/developers

--- a/LICENSE
+++ b/LICENSE
@@ -631,7 +631,7 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    Hyprnote Copyright (C) 2023-present  Fastrepl, Inc.
+    Char Copyright (C) 2023-present  Fastrepl, Inc.
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -651,7 +651,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    Hyprnote  Copyright (C) 2023-present  Fastrepl, Inc.
+    Char  Copyright (C) 2023-present  Fastrepl, Inc.
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <p align="center">Char - The AI notepad for <strong>private</strong> meetings</p>
   <p align="center">
    <a href="https://deepwiki.com/fastrepl/char"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
-   <a href="https://hyprnote.com/discord" target="_blank"><img src="https://img.shields.io/static/v1?label=Join%20our&message=Discord&color=blue&logo=Discord" alt="Discord"></a>
+   <a href="https://char.com/discord" target="_blank"><img src="https://img.shields.io/static/v1?label=Join%20our&message=Discord&color=blue&logo=Discord" alt="Discord"></a>
    <a href="https://x.com/getcharnotes" target="_blank"><img src="https://img.shields.io/static/v1?label=Follow%20us%20on&message=X&color=black&logo=x" alt="X"></a>
   </p>
 </p>
@@ -26,7 +26,7 @@ You can also use it for taking notes for lectures or organizing your thoughts.
 brew install --cask fastrepl/fastrepl/char@nightly
 ```
 
-- [macOS](https://hyprnote.com/download) (public beta)
+- [macOS](https://char.com/download) (public beta)
 - [Windows](https://github.com/fastrepl/char/issues/66) (q2 2026)
 - [Linux](https://github.com/fastrepl/char/issues/67) (q2 2026)
 
@@ -72,7 +72,7 @@ Char plays nice with whatever stack you're running.
 
 Prefer a certain style? Choose from predefined templates like bullet points, agenda-based, or paragraph summary. Or create your own.
 
-Check out our [template gallery](https://hyprnote.com/templates) and add your own [here](https://github.com/fastrepl/char/tree/main/apps/web/content/templates).
+Check out our [template gallery](https://char.com/templates) and add your own [here](https://github.com/fastrepl/char/tree/main/apps/web/content/templates).
 
 ### AI Chat
 


### PR DESCRIPTION
Replace all references to hyprnote.com with char.com across documentation and configuration files. Update Discord invite,
download links, template gallery, and developer documentation URLs to reflect the new domain. Also update copyright notices
in LICENSE file from "Hyprnote" to "Char" branding.