### PR TITLE
refactor: rename Hyprnote to Char across codebase

### DIFF
--- a/.github/workflows/devin_explore_issues.yaml
+++ b/.github/workflows/devin_explore_issues.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           api_key: ${{ secrets.DEVIN_API_KEY }}
           prompt: |
-            A user has submitted an issue via the Hyprnote app. Please explore the codebase and provide helpful context on this issue.
+            A user has submitted an issue via the Char app. Please explore the codebase and provide helpful context on this issue.
 
             ## Issue Details
             - **Title**: {{ title }}
@@ -37,7 +37,7 @@ jobs:
                - Identify any related issues or PRs
 
             3. **Comment on the Issue**
-               - Post a comment on the GitHub issue (fastrepl/hyprnote#{{ number }}) with your findings:
+               - Post a comment on the GitHub issue (fastrepl/char#{{ number }}) with your findings:
                  * Which files and components are relevant
                  * Any recent changes that may be related
                  * Potential approaches or considerations for addressing the issue

--- a/.github/workflows/devin_triage_issues.yaml
+++ b/.github/workflows/devin_triage_issues.yaml
@@ -16,11 +16,11 @@ jobs:
         with:
           api_key: ${{ secrets.DEVIN_API_KEY }}
           prompt: |
-            You are tasked with triaging open GitHub issues for Hyprnote to determine if they have already been addressed.
+            You are tasked with triaging open GitHub issues for Char to determine if they have already been addressed.
 
             ## Context
-            Hyprnote is a Tauri-based desktop app for AI meeting notes that prioritizes privacy.
-            Repository: fastrepl/hyprnote
+            Char is a Tauri-based desktop app for AI meeting notes that prioritizes privacy.
+            Repository: fastrepl/char
 
             ## Your Task
             1. **Fetch Open Issues**

--- a/apps/desktop/flatpak/com.hyprnote.Hyprnote.metainfo.xml
+++ b/apps/desktop/flatpak/com.hyprnote.Hyprnote.metainfo.xml
@@ -27,7 +27,7 @@
 
   <launchable type="desktop-id">com.hyprnote.Hyprnote.desktop</launchable>
 
-  <url type="homepage">https://hyprnote.com</url>
+  <url type="homepage">https://char.com</url>
   <url type="bugtracker">https://github.com/fastrepl/char/issues</url>
   <url type="vcs-browser">https://github.com/fastrepl/char</url>
   <url type="contribute">https://github.com/fastrepl/char/blob/main/CONTRIBUTING.md</url>

--- a/crates/api-bot/src/routes/bot.rs
+++ b/crates/api-bot/src/routes/bot.rs
@@ -45,7 +45,7 @@ pub async fn send_bot(
     let bot = client
         .create_bot(CreateBotRequest {
             meeting_url: req.meeting_url,
-            bot_name: req.bot_name.unwrap_or_else(|| "Hyprnote".into()),
+            bot_name: req.bot_name.unwrap_or_else(|| "Char".into()),
             transcription_options: Some(TranscriptionOptions {
                 provider: TranscriptionProvider::MeetingCaptions,
             }),
@@ -100,7 +100,7 @@ pub async fn start_demo(
     let bot = client
         .create_bot(CreateBotRequest {
             meeting_url: req.meeting_url.clone(),
-            bot_name: "Hyprnote Demo".into(),
+            bot_name: "Char Demo".into(),
             transcription_options: None,
             real_time_transcription: None,
             output_media: Some(OutputMedia {

--- a/crates/api-research/assets/research_chat.md.jinja
+++ b/crates/api-research/assets/research_chat.md.jinja
@@ -1,4 +1,4 @@
-You are a helpful research assistant for Hyprnote, a privacy-first AI-powered note-taking application.
+You are a helpful research assistant for Char, a privacy-first AI-powered note-taking application.
 
 Your role is to help users with:
 

--- a/crates/api-support/src/github.rs
+++ b/crates/api-support/src/github.rs
@@ -3,7 +3,7 @@ use crate::logs;
 use crate::state::AppState;
 
 const GITHUB_OWNER: &str = "fastrepl";
-const GITHUB_REPO: &str = "hyprnote";
+const GITHUB_REPO: &str = "char";
 
 pub(crate) struct BugReportInput<'a> {
     pub description: &'a str,

--- a/crates/buffer/src/lib.rs
+++ b/crates/buffer/src/lib.rs
@@ -304,7 +304,7 @@ mod tests {
     fn test_md_to_md_3() {
         let input = r#"
 # Enhanced Meeting Notes
-## What Hyprnote Does
+## What Char Does
 - A smart notepad for people with back-to-back meetings.
 - Listens to the meeting so you don't have to write everything down.
 - Merges your notes and the transcript into a clean, context-aware summary.
@@ -320,20 +320,20 @@ mod tests {
 - Offers powerful extensions—like real-time transcripts and CRM uploads (e.g. Twenty).
 
 ## Stay Connected
-- Follow updates on [X](https://hyprnote.com/x).
-- Join the community and chat on [Discord](https://hyprnote.com/discord). 
+- Follow updates on [X](https://char.com/x).
+- Join the community and chat on [Discord](https://char.com/discord).
 
 # Participants:
 
-* [John Jeong](mailto:john@hyprnote.com)
-* [Yujong Lee](mailto:yujonglee@hyprnote.com)
+* [John Jeong](mailto:john@char.com)
+* [Yujong Lee](mailto:yujonglee@char.com)
 
 # Meeting Transcript
 (No raw excerpt provided, utilized to generate the enhanced note)
 "#;
 
         insta::assert_snapshot!(md_to_md(input).unwrap().to_string(), @"
-        # What Hyprnote Does
+        # What Char Does
 
         - A smart notepad for people with back-to-back meetings.
         - Listens to the meeting so you don't have to write everything down.
@@ -359,15 +359,15 @@ mod tests {
 
         # Stay Connected
 
-        - Follow updates on [X](https://hyprnote.com/x).
-        - Join the community and chat on [Discord](https://hyprnote.com/discord).
+        - Follow updates on [X](https://char.com/x).
+        - Join the community and chat on [Discord](https://char.com/discord).
 
          
 
         # Participants:
 
-        - [John Jeong](mailto:john@hyprnote.com)
-        - [Yujong Lee](mailto:yujonglee@hyprnote.com)
+        - [John Jeong](mailto:john@char.com)
+        - [Yujong Lee](mailto:yujonglee@char.com)
 
          
 
@@ -381,12 +381,12 @@ mod tests {
     #[test]
     fn test_md_to_md_4() {
         let input = r#"
-# Hyprnote: Enhanced Meeting Notes
+# Char: Enhanced Meeting Notes
 
-# Objective: Introduce Hyprnote as a smart notepad for enhanced meeting productivity.
+# Objective: Introduce Char as a smart notepad for enhanced meeting productivity.
 # Privacy & Performance: Built locally, prioritizing user data security and seamless experience.
 # Flexible & Extendable: Supports various use cases beyond sales, offering a simple and powerful solution.
-# Stay Connected: Promote Hyprnote through X and Discord.
+# Stay Connected: Promote Char through X and Discord.
 
 # Key Features:
 # - Offline transcription and note-taking.
@@ -396,7 +396,7 @@ mod tests {
 
 # Benefits: Streamlines meetings, improves productivity, and enhances data capture.
 
-# Further Information: Follow updates on [X](https://hyprnote.com/x) and [Discord](https://hyprnote.com/discord).
+# Further Information: Follow updates on [X](https://char.com/x) and [Discord](https://char.com/discord).
         "#;
 
         insta::assert_snapshot!(md_to_md(input).unwrap().to_string(), @"# Further Information: Follow updates on [X](https://hyprnote.com/x) and [Discord](https://hyprnote.com/discord).");
@@ -406,7 +406,7 @@ mod tests {
     fn test_opinionated_md_to_html() {
         let input = r#"
 # Enhanced Meeting Notes
-## What Hyprnote Does
+## What Char Does
 - A smart notepad for people with back-to-back meetings.
 - Listens to the meeting so you don't have to write everything down.
 - Merges your notes and the transcript into a clean, context-aware summary.
@@ -422,12 +422,12 @@ mod tests {
 - Offers powerful extensions—like real-time transcripts and CRM uploads (e.g. Twenty).
 
 ## Stay Connected
-- Follow updates on [X](https://hyprnote.com/x).
-- Join the community and chat on [Discord](https://hyprnote.com/discord).
+- Follow updates on [X](https://char.com/x).
+- Join the community and chat on [Discord](https://char.com/discord).
 "#;
 
         insta::assert_snapshot!(opinionated_md_to_html(input).unwrap().to_string(), @r#"
-        <h1>What Hyprnote Does</h1>
+        <h1>What Char Does</h1>
         <ul>
         <li>A smart notepad for people with back-to-back meetings.</li>
         <li>Listens to the meeting so you don't have to write everything down.</li>
@@ -450,8 +450,8 @@ mod tests {
         <p> </p>
         <h1>Stay Connected</h1>
         <ul>
-        <li>Follow updates on <a href="https://hyprnote.com/x">X</a>.</li>
-        <li>Join the community and chat on <a href="https://hyprnote.com/discord">Discord</a>.</li>
+        <li>Follow updates on <a href="https://char.com/x">X</a>.</li>
+        <li>Join the community and chat on <a href="https://char.com/discord">Discord</a>.</li>
         </ul>
         "#);
     }

--- a/crates/llm-types/src/parser.rs
+++ b/crates/llm-types/src/parser.rs
@@ -242,14 +242,14 @@ mod tests {
 <think>
 something blabla1
 something blabla2
-</think>        
+</think>
      "###
         .trim();
 
         let summary = r###"
-# Hyprnote Overview
+# Char Overview
 
-Hyprnote is an AI-powered notepad designed for private meetings with complete on-device processing. No data leaves your computer, with optional telemetry.
+Char is an AI-powered notepad designed for private meetings with complete on-device processing. No data leaves your computer, with optional telemetry.
 
 # How It Works
 

--- a/crates/notification-linux/examples/test_notification.rs
+++ b/crates/notification-linux/examples/test_notification.rs
@@ -7,7 +7,7 @@ fn main() {
 
     let notification = Notification::builder()
         .title("Test Notification")
-        .message("This is a test notification from hyprnote")
+        .message("This is a test notification from Char")
         .timeout(std::time::Duration::from_secs(5))
         .build();
 

--- a/crates/notification-macos/examples/test_notification_with_event.rs
+++ b/crates/notification-macos/examples/test_notification_with_event.rs
@@ -31,23 +31,23 @@ fn main() {
             },
             Participant {
                 name: Some("John Jeong".to_string()),
-                email: "john@hyprnote.com".to_string(),
+                email: "john@char.com".to_string(),
                 status: ParticipantStatus::Accepted,
             },
             Participant {
                 name: Some("Yujong Lee".to_string()),
-                email: "yujonglee@hyprnote.com".to_string(),
+                email: "yujonglee@char.com".to_string(),
                 status: ParticipantStatus::Maybe,
             },
             Participant {
                 name: Some("Tony Stark".to_string()),
-                email: "tony@hyprnote.com".to_string(),
+                email: "tony@char.com".to_string(),
                 status: ParticipantStatus::Declined,
             },
         ];
 
         let event_details = EventDetails {
-            what: "Discovery call - Apple <> Hyprnote".to_string(),
+            what: "Discovery call - Apple <> Char".to_string(),
             timezone: Some("America/Cupertino".to_string()),
             location: Some("https://zoom.us/j/123456789".to_string()),
         };

--- a/openstatus.lock
+++ b/openstatus.lock
@@ -19,7 +19,7 @@
     - koyeb_was
     request:
       method: GET
-      url: https://hyprnote.com
+      url: https://char.com
     retry: 3
 "8351":
   ID: 8351
@@ -65,7 +65,7 @@
     - koyeb_was
     request:
       method: GET
-      url: https://hyprnote.com
+      url: https://char.com
     retry: 3
 "8355":
   ID: 8355

--- a/plugins/local-llm/assets/onboarding-enhanced.md
+++ b/plugins/local-llm/assets/onboarding-enhanced.md
@@ -1,6 +1,6 @@
-# Hyprnote Overview
+# Char Overview
 
-Hyprnote is an AI-powered notepad designed for private meetings with complete on-device processing. No data leaves your computer, with optional telemetry.
+Char is an AI-powered notepad designed for private meetings with complete on-device processing. No data leaves your computer, with optional telemetry.
 
 # How It Works
 

--- a/plugins/webhook/docs/webhook-openapi.json
+++ b/plugins/webhook/docs/webhook-openapi.json
@@ -25,7 +25,12 @@
     "schemas": {
       "NoteEventData": {
         "type": "object",
-        "required": ["note_id", "title", "tags", "created_at"],
+        "required": [
+          "note_id",
+          "title",
+          "tags",
+          "created_at"
+        ],
         "properties": {
           "note_id": {
             "type": "string",
@@ -38,7 +43,10 @@
             "example": "Meeting Notes - Q1 Planning"
           },
           "content": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Content of the note (may be truncated for large notes)",
             "example": "Today we discussed..."
           },
@@ -48,7 +56,11 @@
               "type": "string"
             },
             "description": "Tags associated with the note",
-            "example": ["meeting", "planning", "q1"]
+            "example": [
+              "meeting",
+              "planning",
+              "q1"
+            ]
           },
           "created_at": {
             "type": "string",
@@ -56,7 +68,10 @@
             "example": "2024-01-10T10:00:00Z"
           },
           "updated_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "ISO 8601 timestamp when the note was last updated",
             "example": "2024-01-10T10:30:00Z"
           }
@@ -64,7 +79,11 @@
       },
       "RecordingEventData": {
         "type": "object",
-        "required": ["recording_id", "status", "started_at"],
+        "required": [
+          "recording_id",
+          "status",
+          "started_at"
+        ],
         "properties": {
           "recording_id": {
             "type": "string",
@@ -72,14 +91,20 @@
             "example": "rec_xyz789"
           },
           "duration_seconds": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "int32",
             "description": "Duration of the recording in seconds",
             "example": 300,
             "minimum": 0
           },
           "file_size_bytes": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "int64",
             "description": "File size in bytes",
             "example": 1048576,
@@ -95,7 +120,10 @@
             "example": "2024-01-10T10:00:00Z"
           },
           "completed_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "ISO 8601 timestamp when recording completed",
             "example": "2024-01-10T10:05:00Z"
           }
@@ -103,11 +131,21 @@
       },
       "RecordingStatus": {
         "type": "string",
-        "enum": ["started", "in_progress", "completed", "failed"]
+        "enum": [
+          "started",
+          "in_progress",
+          "completed",
+          "failed"
+        ]
       },
       "TranscriptionEventData": {
         "type": "object",
-        "required": ["recording_id", "transcription_id", "text", "processing_time_ms"],
+        "required": [
+          "recording_id",
+          "transcription_id",
+          "text",
+          "processing_time_ms"
+        ],
         "properties": {
           "recording_id": {
             "type": "string",
@@ -125,12 +163,18 @@
             "example": "Hello, this is the transcribed text from the recording."
           },
           "language": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Language detected in the transcription",
             "example": "en"
           },
           "confidence": {
-            "type": ["number", "null"],
+            "type": [
+              "number",
+              "null"
+            ],
             "format": "float",
             "description": "Confidence score of the transcription (0.0 to 1.0)",
             "example": 0.95
@@ -146,7 +190,10 @@
       },
       "WebhookDeliveryRequest": {
         "type": "object",
-        "required": ["event", "signature"],
+        "required": [
+          "event",
+          "signature"
+        ],
         "properties": {
           "event": {
             "$ref": "#/components/schemas/WebhookEvent",
@@ -161,21 +208,32 @@
       },
       "WebhookDeliveryResponse": {
         "type": "object",
-        "required": ["success"],
+        "required": [
+          "success"
+        ],
         "properties": {
           "success": {
             "type": "boolean",
             "description": "Whether the webhook was successfully processed"
           },
           "message": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Optional message from the receiver"
           }
         }
       },
       "WebhookEvent": {
         "type": "object",
-        "required": ["id", "event_type", "timestamp", "api_version", "data"],
+        "required": [
+          "id",
+          "event_type",
+          "timestamp",
+          "api_version",
+          "data"
+        ],
         "properties": {
           "id": {
             "type": "string",

--- a/scripts/download_releases.sh
+++ b/scripts/download_releases.sh
@@ -7,16 +7,16 @@ mkdir -p "$base_dir"
 download_version() {
     local version=$1
     local dir="$base_dir/$version"
-    
+
     release_data=$(cn release show fastrepl/hyprnote "$version" --channel=stable 2>/dev/null)
-    
+
     if [ $? -ne 0 ]; then
         return 1
     fi
-    
+
     dmg_x86_64=$(echo "$release_data" | jq -r '.assets[] | select(.publicPlatform == "dmg-x86_64") | .filename')
     dmg_aarch64=$(echo "$release_data" | jq -r '.assets[] | select(.publicPlatform == "dmg-aarch64") | .filename')
-    
+
     mkdir -p "$dir"
 
     if [ ! -z "$dmg_x86_64" ] && [ "$dmg_x86_64" != "null" ]; then


### PR DESCRIPTION
Update project branding from Hyprnote to Char throughout the application including documentation, API endpoints, notification 
messages, GitHub configurations, and example code. Change domain references from hyprnote.com to char.com and update bot naming conventions to reflect the new brand identity.