### PR TITLE
feat: Update blog filename format to use ISO week numbers

### DIFF
--- a/.github/workflows/devin_weekly_blog.yaml
+++ b/.github/workflows/devin_weekly_blog.yaml
@@ -37,7 +37,7 @@ jobs:
                  * New integrations or providers
 
             2. **Write the Blog Post**
-               Create a new MDX file at `apps/web/content/articles/char-weekly-YYYY-MM-DD.mdx` where YYYY-MM-DD is today's date.
+               Determine the ISO week number (W) and year (Y) for today's date, then create a new MDX file at `apps/web/content/articles/wW-Y.mdx` (e.g. `w9-2026.mdx` for ISO week 9 of 2026). You can compute this with: `date -u +"%V-%G"` on Linux.
 
                Use this frontmatter format:
                ```


### PR DESCRIPTION
Change blog post filename from char-weekly-YYYY-MM-DD.mdx to wW-Y.mdx format based on ISO week numbers. Add command to compute ISO week and year using date utility for consistent weekly naming convention.