### PR TITLE
fix: replace "Reveal in Finder" with unified "Show in Finder"

### DIFF
--- a/apps/desktop/src/components/main/body/sessions/outer-header/overflow/delete.tsx
+++ b/apps/desktop/src/components/main/body/sessions/outer-header/overflow/delete.tsx
@@ -1,11 +1,9 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Loader2Icon, TrashIcon } from "lucide-react";
+import { TrashIcon } from "lucide-react";
 import { useCallback } from "react";
 
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 import { DropdownMenuItem } from "@hypr/ui/components/ui/dropdown-menu";
-import { cn } from "@hypr/utils";
 
 import {
   captureSessionData,
@@ -51,61 +49,7 @@ export function DeleteNote({ sessionId }: { sessionId: string }) {
       className="text-red-600 hover:bg-red-50 hover:text-red-700 cursor-pointer"
     >
       <TrashIcon />
-      <span>Delete note</span>
-    </DropdownMenuItem>
-  );
-}
-
-export function DeleteRecording({ sessionId }: { sessionId: string }) {
-  const queryClient = useQueryClient();
-  const { mutate, isPending, isError } = useMutation({
-    mutationFn: async () => {
-      await Promise.all([
-        new Promise((resolve) => setTimeout(resolve, 300)),
-        fsSyncCommands.audioDelete(sessionId).then((result) => {
-          if (result.status === "error") {
-            throw new Error(result.error);
-          }
-
-          return result.data;
-        }),
-      ]);
-    },
-    onSuccess: () => {
-      void analyticsCommands.event({
-        event: "recording_deleted",
-      });
-      void queryClient.invalidateQueries({
-        predicate: (query) =>
-          query.queryKey.length >= 2 &&
-          query.queryKey[0] === "audio" &&
-          query.queryKey[1] === sessionId,
-      });
-    },
-  });
-
-  return (
-    <DropdownMenuItem
-      onClick={(e) => {
-        e.preventDefault();
-        mutate();
-      }}
-      disabled={isPending}
-      className={cn([
-        "cursor-pointer",
-        isError
-          ? "text-orange-600 hover:bg-orange-50 hover:text-orange-700"
-          : "text-red-600 hover:bg-red-50 hover:text-red-700",
-      ])}
-    >
-      {isPending ? <Loader2Icon className="animate-spin" /> : <TrashIcon />}
-      <span>
-        {isPending
-          ? "Deleting..."
-          : isError
-            ? "Failed to delete"
-            : "Delete only recording"}
-      </span>
+      <span>Delete</span>
     </DropdownMenuItem>
   );
 }

--- a/apps/desktop/src/components/main/body/sessions/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/components/main/body/sessions/outer-header/overflow/index.tsx
@@ -1,8 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
 import { FileTextIcon, MoreHorizontalIcon } from "lucide-react";
 import { useState } from "react";
 
-import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 import { Button } from "@hypr/ui/components/ui/button";
 import {
   DropdownMenu,
@@ -14,10 +12,10 @@ import {
 
 import type { EditorView } from "../../../../../../store/zustand/tabs/schema";
 import { useHasTranscript } from "../../shared";
-import { DeleteNote, DeleteRecording } from "./delete";
+import { DeleteNote } from "./delete";
 import { ExportModal } from "./export-modal";
 import { Listening } from "./listening";
-import { Copy, Folder, RevealInFinder, ShowInFinder } from "./misc";
+import { Copy, Folder, ShowInFinder } from "./misc";
 
 export function OverflowButton({
   sessionId,
@@ -28,16 +26,6 @@ export function OverflowButton({
 }) {
   const [open, setOpen] = useState(false);
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
-  const audioExists = useQuery({
-    queryKey: ["audio", sessionId, "exist"],
-    queryFn: () => fsSyncCommands.audioExist(sessionId),
-    select: (result) => {
-      if (result.status === "error") {
-        throw new Error(result.error);
-      }
-      return result.data;
-    },
-  });
   const hasTranscript = useHasTranscript(sessionId);
   const openExportModal = () => {
     setOpen(false);
@@ -69,10 +57,9 @@ export function OverflowButton({
           <DropdownMenuSeparator />
           <Listening sessionId={sessionId} hasTranscript={hasTranscript} />
           <DropdownMenuSeparator />
-          <RevealInFinder sessionId={sessionId} />
-          {audioExists.data && <ShowInFinder sessionId={sessionId} />}
+          <ShowInFinder sessionId={sessionId} />
+          <DropdownMenuSeparator />
           <DeleteNote sessionId={sessionId} />
-          {audioExists.data && <DeleteRecording sessionId={sessionId} />}
         </DropdownMenuContent>
       </DropdownMenu>
       <ExportModal

--- a/apps/desktop/src/components/main/body/sessions/outer-header/overflow/misc.tsx
+++ b/apps/desktop/src/components/main/body/sessions/outer-header/overflow/misc.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "@iconify-icon/react";
 import { useMutation } from "@tanstack/react-query";
-import { FolderIcon, Link2Icon, Loader2Icon, SearchIcon } from "lucide-react";
+import { FolderIcon, Link2Icon, Loader2Icon } from "lucide-react";
 
 import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
@@ -15,7 +15,6 @@ import {
   TooltipTrigger,
 } from "@hypr/ui/components/ui/tooltip";
 
-import { save } from "../../../../../../store/tinybase/store/save";
 import { SearchableFolderSubmenuContent } from "../shared/folder";
 
 export function Copy() {
@@ -82,33 +81,6 @@ export function ShowInFinder({ sessionId }: { sessionId: string }) {
         <Icon icon="ri:finder-line" />
       )}
       <span>{isPending ? "Opening..." : "Show in Finder"}</span>
-    </DropdownMenuItem>
-  );
-}
-
-export function RevealInFinder({ sessionId }: { sessionId: string }) {
-  const { mutate, isPending } = useMutation({
-    mutationFn: async () => {
-      await save();
-      const result = await fsSyncCommands.sessionDir(sessionId);
-      if (result.status === "error") {
-        throw new Error(result.error);
-      }
-      await openerCommands.revealItemInDir(result.data);
-    },
-  });
-
-  return (
-    <DropdownMenuItem
-      onClick={(e) => {
-        e.preventDefault();
-        mutate();
-      }}
-      disabled={isPending}
-      className="cursor-pointer"
-    >
-      {isPending ? <Loader2Icon className="animate-spin" /> : <SearchIcon />}
-      <span>{isPending ? "Revealing..." : "Reveal in Finder"}</span>
     </DropdownMenuItem>
   );
 }

--- a/apps/desktop/src/components/main/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/components/main/sidebar/timeline/item.tsx
@@ -13,12 +13,12 @@ import { cn, format, getYear, safeParseDate, TZDate } from "@hypr/utils";
 import { useListener } from "../../../../contexts/listener";
 import { useIgnoredEvents } from "../../../../hooks/tinybase";
 import { useIsSessionEnhancing } from "../../../../hooks/useEnhancedNotes";
+import type { MenuItemDef } from "../../../../hooks/useNativeContextMenu";
 import {
   captureSessionData,
   deleteSessionCascade,
 } from "../../../../store/tinybase/store/deleteSession";
 import * as main from "../../../../store/tinybase/store/main";
-import { save } from "../../../../store/tinybase/store/save";
 import { getOrCreateSessionForEventId } from "../../../../store/tinybase/store/sessions";
 import { useSessionTitle } from "../../../../store/zustand/live-title";
 import { type TabInput, useTabs } from "../../../../store/zustand/tabs";
@@ -98,7 +98,7 @@ function ItemBase({
   onClick: () => void;
   onCmdClick: () => void;
   onShiftClick: () => void;
-  contextMenu: Array<{ id: string; text: string; action: () => void }>;
+  contextMenu: MenuItemDef[];
 }) {
   const hasSelection = useTimelineSelection((s) => s.selectedIds.length > 0);
 
@@ -396,11 +396,10 @@ const SessionItem = memo(
       }
     }, [store, indexes, sessionId, invalidateResource, addDeletion]);
 
-    const handleRevealInFinder = useCallback(async () => {
-      await save();
+    const handleShowInFinder = useCallback(async () => {
       const result = await fsSyncCommands.sessionDir(sessionId);
       if (result.status === "ok") {
-        await openerCommands.revealItemInDir(result.data);
+        await openerCommands.openPath(result.data, null);
       }
     }, [sessionId]);
 
@@ -412,17 +411,18 @@ const SessionItem = memo(
           action: handleOpenNewTab,
         },
         {
-          id: "reveal",
-          text: "Reveal in Finder",
-          action: handleRevealInFinder,
+          id: "show",
+          text: "Show in Finder",
+          action: handleShowInFinder,
         },
+        { separator: true as const },
         {
           id: "delete",
           text: hasEvent ? "Delete Attached Note" : "Delete Note",
           action: handleDelete,
         },
       ],
-      [handleOpenNewTab, handleRevealInFinder, handleDelete, hasEvent],
+      [handleOpenNewTab, handleShowInFinder, handleDelete, hasEvent],
     );
 
     return (


### PR DESCRIPTION
Replace separate "Reveal in Finder" and "Show in Finder" actions with a single "Show in Finder" option that opens the folder  directly. Remove audio existence checks and redundant delete recording option. Add separator to improve context menu grouping. Update function names and imports to reflect the simplified approach.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #4264 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #4263 
- <kbd>&nbsp;1&nbsp;</kbd> #4225 
<!-- GitButler Footer Boundary Bottom -->

