### PR TITLE
feat: update featured articles selection

### DIFF
--- a/apps/web/content/articles/ai-didnt-lower-the-bar.mdx
+++ b/apps/web/content/articles/ai-didnt-lower-the-bar.mdx
@@ -3,6 +3,7 @@ meta_title: "AI Didn't Lower the Bar — It Exposed Who Never Had One"
 display_title: "AI Didn't Lower the Bar — It Exposed Who Never Had One"
 meta_description: "AI exposed how many people were coasting on execution alone. Taste is what doesn't get automated. And AI slop is a moral failure, not a technical one."
 author: "John Jeong"
+featured: true
 category: "Founders' notes"
 date: "2026-01-27"
 ---

--- a/apps/web/content/articles/devin-ai-review.mdx
+++ b/apps/web/content/articles/devin-ai-review.mdx
@@ -4,7 +4,7 @@ display_title: "Is Devin AI Worth It? We Spent $5,000 to Find Out"
 meta_description: "Real results from spending $5,000 on Devin AI: how we automated migrations, enabled non-technical teams to ship code, and cut maintenance work in half."
 author:
   - "Yujong Lee"
-featured: false
+featured: true
 category: "Engineering"
 date: "2026-02-13"
 ---

--- a/apps/web/content/articles/how-to-participate-in-meetings-effectively.mdx
+++ b/apps/web/content/articles/how-to-participate-in-meetings-effectively.mdx
@@ -4,7 +4,7 @@ display_title: "How to Participate in Meetings Effectively?"
 meta_description: "Learn how to contribute meaningfully in meetings without exhausting your brain. Strategies for speaking strategically, building on context, and following through."
 author: "John Jeong"
 coverImage: "/api/images/blog/how-to-participate-in-meetings-effectively/cover.png"
-featured: true
+featured: false
 category: "Guides"
 date: "2025-11-07"
 ---

--- a/apps/web/content/articles/meeting-preparation-checklist.mdx
+++ b/apps/web/content/articles/meeting-preparation-checklist.mdx
@@ -4,7 +4,7 @@ display_title: "Meeting Preparation Checklist: 7 Steps to Run More Productive Me
 meta_description: "Use this meeting preparation checklist to walk into every call with clarity and confidence. Build a repeatable system to have productive meetings."
 author: "John Jeong"
 coverImage: "/api/images/blog/meeting-preparation-checklist/cover.png"
-featured: true
+featured: false
 category: "Guides"
 date: "2025-11-03"
 ---

--- a/apps/web/content/articles/using-ide-for-writing.mdx
+++ b/apps/web/content/articles/using-ide-for-writing.mdx
@@ -4,7 +4,7 @@ display_title: "Why We Write Our Blog in an IDE (Not a WYSIWYG Editor)"
 meta_description: "Most teams write in a browser. We write in our IDE. Here's why treating content like code gives us more control, fewer surprises, and a workflow that actually scales."
 author: "John Jeong"
 coverImage: "/api/images/blog/using-ide-for-writing/cover.png"
-featured: true
+featured: false
 category: "Engineering"
 date: "2025-11-24"
 ---

--- a/apps/web/content/articles/we-fired-everyone.mdx
+++ b/apps/web/content/articles/we-fired-everyone.mdx
@@ -3,6 +3,7 @@ meta_title: "We Fired Everyone and Became More Productive"
 display_title: "We Fired Everyone and Became More Productive"
 meta_description: "At Char, we hired five people total. Then we let them all go. We started shipping faster. Coordination cost was the real problem."
 author: "John Jeong"
+featured: true
 category: "Founders' notes"
 date: "2026-02-15"
 ---

--- a/apps/web/content/articles/why-our-cms-is-github.mdx
+++ b/apps/web/content/articles/why-our-cms-is-github.mdx
@@ -3,7 +3,7 @@ meta_title: "Why Our CMS Is GitHub"
 meta_description: "Most teams store code in GitHub. We store everything — blog posts, docs, ideas — because Git already solves the hardest parts of publishing: versioning, reviews, portability, and scale."
 author: "John Jeong"
 coverImage: "/api/images/blog/why-our-cms-is-github/cover.png"
-featured: true
+featured: false
 category: "Engineering"
 date: "2025-11-26"
 ---


### PR DESCRIPTION
Change featured status for several blog articles to highlight newer content. Set "Devin AI review", "We fired everyone", and "AI didn't lower the bar" as featured while removing featured status from meeting guides and technical posts. This rotation emphasizes recent founder insights and AI-related content over older procedural guides.