### PR TITLE
fix: adjust chat input border radius and container height

### DIFF
--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -128,7 +128,7 @@ function Container({
     <div className={cn(["relative", "px-2 pb-2"])}>
       <div
         className={cn([
-          "flex flex-col border border-neutral-200 rounded-xl",
+          "flex flex-col border border-neutral-200 rounded-b-xl",
           hasContextBar && "rounded-t-none border-t-0",
         ])}
       >

--- a/apps/desktop/src/chat/components/session.tsx
+++ b/apps/desktop/src/chat/components/session.tsx
@@ -193,7 +193,7 @@ export function ChatSession({
     });
 
   return (
-    <div className="flex-1 h-full flex flex-col">
+    <div className="flex-1 min-h-0 flex flex-col">
       {children({
         sessionId,
         messages,


### PR DESCRIPTION
Change input component border radius from rounded-xl to rounded-b-xl to match design requirements and set session container min-height to 0 instead of full height to prevent layout overflow issues.