### PR TITLE
style: remove empty mention text CSS rule

### DIFF
--- a/packages/tiptap/src/styles/mention.css
+++ b/packages/tiptap/src/styles/mention.css
@@ -89,8 +89,6 @@
   height: 1em;
 }
 
-.mention .mention-text {}
-
 /* NodeView wrapper for inline mention rendering */
 span[data-node-view-wrapper] {
   display: inline !important;


### PR DESCRIPTION
Remove unused empty CSS rule for .mention .mention-text selector to clean up the stylesheet and improve maintainability.