### PR TITLE
docs: add platform support, speaker diarization, and billing info

### DIFF
--- a/apps/web/content/docs/faq/0.general.mdx
+++ b/apps/web/content/docs/faq/0.general.mdx
@@ -8,6 +8,10 @@ description: "General questions about Char and how it works."
 
 Char is a desktop notetaking application that captures both your microphone and system audio. It uses local AI to transcribe conversations, generate summaries, and help you organize your notes - all while keeping your data private on your device.
 
+## What platforms does Char support?
+
+Char is currently available for **macOS** only (Apple Silicon and Intel). Windows, Linux, and mobile are not yet available — they are on our roadmap but we don't have a timeline to share. Follow our [GitHub](https://github.com/charapp/char) or [changelog](/changelog) for updates.
+
 ## How is Char different from other meeting recorders?
 
 Unlike bot-based recorders that join your meetings, Char runs locally on your computer and captures audio directly from your system. This means it works with any application, doesn't require meeting permissions, and keeps all your data private. Learn more in [What is Char?](/docs/about/what-is-hyprnote) and [Why Local-First?](/docs/about/why-local-first).

--- a/apps/web/content/docs/faq/1.features.mdx
+++ b/apps/web/content/docs/faq/1.features.mdx
@@ -14,21 +14,13 @@ Yes! Char captures your microphone input, so you can record in-person meetings, 
 
 ## What languages does Char support?
 
-Char supports transcription and AI features in 45+ languages including:
+Char supports transcription and AI features in 90+ languages across multiple providers. You can select your main language and add additional spoken languages in **Settings** > **Language & Vocabulary**. The main language is used for summaries, chats, and AI-generated responses, while spoken languages help improve transcription accuracy in multilingual conversations.
 
-**Major Languages:**
+See the [full language support table](/docs/developers/languages) for a detailed breakdown by provider.
 
-- English, Spanish, French, German, Italian, Portuguese, Russian, Chinese, Japanese, Korean
+## Does Char support speaker diarization?
 
-**European Languages:**
-
-- Dutch, Polish, Swedish, Finnish, Norwegian, Romanian, Czech, Slovak, Croatian, Serbian, Bulgarian, Hungarian, Greek, Danish, Ukrainian, Turkish
-
-**Other Languages:**
-
-- Arabic, Indonesian, Malay, Vietnamese, Thai, Tagalog, Tamil, Hindi, Hebrew, Azerbaijani, Catalan, Galician, Macedonian, Bosnian, Estonian, Slovenian, Latvian, Lithuanian
-
-You can select your main language and add additional spoken languages in the app's settings under "Language & Vocabulary". The main language is used for summaries, chats, and AI-generated responses, while spoken languages help improve transcription accuracy when multiple languages are used in a meeting. See [Better Transcription](/docs/pro/better-transcription) for provider language support details.
+Yes. Speaker diarization (identifying who said what) is available through select cloud transcription providers on Char Pro. Accuracy depends on the provider and audio quality. For best results, ensure each speaker has a distinct audio source. Local transcription via Whisper does not currently support diarization.
 
 ## Do my pinned tabs persist across restarts?
 

--- a/apps/web/content/docs/faq/4.pricing.mdx
+++ b/apps/web/content/docs/faq/4.pricing.mdx
@@ -10,4 +10,12 @@ Char offers a free tier with core features. Pro features like unlimited recordin
 
 ## Can I try Pro features before subscribing?
 
-Yes! New users get a 14-day free trial of Char Pro to try all features before committing to a subscription.
+Yes! New users get a 14-day free trial of Char Pro to try all features before committing to a subscription. Your trial ends automatically — you won't be charged unless you explicitly subscribe.
+
+## How do I cancel my subscription?
+
+Open Char and go to **Settings** > **Account** > **Manage Subscription**. This opens the Stripe billing portal where you can cancel, update payment info, or switch plans. Cancellation takes effect at the end of your current billing period — you keep Pro access until then. You can also reach the billing portal through the in-app support chat.
+
+## Can I get a refund?
+
+If you were charged unexpectedly or are unhappy with your subscription, reach out via the in-app support chat or email us. We handle refund requests on a case-by-case basis through Stripe.


### PR DESCRIPTION
Add macOS platform support details to general FAQ. Update language support section to reference 90+ languages across providers with
link to detailed breakdown. Add speaker diarization FAQ explaining cloud provider availability. Expand pricing section with trial
auto-expiry, cancellation process via Stripe portal, and refund policy information.