### PR TITLE
feat: improve tiptap content handling

### DIFF
--- a/apps/desktop/src/store/tinybase/persister/session/load/note.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/load/note.ts
@@ -2,7 +2,7 @@ import type { NoteFrontmatter } from "~/store/tinybase/persister/session/types";
 import { SESSION_MEMO_FILE } from "~/store/tinybase/persister/shared";
 
 import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
-import { md2json } from "@hypr/tiptap/shared";
+import { isValidTiptapContent, md2json } from "@hypr/tiptap/shared";
 
 import type { LoadedSessionData } from "./types";
 
@@ -31,8 +31,7 @@ export async function processMdFile(
       return;
     }
 
-    const tiptapJson = md2json(markdownBody);
-    const tiptapContent = JSON.stringify(tiptapJson);
+    const tiptapContent = parseTiptapContent(markdownBody);
 
     if (path.endsWith(SESSION_MEMO_FILE)) {
       if (result.sessions[fm.session_id]) {
@@ -51,4 +50,17 @@ export async function processMdFile(
   } catch (error) {
     console.error(`[${LABEL}] Failed to load note from ${path}:`, error);
   }
+}
+
+function parseTiptapContent(content: string): string {
+  try {
+    const parsed = JSON.parse(content);
+    if (isValidTiptapContent(parsed)) {
+      return JSON.stringify(parsed);
+    }
+  } catch {
+    // fall back to markdown parser
+  }
+
+  return JSON.stringify(md2json(content));
 }

--- a/apps/desktop/src/store/tinybase/persister/session/save/note.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/save/note.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test, vi } from "vitest";
+import { createTestMainStore } from "~/store/tinybase/persister/testing/mocks";
+
+import type { ParsedDocument } from "@hypr/plugin-fs-sync";
+
+import { SESSION_MEMO_FILE } from "../../shared";
+import { buildNoteSaveOps } from "./note";
+
+vi.mock("@tauri-apps/api/path", () => ({
+  sep: () => "/",
+}));
+
+describe("buildNoteSaveOps", () => {
+  test("stores mention content as json to avoid lossy markdown conversion", () => {
+    const store = createTestMainStore();
+    const sessionId = "session-1";
+    const contentWithMention = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "Talk to " },
+            {
+              type: "mention-@",
+              attrs: { id: "human-1", type: "human", label: "Alice" },
+            },
+          ],
+        },
+      ],
+    });
+
+    store.setRow("sessions", sessionId, {
+      user_id: "user-1",
+      created_at: "2024-01-01T00:00:00Z",
+      title: "Test Session",
+      folder_id: "",
+      event_json: "",
+      raw_md: contentWithMention,
+    });
+
+    const ops = buildNoteSaveOps(store, store.getTables(), "/data");
+    const writeBatch = ops.find((op) => op.type === "write-document-batch");
+
+    expect(writeBatch).toBeDefined();
+
+    const memoItem = (
+      writeBatch as { items: Array<[ParsedDocument, string]> }
+    ).items.find(
+      ([_, path]) =>
+        path === `/data/sessions/${sessionId}/${SESSION_MEMO_FILE}`,
+    );
+
+    expect(memoItem).toBeDefined();
+    expect(memoItem?.[0].content).toBe(contentWithMention);
+  });
+
+  test("converts non-mention tiptap json to markdown", () => {
+    const store = createTestMainStore();
+    const sessionId = "session-2";
+    const contentWithoutMention = JSON.stringify({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "hello world" }],
+        },
+      ],
+    });
+
+    store.setRow("sessions", sessionId, {
+      user_id: "user-1",
+      created_at: "2024-01-01T00:00:00Z",
+      title: "Test Session",
+      folder_id: "",
+      event_json: "",
+      raw_md: contentWithoutMention,
+    });
+
+    const ops = buildNoteSaveOps(store, store.getTables(), "/data");
+    const writeBatch = ops.find((op) => op.type === "write-document-batch");
+    const memoItem = (
+      writeBatch as { items: Array<[ParsedDocument, string]> }
+    ).items.find(
+      ([_, path]) =>
+        path === `/data/sessions/${sessionId}/${SESSION_MEMO_FILE}`,
+    );
+
+    expect(memoItem).toBeDefined();
+    expect(memoItem?.[0].content).toContain("hello world");
+    expect(memoItem?.[0].content.startsWith('{"type":"doc"')).toBe(false);
+  });
+});

--- a/apps/desktop/src/store/tinybase/persister/session/save/note.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/save/note.ts
@@ -136,7 +136,32 @@ function tryParseAndConvertToMarkdown(content: string): string | undefined {
     return undefined;
   }
 
+  if (containsMentionNode(parsed)) {
+    return JSON.stringify(parsed);
+  }
+
   return json2md(parsed);
+}
+
+function containsMentionNode(node: unknown): boolean {
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  const contentNode = node as { type?: unknown; content?: unknown };
+
+  if (
+    typeof contentNode.type === "string" &&
+    contentNode.type.startsWith("mention-")
+  ) {
+    return true;
+  }
+
+  if (!Array.isArray(contentNode.content)) {
+    return false;
+  }
+
+  return contentNode.content.some((child) => containsMentionNode(child));
 }
 
 function getEnhancedNoteFilename(


### PR DESCRIPTION
Add support for preserving pre-serialized JSON content and **prevent lossy conversion of mention nodes**. Implement content validation to detect valid tiptap JSON format and avoid unnecessary markdown conversion. Store mention nodes as JSON to maintain data integrity during save/load operations.