### PR TITLE
feat(content): add "7 Best tl;dv Alternatives in2025" articleAdd a new detailed comparison article listing seven alternatives to tl;dv,

### DIFF
--- a/apps/web/content/articles/tldv-alternatives.mdx
+++ b/apps/web/content/articles/tldv-alternatives.mdx
@@ -1,32 +1,16 @@
 ---
-meta_title: "7 Best tl;dv Alternatives in 2025"
+meta_title: "7 Best tl;dv Alternatives in 2026"
 meta_description: "Looking for tl;dv alternatives? Compare 7 AI meeting assistants with better pricing, no bots, and free plans that don't run out after 10 uses."
 author: "Harshika"
 category: "Comparisons"
-date: "2025-02-27"
+date: "2026-02-27"
 ---
 
-tl;dv markets itself as "free forever." It is, technically. You can record unlimited meetings and get transcripts without paying. But the AI summaries that make those transcripts useful? You get 10. Total. Not monthly. After that, you're reading raw transcripts or paying $29/month.
+tl;dv does a lot well but at $29/month, you're paying for sales coaching and multi-meeting intelligence you may never use. Add a visible bot in every call and no HIPAA compliance, and the cracks start to show for a lot of teams. (We covered this in detail in our [tl;dv review](/blog/tldv-review).)
 
-That pricing gap between free and paid is one of the steepest in the market. Most competitors charge $12-19 for comparable features. Some are actually free.
+So, if you're in the market for a tl;dv alternative, I have compiled the best options in this article.
 
-I've been testing meeting tools for months and wrote a [full tl;dv review](/blog/tldv-review) if you want the deep dive. This article is for people who already know they want something else and need to decide what.
-
-## What pushes people away from tl;dv
-
-I've analyzed hundreds of G2 and Reddit reviews. These come up repeatedly:
-
-**The free plan runs out fast.** 10 lifetime AI summaries sounds like a trial, not a free tier. Most people burn through them in their first two weeks, then face raw transcripts or a $29/month bill.
-
-**$29/month is a lot.** Fireflies is $18. MeetGeek is $19. Otter is $16.99. Char's managed cloud is $8, and it's free with your own API keys. tl;dv's Pro plan doesn't include anything that justifies the premium.
-
-**The bot.** tl;dv joins meetings as a visible participant. In client calls and investor meetings, "tl;dv Notetaker" in the participant list creates questions you'd rather not answer.
-
-**No offline, no in-person.** Cloud-only, and limited to Zoom, Google Meet, and Teams. Drop your WiFi mid-meeting and you lose everything. Need to record a phone call or in-person conversation? Can't.
-
-**Accuracy with accents.** Users in our review noted that transcription quality drops with non-native English speakers and technical jargon. No custom vocabulary option, so specialized teams edit transcripts after every call.
-
-## Top tl;dv Alternatives: At a Glance
+## Top tl;dv Competitors for Specific Use Cases
 
 | Tool         | Best for                                      | Pricing                                   | Bot-free? |
 | ------------ | --------------------------------------------- | ----------------------------------------- | --------- |
@@ -36,21 +20,27 @@ I've analyzed hundreds of G2 and Reddit reviews. These come up repeatedly:
 | Fireflies    | Conversation analytics at a lower price       | Free (limited). Pro: $18/mo               | No        |
 | Tactiq       | Bot-free recording via Chrome                 | Free (10 meetings/mo). Pro: $12/mo        | Yes       |
 | MeetGeek     | Smart meeting categorization and workflows    | Free (3 hours/mo). Pro: $19/mo            | No        |
-| Supernormal  | Budget-friendly basics                        | Free. Pro: $10/mo                         | No        |
+| Supernormal  | AI agents for agencies                        | Free. Pro: $10/mo                         | Yes       |
 
 ## 7 Best tl;dv Alternatives: Detailed Reviews
 
 ### 1. Char
 
-[Char](/) is an open-source AI notepad for meetings that stores everything as plain markdown files on your device. No proprietary database, no cloud dependency. You pick the AI provider: managed cloud, your own API keys (OpenAI, Deepgram, Anthropic, whatever), or local models through Ollama. It looks like Apple Notes with AI superpowers, capturing audio from any meeting platform without joining as a bot.
+[Char](/) is an open-source AI notepad for meetings that stores everything as plain markdown files on your device. No proprietary database, no cloud dependency.
+
+It looks like Apple Notes with AI superpowers, capturing audio from any meeting platform without joining as a bot.
 
 #### How it compares to tl;dv
 
-tl;dv sends your audio to their servers, then to Anthropic for processing. You get video clips and sales coaching in return. Char skips the video entirely and gives you text-based meeting intelligence with complete data ownership. tl;dv Pro is $29/month. Char is free for local transcription and BYOK, or $8/month for managed cloud. If you left tl;dv over pricing or privacy, the gap here is wide.
+tl;dv sends your audio to their servers, then to Anthropic for processing. You get video clips and sales coaching in return.
+
+Char skips the video entirely and gives you text-based meeting intelligence with complete data ownership.
+
+tl;dv Pro is $29/month. Char is free for local transcription and BYOK, or $8/month for managed cloud. If you left tl;dv over pricing or privacy, the gap here is wide.
 
 #### Top Features
 
-- Plain markdown files stored locally—works with any tool (Obsidian, Notion, VS Code)
+- Plain markdown files stored locally that work with any tool (Obsidian, Notion, VS Code)
 - Your choice of AI stack: managed cloud, bring your own keys, or run local models
 - Open source with full transparency into the codebase
 - Customizable templates for different meeting types (therapy, legal, interviews)
@@ -61,7 +51,7 @@ tl;dv sends your audio to their servers, then to Anthropic for processing. You g
 
 #### Pros
 
-- Zero vendor lock-in—switch AI providers anytime, export your files anywhere
+- Zero vendor lock-in. You can switch AI providers anytime, export your files anywhere
 - No meeting bots to disrupt conversations
 - Free forever for local transcription, BYOK, and all core features
 - Works with any meeting platform or in-person discussions
@@ -70,22 +60,23 @@ tl;dv sends your audio to their servers, then to Anthropic for processing. You g
 
 - Currently macOS only (Windows coming soon)
 - No video recording by design for maximum privacy
-- Mic level speaker identification
 - No direct CRM sync
 
 #### Pricing
 
-Free forever for local transcription, BYOK, and all core features. Managed cloud is $8/month. Enterprise plans include on-premises deployment, SSO integration, and consent management.
+Free forever for local transcription, BYOK, and all core features. Managed cloud is $8/month.
 
-<CtaCard/>
+<CtaCard title="Try Char for free" description="Open-source meeting notes. Your data stays on your device." buttonText="Download Char" buttonUrl="/download" />
 
 ### 2. Fathom
 
-[Fathom](https://fathom.video/) has the free plan tl;dv pretends to have. Unlimited recording, unlimited transcription, and AI summaries that reset monthly instead of running out forever. You get 5 AI summaries per month on the free tier, which is enough for most people who aren't in meetings all day.
+[Fathom](https://fathom.video/) is built for sales and customer-facing teams who need meeting notes to automatically flow into their CRM without any manual input.
 
 #### How it compares to tl;dv
 
-Both tools use bots and generate post-meeting summaries. Fathom's analytics are shallower than tl;dv's multi-meeting intelligence. But if you left tl;dv over pricing or the misleading free plan, Fathom is the most direct replacement. Processing is faster too—summaries appear almost immediately after the call ends, where tl;dv sometimes takes a minute.
+The overlap with tl;dv is real: both record video, both let you clip and share moments, both generate AI summaries. Where they diverge is depth. tl;dv built toward multi-meeting intelligence, coaching playbooks, and trend tracking across calls. Fathom went deeper on CRM automation and sales workflow.
+
+If you used tl;dv mainly for clipping moments and sharing them with your team, Fathom is a fair switch. If you relied on the cross-meeting analytics or sales coaching features, Fathom doesn't cover that.
 
 #### Top Features
 
@@ -112,7 +103,7 @@ Both tools use bots and generate post-meeting summaries. Fathom's analytics are 
 
 #### Pricing
 
-Free unlimited recording. Premium at $19/month for team features and unlimited AI summaries.
+Free unlimited recording. Premium at $20/month to unlock advanced summaries and AI search. CRM sync available on $29 Business plan.
 
 Also check: [Fathom AI alternatives](/blog/fathom-ai-alternatives)
 
@@ -149,7 +140,7 @@ Grain's clip creation and highlight reels are more polished than tl;dv's. The in
 
 #### Pricing
 
-Free with 5 recordings. Starter at $15/month. Business at $29/month.
+Free with 5 recordings. Starter at $19/month. Business at $39/month.
 
 ### 4. Fireflies
 
@@ -193,7 +184,7 @@ Also check: [Fireflies AI alternatives](/blog/fireflies-ai-alternatives)
 
 #### How it compares to tl;dv
 
-Unlike tl;dv's bot-based approach, Tactiq works invisibly in your browser and shows the transcript live during the meeting. tl;dv doesn't offer that real-time view. The trade-off: Chrome only, no video recording, and limited to three meeting platforms. At $12/month it's less than half tl;dv's price.
+Unlike tl;dv's bot-based approach, Tactiq works invisibly in your browser and shows the transcript live during the meeting. tl;dv doesn't offer that real-time view. The trade-off: Chrome only, no video recording, and limited to three meeting platforms.
 
 #### Top Features
 
@@ -213,7 +204,6 @@ Unlike tl;dv's bot-based approach, Tactiq works invisibly in your browser and sh
 #### Cons
 
 - Chrome only. No Firefox, Safari, Arc, or desktop app.
-- Limited to Google Meet, Zoom, and Teams
 - No video recording or clips
 - Accuracy issues with accents
 - Can't record in-person meetings
@@ -224,11 +214,13 @@ Free with 10 meetings/month and 5 AI credits. Pro at $12/month.
 
 ### 6. MeetGeek
 
-[MeetGeek](https://meetgeek.ai/) auto-detects whether you're in a sales call, team standup, or client review, then applies the right template and workflow. tl;dv has custom templates but you configure them manually. MeetGeek does it for you, which saves time when you're moving between 8 different meeting types per week.
+[MeetGeek](https://meetgeek.ai/) auto-detects whether you're in a sales call, team standup, or client review, then applies the right template and workflow.
 
 #### How it compares to tl;dv
 
-MeetGeek intelligently categorizes meetings and provides specialized insights for different contexts. tl;dv treats all meetings similarly unless you manually configure templates. The pricing makes more sense too—Pro is $19/month for features that overlap heavily with tl;dv's $29/month plan. MeetGeek also offers HIPAA compliance, which tl;dv doesn't.
+MeetGeek has analytics, but it's more about meeting health than revenue coaching. If you used tl;dv primarily for its cross-meeting AI reports or sales coaching, MeetGeek isn't a straight swap.
+
+If you used it for solid transcription, summaries, and workflow integrations across a broader team, MeetGeek is a strong and cheaper alternative. MeetGeek also offers HIPAA compliance, which tl;dv doesn't.
 
 #### Top Features
 
@@ -259,19 +251,22 @@ Free with 3 hours/month. Pro at $19/month. Business at $29/month.
 
 ### 7. Supernormal
 
-[Supernormal](https://www.supernormal.com/) costs $10/month. That's a third of tl;dv's Pro plan. If you're paying $29/month and mostly just reading the AI summaries and action items, you're overpaying.
+[Supernormal](https://www.supernormal.com/) is AI for agencies. It pulls context from your meetings, emails, and docs to complete actual client work, such as creating slide decks, project briefs, research reports, follow-up emails, and mood boards.
 
 #### How it compares to tl;dv
 
-Supernormal handles the basics: transcription, summaries, action items, integrations with Slack and Notion. It has a pre-meeting prep feature that pulls context from past meetings before you join a new one, which nobody else does. What you lose: video recording, multi-meeting analytics, sales coaching. What you keep: the part most people actually use every day.
+Supernormal starts from meeting capture and goes further into actually completing the work that comes out of those meetings.
+
+If you used tl;dv mainly as a notetaker with CRM sync or sales coaching, Supernormal isn't the right swap. But if you left tl;dv wishing it would just do the post-meeting work for you, especially in an agency context where every client call produces deliverables, Supernormal is worth a serious look.
 
 #### Top Features
 
-- Meeting notes with summaries and action items
-- Pre-meeting prep from past meeting context
-- Video recording with key moment detection
-- Slack, Notion, and CRM integrations
-- Chrome extension for lightweight capture
+- Bot-free capture via desktop app
+- AI agents that produce deliverables: decks, briefs, emails, spreadsheets
+- Context memory across meetings, emails, and docs
+- Real-time AI chat during live meetings
+- Group meetings into projects for shared context
+- Integrations with Slack, Gmail, HubSpot, Salesforce, Notion, and more
 
 #### Pros
 
@@ -292,18 +287,10 @@ Supernormal handles the basics: transcription, summaries, action items, integrat
 
 Free plan available. Pro at $10/month.
 
-## Picking the right one
+## Our top recommendation
 
-This depends on why you're leaving tl;dv.
+Char is worth trying if you value both functionality and control.
 
-**Leaving over the free plan?** Fathom has unlimited free recording with monthly-resetting AI summaries.
+You get AI-powered features without giving up ownership of your data. You get enterprise-grade functionality without vendor lock-in. You get ease of use without sacrificing flexibility.
 
-**Leaving over the bot?** Char records system audio directly. Tactiq works through Chrome. Neither joins your call as a participant.
-
-**Leaving over the price?** Fireflies ($18/mo) and MeetGeek ($19/mo) offer comparable conversation intelligence. Supernormal ($10/mo) covers the basics. Char is free with BYOK.
-
-**Leaving for privacy reasons?** Char processes everything on your device. Open source, auditable, works offline. Nothing else on this list comes close on data control.
-
-**Leaving because you need in-person recording?** Char captures system audio and microphone input. Works for in-person conversations, phone calls, and any meeting platform.
-
-<CtaCard/>
+You can [try the tool out for free](/download). If it's not for you, you can walk away and your notes stay yours.


### PR DESCRIPTION
including Char, Fathom, Grain, Fireflies, Tactiq, MeetGeek, and Supernormal.
Explain why users leave tl;dv (limited free AI summaries, high Pro cost,
visible bot participant, cloud-only recording, and transcription issueswith accents). Provide an at-a-glance pricing and bot-free table and adetailed review for Char covering data ownership, offline use, BYOK/localmodels, features, pros, and how it compares to tl;dv.

This gives readers a quick way to evaluate replacement options andhighlights privacy, pricing, and offline capabilities as primary reasonsto switch from tl;dv.