### PR TITLE
feat: extend early bird discount deadline

### DIFF
--- a/apps/web/src/routes/_view/pricing.tsx
+++ b/apps/web/src/routes/_view/pricing.tsx
@@ -130,7 +130,7 @@ function TeamPricingBanner() {
       <span>
         <strong>Early Bird Discount:</strong> Get 68% off as we launch our new
         version and help with migration —{" "}
-        <strong>offer ends February 28th</strong>
+        <strong>offer extended while we finalize the new timeline</strong>
       </span>
     </div>
   );


### PR DESCRIPTION
Update early bird discount message to reflect extended offer period instead of fixed February 28th deadline while new timeline is being finalized.