### PR TITLE
feat: improve hashtag parsing to ignore URL fragments

### DIFF
--- a/packages/tiptap/src/shared/hashtag.test.ts
+++ b/packages/tiptap/src/shared/hashtag.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { findHashtags } from "./hashtag";
+
+describe("findHashtags", () => {
+  it("extracts regular hashtags", () => {
+    expect(findHashtags("#alpha #beta").map((match) => match.tag)).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  it("ignores url fragments", () => {
+    expect(
+      findHashtags("https://web4.ai/#free #valid").map((match) => match.tag),
+    ).toEqual(["valid"]);
+  });
+
+  it("ignores www url fragments", () => {
+    expect(
+      findHashtags("www.web4.ai/#free #valid").map((match) => match.tag),
+    ).toEqual(["valid"]);
+  });
+});


### PR DESCRIPTION
Add findHashtags function that filters out hashtags appearing in URLs while preserving valid standalone hashtags. Refactor existing hashtag extraction logic to use the new centralized parsing function.

The change prevents false positive hashtag detection in URLs like https://example.com/#section while still capturing legitimate hashtags. Add comprehensive test coverage for regular hashtags, HTTP URLs, and www URLs to ensure reliable hashtag detection across different text contexts.