### PR TITLE
adjusted hero video thumbnail to show appropriate frame

### DIFF
--- a/apps/web/src/components/video-thumbnail.tsx
+++ b/apps/web/src/components/video-thumbnail.tsx
@@ -24,7 +24,7 @@ export function VideoThumbnail({
     >
       <MuxPlayer
         playbackId={playbackId}
-        poster="https://image.mux.com/bpcBHf4Qv5FbhwWD02zyFDb24EBuEuTPHKFUrZEktULQ/thumbnail.png?width=1152&height=648&time=58"
+        poster="https://image.mux.com/bpcBHf4Qv5FbhwWD02zyFDb24EBuEuTPHKFUrZEktULQ/thumbnail.png?width=1152&height=648&time=58.6"
         muted
         playsInline
         className="pointer-events-none aspect-video h-full w-full object-cover"


### PR DESCRIPTION
Update video thumbnail time parameter from 58 to 58.6 seconds to
capture a more appropriate frame for the video preview poster.