### PR TITLE
refactor: Replace ComponentRef with explicit types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20070,7 +20070,6 @@ dependencies = [
  "owhisper-interface",
  "pyannote-local",
  "rodio",
- "segmentation",
  "serde_json",
  "serde_qs",
  "thiserror 2.0.18",

--- a/apps/desktop/src/routes/app/main/_layout.index.tsx
+++ b/apps/desktop/src/routes/app/main/_layout.index.tsx
@@ -1,8 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
-import type { ComponentRef } from "react";
 
 import {
+  type ImperativePanelHandle,
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
@@ -29,7 +29,7 @@ function Component() {
   const isOnboarding = currentTab?.type === "onboarding";
   const previousModeRef = useRef(chat.mode);
   const previousQueryRef = useRef(query);
-  const bodyPanelRef = useRef<ComponentRef<typeof ResizablePanel>>(null);
+  const bodyPanelRef = useRef<ImperativePanelHandle>(null);
   const chatPanelContainerRef = useRef<HTMLDivElement>(null);
 
   const isChatOpen = chat.mode === "RightPanelOpen";

--- a/apps/desktop/src/session/components/outer-header/listen.tsx
+++ b/apps/desktop/src/session/components/outer-header/listen.tsx
@@ -116,7 +116,7 @@ function InMeetingIndicator({ sessionId }: { sessionId: string }) {
     <Tooltip>
       <TooltipTrigger asChild>
         <button
-          ref={ref}
+          ref={ref as React.Ref<HTMLButtonElement>}
           type="button"
           onClick={finalizing ? undefined : stop}
           disabled={finalizing}

--- a/apps/desktop/src/templates/index.tsx
+++ b/apps/desktop/src/templates/index.tsx
@@ -7,14 +7,7 @@ import {
   Star,
   X,
 } from "lucide-react";
-import {
-  type ComponentRef,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { Template, TemplateSection, TemplateStorage } from "@hypr/store";
 import { Button } from "@hypr/ui/components/ui/button";
@@ -25,6 +18,7 @@ import {
   DropdownMenuTrigger,
 } from "@hypr/ui/components/ui/dropdown-menu";
 import {
+  type ImperativePanelHandle,
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
@@ -155,7 +149,7 @@ function normalizeTemplateWithId(id: string, template: unknown) {
 function TemplateView({ tab }: { tab: Extract<Tab, { type: "templates" }> }) {
   const updateTabState = useTabs((state) => state.updateTemplatesTabState);
   const { user_id } = main.UI.useValues(main.STORE_ID);
-  const leftPanelRef = useRef<ComponentRef<typeof ResizablePanel>>(null);
+  const leftPanelRef = useRef<ImperativePanelHandle>(null);
   const [isLeftPanelCollapsed, setIsLeftPanelCollapsed] = useState(false);
 
   const userTemplates = useUserTemplates();

--- a/packages/ui/src/components/ui/resizable.tsx
+++ b/packages/ui/src/components/ui/resizable.tsx
@@ -40,4 +40,5 @@ const ResizableHandle = ({
   </ResizablePrimitive.PanelResizeHandle>
 );
 
+export type { ImperativePanelHandle } from "react-resizable-panels";
 export { ResizableHandle, ResizablePanel, ResizablePanelGroup };


### PR DESCRIPTION
Remove unused ComponentRef imports and replace with specific types like ImperativePanelHandle for better type safety. Export ImperativePanelHandle from resizable components and add explicit ref casting for HTMLButtonElement. Remove segmentation dependency from Cargo.lock as it's no longer needed.