### PR TITLE
docs: update analytics event documentation

### DIFF
--- a/apps/web/content/docs/developers/12.analytics.mdx
+++ b/apps/web/content/docs/developers/12.analytics.mdx
@@ -17,7 +17,7 @@ Events tracked on the web app (`apps/web`):
 | Event | Description | Properties | Source |
 |-------|-------------|------------|--------|
 | `hero_section_viewed` | User views the landing page hero section | `timestamp` | `routes/_view/index.tsx` |
-| `download_clicked` | User clicks a download button | `platform`, `spec`, `source`, `timestamp` | `components/download-button.tsx`, `routes/_view/download/index.tsx` |
+| `download_clicked` | User clicks a download button | `platform`, `timestamp` (homepage); `platform`, `spec`, `source` (download page) | `components/download-button.tsx`, `routes/_view/download/index.tsx` |
 | `reminder_requested` | User requests a mobile reminder | `platform`, `timestamp`, `email` | `routes/_view/index.tsx` |
 | `os_waitlist_joined` | User joins waitlist for unsupported OS | `platform`, `timestamp`, `email` | `routes/_view/index.tsx` |
 
@@ -30,12 +30,16 @@ Events tracked when users first launch the desktop app:
 | Event | Description | Properties | Source |
 |-------|-------------|------------|--------|
 | `show_main_window` | Main window is shown (fires on every app launch) | - | `plugins/windows/src/ext.rs` |
-| `onboarding_step_viewed` | User views an onboarding step | `step`, `platform` | `components/main/body/onboarding/index.tsx` |
-| `onboarding_completed` | User finishes the onboarding flow | - | `components/onboarding/final.tsx` |
+| `onboarding_step_viewed` | User views an onboarding step | `step`, `platform` | `onboarding/index.tsx` |
+| `onboarding_completed` | User finishes the onboarding flow | - | `onboarding/final.tsx` |
 | `user_signed_in` | User signs in (triggers `$identify` to link anonymous ID) | - | `auth/context.tsx` |
-| `trial_started` | User starts a free trial | `plan` | `components/onboarding/login.tsx`, `components/settings/general/account.tsx` |
-| `ai_provider_configured` | User configures an AI provider | `provider` | `components/settings/ai/shared/index.tsx` |
-| `data_imported` | User imports data from another app | `source` | `components/settings/data/index.tsx` |
+| `trial_started` | User starts a free trial (server-side) | `plan`, `source` | `crates/api-subscription/src/trial.rs` |
+| `trial_flow_client_error` | Trial activation failed on client | `error` | `onboarding/account/trial.tsx` |
+| `trial_flow_skipped` | Trial flow skipped on client | `reason` (`already_pro` or `already_trialing`) | `onboarding/account/trial.tsx` |
+| `trial_skipped` | Trial not started (server-side) | `reason: "not_eligible"`, `source` | `crates/api-subscription/src/trial.rs` |
+| `trial_failed` | Trial creation failed (server-side) | `reason` (`stripe_error`, `customer_error`, `rpc_error`), `source` | `crates/api-subscription/src/trial.rs` |
+| `ai_provider_configured` | User configures an AI provider | `provider` | `settings/ai/shared/index.tsx` |
+| `data_imported` | User imports data from another app | `source` | `settings/data/index.tsx` |
 
 ### 3. Before meetings
 
@@ -43,8 +47,8 @@ Events tracked when preparing for meetings:
 
 | Event | Description | Properties | Source |
 |-------|-------------|------------|--------|
-| `note_created` | User creates a new note | `has_event_id` (whether linked to calendar) | `store/tinybase/store/sessions.ts`, `components/main/shared.ts` |
-| `file_uploaded` | User uploads a file | `file_type` (`audio` or `transcript`), `token_count` (transcript only) | `components/main/body/sessions/floating/options-menu.tsx` |
+| `note_created` | User creates a new note | `has_event_id` (whether linked to calendar) | `store/tinybase/store/sessions.ts`, `shared/main/useNewNote.ts` |
+| `file_uploaded` | User uploads a file | `file_type` (`audio` or `transcript`), `token_count` (transcript only) | `session/components/floating/options-menu.tsx` |
 
 ### 4. During meetings
 
@@ -52,9 +56,9 @@ Events tracked during active sessions:
 
 | Event | Description | Properties | Source |
 |-------|-------------|------------|--------|
-| `session_started` | Listening session starts | `has_calendar_event`, `stt_provider`, `stt_model` | `hooks/useStartListening.ts` |
+| `session_started` | Listening session starts | `has_calendar_event`, `stt_provider`, `stt_model` | `stt/useStartListening.ts` |
 | `tab_opened` | User opens a tab | `view` (tab type) | `store/zustand/tabs/basic.ts` |
-| `search_performed` | User performs a search | - | `contexts/search/ui.tsx` |
+| `search_performed` | User performs a search | - | `search/contexts/ui.tsx` |
 
 ### 5. After meetings
 
@@ -62,12 +66,11 @@ Events tracked when working with completed sessions:
 
 | Event | Description | Properties | Source |
 |-------|-------------|------------|--------|
-| `note_edited` | User edits a note | `has_content` | `components/main/body/sessions/note-input/raw.tsx` |
-| `note_enhanced` | AI enhancement is triggered | `is_auto`, `template_id` (manual), `llm_provider` (auto), `llm_model` (auto) | `hooks/autoEnhance/runner.ts`, `components/main/body/sessions/note-input/header.tsx` |
-| `message_sent` | User sends a chat message | - | `components/chat/input/hooks.ts` |
-| `session_exported` | User exports a session | `format` (`pdf` or `vtt`), `word_count` (vtt), `view_type` (pdf), `has_transcript` (pdf), `has_enhanced` (pdf), `has_memo` (pdf) | `components/main/body/sessions/outer-header/overflow/export-transcript.tsx`, `export-pdf.tsx` |
-| `session_deleted` | User deletes a session/note | `includes_recording` | `components/main/body/sessions/outer-header/overflow/delete.tsx` |
-| `recording_deleted` | User deletes a recording | - | `components/main/body/sessions/outer-header/overflow/delete.tsx` |
+| `note_edited` | User edits a note | `has_content` | `session/components/note-input/raw.tsx` |
+| `note_enhanced` | AI enhancement is triggered | `is_auto`, `llm_provider`, `llm_model`, `template_id` | `services/enhancer/index.ts`, `session/components/note-input/header.tsx` |
+| `message_sent` | User sends a chat message | - | `chat/components/input/hooks.ts` |
+| `session_exported` | User exports a session | `format` (`pdf`, `vtt`, `txt`, `md`, `org`), `word_count` (vtt), `view_type` (pdf), `has_transcript` (pdf), `has_enhanced` (pdf), `has_memo` (pdf), `include_summary` (modal), `include_transcript` (modal) | `session/components/outer-header/overflow/export-transcript.tsx`, `export-pdf.tsx`, `export-modal.tsx` |
+| `session_deleted` | User deletes a session/note | `includes_recording` | `session/components/outer-header/overflow/delete.tsx` |
 
 ### 6. Settings & account management
 
@@ -75,9 +78,9 @@ Events tracked when managing settings and account:
 
 | Event | Description | Properties | Source |
 |-------|-------------|------------|--------|
-| `settings_changed` | User changes settings | `autostart`, `notification_detect`, `save_recordings`, `telemetry_consent` | `components/settings/general/index.tsx` |
-| `upgrade_clicked` | User clicks upgrade button | `plan` | `components/settings/general/account.tsx` |
-| `user_signed_out` | User signs out | - | `components/settings/general/account.tsx` |
+| `settings_changed` | User changes settings | `autostart`, `notification_detect`, `save_recordings`, `telemetry_consent` | `settings/general/index.tsx` |
+| `upgrade_clicked` | User clicks upgrade button | `plan` | `settings/general/account.tsx` |
+| `user_signed_out` | User signs out | - | `settings/general/account.tsx` |
 
 ### 7. Notification interactions
 
@@ -87,6 +90,7 @@ Events tracked when users interact with system notifications (`plugins/notificat
 |-------|-------------|------------|
 | `collapsed_confirm` | User clicks collapsed notification to open app | - |
 | `expanded_accept` | User accepts expanded notification | - |
+| `option_selected` | User selects a notification option | - |
 | `dismiss` | User dismisses notification | - |
 | `collapsed_timeout` | Collapsed notification times out | - |
 
@@ -105,15 +109,16 @@ Properties set to track user context and configuration:
 
 | Property | Description | Type | Source |
 |----------|-------------|------|--------|
-| `is_signed_up` | Whether user has signed up | set | `auth/context.tsx`, `components/settings/general/account.tsx` |
+| `is_signed_up` | Whether user has signed up | set | `auth/context.tsx`, `settings/general/account.tsx` |
+| `email` | User email | identify | `auth/context.tsx` |
 | `platform` | Operating system (macos, linux, windows) | set | `auth/context.tsx` |
 | `os_version` | Operating system version | set | `auth/context.tsx` |
 | `app_version` | Application version | set | `auth/context.tsx` |
-| `account_created_date` | When account was created | set_once | `auth/context.tsx` |
-| `telemetry_opt_out` | Whether user opted out of telemetry | set | `components/settings/general/index.tsx` |
-| `has_configured_ai` | Whether user has configured an AI provider | set | `components/settings/ai/shared/index.tsx` |
-| `plan` | Current subscription plan | set | `components/onboarding/login.tsx`, `components/settings/general/account.tsx` |
-| `trial_end_date` | When trial ends | set | `components/onboarding/login.tsx`, `components/settings/general/account.tsx` |
+| `account_created_date` | When account was created | set | `auth/context.tsx` |
+| `telemetry_opt_out` | Whether user opted out of telemetry | set | `settings/general/index.tsx` |
+| `has_configured_ai` | Whether user has configured an AI provider | set | `settings/ai/shared/index.tsx` |
+| `plan` | Current subscription plan | set | `crates/api-subscription/src/trial.rs` |
+| `trial_end_date` | When trial ends | set | `crates/api-subscription/src/trial.rs` |
 | `spoken_languages` | Configured spoken languages for transcription | set | `store/tinybase/persister/settings/persister.ts` |
 | `current_stt_provider` | Currently selected speech-to-text provider | set | `store/tinybase/persister/settings/persister.ts` |
 | `current_stt_model` | Currently selected speech-to-text model | set | `store/tinybase/persister/settings/persister.ts` |
@@ -168,6 +173,8 @@ Each feature defines a `FlagStrategy`:
 | `Debug` | Enabled only in debug builds |
 | `Posthog(key)` | Resolved via PostHog `is_feature_enabled` (through `posthog-rs`) |
 | `Hardcoded(bool)` | Always enabled or disabled |
+
+Currently only `Chat` is defined as a feature flag, using `Hardcoded(true)`.
 
 Features can also be overridden at build time using environment variables (e.g., `CHAT=1` forces the Chat feature on).
 


### PR DESCRIPTION
Update analytics event tracking documentation to reflect recent code restructuring and enhanced trial flow monitoring. Clarify download_clicked event properties by page context, update file paths for relocated components, and document comprehensive trial tracking events including client errors and server-side failures.