### PR TITLE
feat: restructure analytics docs with detailed tracking inventory

### DIFF
--- a/apps/web/content/docs/developers/12.analytics.mdx
+++ b/apps/web/content/docs/developers/12.analytics.mdx
@@ -4,180 +4,183 @@ section: "Developers"
 description: "Learn about analytics in Char"
 ---
 
-## What are we tracking?
+## Scope
 
-We use PostHog for analytics in both the web and desktop applications. The web application also uses Outlit for pageview tracking. You can opt-out from the settings menu in the desktop app.
+This is a code-derived inventory of what Char sends to PostHog across:
 
-## User journey events
+- `apps/web` (browser events)
+- `apps/desktop` + `plugins/analytics` (desktop events)
+- `apps/api` + proxy/subscription crates (server-side events)
 
-### 1. Visiting the website
+## Collection paths
 
-Events tracked on the web app (`apps/web`):
+### Web (`apps/web`)
 
-| Event | Description | Properties | Source |
-|-------|-------------|------------|--------|
-| `hero_section_viewed` | User views the landing page hero section | `timestamp` | `routes/_view/index.tsx` |
-| `download_clicked` | User clicks a download button | `platform`, `timestamp` (homepage); `platform`, `spec`, `source` (download page) | `components/download-button.tsx`, `routes/_view/download/index.tsx` |
-| `reminder_requested` | User requests a mobile reminder | `platform`, `timestamp`, `email` | `routes/_view/index.tsx` |
-| `os_waitlist_joined` | User joins waitlist for unsupported OS | `platform`, `timestamp`, `email` | `routes/_view/index.tsx` |
+- PostHog is initialized in `apps/web/src/providers/posthog.tsx` only when:
+  - `VITE_POSTHOG_API_KEY` is set
+  - build is not dev (`!import.meta.env.DEV`)
+- Enabled options:
+  - `autocapture: true`
+  - `capture_pageview: true`
 
-The web app also has PostHog autocapture and pageview tracking enabled.
+### Desktop (`apps/desktop` + `plugins/analytics`)
 
-### 2. Getting started
+- Frontend calls `analyticsCommands.event`, `analyticsCommands.setProperties`, and `analyticsCommands.identify`.
+- Rust plugin forwards to `hypr_analytics::AnalyticsClient` in `plugins/analytics/src/ext.rs`.
+- Distinct ID for desktop telemetry is `hypr_host::fingerprint()` (hashed machine UID).
 
-Events tracked when users first launch the desktop app:
+### API/server (`apps/api` + crates)
 
-| Event | Description | Properties | Source |
-|-------|-------------|------------|--------|
-| `show_main_window` | Main window is shown (fires on every app launch) | - | `plugins/windows/src/ext.rs` |
-| `onboarding_step_viewed` | User views an onboarding step | `step`, `platform` | `onboarding/index.tsx` |
-| `onboarding_completed` | User finishes the onboarding flow | - | `onboarding/final.tsx` |
-| `user_signed_in` | User signs in (triggers `$identify` to link anonymous ID) | - | `auth/context.tsx` |
-| `trial_started` | User starts a free trial (server-side) | `plan`, `source` | `crates/api-subscription/src/trial.rs` |
-| `trial_flow_client_error` | Trial activation failed on client | `error` | `onboarding/account/trial.tsx` |
-| `trial_flow_skipped` | Trial flow skipped on client | `reason` (`already_pro` or `already_trialing`) | `onboarding/account/trial.tsx` |
-| `trial_skipped` | Trial not started (server-side) | `reason: "not_eligible"`, `source` | `crates/api-subscription/src/trial.rs` |
-| `trial_failed` | Trial creation failed (server-side) | `reason` (`stripe_error`, `customer_error`, `rpc_error`), `source` | `crates/api-subscription/src/trial.rs` |
-| `ai_provider_configured` | User configures an AI provider | `provider` | `settings/ai/shared/index.tsx` |
-| `data_imported` | User imports data from another app | `source` | `settings/data/index.tsx` |
+- API builds a PostHog client in production in `apps/api/src/main.rs`.
+- Request middleware maps `x-device-fingerprint` and auth user ID into request extensions in `apps/api/src/auth.rs`.
+- LLM/STT/trial analytics emit from backend crates (details below).
 
-### 3. Before meetings
+## Identity and distinct IDs
 
-Events tracked when preparing for meetings:
+| Surface | Distinct ID | Identify behavior |
+|--------|-------------|-------------------|
+| Desktop custom events | Machine fingerprint (`hypr_host::fingerprint()`) | `identify(userId, payload)` sends PostHog `$identify` with `$anon_distinct_id` = machine fingerprint. |
+| Web custom/autocapture events | PostHog browser distinct ID | Auth callback calls `posthog.identify(userId, { email })`. |
+| API `$ai_generation` | `x-device-fingerprint` if present, else `generation_id` | Optional `user_id` also included as event property. |
+| API `$stt_request` | `x-device-fingerprint` if present, else random UUID | Optional `user_id` also included as event property. |
+| API trial events | Authenticated `user_id` | No separate `$identify` call here. |
 
-| Event | Description | Properties | Source |
-|-------|-------------|------------|--------|
-| `note_created` | User creates a new note | `has_event_id` (whether linked to calendar) | `store/tinybase/store/sessions.ts`, `shared/main/useNewNote.ts` |
-| `file_uploaded` | User uploads a file | `file_type` (`audio` or `transcript`), `token_count` (transcript only) | `session/components/floating/options-menu.tsx` |
+## Automatic desktop event enrichment
 
-### 4. During meetings
+Every desktop `event(...)` call is enriched in `plugins/analytics/src/ext.rs` with:
 
-Events tracked during active sessions:
+| Property | Value |
+|----------|-------|
+| `app_version` | `env!("APP_VERSION")` |
+| `app_identifier` | Tauri app identifier |
+| `git_hash` | `tauri_plugin_misc::get_git_hash()` |
+| `bundle_id` | Tauri app identifier |
+| `$set.app_version` | user property update on each event |
 
-| Event | Description | Properties | Source |
-|-------|-------------|------------|--------|
-| `session_started` | Listening session starts | `has_calendar_event`, `stt_provider`, `stt_model` | `stt/useStartListening.ts` |
-| `tab_opened` | User opens a tab | `view` (tab type) | `store/zustand/tabs/basic.ts` |
-| `search_performed` | User performs a search | - | `search/contexts/ui.tsx` |
+This enrichment applies to desktop frontend events and Rust plugin `event_fire_and_forget` events (for example notification/window events).
 
-### 5. After meetings
+## Event catalog
 
-Events tracked when working with completed sessions:
+### Web custom events
 
-| Event | Description | Properties | Source |
-|-------|-------------|------------|--------|
-| `note_edited` | User edits a note | `has_content` | `session/components/note-input/raw.tsx` |
-| `note_enhanced` | AI enhancement is triggered | `is_auto`, `llm_provider`, `llm_model`, `template_id` | `services/enhancer/index.ts`, `session/components/note-input/header.tsx` |
-| `message_sent` | User sends a chat message | - | `chat/components/input/hooks.ts` |
-| `session_exported` | User exports a session | `format` (`pdf`, `vtt`, `txt`, `md`, `org`), `word_count` (vtt), `view_type` (pdf), `has_transcript` (pdf), `has_enhanced` (pdf), `has_memo` (pdf), `include_summary` (modal), `include_transcript` (modal) | `session/components/outer-header/overflow/export-transcript.tsx`, `export-pdf.tsx`, `export-modal.tsx` |
-| `session_deleted` | User deletes a session/note | `includes_recording` | `session/components/outer-header/overflow/delete.tsx` |
+| Event | Properties | Source |
+|------|------------|--------|
+| `hero_section_viewed` | `timestamp` | `apps/web/src/routes/_view/index.tsx` |
+| `download_clicked` | Homepage: `platform`, `timestamp` | `apps/web/src/components/download-button.tsx` |
+| `download_clicked` | Download page: `platform`, `spec`, `source` (`"download_page"`) | `apps/web/src/routes/_view/download/index.tsx` |
+| `reminder_requested` | `platform`, `timestamp`, `email` | `apps/web/src/routes/_view/index.tsx` |
+| `os_waitlist_joined` | `platform`, `timestamp`, `email` | `apps/web/src/routes/_view/index.tsx` |
 
-### 6. Settings & account management
+Notes:
 
-Events tracked when managing settings and account:
+- PostHog autocapture and pageview are also on (production only), so PostHog default browser events are collected in addition to the custom events above.
+- Web auth callback calls `identify(userId, { email })` in `apps/web/src/routes/_view/callback/auth.tsx`.
 
-| Event | Description | Properties | Source |
-|-------|-------------|------------|--------|
-| `settings_changed` | User changes settings | `autostart`, `notification_detect`, `save_recordings`, `telemetry_consent` | `settings/general/index.tsx` |
-| `upgrade_clicked` | User clicks upgrade button | `plan` | `settings/general/account.tsx` |
-| `user_signed_out` | User signs out | - | `settings/general/account.tsx` |
+### Desktop product events
 
-### 7. Notification interactions
+| Event | Properties | Source |
+|------|------------|--------|
+| `show_main_window` | none (plus auto-enriched desktop props) | `plugins/windows/src/ext.rs` |
+| `onboarding_step_viewed` | `step`, `platform` | `apps/desktop/src/onboarding/index.tsx` |
+| `onboarding_completed` | none | `apps/desktop/src/onboarding/final.tsx` |
+| `user_signed_in` | none | `apps/desktop/src/auth/context.tsx` |
+| `trial_flow_client_error` | `properties.error` (nested object) | `apps/desktop/src/onboarding/account/trial.tsx` |
+| `trial_flow_skipped` | `properties.reason` (`already_pro` or `already_trialing`) | `apps/desktop/src/onboarding/account/trial.tsx` |
+| `data_imported` | `source` | `apps/desktop/src/settings/data/index.tsx` |
+| `note_created` | `has_event_id` | `apps/desktop/src/store/tinybase/store/sessions.ts`, `apps/desktop/src/shared/main/useNewNote.ts` |
+| `file_uploaded` | Audio: `file_type = "audio"`; Transcript: `file_type = "transcript"`, `token_count` | `apps/desktop/src/session/components/floating/options-menu.tsx` |
+| `session_started` | `has_calendar_event`, `stt_provider`, `stt_model` | `apps/desktop/src/stt/useStartListening.ts` |
+| `tab_opened` | `view` | `apps/desktop/src/store/zustand/tabs/basic.ts` |
+| `search_performed` | none | `apps/desktop/src/search/contexts/ui.tsx` |
+| `note_edited` | `has_content` (currently emitted as `true`) | `apps/desktop/src/session/components/note-input/raw.tsx` |
+| `note_enhanced` | Variant A: `is_auto`; Variant B: `is_auto`, `llm_provider`, `llm_model`, `template_id` | `apps/desktop/src/session/components/note-input/header.tsx`, `apps/desktop/src/services/enhancer/index.ts` |
+| `message_sent` | none | `apps/desktop/src/chat/components/input/hooks.ts` |
+| `session_exported` | Modal export: `format`, `include_summary`, `include_transcript` | `apps/desktop/src/session/components/outer-header/overflow/export-modal.tsx` |
+| `session_exported` | PDF export: `format = "pdf"`, `view_type`, `has_transcript`, `has_enhanced`, `has_memo` | `apps/desktop/src/session/components/outer-header/overflow/export-pdf.tsx` |
+| `session_exported` | Transcript export: `format = "vtt"`, `word_count` | `apps/desktop/src/session/components/outer-header/overflow/export-transcript.tsx` |
+| `session_deleted` | `includes_recording` (currently always `true`) | `apps/desktop/src/session/components/outer-header/overflow/delete.tsx` |
+| `settings_changed` | `autostart`, `notification_detect`, `save_recordings`, `telemetry_consent` | `apps/desktop/src/settings/general/index.tsx` |
+| `ai_provider_configured` | `provider` | `apps/desktop/src/settings/ai/shared/index.tsx` |
+| `upgrade_clicked` | `plan` (`"pro"`) | `apps/desktop/src/settings/general/account.tsx` |
+| `user_signed_out` | none | `apps/desktop/src/settings/general/account.tsx` |
 
-Events tracked when users interact with system notifications (`plugins/notification/src/handler.rs`):
+### Desktop notification events
 
-| Event | Description | Properties |
-|-------|-------------|------------|
-| `collapsed_confirm` | User clicks collapsed notification to open app | - |
-| `expanded_accept` | User accepts expanded notification | - |
-| `option_selected` | User selects a notification option | - |
-| `dismiss` | User dismisses notification | - |
-| `collapsed_timeout` | Collapsed notification times out | - |
+| Event | Properties | Source |
+|------|------------|--------|
+| `collapsed_confirm` | none | `plugins/notification/src/handler.rs` |
+| `expanded_accept` | none | `plugins/notification/src/handler.rs` |
+| `dismiss` | none | `plugins/notification/src/handler.rs` |
+| `collapsed_timeout` | none | `plugins/notification/src/handler.rs` |
+| `option_selected` | none | `plugins/notification/src/handler.rs` |
 
-### 8. Server-side proxy events
+### API/server events
 
-Events tracked by the API proxy layer. These use the `$` prefix following PostHog conventions for built-in event types.
+| Event | Properties | Source |
+|------|------------|--------|
+| `$stt_request` | `$stt_provider`, `$stt_duration`, optional `user_id` | `crates/transcribe-proxy/src/analytics.rs` |
+| `$ai_generation` | `$ai_provider`, `$ai_model`, `$ai_input_tokens`, `$ai_output_tokens`, `$ai_latency`, `$ai_trace_id`, `$ai_http_status`, `$ai_base_url`, optional `$ai_total_cost_usd`, optional `user_id` | `crates/llm-proxy/src/analytics.rs` |
+| `trial_started` | `plan`, `source` (`desktop` or `web`) | `crates/api-subscription/src/trial.rs`, `crates/api-subscription/src/routes/billing.rs` |
+| `trial_skipped` | `reason = "not_eligible"`, `source` | `crates/api-subscription/src/trial.rs`, `crates/api-subscription/src/routes/billing.rs` |
+| `trial_failed` | `reason` (`stripe_error`, `customer_error`, `rpc_error`), `source` | `crates/api-subscription/src/trial.rs`, `crates/api-subscription/src/routes/billing.rs` |
 
-| Event | Description | Properties | Source |
-|-------|-------------|------------|--------|
-| `$stt_request` | Speech-to-text request processed | `$stt_provider`, `$stt_duration`, `user_id` | `crates/transcribe-proxy/src/analytics.rs` |
-| `$ai_generation` | LLM generation request processed | `$ai_provider`, `$ai_model`, `$ai_input_tokens`, `$ai_output_tokens`, `$ai_latency`, `$ai_trace_id`, `$ai_http_status`, `$ai_base_url`, `$ai_total_cost_usd`, `user_id` | `crates/llm-proxy/src/analytics.rs` |
+## User property catalog
 
-## User properties
+PostHog user properties are set via `$set`, `$set_once`, and `$identify` payloads.
 
-Properties set to track user context and configuration:
+| Property | How it is set | Source |
+|----------|---------------|--------|
+| `email` | `identify(..., { email })` (desktop and web) | `apps/desktop/src/auth/context.tsx`, `apps/web/src/routes/_view/callback/auth.tsx` |
+| `account_created_date` | `identify(..., { set: { ... } })` | `apps/desktop/src/auth/context.tsx` |
+| `is_signed_up` | `true` on sign-in identify, `false` on sign-out `setProperties` | `apps/desktop/src/auth/context.tsx`, `apps/desktop/src/settings/general/account.tsx` |
+| `platform` | `identify(..., set.platform)` | `apps/desktop/src/auth/context.tsx` |
+| `os_version` | `identify(..., set.os_version)` | `apps/desktop/src/auth/context.tsx` |
+| `app_version` | `identify(..., set.app_version)` and per-event `$set.app_version` enrichment | `apps/desktop/src/auth/context.tsx`, `plugins/analytics/src/ext.rs` |
+| `telemetry_opt_out` | `setProperties({ set: { telemetry_opt_out } })` | `apps/desktop/src/settings/general/index.tsx` |
+| `has_configured_ai` | `setProperties({ set: { has_configured_ai: true } })` | `apps/desktop/src/settings/ai/shared/index.tsx` |
+| `spoken_languages` | settings persister `setProperties` | `apps/desktop/src/store/tinybase/persister/settings/persister.ts` |
+| `current_stt_provider` | settings persister `setProperties` | `apps/desktop/src/store/tinybase/persister/settings/persister.ts` |
+| `current_stt_model` | settings persister `setProperties` | `apps/desktop/src/store/tinybase/persister/settings/persister.ts` |
+| `current_llm_provider` | settings persister `setProperties` | `apps/desktop/src/store/tinybase/persister/settings/persister.ts` |
+| `current_llm_model` | settings persister `setProperties` | `apps/desktop/src/store/tinybase/persister/settings/persister.ts` |
+| `plan` | server `set_properties` on successful trial start | `crates/api-subscription/src/trial.rs` |
+| `trial_end_date` | server `set_properties` on successful trial start (`UTC now + 14 days`) | `crates/api-subscription/src/trial.rs` |
 
-| Property | Description | Type | Source |
-|----------|-------------|------|--------|
-| `is_signed_up` | Whether user has signed up | set | `auth/context.tsx`, `settings/general/account.tsx` |
-| `email` | User email | identify | `auth/context.tsx` |
-| `platform` | Operating system (macos, linux, windows) | set | `auth/context.tsx` |
-| `os_version` | Operating system version | set | `auth/context.tsx` |
-| `app_version` | Application version | set | `auth/context.tsx` |
-| `account_created_date` | When account was created | set | `auth/context.tsx` |
-| `telemetry_opt_out` | Whether user opted out of telemetry | set | `settings/general/index.tsx` |
-| `has_configured_ai` | Whether user has configured an AI provider | set | `settings/ai/shared/index.tsx` |
-| `plan` | Current subscription plan | set | `crates/api-subscription/src/trial.rs` |
-| `trial_end_date` | When trial ends | set | `crates/api-subscription/src/trial.rs` |
-| `spoken_languages` | Configured spoken languages for transcription | set | `store/tinybase/persister/settings/persister.ts` |
-| `current_stt_provider` | Currently selected speech-to-text provider | set | `store/tinybase/persister/settings/persister.ts` |
-| `current_stt_model` | Currently selected speech-to-text model | set | `store/tinybase/persister/settings/persister.ts` |
-| `current_llm_provider` | Currently selected LLM provider | set | `store/tinybase/persister/settings/persister.ts` |
-| `current_llm_model` | Currently selected LLM model | set | `store/tinybase/persister/settings/persister.ts` |
+## Telemetry controls and environment behavior
 
-## Analytics commands
-
-Available methods for tracking events and properties:
-
-- `event(payload)` - Track a custom event with optional properties
-- `setProperties(payload)` - Set user properties (supports `set` and `set_once` types)
-- `identify(userId, payload)` - Link anonymous device ID to authenticated user ID using PostHog's `$identify` event
-- `setDisabled(disabled)` - Enable or disable analytics tracking
-- `isDisabled()` - Check if analytics is currently disabled
-
-## User identification
-
-When a user signs in, the `identify` command is called to link their anonymous device ID (machine fingerprint) to their authenticated user ID. This uses PostHog's `$identify` event with the `$anon_distinct_id` property, enabling:
-
-- Attribution of pre-login activity to the authenticated user
-- Unified user profiles across anonymous and authenticated sessions
-- Accurate conversion funnel analysis from first visit to active usage
-
-The identification flow works as follows: before sign-in, events are tracked using the device fingerprint as the distinct ID. Upon successful authentication, `identify(userId, payload)` is called, which sends a `$identify` event to PostHog with both the new user ID and the anonymous device ID, merging the two identities.
-
-## Conversion funnel tracking
-
-To track the user journey from website visit to active usage, use PostHog's funnel analysis with these key events:
-
-1. `download_clicked` (web) - User downloads the app
-2. `show_main_window` (desktop) - User launches the app
-3. `onboarding_completed` (desktop) - User finishes onboarding
-4. `user_signed_in` (desktop) - User signs in (triggers identity merge)
-5. `note_created` (desktop) - User creates their first note
-6. `session_started` (desktop) - User starts a listening session
-7. `note_enhanced` (desktop) - User uses AI enhancement
-
-PostHog's `$identify` event links anonymous device IDs to authenticated user IDs, enabling accurate conversion analysis across the entire user journey.
+- Desktop opt-out:
+  - `telemetry_consent` config side effect calls `analyticsCommands.setDisabled(!value)`.
+  - When disabled, desktop plugin drops `event`, `setProperties`, and `identify` calls.
+  - Source: `apps/desktop/src/shared/config/registry.ts`, `plugins/analytics/src/ext.rs`.
+- Desktop PostHog initialization:
+  - Release builds require `POSTHOG_API_KEY` at compile time.
+  - Debug builds use `option_env!("POSTHOG_API_KEY")`; if missing, events are not sent to PostHog (they only hit local tracing fallback).
+  - Source: `plugins/analytics/src/lib.rs`, `crates/analytics/src/lib.rs`.
+- Web:
+  - PostHog is not initialized in dev mode.
+  - Source: `apps/web/src/providers/posthog.tsx`.
+- API:
+  - PostHog client is active only in non-debug builds (production requires `POSTHOG_API_KEY`).
+  - Source: `apps/api/src/main.rs`.
+- Note on scope:
+  - Desktop `telemetry_consent` only controls the desktop plugin path. No code path currently applies that toggle to server-side `$stt_request` / `$ai_generation` / trial events.
 
 ## Feature flags
 
-Char uses PostHog feature flags to control feature rollouts. The system is built on two layers:
+Feature flag checks are wired through PostHog capability in `hypr_analytics`, but current desktop feature strategy is hardcoded:
 
-- **`crates/analytics`** - Uses the official `posthog-rs` 0.4 client with lazy initialization. Supports optional local flag evaluation via `PostHog LocalEvaluator` when a personal API key is configured.
-- **`plugins/flag`** - A Tauri plugin that delegates to the shared `AnalyticsClient` from `crates/analytics` and provides the `FlagPluginExt` trait for checking flags from application code via `app.flag().is_enabled(feature)`.
+- `Feature::Chat => FlagStrategy::Hardcoded(true)`
+- Source: `plugins/flag/src/feature.rs`.
 
-Each feature defines a `FlagStrategy`:
+If a feature uses `FlagStrategy::Posthog(key)`, the check resolves via `is_feature_enabled(flag_key, distinct_id)` with desktop machine fingerprint as distinct ID.
 
-| Strategy | Behavior |
-|----------|----------|
-| `Debug` | Enabled only in debug builds |
-| `Posthog(key)` | Resolved via PostHog `is_feature_enabled` (through `posthog-rs`) |
-| `Hardcoded(bool)` | Always enabled or disabled |
+## How to update this document
 
-Currently only `Chat` is defined as a feature flag, using `Hardcoded(true)`.
-
-Features can also be overridden at build time using environment variables (e.g., `CHAT=1` forces the Chat feature on).
-
-## How to make changes?
-
-See `.cursor/commands/add-analytics.md` for detailed instructions.
+1. Search for all emitters:
+   - `analyticsCommands.event(`
+   - `analyticsCommands.setProperties(`
+   - `analyticsCommands.identify(`
+   - `AnalyticsPayload::builder("...`)`
+   - `posthog.capture(` / `posthog.identify(`
+2. Verify payload keys at each callsite (watch for nested objects like `properties: {...}`).
+3. Re-run this inventory after any analytics refactor in `plugins/analytics`, `crates/analytics`, `crates/llm-proxy`, `crates/transcribe-proxy`, or `crates/api-subscription`.


### PR DESCRIPTION
Reorganize analytics documentation to provide comprehensive inventory
of PostHog tracking across web, desktop, and API surfaces. Add detailed
collection paths, identity mapping, and complete event catalog.

Replace generic "What are we tracking?" section with structured
breakdown showing distinct ID handling, automatic enrichment, and
specific event properties for each platform. Document web autocapture
settings, desktop fingerprinting, and API telemetry flows.