### PR TITLE
Fix proxy forwarding Hyprnote control messages to upstream providers

### DIFF
--- a/crates/listener-core/src/actors/recorder/mod.rs
+++ b/crates/listener-core/src/actors/recorder/mod.rs
@@ -25,6 +25,7 @@ pub enum RecMsg {
 pub struct RecArgs {
     pub app_dir: PathBuf,
     pub session_id: String,
+    pub done_tx: Option<tokio::sync::oneshot::Sender<()>>,
 }
 
 pub struct RecState {
@@ -34,6 +35,7 @@ pub struct RecState {
     wav_path: PathBuf,
     last_flush: Instant,
     is_stereo: bool,
+    done_tx: Option<tokio::sync::oneshot::Sender<()>>,
 }
 
 pub struct RecorderActor<E: AudioCodec = Mp3Codec> {
@@ -134,6 +136,7 @@ impl<E: AudioCodec> Actor for RecorderActor<E> {
             wav_path,
             last_flush: Instant::now(),
             is_stereo,
+            done_tx: args.done_tx,
         })
     }
 
@@ -207,6 +210,9 @@ impl<E: AudioCodec> Actor for RecorderActor<E> {
             }
         }
 
+        if let Some(tx) = st.done_tx.take() {
+            let _ = tx.send(());
+        }
         Ok(())
     }
 }

--- a/crates/listener-core/src/actors/session/supervisor.rs
+++ b/crates/listener-core/src/actors/session/supervisor.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use hypr_supervisor::{RestartBudget, RestartTracker, RetryStrategy, spawn_with_retry};
 use ractor::concurrency::Duration;
 use ractor::{Actor, ActorCell, ActorProcessingErr, ActorRef, SupervisionEvent};
@@ -34,6 +36,7 @@ pub struct SessionState {
     source_cell: Option<ActorCell>,
     listener_cell: Option<ActorCell>,
     recorder_cell: Option<ActorCell>,
+    recorder_done: Option<tokio::sync::oneshot::Receiver<()>>,
     source_restarts: RestartTracker,
     recorder_restarts: RestartTracker,
     shutting_down: bool,
@@ -74,20 +77,22 @@ impl Actor for SessionActor {
             )
             .await?;
 
-            let recorder_cell = if ctx.params.record_enabled {
+            let (recorder_cell, recorder_done) = if ctx.params.record_enabled {
+                let (done_tx, done_rx) = tokio::sync::oneshot::channel();
                 let (recorder_ref, _): (ActorRef<RecMsg>, _) = Actor::spawn_linked(
                     Some(RecorderActor::name()),
                     RecorderActor::new(),
                     RecArgs {
                         app_dir: ctx.app_dir.clone(),
                         session_id: ctx.params.session_id.clone(),
+                        done_tx: Some(done_tx),
                     },
                     myself.get_cell(),
                 )
                 .await?;
-                Some(recorder_ref.get_cell())
+                (Some(recorder_ref.get_cell()), Some(done_rx))
             } else {
-                None
+                (None, None)
             };
 
             Ok(SessionState {
@@ -95,6 +100,7 @@ impl Actor for SessionActor {
                 source_cell: Some(source_ref.get_cell()),
                 listener_cell: None,
                 recorder_cell,
+                recorder_done,
                 source_restarts: RestartTracker::new(),
                 recorder_restarts: RestartTracker::new(),
                 shutting_down: false,
@@ -170,8 +176,9 @@ impl Actor for SessionActor {
                 state.shutting_down = true;
 
                 if let Some(cell) = state.recorder_cell.take() {
+                    let done = state.recorder_done.take();
                     cell.stop(Some("session_stop".to_string()));
-                    lifecycle::wait_for_actor_shutdown(RecorderActor::name()).await;
+                    wait_for_recorder_done(done).await;
                 }
 
                 if let Some(cell) = state.source_cell.take() {
@@ -367,11 +374,14 @@ async fn try_restart_recorder(supervisor_cell: ActorCell, state: &mut SessionSta
     let sup = supervisor_cell;
     let app_dir = state.ctx.app_dir.clone();
     let session_id = state.ctx.params.session_id.clone();
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+    let done_tx = Arc::new(std::sync::Mutex::new(Some(done_tx)));
 
     let cell = spawn_with_retry(&RETRY_STRATEGY, || {
         let sup = sup.clone();
         let app_dir = app_dir.clone();
         let session_id = session_id.clone();
+        let done_tx = done_tx.lock().unwrap().take();
         async move {
             let (r, _): (ActorRef<RecMsg>, _) = Actor::spawn_linked(
                 Some(RecorderActor::name()),
@@ -379,6 +389,7 @@ async fn try_restart_recorder(supervisor_cell: ActorCell, state: &mut SessionSta
                 RecArgs {
                     app_dir,
                     session_id,
+                    done_tx,
                 },
                 sup,
             )
@@ -391,6 +402,7 @@ async fn try_restart_recorder(supervisor_cell: ActorCell, state: &mut SessionSta
     match cell {
         Some(c) => {
             state.recorder_cell = Some(c);
+            state.recorder_done = Some(done_rx);
             true
         }
         None => false,
@@ -407,10 +419,22 @@ async fn meltdown(myself: ActorRef<SessionMsg>, state: &mut SessionState) {
         cell.stop(Some("meltdown".to_string()));
     }
     if let Some(cell) = state.recorder_cell.take() {
+        let done = state.recorder_done.take();
         cell.stop(Some("meltdown".to_string()));
-        lifecycle::wait_for_actor_shutdown(RecorderActor::name()).await;
+        wait_for_recorder_done(done).await;
     }
     myself.stop(Some("restart_limit_exceeded".to_string()));
+}
+
+async fn wait_for_recorder_done(done: Option<tokio::sync::oneshot::Receiver<()>>) {
+    match done {
+        Some(rx) => {
+            tokio::time::timeout(Duration::from_secs(30), rx).await.ok();
+        }
+        None => {
+            lifecycle::wait_for_actor_shutdown(RecorderActor::name()).await;
+        }
+    }
 }
 
 fn classify_connection_failure(base_url: &str) -> String {

--- a/crates/owhisper-client/src/adapter/deepgram/live.rs
+++ b/crates/owhisper-client/src/adapter/deepgram/live.rs
@@ -307,5 +307,4 @@ mod tests {
 
         run_dual_test(client, "deepgram").await;
     }
-
 }

--- a/crates/owhisper-client/src/adapter/soniox/live.rs
+++ b/crates/owhisper-client/src/adapter/soniox/live.rs
@@ -452,5 +452,4 @@ mod tests {
 
         run_dual_test(client, "soniox").await;
     }
-
 }

--- a/crates/transcribe-proxy/src/relay/channel_split.rs
+++ b/crates/transcribe-proxy/src/relay/channel_split.rs
@@ -15,8 +15,7 @@ use tokio_tungstenite::{
 use owhisper_client::Provider;
 
 use super::types::{
-    ClientFilterAction, ClientMessageFilter, InitialMessage, OnCloseCallback, ResponseTransformer,
-    convert,
+    ClientMessageFilter, InitialMessage, OnCloseCallback, ResponseTransformer, convert,
 };
 
 const SAMPLE_BYTES: usize = 2;
@@ -231,11 +230,10 @@ impl ChannelSplitProxy {
                                 }
                                 Message::Text(text) => {
                                     let text_str = text.to_string();
-                                    let forwarded = match &client_message_filter {
-                                        Some(filter) => match filter(&text_str) {
-                                            ClientFilterAction::Drop => continue,
-                                            ClientFilterAction::Replace(replacement) => replacement,
-                                            ClientFilterAction::PassThrough => text_str,
+                                    let forwarded = match client_message_filter.as_ref() {
+                                        Some(filter) => match filter(text_str) {
+                                            Some(s) => s,
+                                            None => continue,
                                         },
                                         None => text_str,
                                     };

--- a/crates/transcribe-proxy/src/relay/handler.rs
+++ b/crates/transcribe-proxy/src/relay/handler.rs
@@ -17,9 +17,9 @@ use owhisper_client::Provider;
 use super::builder::WebSocketProxyBuilder;
 use super::pending::{FlushError, PendingState, QueuedPayload};
 use super::types::{
-    ClientFilterAction, ClientMessageFilter, ClientReceiver, ClientSender, ControlMessageTypes,
-    DEFAULT_CLOSE_CODE, FirstMessageTransformer, InitialMessage, OnCloseCallback,
-    ResponseTransformer, UpstreamReceiver, UpstreamSender, convert, is_control_message,
+    ClientMessageFilter, ClientReceiver, ClientSender, ControlMessageTypes, DEFAULT_CLOSE_CODE,
+    FirstMessageTransformer, InitialMessage, OnCloseCallback, ResponseTransformer,
+    UpstreamReceiver, UpstreamSender, convert, is_control_message,
 };
 
 #[derive(Clone)]
@@ -272,11 +272,10 @@ impl WebSocketProxy {
                                 None => text_owned,
                             };
 
-                            let text_str = match &client_message_filter {
-                                Some(filter) => match filter(&text_str) {
-                                    ClientFilterAction::Drop => continue,
-                                    ClientFilterAction::Replace(replacement) => replacement,
-                                    ClientFilterAction::PassThrough => text_str,
+                            let text_str = match client_message_filter.as_ref() {
+                                Some(filter) => match filter(text_str) {
+                                    Some(s) => s,
+                                    None => continue,
                                 },
                                 None => text_str,
                             };

--- a/crates/transcribe-proxy/src/relay/mod.rs
+++ b/crates/transcribe-proxy/src/relay/mod.rs
@@ -8,7 +8,5 @@ mod upstream_error;
 pub use builder::ClientRequestBuilder;
 pub use channel_split::ChannelSplitProxy;
 pub use handler::WebSocketProxy;
-pub use types::{
-    ClientFilterAction, ClientMessageFilter, InitialMessage, OnCloseCallback, ResponseTransformer,
-};
+pub use types::{ClientMessageFilter, InitialMessage, OnCloseCallback, ResponseTransformer};
 pub use upstream_error::{UpstreamError, detect_upstream_error};

--- a/crates/transcribe-proxy/src/relay/types.rs
+++ b/crates/transcribe-proxy/src/relay/types.rs
@@ -17,14 +17,7 @@ pub type FirstMessageTransformer = Arc<dyn Fn(String) -> String + Send + Sync>;
 pub type InitialMessage = Arc<String>;
 pub type ResponseTransformer = Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ClientFilterAction {
-    Drop,
-    Replace(String),
-    PassThrough,
-}
-
-pub type ClientMessageFilter = Arc<dyn Fn(&str) -> ClientFilterAction + Send + Sync>;
+pub type ClientMessageFilter = Arc<dyn Fn(String) -> Option<String> + Send + Sync>;
 
 pub type UpstreamSender = SplitSink<
     WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>,

--- a/crates/transcribe-proxy/src/routes/streaming/hyprnote.rs
+++ b/crates/transcribe-proxy/src/routes/streaming/hyprnote.rs
@@ -10,7 +10,7 @@ use owhisper_interface::ListenParams;
 use crate::config::SttProxyConfig;
 use crate::provider_selector::SelectedProvider;
 use crate::query_params::{QueryParams, QueryValue};
-use crate::relay::{ChannelSplitProxy, ClientFilterAction, ClientMessageFilter, WebSocketProxy};
+use crate::relay::{ChannelSplitProxy, ClientMessageFilter, WebSocketProxy};
 use crate::routes::AppState;
 use crate::routes::model_resolution::resolve_model;
 
@@ -104,15 +104,12 @@ fn build_response_transformer(
 }
 
 fn build_client_message_filter(provider: Provider) -> ClientMessageFilter {
-    Arc::new(move |text: &str| {
-        let msg = match serde_json::from_str::<owhisper_interface::ControlMessage>(text) {
+    Arc::new(move |text: String| {
+        let msg = match serde_json::from_str::<owhisper_interface::ControlMessage>(&text) {
             Ok(msg) => msg,
-            Err(_) => return ClientFilterAction::PassThrough,
+            Err(_) => return Some(text),
         };
-        match provider.translate_control_message(&msg) {
-            Some(translated) => ClientFilterAction::Replace(translated),
-            None => ClientFilterAction::Drop,
-        }
+        provider.translate_control_message(&msg)
     })
 }
 
@@ -517,16 +514,13 @@ mod tests {
     fn test_client_message_filter_deepgram_identity() {
         let filter = build_client_message_filter(Provider::Deepgram);
         assert_eq!(
-            filter(r#"{"type":"KeepAlive"}"#),
-            ClientFilterAction::Replace(r#"{"type":"KeepAlive"}"#.to_string())
+            filter(r#"{"type":"KeepAlive"}"#.to_string()),
+            Some(r#"{"type":"KeepAlive"}"#.to_string())
         );
+        assert_eq!(filter(r#"{"type":"CloseStream"}"#.to_string()), None);
         assert_eq!(
-            filter(r#"{"type":"CloseStream"}"#),
-            ClientFilterAction::Replace(r#"{"type":"CloseStream"}"#.to_string())
-        );
-        assert_eq!(
-            filter(r#"{"type":"Finalize"}"#),
-            ClientFilterAction::Replace(r#"{"type":"Finalize"}"#.to_string())
+            filter(r#"{"type":"Finalize"}"#.to_string()),
+            Some(r#"{"type":"Finalize"}"#.to_string())
         );
     }
 
@@ -534,34 +528,31 @@ mod tests {
     fn test_client_message_filter_soniox_translates_control_messages() {
         let filter = build_client_message_filter(Provider::Soniox);
 
+        assert_eq!(filter(r#"{"type":"CloseStream"}"#.to_string()), None);
         assert_eq!(
-            filter(r#"{"type":"CloseStream"}"#),
-            ClientFilterAction::Drop
+            filter(r#"{"type":"KeepAlive"}"#.to_string()),
+            Some(r#"{"type":"keepalive"}"#.to_string())
         );
         assert_eq!(
-            filter(r#"{"type":"KeepAlive"}"#),
-            ClientFilterAction::Replace(r#"{"type":"keepalive"}"#.to_string())
-        );
-        assert_eq!(
-            filter(r#"{"type":"Finalize"}"#),
-            ClientFilterAction::Replace(r#"{"type":"finalize"}"#.to_string())
+            filter(r#"{"type":"Finalize"}"#.to_string()),
+            Some(r#"{"type":"finalize"}"#.to_string())
         );
     }
 
     #[test]
     fn test_client_message_filter_assemblyai_translates_finalize() {
         let filter = build_client_message_filter(Provider::AssemblyAI);
-        assert_eq!(filter(r#"{"type":"KeepAlive"}"#), ClientFilterAction::Drop);
+        assert_eq!(filter(r#"{"type":"KeepAlive"}"#.to_string()), None);
         assert_eq!(
-            filter(r#"{"type":"Finalize"}"#),
-            ClientFilterAction::Replace(r#"{"type":"Terminate"}"#.to_string())
+            filter(r#"{"type":"Finalize"}"#.to_string()),
+            Some(r#"{"type":"Terminate"}"#.to_string())
         );
     }
 
     #[test]
     fn test_client_message_filter_non_json_passthrough() {
         let filter = build_client_message_filter(Provider::Soniox);
-        assert_eq!(filter("not json"), ClientFilterAction::PassThrough);
+        assert_eq!(filter("not json".to_string()), Some("not json".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
- Sentry soniox_error: Soniox returns "Control request invalid type." (400)
- Proxy blindly forwards Hyprnote-protocol messages `({"type":"KeepAlive"}, {"type":"Finalize"})` to upstream providers that expect different casing/naming
- Affects both WebSocketProxy and ChannelSplitProxy on the hyprnote route