### PR TITLE
docs: Update handbook URLs from /handbook to /company-handbook

### DIFF
--- a/apps/web/content/handbook/about/5.brand-over-features.mdx
+++ b/apps/web/content/handbook/about/5.brand-over-features.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Brand Over Features"
-section: "Go To Market"
+section: "About"
 summary: "We don't differentiate through features — we build a brand through values, consistency, and trust"
 ---
 

--- a/apps/web/content/handbook/onboarding/0.getting-started.mdx
+++ b/apps/web/content/handbook/onboarding/0.getting-started.mdx
@@ -21,15 +21,15 @@ Everyone at Char works from the same repo and ships through the same workflow. W
 
 **Foundations (Everyone)**
 
-- [ ] [Homebrew](/handbook/onboarding/homebrew) — Mac package manager. You'll use this to install almost everything else.
-- [ ] [Warp](/handbook/onboarding/warp) — Our recommended terminal. This is where you run commands.
-- [ ] [Node.js & pnpm](/handbook/onboarding/node-and-pnpm) — JavaScript runtime and package manager. Required even if you never write code.
-- [ ] [GitButler](/handbook/onboarding/gitbutler) — Our git client. Visual interface instead of raw git commands.
+- [ ] [Homebrew](/company-handbook/onboarding/homebrew) — Mac package manager. You'll use this to install almost everything else.
+- [ ] [Warp](/company-handbook/onboarding/warp) — Our recommended terminal. This is where you run commands.
+- [ ] [Node.js & pnpm](/company-handbook/onboarding/node-and-pnpm) — JavaScript runtime and package manager. Required even if you never write code.
+- [ ] [GitButler](/company-handbook/onboarding/gitbutler) — Our git client. Visual interface instead of raw git commands.
 
 **Development Tools (Engineers + Technical Roles)**
 
-- [ ] [Cursor](/handbook/onboarding/cursor) — AI-powered code editor. Our primary IDE recommendation.
-- [ ] [Claude Code](/handbook/onboarding/claude-code) — AI coding assistant that runs in your terminal.
+- [ ] [Cursor](/company-handbook/onboarding/cursor) — AI-powered code editor. Our primary IDE recommendation.
+- [ ] [Claude Code](/company-handbook/onboarding/claude-code) — AI coding assistant that runs in your terminal.
 - [ ] [Rust](https://rustup.rs) — Install via rustup. Required for building the desktop app.
 - [ ] [Taskfile](https://taskfile.dev/installation) — Task runner we use for dev commands.
 - [ ] [Docker](https://www.docker.com/products/docker-desktop/) — Required for local Supabase.
@@ -59,7 +59,7 @@ We have dedicated [developer documentation](/docs/developers/setup) covering set
 - [ ] Read the [developer documentation](/docs/developers/setup)
 - [ ] Dev environment set up (repo cloned, builds locally)
 - [ ] Read this handbook — seriously, all of it
-- [ ] Downloaded a [staging build](/handbook/onboarding/staging-builds) and opened Char
+- [ ] Downloaded a [staging build](/company-handbook/onboarding/staging-builds) and opened Char
 
 ## Days 2-3: Get familiar
 

--- a/apps/web/content/handbook/onboarding/3.tooling-checklist.mdx
+++ b/apps/web/content/handbook/onboarding/3.tooling-checklist.mdx
@@ -4,16 +4,16 @@ section: "Onboarding"
 summary: "Step-by-step setup guides for every tool we use — written for all roles"
 ---
 
-Each guide below explains what the tool is, why we use it, and how to install it. See the [Getting Started](/handbook/onboarding/getting-started) page for the full checklist.
+Each guide below explains what the tool is, why we use it, and how to install it. See the [Getting Started](/company-handbook/onboarding/getting-started) page for the full checklist.
 
 ## Foundations
 
-- [Homebrew](/handbook/onboarding/homebrew) — Mac package manager
-- [Warp](/handbook/onboarding/warp) — Terminal
-- [Node.js & pnpm](/handbook/onboarding/node-and-pnpm) — JavaScript runtime and package manager
-- [GitButler](/handbook/onboarding/gitbutler) — Git client
+- [Homebrew](/company-handbook/onboarding/homebrew) — Mac package manager
+- [Warp](/company-handbook/onboarding/warp) — Terminal
+- [Node.js & pnpm](/company-handbook/onboarding/node-and-pnpm) — JavaScript runtime and package manager
+- [GitButler](/company-handbook/onboarding/gitbutler) — Git client
 
 ## Development
 
-- [Cursor](/handbook/onboarding/cursor) — Code editor
-- [Claude Code](/handbook/onboarding/claude-code) — AI coding assistant
+- [Cursor](/company-handbook/onboarding/cursor) — Code editor
+- [Claude Code](/company-handbook/onboarding/claude-code) — AI coding assistant

--- a/apps/web/content/handbook/onboarding/4.homebrew.mdx
+++ b/apps/web/content/handbook/onboarding/4.homebrew.mdx
@@ -43,4 +43,4 @@ You'll use `brew install` frequently during the rest of this setup.
 
 ## Back to checklist
 
-[Return to Tooling Checklist](/handbook/onboarding/tooling-checklist)
+[Return to Tooling Checklist](/company-handbook/onboarding/tooling-checklist)

--- a/apps/web/content/handbook/onboarding/5.cursor.mdx
+++ b/apps/web/content/handbook/onboarding/5.cursor.mdx
@@ -12,8 +12,8 @@ Even if you're not an engineer, Cursor is useful for editing MDX content files, 
 
 ## Prerequisites
 
-- [Homebrew](/handbook/onboarding/homebrew) installed
-- [Node.js & pnpm](/handbook/onboarding/node-and-pnpm) installed (for working with the codebase)
+- [Homebrew](/company-handbook/onboarding/homebrew) installed
+- [Node.js & pnpm](/company-handbook/onboarding/node-and-pnpm) installed (for working with the codebase)
 
 ## Install
 
@@ -64,4 +64,4 @@ You don't need to understand code to use Cursor productively:
 
 ## Back to checklist
 
-[Return to Tooling Checklist](/handbook/onboarding/tooling-checklist)
+[Return to Tooling Checklist](/company-handbook/onboarding/tooling-checklist)

--- a/apps/web/content/handbook/onboarding/6.gitbutler.mdx
+++ b/apps/web/content/handbook/onboarding/6.gitbutler.mdx
@@ -61,4 +61,4 @@ If you're editing content (blog posts, docs, handbook):
 
 ## Back to checklist
 
-[Return to Tooling Checklist](/handbook/onboarding/tooling-checklist)
+[Return to Tooling Checklist](/company-handbook/onboarding/tooling-checklist)

--- a/apps/web/content/handbook/onboarding/7.claude-code.mdx
+++ b/apps/web/content/handbook/onboarding/7.claude-code.mdx
@@ -12,9 +12,9 @@ We use Claude Code for everything from writing features to debugging to content 
 
 ## Prerequisites
 
-- [Homebrew](/handbook/onboarding/homebrew) installed
-- [Node.js & pnpm](/handbook/onboarding/node-and-pnpm) installed
-- A terminal ([Warp](/handbook/onboarding/warp) recommended)
+- [Homebrew](/company-handbook/onboarding/homebrew) installed
+- [Node.js & pnpm](/company-handbook/onboarding/node-and-pnpm) installed
+- A terminal ([Warp](/company-handbook/onboarding/warp) recommended)
 
 ## Install
 
@@ -60,4 +60,4 @@ You review every change before it's applied, so you can't accidentally break any
 
 ## Back to checklist
 
-[Return to Tooling Checklist](/handbook/onboarding/tooling-checklist)
+[Return to Tooling Checklist](/company-handbook/onboarding/tooling-checklist)

--- a/apps/web/content/handbook/onboarding/8.warp.mdx
+++ b/apps/web/content/handbook/onboarding/8.warp.mdx
@@ -27,7 +27,7 @@ brew install --cask warp
 
 Or download from [warp.dev](https://www.warp.dev).
 
-If you don't have Homebrew yet, install Warp from the website first, then use Warp to [install Homebrew](/handbook/onboarding/homebrew).
+If you don't have Homebrew yet, install Warp from the website first, then use Warp to [install Homebrew](/company-handbook/onboarding/homebrew).
 
 ## First launch
 
@@ -69,4 +69,4 @@ See the [developer setup docs](/docs/developers/setup) for more details on permi
 
 ## Back to checklist
 
-[Return to Tooling Checklist](/handbook/onboarding/tooling-checklist)
+[Return to Tooling Checklist](/company-handbook/onboarding/tooling-checklist)

--- a/apps/web/content/handbook/onboarding/9.node-and-pnpm.mdx
+++ b/apps/web/content/handbook/onboarding/9.node-and-pnpm.mdx
@@ -14,7 +14,7 @@ You need both installed even if you never write JavaScript. Building the website
 
 ## Prerequisites
 
-- [Homebrew](/handbook/onboarding/homebrew) installed
+- [Homebrew](/company-handbook/onboarding/homebrew) installed
 
 ## Install Node.js
 
@@ -75,4 +75,4 @@ Most of these commands are wrapped in Taskfile commands, so you'll often just ru
 
 ## Back to checklist
 
-[Return to Tooling Checklist](/handbook/onboarding/tooling-checklist)
+[Return to Tooling Checklist](/company-handbook/onboarding/tooling-checklist)


### PR DESCRIPTION
Update internal links in onboarding documentation to use the new /company-handbook URL structure instead of /handbook. This ensures all navigation links work correctly after the handbook restructure.