### PR TITLE
refactor: use HTMLInputElement ref in CommandInput

### DIFF
--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -34,7 +34,7 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
 };
 
 const CommandInput = React.forwardRef<
-  React.ComponentRef<typeof CommandPrimitive.Input>,
+  HTMLInputElement,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
   <div className="flex items-center border-b px-3" cmdk-input-wrapper="">


### PR DESCRIPTION
Replace CommandPrimitive.Input component ref with HTMLInputElement type to improve type safety and provide more direct access to the underlying input element.