### PR TITLE
ensure trial analytics identity stitching with fingerprint headers

### DIFF
--- a/apps/desktop/src/auth/billing.tsx
+++ b/apps/desktop/src/auth/billing.tsx
@@ -63,7 +63,7 @@ export function BillingProvider({ children }: { children: ReactNode }) {
     enabled: !!auth?.session && !billing.isPro,
     queryKey: [auth?.session?.user.id ?? "", "canStartTrial"],
     queryFn: async () => {
-      const headers = auth?.getHeaders();
+      const headers = await auth?.getHeadersWithFingerprint();
       if (!headers) {
         return false;
       }

--- a/apps/desktop/src/auth/context.tsx
+++ b/apps/desktop/src/auth/context.tsx
@@ -50,6 +50,7 @@ type AuthTokenHandlers = {
 
 type AuthUtils = {
   getHeaders: () => Record<string, string> | null;
+  getHeadersWithFingerprint: () => Promise<Record<string, string> | null>;
   getAvatarUrl: () => Promise<string | null>;
 };
 
@@ -105,37 +106,41 @@ async function initSession(
 }
 
 let trackedUserId: string | null = null;
+let trackedSignedInEventUserId: string | null = null;
 
 async function trackAuthEvent(
   event: AuthChangeEvent,
   session: Session | null,
 ): Promise<void> {
   if ((event === "SIGNED_IN" || event === "INITIAL_SESSION") && session) {
-    if (session.user.id === trackedUserId) {
-      return;
+    if (session.user.id !== trackedUserId) {
+      trackedUserId = session.user.id;
+
+      const appVersion = await getVersion();
+      await analyticsCommands.identify(session.user.id, {
+        email: session.user.email,
+        set: {
+          account_created_date: session.user.created_at,
+          is_signed_up: true,
+          app_version: appVersion,
+          os_version: osVersion(),
+          platform: platform(),
+        },
+      });
     }
 
-    trackedUserId = session.user.id;
-
-    const appVersion = await getVersion();
-    void analyticsCommands.identify(session.user.id, {
-      email: session.user.email,
-      set: {
-        account_created_date: session.user.created_at,
-        is_signed_up: true,
-        app_version: appVersion,
-        os_version: osVersion(),
-        platform: platform(),
-      },
-    });
-
-    if (event === "SIGNED_IN") {
-      void analyticsCommands.event({ event: "user_signed_in" });
+    if (
+      event === "SIGNED_IN" &&
+      session.user.id !== trackedSignedInEventUserId
+    ) {
+      trackedSignedInEventUserId = session.user.id;
+      await analyticsCommands.event({ event: "user_signed_in" });
     }
   }
 
   if (event === "SIGNED_OUT") {
     trackedUserId = null;
+    trackedSignedInEventUserId = null;
   }
 }
 
@@ -338,6 +343,32 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return headers;
   }, [session, fingerprint]);
 
+  const getHeadersWithFingerprint = useCallback(async () => {
+    if (!session) {
+      return null;
+    }
+
+    let resolvedFingerprint = fingerprint;
+
+    if (!resolvedFingerprint) {
+      const result = await miscCommands.getFingerprint();
+      if (result.status === "ok") {
+        resolvedFingerprint = result.data;
+        setFingerprint((prev) => prev ?? result.data);
+      }
+    }
+
+    const headers: Record<string, string> = {
+      Authorization: `${session.token_type} ${session.access_token}`,
+    };
+
+    if (resolvedFingerprint) {
+      headers[DEVICE_FINGERPRINT_HEADER] = resolvedFingerprint;
+    }
+
+    return headers;
+  }, [session, fingerprint]);
+
   const getAvatarUrl = useCallback(async () => {
     const email = session?.user.email;
 
@@ -366,6 +397,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       handleAuthCallback,
       setSessionFromTokens,
       getHeaders,
+      getHeadersWithFingerprint,
       getAvatarUrl,
     }),
     [
@@ -377,6 +409,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       handleAuthCallback,
       setSessionFromTokens,
       getHeaders,
+      getHeadersWithFingerprint,
       getAvatarUrl,
     ],
   );

--- a/apps/desktop/src/auth/useConnections.ts
+++ b/apps/desktop/src/auth/useConnections.ts
@@ -14,7 +14,7 @@ export function useConnections(enabled = true) {
   return useQuery({
     queryKey: ["integration-status", userId],
     queryFn: async () => {
-      const headers = auth?.getHeaders();
+      const headers = await auth?.getHeadersWithFingerprint();
       if (!headers) {
         return [];
       }

--- a/apps/desktop/src/calendar/components/oauth/calendar-selection.tsx
+++ b/apps/desktop/src/calendar/components/oauth/calendar-selection.tsx
@@ -46,7 +46,7 @@ export function useOAuthCalendarSelection(config: CalendarProvider) {
   } = useQuery({
     queryKey: ["oauthCalendars", config.id],
     queryFn: async () => {
-      const headers = auth?.getHeaders();
+      const headers = await auth?.getHeadersWithFingerprint();
       if (!headers) return [];
       const client = createClient({ baseUrl: env.VITE_API_URL, headers });
       const { data, error } = await googleListCalendars({ client });

--- a/apps/desktop/src/onboarding/account/trial.tsx
+++ b/apps/desktop/src/onboarding/account/trial.tsx
@@ -28,7 +28,7 @@ export function useTrialFlow(onContinue: () => void) {
 
   const mutation = useMutation({
     mutationFn: async () => {
-      const headers = auth.getHeaders();
+      const headers = await auth.getHeadersWithFingerprint();
       if (!headers) throw new Error("no headers");
       const client = createClient({ baseUrl: env.VITE_API_URL, headers });
       const { data, error } = await startTrial({

--- a/apps/desktop/src/settings/general/account.tsx
+++ b/apps/desktop/src/settings/general/account.tsx
@@ -306,7 +306,7 @@ function BillingButton() {
     enabled: !!auth?.session && !isPro,
     queryKey: [auth?.session?.user.id ?? "", "canStartTrial"],
     queryFn: async () => {
-      const headers = auth?.getHeaders();
+      const headers = await auth?.getHeadersWithFingerprint();
       if (!headers) {
         return false;
       }
@@ -322,7 +322,7 @@ function BillingButton() {
 
   const startTrialMutation = useMutation({
     mutationFn: async () => {
-      const headers = auth?.getHeaders();
+      const headers = await auth?.getHeadersWithFingerprint();
       if (!headers) {
         throw new Error("Not authenticated");
       }


### PR DESCRIPTION
- Add `getHeadersWithFingerprint()` in auth context to guarantee `x-device-fingerprint` in desktop API requests, even when fingerprint is not yet cached.
- Replace `getHeaders()` with `getHeadersWithFingerprint()` in:
  - billing trial checks/start
  - onboarding trial start
  - connections
  - calendar OAuth list
- Fix auth analytics sequencing in `trackAuthEvent`:
  - prevent `INITIAL_SESSION` from suppressing SIGNED_IN
  - dedupe `identify` and `user_signed_in` independently
  - await identify/event calls to reduce race conditions


Why: `user_signed_in` and `trial_started` were not reliably linked for some new users due to missing fingerprint header timing and auth event suppression.