### PR TITLE
remove chat modal size limits

### DIFF
--- a/apps/desktop/src/chat/components/body/index.tsx
+++ b/apps/desktop/src/chat/components/body/index.tsx
@@ -33,7 +33,10 @@ export function ChatBody({
   }, [messages, status, error]);
 
   return (
-    <div ref={scrollRef} className="flex flex-1 flex-col overflow-y-auto">
+    <div
+      ref={scrollRef}
+      className="flex min-h-0 flex-1 flex-col overflow-y-auto"
+    >
       <div className="flex-1" />
       {messages.length === 0 ? (
         <ChatBodyEmpty

--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -45,7 +45,7 @@ export function ChatView() {
   return (
     <div
       className={cn([
-        "flex h-full flex-col",
+        "flex h-full min-h-0 flex-col overflow-hidden",
         chat.mode === "RightPanelOpen" &&
           "overflow-hidden rounded-xl border border-neutral-200",
       ])}

--- a/apps/desktop/src/chat/components/content.tsx
+++ b/apps/desktop/src/chat/components/content.tsx
@@ -52,7 +52,7 @@ export function ChatContent({
   const disabled = !model || !isSystemPromptReady;
 
   return (
-    <>
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       {children ?? (
         <ChatBody
           messages={messages}
@@ -81,6 +81,6 @@ export function ChatContent({
         onStop={stop}
         mcpIndicator={mcpIndicator}
       />
-    </>
+    </div>
   );
 }

--- a/apps/desktop/src/chat/components/context-bar.tsx
+++ b/apps/desktop/src/chat/components/context-bar.tsx
@@ -281,7 +281,7 @@ export function ContextBar({
   }
 
   return (
-    <div className="mx-2 rounded-t-xl border-t border-r border-l border-neutral-200 bg-neutral-100">
+    <div className="mx-2 shrink-0 rounded-t-xl border-t border-r border-l border-neutral-200 bg-neutral-100">
       <div className="flex items-start gap-1.5 px-2.5 py-2">
         <div className="min-w-0 flex-1">
           <ChipList chips={chips} onRemove={onRemoveEntity} />

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -126,7 +126,7 @@ function Container({
   hasContextBar?: boolean;
 }) {
   return (
-    <div className={cn(["relative", "px-2 pb-2"])}>
+    <div className={cn(["relative shrink-0", "px-2 pb-2"])}>
       <div
         className={cn([
           "flex flex-col rounded-b-xl border border-neutral-200",


### PR DESCRIPTION
- Add shrink-0 and min-h-0 utility classes to context bar- Add shrink-0 and min-h-0 utility classes to input wrapper- Add shrink-0 and min-h-0 utility classes to content container- Add shrink-0 and min-h-0 utility classes to message body container- Add shrink-0 and min-h-0 utility classes to chat panel- Wrap content children in a flex container to ensure proper growth and overflow handling