### PR TITLE
enable text selection in metadata chip

### DIFF
--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -34,7 +34,7 @@ export function MetadataButton({ sessionId }: { sessionId: string }) {
       </PopoverTrigger>
       <PopoverContent
         align="end"
-        className="flex max-h-[80vh] w-85 flex-col rounded-lg p-0 shadow-lg"
+        className="select-text-deep flex max-h-[80vh] w-85 flex-col rounded-lg p-0 shadow-lg"
       >
         <ContentInner sessionId={sessionId} />
       </PopoverContent>


### PR DESCRIPTION
This addresses a UX issue where users could not copy/select session metadatafrom the popover due to inherited styles preventing text selection.