### PR TITLE
refactor: invert progress calculation for inside variant

### DIFF
--- a/apps/desktop/src/sidebar/timeline/realtime.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/realtime.test.tsx
@@ -1,0 +1,29 @@
+import { render } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { CurrentTimeIndicator } from "./realtime";
+
+describe("CurrentTimeIndicator", () => {
+  test("renders inside-item progress from bottom to top", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+
+      const { container, rerender } = render(
+        <CurrentTimeIndicator variant="inside" progress={0} />,
+      );
+
+      expect((container.firstChild as HTMLDivElement | null)?.style.top).toBe(
+        "100%",
+      );
+
+      rerender(<CurrentTimeIndicator variant="inside" progress={1} />);
+
+      expect((container.firstChild as HTMLDivElement | null)?.style.top).toBe(
+        "0%",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/desktop/src/sidebar/timeline/realtime.tsx
+++ b/apps/desktop/src/sidebar/timeline/realtime.tsx
@@ -14,6 +14,7 @@ export const CurrentTimeIndicator = forwardRef<
   ref,
 ) {
   const currentTimeMs = useCurrentTimeMs();
+  const insideOffset = `${(1 - progress) * 100}%`;
   const label = useMemo(() => {
     const now = timezone
       ? new TZDate(new Date(currentTimeMs), timezone)
@@ -30,7 +31,7 @@ export const CurrentTimeIndicator = forwardRef<
           ? "group absolute inset-x-0 z-20 h-px"
           : "group relative z-20 h-px"
       }
-      style={variant === "inside" ? { top: `${progress * 100}%` } : undefined}
+      style={variant === "inside" ? { top: insideOffset } : undefined}
     >
       <div className="absolute top-0 right-3 left-3 -translate-y-1/2">
         <div className="absolute top-1/2 right-0 left-0 h-px -translate-y-1/2 bg-red-400/90 mix-blend-multiply" />


### PR DESCRIPTION
Extract progress calculation to insideOffset variable and invert the formula from progress * 100% to (1 - progress) * 100% so that progress 0 positions the indicator at bottom (100%) and progress 1 at top (0%).

Add test coverage to verify the inside variant renders progress from bottom to top as expected.