### PR TITLE
feat: enable text selection in event description

### DIFF
--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -235,7 +235,7 @@ export function EventDisplay({
       {event.description && (
         <>
           <div className="h-px bg-neutral-200" />
-          <div className="max-h-40 overflow-y-auto text-sm break-words whitespace-pre-wrap text-neutral-700">
+          <div className="select-text-deep max-h-40 overflow-y-auto text-sm break-words whitespace-pre-wrap text-neutral-700">
             {renderDescriptionWithLinks(event.description)}
           </div>
         </>


### PR DESCRIPTION
Add select-text-deep class to event description container to allow users to select and copy description text content.