### PR TITLE
Handle macOS app rename during app updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18886,16 +18886,19 @@ dependencies = [
 name = "tauri-plugin-updater2"
 version = "0.1.0"
 dependencies = [
+ "flate2",
  "serde",
  "specta",
  "specta-typescript",
  "strum 0.27.2",
+ "tar",
  "tauri",
  "tauri-plugin",
  "tauri-plugin-fs-db",
  "tauri-plugin-store2",
  "tauri-plugin-updater",
  "tauri-specta",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -23,6 +23,7 @@ import {
 import { cn } from "@hypr/utils";
 
 import { TabContentEmpty, TabItemEmpty } from "./empty";
+import { HeaderListenButton } from "./header-listen-button";
 import { useNewNote, useNewNoteAndListen } from "./useNewNote";
 
 import { TabContentAI, TabItemAI } from "~/ai";
@@ -289,10 +290,10 @@ function Header({ tabs }: { tabs: Tab[] }) {
           </Reorder.Group>
         </div>
         {!scrollState.atStart && (
-          <div className="pointer-events-none absolute top-0 left-0 z-20 h-full w-8 bg-linear-to-r from-white to-transparent" />
+          <div className="pointer-events-none absolute top-0 left-0 z-20 h-full w-8 bg-linear-to-r from-stone-50 to-transparent" />
         )}
         {!scrollState.atEnd && (
-          <div className="pointer-events-none absolute top-0 right-0 z-20 h-full w-8 bg-linear-to-l from-white to-transparent" />
+          <div className="pointer-events-none absolute top-0 right-0 z-20 h-full w-8 bg-linear-to-l from-stone-50 to-transparent" />
         )}
       </div>
 
@@ -315,6 +316,7 @@ function Header({ tabs }: { tabs: Tab[] }) {
         </Button>
 
         <div className="ml-auto flex h-full items-center gap-1">
+          <HeaderListenButton compact={!(scrollState.atStart && scrollState.atEnd)} />
           <Update />
         </div>
       </div>

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -213,7 +213,7 @@ export function TimelineView() {
         onContextMenu={showContextMenu}
         className={cn([
           "scrollbar-hide flex h-full flex-col overflow-y-auto",
-          "rounded-xl bg-neutral-50",
+          "rounded-xl",
         ])}
       >
         {buckets.map((bucket, index) => {
@@ -229,12 +229,7 @@ export function TimelineView() {
                   timezone={timezone}
                 />
               )}
-              <div
-                className={cn([
-                  "sticky top-0 z-10",
-                  "bg-neutral-50 py-1 pr-1 pl-3",
-                ])}
-              >
+              <div className={cn(["sticky top-0 z-10", "bg-neutral-50 py-1 pr-1 pl-3"])}>
                 <div className="text-base font-bold text-neutral-900">
                   {bucket.label}
                 </div>

--- a/apps/desktop/src/sidebar/update.tsx
+++ b/apps/desktop/src/sidebar/update.tsx
@@ -1,6 +1,5 @@
 import { type UnlistenFn } from "@tauri-apps/api/event";
 import { message } from "@tauri-apps/plugin-dialog";
-import { relaunch } from "@tauri-apps/plugin-process";
 import { useCallback, useEffect, useState } from "react";
 
 import { commands, events } from "@hypr/plugin-updater2";
@@ -14,11 +13,18 @@ export function Update() {
     if (!version) {
       return;
     }
-    const result = await commands.install(version);
-    if (result.status === "ok") {
-      await relaunch();
-    } else {
-      await message(`Failed to install update: ${result.error}`, {
+    const installResult = await commands.install(version);
+    if (installResult.status !== "ok") {
+      await message(`Failed to install update: ${installResult.error}`, {
+        title: "Update Failed",
+        kind: "error",
+      });
+      return;
+    }
+
+    const postInstallResult = await commands.postinstall(installResult.data);
+    if (postInstallResult.status !== "ok") {
+      await message(`Failed to apply update: ${postInstallResult.error}`, {
         title: "Update Failed",
         kind: "error",
       });

--- a/plugins/tray/src/menu_items/tray_check_update.rs
+++ b/plugins/tray/src/menu_items/tray_check_update.rs
@@ -107,7 +107,14 @@ impl MenuItemHandler for TrayCheckUpdate {
                 let app = app.clone();
                 tauri::async_runtime::spawn(async move {
                     match app.updater2().install(&version).await {
-                        Ok(()) => app.restart(),
+                        Ok(result) => {
+                            if let Err(e) = app.updater2().postinstall(result).await {
+                                app.dialog()
+                                    .message(format!("Failed to apply update: {}", e))
+                                    .title("Update Failed")
+                                    .show(|_| {});
+                            }
+                        }
                         Err(e) => {
                             app.dialog()
                                 .message(format!("Failed to install update: {}", e))

--- a/plugins/updater2/Cargo.toml
+++ b/plugins/updater2/Cargo.toml
@@ -22,9 +22,12 @@ tokio = { workspace = true, features = ["macros", "time"] }
 tauri = { workspace = true, features = ["test"] }
 tauri-specta = { workspace = true, features = ["derive", "typescript"] }
 
+flate2 = "1"
 serde = { workspace = true }
 specta = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
+tar = "0.4"
+tempfile = { workspace = true }
 
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/plugins/updater2/build.rs
+++ b/plugins/updater2/build.rs
@@ -1,4 +1,4 @@
-const COMMANDS: &[&str] = &["check", "download", "install"];
+const COMMANDS: &[&str] = &["check", "download", "install", "postinstall"];
 
 fn main() {
     tauri_plugin::Builder::new(COMMANDS).build();

--- a/plugins/updater2/js/bindings.gen.ts
+++ b/plugins/updater2/js/bindings.gen.ts
@@ -22,9 +22,17 @@ async download(version: string) : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async install(version: string) : Promise<Result<null, string>> {
+async install(version: string) : Promise<Result<InstallResult, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("plugin:updater2|install", { version }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async postinstall(result: InstallResult) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:updater2|postinstall", { result }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -39,10 +47,12 @@ async maybeEmitUpdated() : Promise<void> {
 
 
 export const events = __makeEvents__<{
+updateDownloadFailedEvent: UpdateDownloadFailedEvent,
 updateDownloadingEvent: UpdateDownloadingEvent,
 updateReadyEvent: UpdateReadyEvent,
 updatedEvent: UpdatedEvent
 }>({
+updateDownloadFailedEvent: "plugin:updater2:update-download-failed-event",
 updateDownloadingEvent: "plugin:updater2:update-downloading-event",
 updateReadyEvent: "plugin:updater2:update-ready-event",
 updatedEvent: "plugin:updater2:updated-event"
@@ -54,6 +64,8 @@ updatedEvent: "plugin:updater2:updated-event"
 
 /** user-defined types **/
 
+export type InstallResult = { kind: "relaunch_current" } | { kind: "launch_new_bundle"; bundle_path: string }
+export type UpdateDownloadFailedEvent = { version: string }
 export type UpdateDownloadingEvent = { version: string }
 export type UpdateReadyEvent = { version: string }
 export type UpdatedEvent = { previous: string | null; current: string }

--- a/plugins/updater2/permissions/autogenerated/commands/postinstall.toml
+++ b/plugins/updater2/permissions/autogenerated/commands/postinstall.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-postinstall"
+description = "Enables the postinstall command without any pre-configured scope."
+commands.allow = ["postinstall"]
+
+[[permission]]
+identifier = "deny-postinstall"
+description = "Denies the postinstall command without any pre-configured scope."
+commands.deny = ["postinstall"]

--- a/plugins/updater2/permissions/autogenerated/reference.md
+++ b/plugins/updater2/permissions/autogenerated/reference.md
@@ -7,6 +7,7 @@ Default permissions for the plugin
 - `allow-check`
 - `allow-download`
 - `allow-install`
+- `allow-postinstall`
 - `allow-maybe-emit-updated`
 
 ## Permission Table
@@ -118,6 +119,32 @@ Enables the maybe_emit_updated command without any pre-configured scope.
 <td>
 
 Denies the maybe_emit_updated command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`updater2:allow-postinstall`
+
+</td>
+<td>
+
+Enables the postinstall command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`updater2:deny-postinstall`
+
+</td>
+<td>
+
+Denies the postinstall command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/updater2/permissions/default.toml
+++ b/plugins/updater2/permissions/default.toml
@@ -1,3 +1,3 @@
 [default]
 description = "Default permissions for the plugin"
-permissions = ["allow-check", "allow-download", "allow-install", "allow-maybe-emit-updated"]
+permissions = ["allow-check", "allow-download", "allow-install", "allow-postinstall", "allow-maybe-emit-updated"]

--- a/plugins/updater2/permissions/schemas/schema.json
+++ b/plugins/updater2/permissions/schemas/schema.json
@@ -343,10 +343,22 @@
           "markdownDescription": "Denies the maybe_emit_updated command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-maybe-emit-updated`",
+          "description": "Enables the postinstall command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-postinstall",
+          "markdownDescription": "Enables the postinstall command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the postinstall command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-postinstall",
+          "markdownDescription": "Denies the postinstall command without any pre-configured scope."
+        },
+        {
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-postinstall`\n- `allow-maybe-emit-updated`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-maybe-emit-updated`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-check`\n- `allow-download`\n- `allow-install`\n- `allow-postinstall`\n- `allow-maybe-emit-updated`"
         }
       ]
     }

--- a/plugins/updater2/src/commands.rs
+++ b/plugins/updater2/src/commands.rs
@@ -1,4 +1,4 @@
-use crate::Updater2PluginExt;
+use crate::{InstallResult, Updater2PluginExt};
 
 #[tauri::command]
 #[specta::specta]
@@ -25,9 +25,21 @@ pub(crate) async fn download<R: tauri::Runtime>(
 pub(crate) async fn install<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
     version: String,
-) -> Result<(), String> {
+) -> Result<InstallResult, String> {
     app.updater2()
         .install(&version)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn postinstall<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    result: InstallResult,
+) -> Result<(), String> {
+    app.updater2()
+        .postinstall(result)
         .await
         .map_err(|e| e.to_string())
 }

--- a/plugins/updater2/src/error.rs
+++ b/plugins/updater2/src/error.rs
@@ -18,6 +18,20 @@ pub enum Error {
     UpdateNotAvailable,
     #[error("version mismatch: expected {expected}, got {actual}")]
     VersionMismatch { expected: String, actual: String },
+    #[error("failed to determine current app path")]
+    FailedToDetermineCurrentAppPath,
+    #[error("failed to determine target app path")]
+    FailedToDetermineTargetAppPath,
+    #[error("invalid update archive: {0}")]
+    InvalidUpdateArchive(String),
+    #[error("failed to schedule installed app launch at {path}: {details}")]
+    FailedToScheduleInstalledAppLaunch { path: String, details: String },
+    #[error("macOS authorization step failed: {details}")]
+    MacosAuthorizationFailed { details: String },
+    #[error("macOS target bundle already exists at {path}")]
+    MacosTargetBundleConflict { path: String },
+    #[error("invalid postinstall state: {0}")]
+    InvalidPostinstallState(String),
 }
 
 impl Serialize for Error {

--- a/plugins/updater2/src/ext.rs
+++ b/plugins/updater2/src/ext.rs
@@ -9,6 +9,19 @@ use crate::events::{
     UpdateDownloadFailedEvent, UpdateDownloadingEvent, UpdateReadyEvent, UpdatedEvent,
 };
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum InstallResult {
+    RelaunchCurrent,
+    MacosBundleUpdate {
+        current_path: String,
+        staged_path: String,
+        target_path: String,
+        backup_path: String,
+        stage_dir: String,
+    },
+}
+
 pub struct Updater2<'a, R: tauri::Runtime, M: tauri::Manager<R>> {
     manager: &'a M,
     _runtime: std::marker::PhantomData<fn() -> R>,
@@ -156,7 +169,7 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Updater2<'a, R, M> {
         Ok(())
     }
 
-    pub async fn install(&self, version: &str) -> Result<(), crate::Error> {
+    pub async fn install(&self, version: &str) -> Result<InstallResult, crate::Error> {
         let bytes = self.get_cached_update_bytes(version)?;
 
         let updater = self.manager.updater()?;
@@ -165,12 +178,89 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Updater2<'a, R, M> {
             .await?
             .ok_or(crate::Error::UpdateNotAvailable)?;
 
+        if update.version != version {
+            return Err(crate::Error::VersionMismatch {
+                expected: version.to_string(),
+                actual: update.version,
+            });
+        }
+
         if let Ok(store) = self.manager.store2().store() {
             let _ = store.save();
         }
 
-        update.install(&bytes)?;
+        #[cfg(target_os = "macos")]
+        {
+            let stage_dir = self.create_macos_update_stage_dir(version)?;
+            let staged_update = match crate::migration::stage_macos_update(&bytes, &stage_dir) {
+                Ok(staged_update) => staged_update,
+                Err(err) => {
+                    let _ = std::fs::remove_dir_all(&stage_dir);
+                    return Err(err);
+                }
+            };
 
+            Ok(InstallResult::MacosBundleUpdate {
+                current_path: staged_update.current_app_path.display().to_string(),
+                staged_path: staged_update.staged_app_path.display().to_string(),
+                target_path: staged_update.target_app_path.display().to_string(),
+                backup_path: staged_update.current_backup_path.display().to_string(),
+                stage_dir: staged_update.stage_dir.display().to_string(),
+            })
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            update.install(&bytes)?;
+            Ok(InstallResult::RelaunchCurrent)
+        }
+    }
+
+    pub async fn postinstall(&self, result: InstallResult) -> Result<(), crate::Error> {
+        match result {
+            InstallResult::RelaunchCurrent => {
+                self.manager.app_handle().restart();
+            }
+            InstallResult::MacosBundleUpdate {
+                current_path,
+                staged_path,
+                target_path,
+                backup_path,
+                stage_dir,
+            } => {
+                #[cfg(target_os = "macos")]
+                {
+                    let handle = self.manager.app_handle().clone();
+                    let current_pid = std::process::id();
+
+                    crate::migration::schedule_macos_update_after_exit(
+                        current_pid,
+                        crate::migration::StagedMacosUpdate {
+                            current_app_path: PathBuf::from(current_path),
+                            staged_app_path: PathBuf::from(staged_path),
+                            target_app_path: PathBuf::from(target_path),
+                            current_backup_path: PathBuf::from(backup_path),
+                            stage_dir: PathBuf::from(stage_dir),
+                        },
+                    )?;
+
+                    handle.exit(0);
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    let _ = (
+                        current_path,
+                        staged_path,
+                        target_path,
+                        backup_path,
+                        stage_dir,
+                    );
+                    return Err(crate::Error::InvalidPostinstallState(
+                        "macos_bundle_update is only valid on macOS".into(),
+                    ));
+                }
+            }
+        }
         Ok(())
     }
 }
@@ -204,4 +294,49 @@ fn get_cache_path<R: tauri::Runtime, M: tauri::Manager<R>>(
         .ok()
         .map(|p: PathBuf| p.join("updates"))?;
     Some(dir.join(format!("{}.bin", version)))
+}
+
+#[cfg(target_os = "macos")]
+impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Updater2<'a, R, M> {
+    fn create_macos_update_stage_dir(&self, version: &str) -> Result<PathBuf, crate::Error> {
+        let base_dir = self
+            .manager
+            .app_handle()
+            .path()
+            .app_cache_dir()
+            .map_err(|_| crate::Error::CachePathUnavailable)?
+            .join("updates")
+            .join("staged");
+        std::fs::create_dir_all(&base_dir)?;
+
+        let version = sanitize_path_component(version);
+        let current_pid = std::process::id();
+
+        for attempt in 0..100 {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos();
+            let stage_dir = base_dir.join(format!("{version}-{current_pid}-{nanos}-{attempt}"));
+
+            match std::fs::create_dir(&stage_dir) {
+                Ok(()) => return Ok(stage_dir),
+                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(err) => return Err(err.into()),
+            }
+        }
+
+        Err(crate::Error::CachePathUnavailable)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn sanitize_path_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' => ch,
+            _ => '_',
+        })
+        .collect()
 }

--- a/plugins/updater2/src/lib.rs
+++ b/plugins/updater2/src/lib.rs
@@ -2,6 +2,8 @@ mod commands;
 mod error;
 mod events;
 mod ext;
+#[cfg(target_os = "macos")]
+mod migration;
 mod store;
 
 pub use error::{Error, Result};
@@ -18,6 +20,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::check::<tauri::Wry>,
             commands::download::<tauri::Wry>,
             commands::install::<tauri::Wry>,
+            commands::postinstall::<tauri::Wry>,
             commands::maybe_emit_updated::<tauri::Wry>,
         ])
         .events(tauri_specta::collect_events![

--- a/plugins/updater2/src/migration.rs
+++ b/plugins/updater2/src/migration.rs
@@ -1,0 +1,492 @@
+use std::{
+    fs,
+    io::Cursor,
+    path::{Component, Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+#[derive(Debug, Clone)]
+pub(crate) struct StagedMacosUpdate {
+    pub(crate) current_app_path: PathBuf,
+    pub(crate) staged_app_path: PathBuf,
+    pub(crate) target_app_path: PathBuf,
+    pub(crate) current_backup_path: PathBuf,
+    pub(crate) stage_dir: PathBuf,
+}
+
+#[derive(Debug)]
+struct ExtractedBundle {
+    name: String,
+    path: PathBuf,
+}
+
+struct MacInstallPaths {
+    current_app_path: PathBuf,
+    staged_app_path: PathBuf,
+    target_app_path: PathBuf,
+    current_backup_path: PathBuf,
+}
+
+impl MacInstallPaths {
+    fn new(
+        current_app_path: PathBuf,
+        backup_dir: &Path,
+        extracted_bundle: ExtractedBundle,
+    ) -> Result<Self, crate::Error> {
+        let target_app_path = install_target_path(&current_app_path, &extracted_bundle.name)?;
+        let current_backup_path = backup_dir.join(
+            current_app_path
+                .file_name()
+                .ok_or(crate::Error::FailedToDetermineCurrentAppPath)?,
+        );
+
+        Ok(Self {
+            staged_app_path: extracted_bundle.path,
+            current_app_path,
+            target_app_path,
+            current_backup_path,
+        })
+    }
+
+    fn staged_update(&self, stage_dir: PathBuf) -> StagedMacosUpdate {
+        StagedMacosUpdate {
+            current_app_path: self.current_app_path.clone(),
+            staged_app_path: self.staged_app_path.clone(),
+            target_app_path: self.target_app_path.clone(),
+            current_backup_path: self.current_backup_path.clone(),
+            stage_dir,
+        }
+    }
+}
+
+pub(crate) fn stage_macos_update(
+    bytes: &[u8],
+    stage_dir: &Path,
+) -> Result<StagedMacosUpdate, crate::Error> {
+    let current_app_path = current_app_bundle_path()?;
+    stage_macos_update_for_current_app(bytes, current_app_path, stage_dir)
+}
+
+fn stage_macos_update_for_current_app(
+    bytes: &[u8],
+    current_app_path: PathBuf,
+    stage_dir: &Path,
+) -> Result<StagedMacosUpdate, crate::Error> {
+    let backup_dir = stage_dir.join("backup");
+    let extract_dir = stage_dir.join("staged");
+    fs::create_dir_all(&backup_dir)?;
+    fs::create_dir_all(&extract_dir)?;
+
+    let extracted_bundle = extract_macos_bundle(bytes, &extract_dir)?;
+    let paths = MacInstallPaths::new(current_app_path, &backup_dir, extracted_bundle)?;
+    ensure_target_app_path_available(&paths)?;
+
+    tracing::info!(
+        current_app_path = %paths.current_app_path.display(),
+        target_app_path = %paths.target_app_path.display(),
+        staged_app_path = %paths.staged_app_path.display(),
+        "staging macOS update"
+    );
+
+    Ok(paths.staged_update(stage_dir.to_path_buf()))
+}
+
+fn install_target_path(
+    current_app_path: &Path,
+    extracted_bundle_name: &str,
+) -> Result<PathBuf, crate::Error> {
+    let parent = current_app_path
+        .parent()
+        .ok_or(crate::Error::FailedToDetermineTargetAppPath)?;
+    Ok(parent.join(extracted_bundle_name))
+}
+
+pub(crate) fn schedule_macos_update_after_exit(
+    current_pid: u32,
+    staged_update: StagedMacosUpdate,
+) -> Result<(), crate::Error> {
+    let mut command = build_macos_update_apply_command(current_pid, &staged_update);
+    command.stdin(Stdio::null());
+    command.stdout(Stdio::null());
+    command.stderr(Stdio::null());
+
+    command.spawn().map_err(|err| {
+        tracing::error!(
+            current_pid,
+            target_app_path = %staged_update.target_app_path.display(),
+            error = %err,
+            "failed to schedule staged macOS update apply"
+        );
+        crate::Error::FailedToScheduleInstalledAppLaunch {
+            path: staged_update.target_app_path.display().to_string(),
+            details: err.to_string(),
+        }
+    })?;
+
+    Ok(())
+}
+
+fn build_macos_update_apply_command(
+    current_pid: u32,
+    staged_update: &StagedMacosUpdate,
+) -> Command {
+    let paths = MacInstallPaths {
+        current_app_path: staged_update.current_app_path.clone(),
+        staged_app_path: staged_update.staged_app_path.clone(),
+        target_app_path: staged_update.target_app_path.clone(),
+        current_backup_path: staged_update.current_backup_path.clone(),
+    };
+    let apply_script = format!(
+        r#"while kill -0 "$1" 2>/dev/null; do sleep 0.1; done;
+apply_update() {{
+  if [ {current} != {target} ] && [ -e {target} ]; then
+    echo 'target bundle already exists' >&2
+    exit 1
+  fi
+
+  if ! mv -f {current} {backup}; then
+    return 1
+  fi
+
+  if ! mv -f {staged} {target}; then
+    if [ -e {backup} ]; then mv -f {backup} {current}; fi
+    exit 1
+  fi
+}}
+
+if ! apply_update; then
+  osascript -e {authorization} || exit 1
+fi
+
+touch {target} >/dev/null 2>&1 || true
+if open -n {target}; then
+  rm -rf {stage_dir}
+fi"#,
+        current = shell_quote(&paths.current_app_path),
+        staged = shell_quote(&paths.staged_app_path),
+        target = shell_quote(&paths.target_app_path),
+        backup = shell_quote(&paths.current_backup_path),
+        stage_dir = shell_quote(&staged_update.stage_dir),
+        authorization = apple_script_quote(&authorization_script(&paths)),
+    );
+    let mut command = Command::new("/bin/sh");
+    command
+        .arg("-c")
+        .arg(apply_script)
+        .arg("sh")
+        .arg(current_pid.to_string());
+    command
+}
+
+fn ensure_target_app_path_available(paths: &MacInstallPaths) -> Result<(), crate::Error> {
+    if paths.target_app_path != paths.current_app_path && paths.target_app_path.exists() {
+        return Err(crate::Error::MacosTargetBundleConflict {
+            path: paths.target_app_path.display().to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+fn authorization_script(paths: &MacInstallPaths) -> String {
+    if paths.current_app_path == paths.target_app_path {
+        format!(
+            "set -e; \
+             if ! mv -f {current} {current_backup}; then exit 1; fi; \
+             if ! mv -f {staged} {target}; then \
+               if [ -e {current_backup} ]; then mv -f {current_backup} {current}; fi; \
+               exit 1; \
+             fi",
+            current = shell_quote(&paths.current_app_path),
+            current_backup = shell_quote(&paths.current_backup_path),
+            staged = shell_quote(&paths.staged_app_path),
+            target = shell_quote(&paths.target_app_path),
+        )
+    } else {
+        format!(
+            "set -e; \
+             if [ -e {target} ]; then echo 'target bundle already exists' >&2; exit 1; fi; \
+             if ! mv -f {current} {current_backup}; then \
+               exit 1; \
+             fi; \
+             if ! mv -f {staged} {target}; then \
+               if [ -e {current_backup} ]; then mv -f {current_backup} {current}; fi; \
+               exit 1; \
+             fi",
+            current = shell_quote(&paths.current_app_path),
+            current_backup = shell_quote(&paths.current_backup_path),
+            staged = shell_quote(&paths.staged_app_path),
+            target = shell_quote(&paths.target_app_path),
+        )
+    }
+}
+
+fn current_app_bundle_path() -> Result<PathBuf, crate::Error> {
+    let executable_path = tauri::utils::platform::current_exe()?;
+    current_app_bundle_path_from_executable(&executable_path)
+}
+
+fn current_app_bundle_path_from_executable(
+    executable_path: &Path,
+) -> Result<PathBuf, crate::Error> {
+    let app_path = executable_path
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+        .ok_or(crate::Error::FailedToDetermineCurrentAppPath)?;
+
+    if app_path.extension().and_then(|ext| ext.to_str()) != Some("app") {
+        return Err(crate::Error::FailedToDetermineCurrentAppPath);
+    }
+
+    Ok(app_path.to_path_buf())
+}
+
+fn extract_macos_bundle(bytes: &[u8], target_dir: &Path) -> Result<ExtractedBundle, crate::Error> {
+    let decoder = flate2::read::GzDecoder::new(Cursor::new(bytes));
+    let mut archive = tar::Archive::new(decoder);
+    let mut root_name: Option<String> = None;
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let entry_path = entry.path()?;
+        let entry_root = archive_entry_root(&entry_path)?;
+        validate_bundle_root(&mut root_name, entry_root)?;
+
+        if !entry.unpack_in(target_dir)? {
+            return Err(crate::Error::InvalidUpdateArchive(
+                "archive entry contains an invalid relative path".into(),
+            ));
+        }
+    }
+
+    let name =
+        root_name.ok_or_else(|| crate::Error::InvalidUpdateArchive("archive is empty".into()))?;
+
+    Ok(ExtractedBundle {
+        path: target_dir.join(&name),
+        name,
+    })
+}
+
+fn archive_entry_root(entry_path: &Path) -> Result<String, crate::Error> {
+    let mut components = entry_path.components();
+    let root_component = components
+        .next()
+        .ok_or_else(|| crate::Error::InvalidUpdateArchive("empty archive entry".into()))?;
+
+    match root_component {
+        Component::Normal(component) => Ok(component.to_string_lossy().to_string()),
+        _ => Err(crate::Error::InvalidUpdateArchive(
+            "archive entry has invalid root".into(),
+        )),
+    }
+}
+
+fn validate_bundle_root(
+    root_name: &mut Option<String>,
+    entry_root: String,
+) -> Result<(), crate::Error> {
+    match root_name {
+        Some(existing) if existing != &entry_root => Err(crate::Error::InvalidUpdateArchive(
+            "archive contains multiple bundle roots".into(),
+        )),
+        Some(_) => Ok(()),
+        None => {
+            if !entry_root.ends_with(".app") {
+                return Err(crate::Error::InvalidUpdateArchive(
+                    "archive root must be an .app bundle".into(),
+                ));
+            }
+            *root_name = Some(entry_root);
+            Ok(())
+        }
+    }
+}
+
+fn shell_quote(path: &Path) -> String {
+    let path = path.display().to_string().replace('\'', "'\"'\"'");
+    format!("'{path}'")
+}
+
+fn apple_script_quote(script: &str) -> String {
+    format!("\"{}\"", script.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gzip_tar(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+
+        for (path, contents) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_mode(0o644);
+            header.set_size(contents.len() as u64);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, path, Cursor::new(*contents))
+                .unwrap();
+        }
+
+        builder.into_inner().unwrap().finish().unwrap()
+    }
+
+    #[test]
+    fn extracts_bundle_root_name() {
+        let archive = gzip_tar(&[("Char.app/Contents/Info.plist", b"plist")]);
+        let dir = tempfile::tempdir().unwrap();
+
+        let bundle = extract_macos_bundle(&archive, dir.path()).unwrap();
+
+        assert_eq!(bundle.name, "Char.app");
+        assert_eq!(bundle.path, dir.path().join("Char.app"));
+        assert!(dir.path().join("Char.app/Contents/Info.plist").exists());
+    }
+
+    #[test]
+    fn rejects_multiple_bundle_roots() {
+        let archive = gzip_tar(&[
+            ("Char.app/Contents/Info.plist", b"plist"),
+            ("Other.app/Contents/Info.plist", b"plist"),
+        ]);
+        let dir = tempfile::tempdir().unwrap();
+
+        let error = extract_macos_bundle(&archive, dir.path()).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("archive contains multiple bundle roots")
+        );
+    }
+
+    #[test]
+    fn rejects_archive_entries_without_app_bundle_root() {
+        let archive = gzip_tar(&[("Char/Contents/Info.plist", b"plist")]);
+        let dir = tempfile::tempdir().unwrap();
+
+        let error = extract_macos_bundle(&archive, dir.path()).unwrap_err();
+
+        assert!(error.to_string().contains("root must be an .app bundle"));
+    }
+
+    #[test]
+    fn install_target_uses_extracted_bundle_name_for_stable_and_nightly() {
+        let cases = [
+            ("/Applications/Hyprnote.app", "Char.app"),
+            ("/Applications/Hyprnote Nightly.app", "Char Nightly.app"),
+        ];
+
+        for (current, extracted_name) in cases {
+            let target = install_target_path(Path::new(current), extracted_name).unwrap();
+
+            assert_eq!(target, PathBuf::from("/Applications").join(extracted_name));
+        }
+    }
+
+    #[test]
+    fn staging_update_uses_stage_dir_for_backup_and_bundle_paths() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let current_app = temp_dir.path().join("Applications/Hyprnote.app");
+        let stage_dir = temp_dir.path().join("stage");
+        fs::create_dir_all(current_app.join("Contents/MacOS")).unwrap();
+
+        let staged_update = stage_macos_update_for_current_app(
+            &gzip_tar(&[("Char.app/Contents/Info.plist", b"plist")]),
+            current_app.clone(),
+            &stage_dir,
+        )
+        .unwrap();
+
+        assert_eq!(staged_update.current_app_path, current_app);
+        assert_eq!(
+            staged_update.staged_app_path,
+            stage_dir.join("staged/Char.app")
+        );
+        assert_eq!(
+            staged_update.target_app_path,
+            temp_dir.path().join("Applications/Char.app")
+        );
+        assert_eq!(
+            staged_update.current_backup_path,
+            stage_dir.join("backup/Hyprnote.app")
+        );
+        assert_eq!(staged_update.stage_dir, stage_dir);
+        assert!(staged_update.staged_app_path.exists());
+    }
+
+    #[test]
+    fn current_bundle_path_from_executable_uses_bundle_root() {
+        let executable = Path::new("/Applications/Char.app/Contents/MacOS/char");
+
+        let bundle = current_app_bundle_path_from_executable(executable).unwrap();
+
+        assert_eq!(bundle, PathBuf::from("/Applications/Char.app"));
+    }
+
+    #[test]
+    fn rename_conflict_is_rejected() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let current = temp_dir.path().join("Hyprnote.app");
+        let target = temp_dir.path().join("Char.app");
+        fs::create_dir(&target).unwrap();
+        let paths = MacInstallPaths {
+            staged_app_path: temp_dir.path().join("Char.app"),
+            current_backup_path: temp_dir.path().join("Hyprnote.app"),
+            current_app_path: current,
+            target_app_path: target.clone(),
+        };
+
+        let error = ensure_target_app_path_available(&paths).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!("macOS target bundle already exists at {}", target.display())
+        );
+    }
+
+    #[test]
+    fn authorization_script_for_renamed_bundle_fails_on_existing_target() {
+        let paths = MacInstallPaths {
+            staged_app_path: PathBuf::from("/tmp/tauri_updated_app/Char.app"),
+            current_backup_path: PathBuf::from("/tmp/tauri_current_app/Hyprnote.app"),
+            current_app_path: PathBuf::from("/Applications/Hyprnote.app"),
+            target_app_path: PathBuf::from("/Applications/Char.app"),
+        };
+
+        let script = authorization_script(&paths);
+
+        assert!(script.contains(
+            "if [ -e '/Applications/Char.app' ]; then echo 'target bundle already exists' >&2; exit 1; fi;"
+        ));
+        assert!(!script.contains("target_backup"));
+    }
+
+    #[test]
+    fn apply_command_waits_for_pid_before_swapping_and_opening_bundle() {
+        let staged_update = StagedMacosUpdate {
+            current_app_path: PathBuf::from("/Applications/Hyprnote.app"),
+            staged_app_path: PathBuf::from("/tmp/stage/staged/Char.app"),
+            target_app_path: PathBuf::from("/Applications/Char.app"),
+            current_backup_path: PathBuf::from("/tmp/stage/backup/Hyprnote.app"),
+            stage_dir: PathBuf::from("/tmp/stage"),
+        };
+        let command = build_macos_update_apply_command(4242, &staged_update);
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(command.get_program(), "/bin/sh");
+        assert_eq!(args[0], "-c");
+        assert!(args[1].contains(r#"while kill -0 "$1" 2>/dev/null; do sleep 0.1; done;"#));
+        assert!(args[1].contains("apply_update() {"));
+        assert!(args[1].contains("osascript -e"));
+        assert!(args[1].contains("open -n '/Applications/Char.app'"));
+        assert!(args[1].contains("rm -rf '/tmp/stage'"));
+        assert_eq!(&args[2..], ["sh", "4242"]);
+    }
+}


### PR DESCRIPTION
  - Add a macOS-specific postinstall flow in updater2 to stage, swap, and relaunch the updated .app bundle after exit
  - Support bundle-name migration during updates, including conflict checks, backup paths, and staged install cleanup
  - Return structured install results from the updater so the client can finish platform-specific post-install behavior
  - Update desktop and tray update actions to call postinstall and show clearer failure dialogs
  - Regenerate updater bindings/permissions and add macOS migration tests