### PR TITLE
Prevent back-to-back live starts from leaking stale transcript data

### DIFF
--- a/apps/desktop/src/store/zustand/listener/general-live.ts
+++ b/apps/desktop/src/store/zustand/listener/general-live.ts
@@ -197,7 +197,7 @@ export const startLiveSession = <T extends LiveStore>(
   get: StoreApi<T>["getState"],
   targetSessionId: string,
   params: SessionParams,
-) => {
+): Promise<boolean> => {
   const handlers = createSessionEventHandlers(set, get, targetSessionId);
 
   const program = Effect.gen(function* () {
@@ -255,7 +255,7 @@ export const startLiveSession = <T extends LiveStore>(
     });
   });
 
-  void Effect.runPromiseExit(program).then((exit) => {
+  return Effect.runPromiseExit(program).then((exit) =>
     Exit.match(exit, {
       onFailure: (cause) => {
         console.error(JSON.stringify(cause));
@@ -265,10 +265,11 @@ export const startLiveSession = <T extends LiveStore>(
         setLiveState(set, (live) => {
           markLiveStartFailed(live);
         });
+        return false;
       },
-      onSuccess: () => {},
-    });
-  });
+      onSuccess: () => true,
+    }),
+  );
 };
 
 export const stopLiveSession = <T extends GeneralState>(

--- a/apps/desktop/src/store/zustand/listener/general.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general.test.ts
@@ -1,3 +1,4 @@
+import { create as mutate } from "mutative";
 import { beforeEach, describe, expect, test } from "vitest";
 
 import { createListenerStore } from ".";
@@ -165,6 +166,31 @@ describe("General Listener Slice", () => {
     test("start action exists and is callable", () => {
       const start = store.getState().start;
       expect(typeof start).toBe("function");
+    });
+
+    test("start returns false while another session is finalizing", async () => {
+      store.setState((state) =>
+        mutate(state, (draft) => {
+          draft.live.status = "finalizing";
+          draft.live.loading = true;
+          draft.live.sessionId = "session-a";
+        }),
+      );
+
+      const result = await store.getState().start({
+        session_id: "session-b",
+        languages: [],
+        onboarding: false,
+        transcription_mode: "live",
+        recording_mode: "disk",
+        model: "test-model",
+        base_url: "http://localhost",
+        api_key: "test-key",
+        keywords: [],
+      });
+
+      expect(result).toBe(false);
+      expect(store.getState().live.sessionId).toBe("session-a");
     });
   });
 });

--- a/apps/desktop/src/store/zustand/listener/general.ts
+++ b/apps/desktop/src/store/zustand/listener/general.ts
@@ -25,7 +25,7 @@ export type GeneralActions = {
   start: (
     params: SessionParams,
     options?: { handlePersist?: HandlePersistCallback },
-  ) => void;
+  ) => Promise<boolean>;
   stop: () => void;
   setMuted: (value: boolean) => void;
   runBatch: (
@@ -46,12 +46,12 @@ export const createGeneralSlice = <
   get: StoreApi<T>["getState"],
 ): GeneralState & GeneralActions => ({
   ...initialGeneralState,
-  start: (params: SessionParams, options) => {
+  start: async (params: SessionParams, options) => {
     const targetSessionId = params.session_id;
 
     if (!targetSessionId) {
       console.error("[listener] 'start' requires a session_id");
-      return;
+      return false;
     }
 
     const currentMode = get().getSessionMode(targetSessionId);
@@ -59,7 +59,15 @@ export const createGeneralSlice = <
       console.warn(
         `[listener] cannot start live session while batch processing session ${targetSessionId}`,
       );
-      return;
+      return false;
+    }
+
+    const currentLive = get().live;
+    if (currentLive.loading || currentLive.status !== "inactive") {
+      console.warn(
+        "[listener] cannot start live session while another session is running",
+      );
+      return false;
     }
 
     setLiveState(set, (live) => {
@@ -75,7 +83,12 @@ export const createGeneralSlice = <
       get().setTranscriptPersist(options.handlePersist);
     }
 
-    startLiveSession(set, get, targetSessionId, params);
+    const started = await startLiveSession(set, get, targetSessionId, params);
+    if (!started && options?.handlePersist) {
+      get().setTranscriptPersist(undefined);
+    }
+
+    return started;
   },
   stop: () => {
     stopLiveSession(set, get);

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -42,7 +42,7 @@ export function useStartListening(
   const recordingMode =
     options?.recordingMode ?? (record_enabled ? "disk" : "memory");
 
-  const startListening = useCallback(() => {
+  const startListening = useCallback(async () => {
     if (!conn || !store) {
       console.error("no_stt_connection");
       return;
@@ -62,13 +62,6 @@ export function useStartListening(
     } satisfies TranscriptStorage;
 
     store.setRow("transcripts", transcriptId, transcriptRow);
-
-    void analyticsCommands.event({
-      event: "session_started",
-      has_calendar_event: !!getSessionEventById(store, sessionId),
-      stt_provider: conn.provider,
-      stt_model: conn.model,
-    });
 
     const handlePersist: HandlePersistCallback = (words, hints) => {
       if (words.length === 0) {
@@ -134,7 +127,7 @@ export function useStartListening(
       });
     };
 
-    start(
+    const started = await start(
       {
         session_id: sessionId,
         languages,
@@ -150,6 +143,18 @@ export function useStartListening(
         handlePersist,
       },
     );
+
+    if (!started) {
+      store.delRow("transcripts", transcriptId);
+      return;
+    }
+
+    void analyticsCommands.event({
+      event: "session_started",
+      has_calendar_event: !!getSessionEventById(store, sessionId),
+      stt_provider: conn.provider,
+      stt_model: conn.model,
+    });
   }, [
     conn,
     store,

--- a/crates/listener-core/src/actors/root.rs
+++ b/crates/listener-core/src/actors/root.rs
@@ -10,10 +10,10 @@ use crate::actors::session::lifecycle::{
 use crate::actors::{
     SessionContext, SessionMsg, SessionParams, session_span, spawn_session_supervisor,
 };
-use crate::{ListenerRuntime, SessionLifecycleEvent, State, StopSessionParams};
+use crate::{ListenerRuntime, SessionLifecycleEvent, StartSessionError, State, StopSessionParams};
 
 pub enum RootMsg {
-    StartSession(SessionParams, RpcReplyPort<bool>),
+    StartSession(SessionParams, RpcReplyPort<Result<(), StartSessionError>>),
     StopSession(StopSessionParams, RpcReplyPort<()>),
     GetState(RpcReplyPort<State>),
 }
@@ -64,8 +64,8 @@ impl Actor for RootActor {
     ) -> Result<(), ActorProcessingErr> {
         match message {
             RootMsg::StartSession(params, reply) => {
-                let success = start_session_impl(myself.get_cell(), params, state).await;
-                let _ = reply.send(success);
+                let result = start_session_impl(myself.get_cell(), params, state).await;
+                let _ = reply.send(result);
             }
             RootMsg::StopSession(params, reply) => {
                 stop_session_impl(state, params).await;
@@ -129,14 +129,14 @@ async fn start_session_impl(
     root_cell: ActorCell,
     params: SessionParams,
     state: &mut RootState,
-) -> bool {
+) -> Result<(), StartSessionError> {
     let session_id = params.session_id.clone();
     let span = session_span(&session_id);
 
     async {
         if state.supervisor.is_some() {
             tracing::warn!("session_already_running");
-            return false;
+            return Err(StartSessionError::SessionAlreadyRunning);
         }
 
         configure_sentry_session_context(&params);
@@ -146,7 +146,7 @@ async fn start_session_impl(
             Err(e) => {
                 tracing::error!(error.message = %e, "failed_to_resolve_sessions_dir");
                 clear_sentry_session_context();
-                return false;
+                return Err(StartSessionError::FailedToResolveSessionsDir);
             }
         };
 
@@ -175,12 +175,12 @@ async fn start_session_impl(
                 state.runtime.emit_lifecycle(evt);
 
                 tracing::info!("session_started");
-                true
+                Ok(())
             }
             Err(e) => {
                 tracing::error!(error.message = ?e, "failed_to_start_session");
                 clear_sentry_session_context();
-                false
+                Err(StartSessionError::FailedToStartSession)
             }
         }
     }

--- a/crates/listener-core/src/lib.rs
+++ b/crates/listener-core/src/lib.rs
@@ -58,3 +58,15 @@ pub enum DegradedError {
     #[serde(rename = "stream_error")]
     StreamError { message: String },
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "specta", derive(specta::Type))]
+#[serde(tag = "type")]
+pub enum StartSessionError {
+    #[serde(rename = "session_already_running")]
+    SessionAlreadyRunning,
+    #[serde(rename = "failed_to_resolve_sessions_dir")]
+    FailedToResolveSessionsDir,
+    #[serde(rename = "failed_to_start_session")]
+    FailedToStartSession,
+}

--- a/plugins/listener/src/commands.rs
+++ b/plugins/listener/src/commands.rs
@@ -48,8 +48,10 @@ pub async fn start_session<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
     params: SessionParams,
 ) -> Result<(), String> {
-    app.listener().start_session(params).await;
-    Ok(())
+    app.listener()
+        .start_session(params)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/plugins/listener/src/error.rs
+++ b/plugins/listener/src/error.rs
@@ -16,6 +16,8 @@ pub enum Error {
     LocalSttError(#[from] tauri_plugin_local_stt::Error),
     #[error("no session")]
     NoneSession,
+    #[error("session already running")]
+    SessionAlreadyRunning,
     #[error("start session failed")]
     StartSessionFailed,
     #[error("stop session failed")]

--- a/plugins/listener/src/ext.rs
+++ b/plugins/listener/src/ext.rs
@@ -1,7 +1,7 @@
 use ractor::{ActorRef, call_t, registry};
 
 use hypr_listener_core::{
-    StopSessionParams,
+    StartSessionError, StopSessionParams,
     actors::{RootActor, RootMsg, SessionParams, SourceActor, SourceMsg},
 };
 
@@ -62,10 +62,19 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Listener<'a, R, M> {
     }
 
     #[tracing::instrument(skip_all)]
-    pub async fn start_session(&self, params: SessionParams) {
+    pub async fn start_session(&self, params: SessionParams) -> Result<(), crate::Error> {
         if let Some(cell) = registry::where_is(RootActor::name()) {
             let actor: ActorRef<RootMsg> = cell.into();
-            let _ = ractor::call!(actor, RootMsg::StartSession, params);
+            match ractor::call!(actor, RootMsg::StartSession, params) {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(StartSessionError::SessionAlreadyRunning)) => {
+                    Err(crate::Error::SessionAlreadyRunning)
+                }
+                Ok(Err(_)) => Err(crate::Error::StartSessionFailed),
+                Err(_) => Err(crate::Error::StartSessionFailed),
+            }
+        } else {
+            Err(crate::Error::ActorNotFound(RootActor::name().to_string()))
         }
     }
 


### PR DESCRIPTION
  - Root cause:
      - The desktop listener flow installed the new transcript persist callback too early during a back-to-back start.
      - Session B’s transcript row and persist handler could be provisioned before session A had fully finished finalizing.
      - If A still had buffered transcript data, A’s final flush/reset could write into B’s transcript target.
      - The listener plugin also swallowed start_session rejection, so the frontend could proceed as though the new session had started.
  - What changed:
      - Reject any new live start while another live session is still active or finalizing.
      - Keep the frontend start path aligned with Rust by returning a real error when start_session is rejected.
      - Remove the provisional transcript row when that start attempt fails.
      - Replace raw rejection-string matching with a typed StartSessionError.
  - Why this fixes it:
      - The transcript persist callback is no longer handed off to a new session while the previous session is still finalizing.
      - A stale finalize/reset from session A cannot land in session B’s persisted transcript row.
      - Rejected starts no longer leave behind transcript artifacts that could be mistaken for valid session output.
  - Validation:
      - Added a listener store test covering rejected start while another session is finalizing.
      - Ran desktop tests and typecheck.
      - Ran Rust cargo check for listener-core and tauri-plugin-listener.
  - Follow-ups:
      - Add a user-facing message when a start is rejected because the previous session is still finalizing.
      - Consider queuing a back-to-back start automatically after finalization if we want smoother handoff UX.
      - If we want stronger long-term isolation, consider session-owned transcript runtime state in the desktop store.