### PR TITLE
feat: Update founders page calendar URL endpoint

### DIFF
--- a/apps/web/src/routes/founders.tsx
+++ b/apps/web/src/routes/founders.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute("/founders")({
     };
   },
   beforeLoad: ({ search }) => {
-    const baseUrl = "https://cal.com/team/char/welcome?duration=20";
+    const baseUrl = "https://cal.com/team/char/ama";
     const url = search.source ? `${baseUrl}&source=${search.source}` : baseUrl;
     throw redirect({
       href: url,


### PR DESCRIPTION
Change calendar booking URL from 'welcome' to 'ama' endpoint to better reflect the purpose of founder meetings as Ask Me Anything sessions rather than generic welcome calls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single constant URL change in a redirect route with no logic or data-handling changes.
> 
> **Overview**
> Updates the `/founders` route redirect to send users to the Cal.com `ama` booking page instead of the previous `welcome` URL, while preserving the optional `source` query parameter passthrough.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b537c45af446d9b73ae7d1e88513148af7a555e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->