### PR TITLE
feat: change article category to Founders' notes

### DIFF
--- a/apps/web/content/articles/hyprnote-is-now-char.mdx
+++ b/apps/web/content/articles/hyprnote-is-now-char.mdx
@@ -5,7 +5,7 @@ meta_description: "From sales notes to AI notepad — why we renamed Hyprnote to
 author: "John Jeong"
 coverImage: "/api/images/blog/announcement.jpg"
 featured: true
-category: "Product"
+category: "Founders' notes"
 date: "2026-02-14"
 ---
 


### PR DESCRIPTION
Update hyprnote-is-now-char article category from "Product” to "Founders' notes" to better reflect the content type and improve article organization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content-only metadata change affecting article grouping/filtering with no runtime logic changes.
> 
> **Overview**
> Updates `apps/web/content/articles/hyprnote-is-now-char.mdx` frontmatter to change the article `category` from `"Product"` to `"Founders' notes"`, aligning it with other founder-focused posts and altering how it’s organized in listings/filters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6624e26045d784a25948d85187e4567c776971ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->