### PR TITLE
refactor: consolidate new note hooks with behavior param

### DIFF
--- a/apps/desktop/src/shared/main/empty/index.tsx
+++ b/apps/desktop/src/shared/main/empty/index.tsx
@@ -5,7 +5,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { Kbd } from "@hypr/ui/components/ui/kbd";
 import { cn } from "@hypr/utils";
 
-import { useNewNote } from "../useNewNote";
+import { useNewNoteAndListen } from "../useNewNote";
 import { OpenNoteDialog } from "./open-note-dialog";
 
 import { StandardTabWrapper } from "~/shared/main";
@@ -53,7 +53,7 @@ export function TabContentEmpty({
 }
 
 function EmptyView() {
-  const newNote = useNewNote({ behavior: "current" });
+  const newNote = useNewNoteAndListen({ behavior: "current" });
   const openCurrent = useTabs((state) => state.openCurrent);
   const [openNoteDialogOpen, setOpenNoteDialogOpen] = useState(false);
 

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -24,7 +24,7 @@ import { cn } from "@hypr/utils";
 
 import { TabContentEmpty, TabItemEmpty } from "./empty";
 import { HeaderListenButton } from "./header-listen-button";
-import { useNewNote, useNewNoteAndListen } from "./useNewNote";
+import { useNewNoteAndListen } from "./useNewNote";
 
 import { TabContentAI, TabItemAI } from "~/ai";
 import { TabContentCalendar, TabItemCalendar } from "~/calendar";
@@ -140,16 +140,10 @@ function Header({ tabs }: { tabs: Tab[] }) {
 
   const tabsScrollContainerRef = useRef<HTMLDivElement>(null);
   const handleNewEmptyTab = useNewEmptyTab();
-  const handleNewNote = useNewNote({ behavior: "new" });
   const handleNewNoteAndListen = useNewNoteAndListen();
   const showNewTabMenu = useNativeContextMenu([
     { id: "empty-tab", text: "Open Empty Tab", action: handleNewEmptyTab },
-    { id: "new-note", text: "Create New Note", action: handleNewNote },
-    {
-      id: "new-note-listen",
-      text: "Create and Start Listening",
-      action: handleNewNoteAndListen,
-    },
+    { id: "new-note", text: "Create New Note", action: handleNewNoteAndListen },
   ]);
 
   const scrollState = useScrollState(
@@ -830,18 +824,17 @@ function useTabsShortcuts() {
   const isListening = liveStatus === "active" || liveStatus === "finalizing";
   const { chat } = useShell();
 
-  const newNote = useNewNote({ behavior: "new" });
-  const newNoteCurrent = useNewNote({ behavior: "current" });
   const newNoteAndListen = useNewNoteAndListen();
+  const newNoteAndListenCurrent = useNewNoteAndListen({ behavior: "current" });
   const newEmptyTab = useNewEmptyTab();
 
   useHotkeys(
     "mod+n",
     () => {
       if (currentTab?.type === "empty") {
-        newNoteCurrent();
+        newNoteAndListenCurrent();
       } else {
-        newNote();
+        newNoteAndListen();
       }
     },
     {
@@ -849,7 +842,7 @@ function useTabsShortcuts() {
       enableOnFormTags: true,
       enableOnContentEditable: true,
     },
-    [currentTab, newNote, newNoteCurrent],
+    [currentTab, newNoteAndListen, newNoteAndListenCurrent],
   );
 
   useHotkeys(
@@ -1008,17 +1001,6 @@ function useTabsShortcuts() {
       enableOnContentEditable: true,
     },
     [openNew],
-  );
-
-  useHotkeys(
-    "mod+shift+n",
-    () => newNoteAndListen(),
-    {
-      preventDefault: true,
-      enableOnFormTags: true,
-      enableOnContentEditable: true,
-    },
-    [newNoteAndListen],
   );
 
   return {};

--- a/apps/desktop/src/shared/main/useNewNote.ts
+++ b/apps/desktop/src/shared/main/useNewNote.ts
@@ -44,11 +44,20 @@ export function useNewNote({
   return handler;
 }
 
-export function useNewNoteAndListen() {
+export function useNewNoteAndListen({
+  behavior = "new",
+}: {
+  behavior?: "new" | "current";
+} = {}) {
   const { persistedStore, internalStore } = useRouteContext({
     from: "__root__",
   });
-  const openNew = useTabs((state) => state.openNew);
+  const { openNew, openCurrent } = useTabs(
+    useShallow((state) => ({
+      openNew: state.openNew,
+      openCurrent: state.openCurrent,
+    })),
+  );
 
   const handler = useCallback(() => {
     const user_id = internalStore?.getValue("user_id");
@@ -65,12 +74,13 @@ export function useNewNoteAndListen() {
       has_event_id: false,
     });
 
-    openNew({
+    const ff = behavior === "new" ? openNew : openCurrent;
+    ff({
       type: "sessions",
       id: sessionId,
       state: { view: null, autoStart: true },
     });
-  }, [persistedStore, internalStore, openNew]);
+  }, [persistedStore, internalStore, openNew, openCurrent, behavior]);
 
   return handler;
 }


### PR DESCRIPTION
Remove useNewNote hook and extend useNewNoteAndListen to support both "new" and "current" behaviors. Simplify context menu by removing separate "Create New Note" option. Update keyboard shortcut Cmd+N to always start listening and remove Cmd+Shift+N shortcut.