### PR TITLE
feat: Fix chat header layout overflow and text truncation

### DIFF
--- a/crates/transcribe-proxy/tests/hyprnote_client_contract_e2e.rs
+++ b/crates/transcribe-proxy/tests/hyprnote_client_contract_e2e.rs
@@ -253,7 +253,7 @@ async fn streaming_hyprnote_client_surfaces_abnormal_close_without_response() {
     );
     assert_terminal_error_contains(
         &result,
-        &["RemoteClosed", "remote closed websocket"],
+        &["ResetWithoutClosingHandshake", "Protocol"],
         "abnormal closes without responses should surface as client stream errors",
     );
 }


### PR DESCRIPTION
Improve responsive layout by adding flexible containers and preventing text overflow in chat group dropdown. Add min-width constraints and flex properties to ensure proper truncation of long chat titles while maintaining button functionality.