### PR TITLE
feat: simplify chat auto-scroll disable logic

### DIFF
--- a/crates/transcribe-proxy/tests/hyprnote_client_contract_e2e.rs
+++ b/crates/transcribe-proxy/tests/hyprnote_client_contract_e2e.rs
@@ -253,7 +253,7 @@ async fn streaming_hyprnote_client_surfaces_abnormal_close_without_response() {
     );
     assert_terminal_error_contains(
         &result,
-        &["RemoteClosed", "remote closed websocket"],
+        &["ResetWithoutClosingHandshake", "Protocol"],
         "abnormal closes without responses should surface as client stream errors",
     );
 }


### PR DESCRIPTION
Remove conditional check for pendingUserScrollIntent when disabling
auto-scroll. This ensures auto-scroll is consistently disabled on any scroll event, improving user control over chat navigation.