### PR TITLE
feat: improve auto-enhance retry logic conditions

### DIFF
--- a/apps/desktop/src/services/enhancer/index.ts
+++ b/apps/desktop/src/services/enhancer/index.ts
@@ -129,7 +129,8 @@ export class EnhancerService {
   private tryAutoEnhance(sessionId: string, attempt: number) {
     const eligibility = this.checkEligibility(sessionId);
     if (!eligibility.eligible) {
-      if (attempt < 20) {
+      const hasTranscripts = this.getTranscriptIds(sessionId).length > 0;
+      if (attempt < 20 && (hasTranscripts || attempt < 2)) {
         const timer = setTimeout(() => {
           this.pendingRetries.delete(sessionId);
           this.tryAutoEnhance(sessionId, attempt + 1);


### PR DESCRIPTION
Add transcript availability check to auto-enhance retry logic. The system now considers both attempt count and transcript presence when deciding whether to retry enhancement. Early attempts (< 2) continue regardless of transcripts, while later attempts require transcripts to be available before proceeding.