### PR TITLE
fix: bypass Netlify body limits for admin media uploads

### DIFF
--- a/apps/web/src/components/admin/media-selector-modal.tsx
+++ b/apps/web/src/components/admin/media-selector-modal.tsx
@@ -6,6 +6,8 @@ import { createPortal } from "react-dom";
 
 import { cn } from "@hypr/utils";
 
+import { uploadMediaLibraryFile } from "@/functions/media-upload";
+
 interface MediaItem {
   name: string;
   path: string;
@@ -27,24 +29,6 @@ async function fetchMediaItems(path: string): Promise<MediaItem[]> {
     throw new Error(data.error || "Failed to fetch media");
   }
   return data.items;
-}
-
-async function uploadFile(params: {
-  filename: string;
-  content: string;
-  folder: string;
-}) {
-  const response = await fetch("/api/admin/media/upload", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(params),
-  });
-
-  if (!response.ok) {
-    const data = await response.json();
-    throw new Error(data.error || "Upload failed");
-  }
-  return response.json();
 }
 
 function getRelativePath(fullPath: string): string {
@@ -123,19 +107,8 @@ export function MediaSelectorModal({
   const uploadMutation = useMutation({
     mutationFn: async (files: FileList) => {
       for (const file of Array.from(files)) {
-        const reader = new FileReader();
-        const content = await new Promise<string>((resolve, reject) => {
-          reader.onload = () => {
-            const base64 = (reader.result as string).split(",")[1];
-            resolve(base64);
-          };
-          reader.onerror = reject;
-          reader.readAsDataURL(file);
-        });
-
-        await uploadFile({
-          filename: file.name,
-          content,
+        await uploadMediaLibraryFile({
+          file,
           folder: selectedPath,
         });
       }

--- a/apps/web/src/functions/media-upload.ts
+++ b/apps/web/src/functions/media-upload.ts
@@ -1,0 +1,132 @@
+import { getSupabaseBrowserClient } from "@/functions/supabase";
+import {
+  extractBase64Images,
+  extractSlugFromPath,
+  getExtensionFromMimeType,
+  getMimeTypeFromExtension,
+  MEDIA_BUCKET_NAME,
+  parseMediaFilename,
+} from "@/lib/media";
+
+interface SignedUploadData {
+  path: string;
+  publicUrl: string;
+  token: string;
+}
+
+async function requestSignedUpload(
+  endpoint: string,
+  body: Record<string, unknown>,
+) {
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(data.error || "Upload failed");
+  }
+
+  return data as SignedUploadData;
+}
+
+async function uploadToSignedUrl(file: File, signedUpload: SignedUploadData) {
+  const supabase = getSupabaseBrowserClient();
+  const parsedFilename = parseMediaFilename(file.name);
+  const contentType =
+    file.type ||
+    (parsedFilename
+      ? getMimeTypeFromExtension(parsedFilename.extension)
+      : undefined);
+  const { error } = await supabase.storage
+    .from(MEDIA_BUCKET_NAME)
+    .uploadToSignedUrl(signedUpload.path, signedUpload.token, file, {
+      contentType,
+    });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return {
+    path: signedUpload.path,
+    publicUrl: signedUpload.publicUrl,
+  };
+}
+
+export async function uploadBlogImageFile(params: {
+  file: File;
+  folder?: string;
+}) {
+  const signedUpload = await requestSignedUpload(
+    "/api/admin/blog/upload-image",
+    {
+      filename: params.file.name,
+      folder: params.folder,
+    },
+  );
+
+  return uploadToSignedUrl(params.file, signedUpload);
+}
+
+export async function uploadMediaLibraryFile(params: {
+  file: File;
+  folder?: string;
+  path?: string;
+  upsert?: boolean;
+}) {
+  const signedUpload = await requestSignedUpload("/api/admin/media/upload", {
+    filename: params.file.name,
+    folder: params.folder,
+    path: params.path,
+    upsert: params.upsert,
+  });
+
+  return uploadToSignedUrl(params.file, signedUpload);
+}
+
+async function dataUrlToFile(
+  dataUrl: string,
+  filename: string,
+  mimeType: string,
+) {
+  const response = await fetch(dataUrl);
+  const blob = await response.blob();
+
+  return new File([blob], filename, {
+    type: blob.type || `image/${mimeType}`,
+  });
+}
+
+export async function uploadInlineMarkdownImages(params: {
+  content: string;
+  path: string;
+}) {
+  const base64Images = extractBase64Images(params.content);
+  if (base64Images.length === 0) {
+    return params.content;
+  }
+
+  const folder = `articles/${extractSlugFromPath(params.path)}`;
+  let nextContent = params.content;
+
+  for (let i = 0; i < base64Images.length; i++) {
+    const image = base64Images[i];
+    const extension = getExtensionFromMimeType(image.mimeType);
+    const file = await dataUrlToFile(
+      image.dataUrl,
+      `image-${i + 1}.${extension}`,
+      image.mimeType,
+    );
+    const uploadResult = await uploadBlogImageFile({ file, folder });
+
+    nextContent = nextContent.replace(
+      image.fullMatch,
+      `![](${uploadResult.publicUrl})`,
+    );
+  }
+
+  return nextContent;
+}

--- a/apps/web/src/functions/supabase-media.ts
+++ b/apps/web/src/functions/supabase-media.ts
@@ -2,8 +2,11 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { createClient } from "@supabase/supabase-js";
 
 import { env, requireEnv } from "@/env";
-
-const BUCKET_NAME = "blog";
+import {
+  getMimeTypeFromExtension,
+  MEDIA_BUCKET_NAME,
+  parseMediaFilename,
+} from "@/lib/media";
 
 export interface MediaItem {
   name: string;
@@ -26,8 +29,100 @@ function getSupabaseClient() {
 
 function getPublicUrl(path: string): string {
   const supabase = getSupabaseClient();
-  const { data } = supabase.storage.from(BUCKET_NAME).getPublicUrl(path);
+  const { data } = supabase.storage.from(MEDIA_BUCKET_NAME).getPublicUrl(path);
   return data.publicUrl;
+}
+
+function normalizePath(path: string): string {
+  return path.split("/").filter(Boolean).join("/");
+}
+
+async function resolveUploadPath(
+  supabase: SupabaseClient,
+  params: {
+    filename?: string;
+    folder?: string;
+    path?: string;
+    upsert?: boolean;
+  },
+): Promise<
+  | {
+      success: true;
+      path: string;
+      contentType: string;
+    }
+  | {
+      success: false;
+      error: string;
+    }
+> {
+  if (params.path) {
+    const path = normalizePath(params.path);
+    const filename = path.split("/").pop();
+    if (!filename) {
+      return {
+        success: false,
+        error: "Invalid file path",
+      };
+    }
+
+    const parsed = parseMediaFilename(filename);
+    if (!parsed) {
+      return {
+        success: false,
+        error: "Invalid file type. Only images and videos are allowed.",
+      };
+    }
+
+    return {
+      success: true,
+      path,
+      contentType: getMimeTypeFromExtension(parsed.extension),
+    };
+  }
+
+  if (!params.filename) {
+    return {
+      success: false,
+      error: "Missing filename",
+    };
+  }
+
+  const parsed = parseMediaFilename(params.filename);
+  if (!parsed) {
+    return {
+      success: false,
+      error: "Invalid file type. Only images and videos are allowed.",
+    };
+  }
+
+  const folder = normalizePath(params.folder || "");
+  let filename = parsed.filename;
+  let path = folder ? `${folder}/${filename}` : filename;
+
+  if (!params.upsert) {
+    const { data: existingFiles } = await supabase.storage
+      .from(MEDIA_BUCKET_NAME)
+      .list(folder || undefined, { limit: 1000 });
+
+    if (existingFiles) {
+      const existingNames = new Set(existingFiles.map((file) => file.name));
+      let counter = 1;
+
+      while (existingNames.has(filename)) {
+        filename = `${parsed.baseName}-${counter}.${parsed.extension}`;
+        counter++;
+      }
+
+      path = folder ? `${folder}/${filename}` : filename;
+    }
+  }
+
+  return {
+    success: true,
+    path,
+    contentType: getMimeTypeFromExtension(parsed.extension),
+  };
 }
 
 export async function listMediaFiles(
@@ -37,7 +132,7 @@ export async function listMediaFiles(
 
   try {
     const { data, error } = await supabase.storage
-      .from(BUCKET_NAME)
+      .from(MEDIA_BUCKET_NAME)
       .list(path, {
         limit: 1000,
         sortBy: { column: "name", order: "asc" },
@@ -98,69 +193,21 @@ export async function uploadMediaFile(
   publicUrl?: string;
   error?: string;
 }> {
-  const allowedExtensions = [
-    "jpg",
-    "jpeg",
-    "png",
-    "gif",
-    "svg",
-    "webp",
-    "avif",
-    "mp4",
-    "webm",
-    "mov",
-  ];
-
-  const parts = filename.split(".");
-  const ext = parts.pop()?.toLowerCase();
-  const baseName = parts.join(".").replace(/[^a-zA-Z0-9.-]/g, "-") || "file";
-
-  if (!ext || !allowedExtensions.includes(ext)) {
+  const resolvedPath = await resolveUploadPath(supabase, { filename, folder });
+  if (!resolvedPath.success) {
     return {
       success: false,
-      error: "Invalid file type. Only images and videos are allowed.",
+      error: resolvedPath.error,
     };
-  }
-
-  let finalFilename = `${baseName}.${ext}`;
-  let path = folder ? `${folder}/${finalFilename}` : finalFilename;
-
-  const { data: existingFiles } = await supabase.storage
-    .from(BUCKET_NAME)
-    .list(folder || undefined, { limit: 1000 });
-
-  if (existingFiles) {
-    const existingNames = new Set(existingFiles.map((f) => f.name));
-    let counter = 1;
-
-    while (existingNames.has(finalFilename)) {
-      finalFilename = `${baseName}-${counter}.${ext}`;
-      counter++;
-    }
-
-    path = folder ? `${folder}/${finalFilename}` : finalFilename;
   }
 
   try {
     const fileBuffer = Buffer.from(content, "base64");
 
-    const mimeTypes: Record<string, string> = {
-      jpg: "image/jpeg",
-      jpeg: "image/jpeg",
-      png: "image/png",
-      gif: "image/gif",
-      svg: "image/svg+xml",
-      webp: "image/webp",
-      avif: "image/avif",
-      mp4: "video/mp4",
-      webm: "video/webm",
-      mov: "video/quicktime",
-    };
-
     const { error } = await supabase.storage
-      .from(BUCKET_NAME)
-      .upload(path, fileBuffer, {
-        contentType: mimeTypes[ext] || "application/octet-stream",
+      .from(MEDIA_BUCKET_NAME)
+      .upload(resolvedPath.path, fileBuffer, {
+        contentType: resolvedPath.contentType,
         upsert: false,
       });
 
@@ -168,10 +215,12 @@ export async function uploadMediaFile(
       return { success: false, error: error.message };
     }
 
-    const { data } = supabase.storage.from(BUCKET_NAME).getPublicUrl(path);
+    const { data } = supabase.storage
+      .from(MEDIA_BUCKET_NAME)
+      .getPublicUrl(resolvedPath.path);
     return {
       success: true,
-      path,
+      path: resolvedPath.path,
       publicUrl: data.publicUrl,
     };
   } catch (error) {
@@ -182,6 +231,52 @@ export async function uploadMediaFile(
   }
 }
 
+export async function createSignedMediaUpload(
+  supabase: SupabaseClient,
+  params: {
+    filename?: string;
+    folder?: string;
+    path?: string;
+    upsert?: boolean;
+  },
+): Promise<{
+  success: boolean;
+  path?: string;
+  publicUrl?: string;
+  token?: string;
+  signedUrl?: string;
+  error?: string;
+}> {
+  const resolvedPath = await resolveUploadPath(supabase, params);
+  if (!resolvedPath.success) {
+    return {
+      success: false,
+      error: resolvedPath.error,
+    };
+  }
+
+  const { data, error } = await supabase.storage
+    .from(MEDIA_BUCKET_NAME)
+    .createSignedUploadUrl(resolvedPath.path, {
+      upsert: params.upsert ?? false,
+    });
+
+  if (error) {
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+
+  return {
+    success: true,
+    path: resolvedPath.path,
+    publicUrl: getPublicUrl(resolvedPath.path),
+    token: data.token,
+    signedUrl: data.signedUrl,
+  };
+}
+
 async function listAllFilesInFolder(
   supabase: SupabaseClient,
   folderPath: string,
@@ -189,7 +284,7 @@ async function listAllFilesInFolder(
   const allFiles: string[] = [];
 
   const { data } = await supabase.storage
-    .from(BUCKET_NAME)
+    .from(MEDIA_BUCKET_NAME)
     .list(folderPath, { limit: 1000 });
 
   if (!data) return allFiles;
@@ -219,7 +314,7 @@ export async function deleteMediaFiles(
   try {
     for (const path of paths) {
       const { data: folderContents } = await supabase.storage
-        .from(BUCKET_NAME)
+        .from(MEDIA_BUCKET_NAME)
         .list(path, { limit: 1 });
 
       const isFolder = folderContents && folderContents.length > 0;
@@ -229,7 +324,7 @@ export async function deleteMediaFiles(
 
         if (allFiles.length > 0) {
           const { error } = await supabase.storage
-            .from(BUCKET_NAME)
+            .from(MEDIA_BUCKET_NAME)
             .remove(allFiles);
 
           if (error) {
@@ -242,7 +337,7 @@ export async function deleteMediaFiles(
         }
       } else {
         const { data, error } = await supabase.storage
-          .from(BUCKET_NAME)
+          .from(MEDIA_BUCKET_NAME)
           .remove([path]);
 
         if (error) {
@@ -288,7 +383,7 @@ export async function createMediaFolder(
 
   try {
     const { data: existing } = await supabase.storage
-      .from(BUCKET_NAME)
+      .from(MEDIA_BUCKET_NAME)
       .list(folderPath, { limit: 1 });
 
     if (existing && existing.length > 0) {
@@ -296,7 +391,7 @@ export async function createMediaFolder(
     }
 
     const { error } = await supabase.storage
-      .from(BUCKET_NAME)
+      .from(MEDIA_BUCKET_NAME)
       .upload(placeholderPath, new Uint8Array(0), {
         contentType: "application/x-empty",
         upsert: false,
@@ -325,7 +420,7 @@ export async function moveMediaFile(
 ): Promise<{ success: boolean; newPath?: string; error?: string }> {
   try {
     const { data: folderContents } = await supabase.storage
-      .from(BUCKET_NAME)
+      .from(MEDIA_BUCKET_NAME)
       .list(fromPath, { limit: 1 });
 
     const isFolder = folderContents && folderContents.length > 0;
@@ -339,14 +434,14 @@ export async function moveMediaFile(
         const newFilePath = toPath + relativePath;
 
         const { error } = await supabase.storage
-          .from(BUCKET_NAME)
+          .from(MEDIA_BUCKET_NAME)
           .move(filePath, newFilePath);
 
         if (error) {
           if (movedFiles.length > 0) {
             for (const moved of movedFiles) {
               const { error: rollbackError } = await supabase.storage
-                .from(BUCKET_NAME)
+                .from(MEDIA_BUCKET_NAME)
                 .move(moved.to, moved.from);
               if (rollbackError) {
                 // Log or handle rollback failure
@@ -372,7 +467,7 @@ export async function moveMediaFile(
       };
     } else {
       const { error } = await supabase.storage
-        .from(BUCKET_NAME)
+        .from(MEDIA_BUCKET_NAME)
         .move(fromPath, toPath);
 
       if (error) {

--- a/apps/web/src/hooks/use-media-api.tsx
+++ b/apps/web/src/hooks/use-media-api.tsx
@@ -8,6 +8,8 @@ import {
 
 import { sonnerToast as toast } from "@hypr/ui/components/ui/toast";
 
+import { uploadMediaLibraryFile } from "@/functions/media-upload";
+
 type FileStatus = "pending" | "uploading" | "done" | "error";
 
 interface FileProgress {
@@ -89,24 +91,6 @@ export async function fetchMediaItems(path: string): Promise<MediaItem[]> {
     throw new Error(data.error || "Failed to fetch media");
   }
   return data.items;
-}
-
-async function uploadFile(params: {
-  filename: string;
-  content: string;
-  folder: string;
-}) {
-  const response = await fetch("/api/admin/media/upload", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(params),
-  });
-
-  if (!response.ok) {
-    const data = await response.json();
-    throw new Error(data.error || "Upload failed");
-  }
-  return response.json();
 }
 
 async function deleteFiles(paths: string[]) {
@@ -197,19 +181,8 @@ export function useMediaApi({
           fileProgress[i].status = "uploading";
           updateToast();
 
-          const reader = new FileReader();
-          const content = await new Promise<string>((resolve, reject) => {
-            reader.onload = () => {
-              const base64 = (reader.result as string).split(",")[1];
-              resolve(base64);
-            };
-            reader.onerror = reject;
-            reader.readAsDataURL(file);
-          });
-
-          await uploadFile({
-            filename: file.name,
-            content,
+          await uploadMediaLibraryFile({
+            file,
             folder: currentFolderPath,
           });
 
@@ -247,20 +220,10 @@ export function useMediaApi({
 
   const replaceMutation = useMutation({
     mutationFn: async (params: { file: File; path: string }) => {
-      const reader = new FileReader();
-      const content = await new Promise<string>((resolve, reject) => {
-        reader.onload = () => {
-          const base64 = (reader.result as string).split(",")[1];
-          resolve(base64);
-        };
-        reader.onerror = reject;
-        reader.readAsDataURL(params.file);
-      });
-
-      await uploadFile({
-        filename: params.file.name,
-        content,
-        folder: params.path.split("/").slice(0, -1).join("/"),
+      await uploadMediaLibraryFile({
+        file: params.file,
+        path: params.path,
+        upsert: true,
       });
     },
     onSuccess: () => {

--- a/apps/web/src/lib/media.ts
+++ b/apps/web/src/lib/media.ts
@@ -1,0 +1,78 @@
+export const MEDIA_BUCKET_NAME = "blog";
+
+const MEDIA_MIME_TYPES: Record<string, string> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  gif: "image/gif",
+  svg: "image/svg+xml",
+  webp: "image/webp",
+  avif: "image/avif",
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime",
+};
+
+const MIME_TYPE_EXTENSIONS: Record<string, string> = {
+  jpeg: "jpg",
+  jpg: "jpg",
+  png: "png",
+  gif: "gif",
+  webp: "webp",
+  svg: "svg",
+  "svg+xml": "svg",
+  avif: "avif",
+};
+
+export interface Base64Image {
+  fullMatch: string;
+  mimeType: string;
+  base64Data: string;
+  dataUrl: string;
+}
+
+export function extractBase64Images(markdown: string): Base64Image[] {
+  const regex = /!\[[^\]]*\]\((data:image\/([^;]+);base64,([^)]+))\)/g;
+  const images: Base64Image[] = [];
+  let match;
+
+  while ((match = regex.exec(markdown)) !== null) {
+    images.push({
+      fullMatch: match[0],
+      mimeType: match[2],
+      base64Data: match[3],
+      dataUrl: match[1],
+    });
+  }
+
+  return images;
+}
+
+export function extractSlugFromPath(path: string): string {
+  const filename = path.split("/").pop() || "";
+  return filename.replace(/\.mdx$/, "");
+}
+
+export function getExtensionFromMimeType(mimeType: string): string {
+  return MIME_TYPE_EXTENSIONS[mimeType] || "png";
+}
+
+export function getMimeTypeFromExtension(extension: string): string {
+  return MEDIA_MIME_TYPES[extension] || "application/octet-stream";
+}
+
+export function parseMediaFilename(filename: string) {
+  const parts = filename.split(".");
+  const extension = parts.pop()?.toLowerCase();
+  const baseName = parts.join(".").replace(/[^a-zA-Z0-9.-]/g, "-") || "file";
+
+  if (!extension || !(extension in MEDIA_MIME_TYPES)) {
+    return null;
+  }
+
+  return {
+    extension,
+    baseName,
+    filename: `${baseName}.${extension}`,
+  };
+}

--- a/apps/web/src/routes/admin/README.md
+++ b/apps/web/src/routes/admin/README.md
@@ -74,14 +74,14 @@ All API endpoints require admin authentication (bypassed in development mode).
 ### Media APIs
 
 - `GET /api/admin/media/list` - List files in a directory
-- `POST /api/admin/media/upload` - Upload files (base64 content)
+- `POST /api/admin/media/upload` - Generate signed uploads for media files
 - `POST /api/admin/media/delete` - Delete files (batch)
 - `POST /api/admin/media/move` - Move/rename files
 - `POST /api/admin/media/create-folder` - Create folders
 
 ### Blog APIs
 
-- `POST /api/admin/blog/upload-image` - Upload images for blog posts to Supabase Storage
+- `POST /api/admin/blog/upload-image` - Generate signed uploads for blog images
 
 ### Import APIs
 

--- a/apps/web/src/routes/admin/collections/index.tsx
+++ b/apps/web/src/routes/admin/collections/index.tsx
@@ -65,6 +65,10 @@ import BlogEditor, { useBlogEditor } from "@/components/admin/blog-editor";
 import { MediaSelectorModal } from "@/components/admin/media-selector-modal";
 import { defaultMDXComponents } from "@/components/mdx";
 import { fetchGitHubCredentials } from "@/functions/admin";
+import {
+  uploadBlogImageFile,
+  uploadInlineMarkdownImages,
+} from "@/functions/media-upload";
 import { AUTHORS } from "@/lib/team";
 
 interface ContentItem {
@@ -1249,32 +1253,53 @@ function ContentPanel({
   const [isPreviewMode, setIsPreviewMode] = useState(false);
   const [editorData, setEditorData] = useState<EditorData | null>(null);
   const fileEditorRef = useRef<{ save: () => void } | null>(null);
+  const queryClient = useQueryClient();
 
-  const { mutate: saveContent, isPending: isSaving } = useMutation({
-    mutationFn: async (params: {
+  const saveArticle = useCallback(
+    async (params: {
       path: string;
       content: string;
       metadata: ArticleMetadata;
       branch?: string;
       isAutoSave?: boolean;
     }) => {
+      const processedContent = await uploadInlineMarkdownImages({
+        content: params.content,
+        path: params.path,
+      });
+
       const response = await fetch("/api/admin/content/save", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(params),
+        body: JSON.stringify({
+          ...params,
+          content: processedContent,
+        }),
       });
+
       if (!response.ok) {
         const error = await response.json();
         throw new Error(error.error || "Failed to save");
       }
+
       return response.json();
     },
+    [],
+  );
+
+  const { mutate: saveContent, isPending: isSaving } = useMutation({
+    mutationFn: saveArticle,
     onSuccess: (data, variables) => {
       if (data.branchName) {
         queryClient.invalidateQueries({
           queryKey: ["pendingPR", variables.path],
         });
       }
+    },
+    onError: (error) => {
+      sonnerToast.error("Save failed", {
+        description: error.message,
+      });
     },
   });
 
@@ -1315,8 +1340,6 @@ function ContentPanel({
     staleTime: 60000,
   });
 
-  const queryClient = useQueryClient();
-
   const { mutate: publish, isPending: isPublishing } = useMutation({
     mutationFn: async (params: {
       path: string;
@@ -1324,21 +1347,7 @@ function ContentPanel({
       metadata: ArticleMetadata;
       branch?: string;
     }) => {
-      const saveResponse = await fetch("/api/admin/content/save", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          path: params.path,
-          content: params.content,
-          metadata: params.metadata,
-          branch: params.branch,
-        }),
-      });
-      if (!saveResponse.ok) {
-        const error = await saveResponse.json();
-        throw new Error(error.error || "Failed to save");
-      }
-      const saveResult = await saveResponse.json();
+      const saveResult = await saveArticle(params);
 
       if (saveResult.prUrl) {
         return { prUrl: saveResult.prUrl as string };
@@ -2726,35 +2735,8 @@ const FileEditor = React.forwardRef<
 
   const handleImageUpload = useCallback(
     async (file: File): Promise<{ url: string; attachmentId: string }> => {
-      const reader = new FileReader();
-      return new Promise((resolve, reject) => {
-        reader.onload = async () => {
-          try {
-            const base64 = (reader.result as string).split(",")[1];
-            const response = await fetch("/api/admin/blog/upload-image", {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({
-                filename: file.name,
-                content: base64,
-              }),
-            });
-
-            if (!response.ok) {
-              throw new Error("Upload failed");
-            }
-
-            const data = await response.json();
-            resolve({ url: data.url, attachmentId: "" });
-          } catch (error) {
-            reject(error);
-          }
-        };
-        reader.onerror = () => reject(reader.error);
-        reader.readAsDataURL(file);
-      });
+      const result = await uploadBlogImageFile({ file });
+      return { url: result.publicUrl, attachmentId: "" };
     },
     [],
   );

--- a/apps/web/src/routes/api/admin/blog/upload-image.ts
+++ b/apps/web/src/routes/api/admin/blog/upload-image.ts
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { fetchAdminUser } from "@/functions/admin";
 import { getSupabaseServerClient } from "@/functions/supabase";
-import { uploadMediaFile } from "@/functions/supabase-media";
+import { createSignedMediaUpload } from "@/functions/supabase-media";
 
 export const Route = createFileRoute("/api/admin/blog/upload-image")({
   server: {
@@ -19,7 +19,7 @@ export const Route = createFileRoute("/api/admin/blog/upload-image")({
           }
         }
 
-        let body: { filename: string; content: string };
+        let body: { filename: string; folder?: string };
         try {
           body = await request.json();
         } catch {
@@ -29,12 +29,12 @@ export const Route = createFileRoute("/api/admin/blog/upload-image")({
           });
         }
 
-        const { filename, content } = body;
+        const { filename, folder } = body;
 
-        if (!filename || !content) {
+        if (!filename) {
           return new Response(
             JSON.stringify({
-              error: "Missing required fields: filename, content",
+              error: "Missing required field: filename",
             }),
             {
               status: 400,
@@ -44,12 +44,10 @@ export const Route = createFileRoute("/api/admin/blog/upload-image")({
         }
 
         const supabase = getSupabaseServerClient();
-        const result = await uploadMediaFile(
-          supabase,
+        const result = await createSignedMediaUpload(supabase, {
           filename,
-          content,
-          "blog",
-        );
+          folder: folder || "blog",
+        });
 
         if (!result.success) {
           return new Response(JSON.stringify({ error: result.error }), {
@@ -60,8 +58,10 @@ export const Route = createFileRoute("/api/admin/blog/upload-image")({
 
         return new Response(
           JSON.stringify({
-            success: true,
-            url: result.publicUrl,
+            path: result.path,
+            publicUrl: result.publicUrl,
+            token: result.token,
+            signedUrl: result.signedUrl,
           }),
           {
             status: 200,

--- a/apps/web/src/routes/api/admin/content/publish.ts
+++ b/apps/web/src/routes/api/admin/content/publish.ts
@@ -6,8 +6,7 @@ import {
   publishArticle,
   updateContentFileOnBranch,
 } from "@/functions/github-content";
-import { getSupabaseServerClient } from "@/functions/supabase";
-import { uploadMediaFile } from "@/functions/supabase-media";
+import { extractBase64Images } from "@/lib/media";
 
 interface ArticleMetadata {
   meta_title?: string;
@@ -65,62 +64,14 @@ export const Route = createFileRoute("/api/admin/content/publish")({
         }
 
         if (content !== undefined && metadata) {
-          let processedContent = content;
-
-          const base64ImageRegex =
-            /!\[[^\]]*\]\((data:image\/([^;]+);base64,([^)]+))\)/g;
-          const base64Images: Array<{
-            fullMatch: string;
-            mimeType: string;
-            base64Data: string;
-          }> = [];
-          let match;
-          while ((match = base64ImageRegex.exec(content)) !== null) {
-            base64Images.push({
-              fullMatch: match[0],
-              mimeType: match[2],
-              base64Data: match[3],
-            });
-          }
-
-          if (base64Images.length > 0) {
-            const supabase = getSupabaseServerClient();
-            const slug =
-              path
-                .split("/")
-                .pop()
-                ?.replace(/\.mdx$/, "") || "";
-            const folder = `articles/${slug}`;
-            const extensionMap: Record<string, string> = {
-              jpeg: "jpg",
-              jpg: "jpg",
-              png: "png",
-              gif: "gif",
-              webp: "webp",
-              svg: "svg",
-              "svg+xml": "svg",
-              avif: "avif",
-            };
-
-            for (let i = 0; i < base64Images.length; i++) {
-              const image = base64Images[i];
-              const extension = extensionMap[image.mimeType] || "png";
-              const filename = `image-${i + 1}.${extension}`;
-
-              const uploadResult = await uploadMediaFile(
-                supabase,
-                filename,
-                image.base64Data,
-                folder,
-              );
-
-              if (uploadResult.success && uploadResult.publicUrl) {
-                processedContent = processedContent.replace(
-                  image.fullMatch,
-                  `![](${uploadResult.publicUrl})`,
-                );
-              }
-            }
+          if (extractBase64Images(content).length > 0) {
+            return new Response(
+              JSON.stringify({
+                error:
+                  "Inline base64 images must be uploaded before publishing",
+              }),
+              { status: 400, headers: { "Content-Type": "application/json" } },
+            );
           }
 
           const frontmatterObj: Record<string, unknown> = {};
@@ -139,7 +90,7 @@ export const Route = createFileRoute("/api/admin/content/publish")({
           if (metadata.category) frontmatterObj.category = metadata.category;
 
           const frontmatter = `---\n${yaml.dump(frontmatterObj, { quotingType: '"', forceQuotes: true, lineWidth: -1 })}---`;
-          const fullContent = `${frontmatter}\n\n${processedContent}`;
+          const fullContent = `${frontmatter}\n\n${content}`;
 
           const saveResult = await updateContentFileOnBranch(
             path,

--- a/apps/web/src/routes/api/admin/content/save.ts
+++ b/apps/web/src/routes/api/admin/content/save.ts
@@ -5,8 +5,7 @@ import {
   savePublishedArticleToBranch,
   updateContentFileOnBranch,
 } from "@/functions/github-content";
-import { getSupabaseServerClient } from "@/functions/supabase";
-import { uploadMediaFile } from "@/functions/supabase-media";
+import { extractBase64Images } from "@/lib/media";
 
 interface ArticleMetadata {
   meta_title?: string;
@@ -65,47 +64,6 @@ function buildFrontmatter(metadata: ArticleMetadata): string {
   return `---\n${lines.join("\n")}\n---\n`;
 }
 
-interface Base64Image {
-  fullMatch: string;
-  mimeType: string;
-  base64Data: string;
-}
-
-export function extractBase64Images(markdown: string): Base64Image[] {
-  const regex = /!\[[^\]]*\]\((data:image\/([^;]+);base64,([^)]+))\)/g;
-  const images: Base64Image[] = [];
-  let match;
-
-  while ((match = regex.exec(markdown)) !== null) {
-    images.push({
-      fullMatch: match[0],
-      mimeType: match[2],
-      base64Data: match[3],
-    });
-  }
-
-  return images;
-}
-
-export function getExtensionFromMimeType(mimeType: string): string {
-  const extensionMap: Record<string, string> = {
-    jpeg: "jpg",
-    jpg: "jpg",
-    png: "png",
-    gif: "gif",
-    webp: "webp",
-    svg: "svg",
-    "svg+xml": "svg",
-    avif: "avif",
-  };
-  return extensionMap[mimeType] || "png";
-}
-
-function extractSlugFromPath(path: string): string {
-  const filename = path.split("/").pop() || "";
-  return filename.replace(/\.mdx$/, "");
-}
-
 export const Route = createFileRoute("/api/admin/content/save")({
   server: {
     handlers: {
@@ -142,37 +100,17 @@ export const Route = createFileRoute("/api/admin/content/save")({
           );
         }
 
-        let processedContent = content;
-
-        const base64Images = extractBase64Images(content);
-        if (base64Images.length > 0) {
-          const supabase = getSupabaseServerClient();
-          const slug = extractSlugFromPath(path);
-          const folder = `articles/${slug}`;
-
-          for (let i = 0; i < base64Images.length; i++) {
-            const image = base64Images[i];
-            const extension = getExtensionFromMimeType(image.mimeType);
-            const filename = `image-${i + 1}.${extension}`;
-
-            const uploadResult = await uploadMediaFile(
-              supabase,
-              filename,
-              image.base64Data,
-              folder,
-            );
-
-            if (uploadResult.success && uploadResult.publicUrl) {
-              processedContent = processedContent.replace(
-                image.fullMatch,
-                `![](${uploadResult.publicUrl})`,
-              );
-            }
-          }
+        if (extractBase64Images(content).length > 0) {
+          return new Response(
+            JSON.stringify({
+              error: "Inline base64 images must be uploaded before saving",
+            }),
+            { status: 400, headers: { "Content-Type": "application/json" } },
+          );
         }
 
         const frontmatter = buildFrontmatter(metadata);
-        const fullContent = `${frontmatter}\n${processedContent}`;
+        const fullContent = `${frontmatter}\n${content}`;
 
         // If there's no branch, the article is on main, so create a PR (handles branch protection)
         // Otherwise, save directly to the draft branch

--- a/apps/web/src/routes/api/admin/import/google-docs.ts
+++ b/apps/web/src/routes/api/admin/import/google-docs.ts
@@ -8,8 +8,7 @@ import { getExtensions, json2md } from "@hypr/tiptap/shared";
 import { fetchAdminUser } from "@/functions/admin";
 import { getSupabaseServerClient } from "@/functions/supabase";
 import { uploadMediaFile } from "@/functions/supabase-media";
-
-import { getExtensionFromMimeType } from "../content/save";
+import { getExtensionFromMimeType } from "@/lib/media";
 
 interface ImportRequest {
   url: string;

--- a/apps/web/src/routes/api/admin/media/upload.ts
+++ b/apps/web/src/routes/api/admin/media/upload.ts
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { fetchAdminUser } from "@/functions/admin";
 import { getSupabaseServerClient } from "@/functions/supabase";
-import { uploadMediaFile } from "@/functions/supabase-media";
+import { createSignedMediaUpload } from "@/functions/supabase-media";
 
 export const Route = createFileRoute("/api/admin/media/upload")({
   server: {
@@ -19,7 +19,12 @@ export const Route = createFileRoute("/api/admin/media/upload")({
           }
         }
 
-        let body: { filename: string; content: string; folder?: string };
+        let body: {
+          filename?: string;
+          folder?: string;
+          path?: string;
+          upsert?: boolean;
+        };
         try {
           body = await request.json();
         } catch {
@@ -29,12 +34,12 @@ export const Route = createFileRoute("/api/admin/media/upload")({
           });
         }
 
-        const { filename, content, folder } = body;
+        const { filename, folder, path, upsert } = body;
 
-        if (!filename || !content) {
+        if (!filename && !path) {
           return new Response(
             JSON.stringify({
-              error: "Missing required fields: filename, content",
+              error: "Missing required field: filename or path",
             }),
             {
               status: 400,
@@ -44,12 +49,12 @@ export const Route = createFileRoute("/api/admin/media/upload")({
         }
 
         const supabase = getSupabaseServerClient();
-        const result = await uploadMediaFile(
-          supabase,
+        const result = await createSignedMediaUpload(supabase, {
           filename,
-          content,
-          folder || "",
-        );
+          folder,
+          path,
+          upsert,
+        });
 
         if (!result.success) {
           return new Response(JSON.stringify({ error: result.error }), {
@@ -60,9 +65,10 @@ export const Route = createFileRoute("/api/admin/media/upload")({
 
         return new Response(
           JSON.stringify({
-            success: true,
             path: result.path,
             publicUrl: result.publicUrl,
+            token: result.token,
+            signedUrl: result.signedUrl,
           }),
           {
             status: 200,


### PR DESCRIPTION
## Why

Admin blog and media uploads were base64-encoding files and sending them through Netlify functions. Large GIFs could exceed Netlify's request body limit, so uploads failed before they ever reached Supabase Storage.

## What changed

- move blog editor image uploads to signed direct-to-Supabase uploads from the browser
- change `/api/admin/blog/upload-image` and `/api/admin/media/upload` to only mint signed upload metadata instead of accepting file bodies
- add shared client/server helpers for storage path resolution and signed upload execution
- pre-upload inline `data:image/...` markdown images before `/api/admin/content/save`
- make `save` and `publish` reject leftover inline base64 so the contract stays explicit
- route media library uploads and replace flows through the same signed upload path

## Outcome

Admin uploads no longer depend on Netlify request body size for the actual file transfer. Large GIFs now go directly from the client to Supabase Storage, while the server only authorizes the upload and returns the final storage metadata.

## Validation

- ran `pnpm exec dprint fmt` on the touched files
- ran `pnpm -F @hypr/web exec tsc --project tsconfig.json --noEmit`

## Known issue

- `pnpm -r typecheck` still fails in the existing `@hypr/web` build/prerender step because prerender tries to fetch `127.0.0.1:63384` and times out