### PR TITLE
fix: correct grammar in user tip message

### DIFF
--- a/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
@@ -53,7 +53,7 @@ export function StreamingView({ enhancedNoteId }: { enhancedNoteId: string }) {
   );
 }
 
-const TIPS = ["Char team love our users!"];
+const TIPS = ["The Char team loves our users!"];
 
 function RotatingTip() {
   const [index, setIndex] = useState(() =>


### PR DESCRIPTION
Fix grammatical error in the rotating tip text by changing "Char team love" to "The Char team loves" to ensure proper subject-verb agreement and article usage.