### PR TITLE
feat: improve meeting section generation guidelines

### DIFF
--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-workflow.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-workflow.ts
@@ -171,6 +171,9 @@ function createTemplatePrompt(
   return `Analyze this meeting content and suggest appropriate section headings for a comprehensive summary.
   The sections should cover the main themes and topics discussed.
   Generate around 5-7 sections based on the content depth.
+  Avoid generic catch-all headings like "Overview", "Meeting Overview", "Introduction", "Summary", or "Participants".
+  Prefer concrete, topic-specific section titles tied to the actual discussion.
+  Do not create a standalone participants section unless the meeting materially focused on stakeholder roles, ownership, or org structure.
   Give me in bullet points.
 
   Content:

--- a/crates/template-app/assets/enhance.system.md.jinja
+++ b/crates/template-app/assets/enhance.system.md.jinja
@@ -30,6 +30,7 @@ You are an expert at creating structured, comprehensive meeting summaries in {{ 
 
 - Notes and transcript may contain errors made by human and STT, respectively. Make the best out of every material.
 - Do not include meeting note title, attendee lists nor explanatory notes about the output structure.
+- Do not create generic opening sections such as "Overview", "Meeting Overview", "Introduction", or "Participants" unless the meeting itself was explicitly about those topics.
 - Use Pre-Meeting Notes to understand the user's intent and agenda. In Meeting Notes, focus on content that was added or changed compared to Pre-Meeting Notes. Naturally integrate entries into relevant sections instead of forcefully converting them into headers.
 - Preserve essential details; avoid excessive abstraction. Ensure content remains concrete and specific.
 - Pay close attention to emphasized text in notes. Users highlight information using four styles: bold(**text**), italic(_text_), underline(<u>text</u>), strikethrough(~~text~~).


### PR DESCRIPTION
Add specific instructions to avoid generic section headings like "Overview" or "Participants" in meeting summaries.
Update both system prompt and workflow config to prefer concrete, topic-specific titles that reflect actual discussion content rather than structural placeholders.