### PR TITLE
extract hot data types for store singletons to fix ci error

### DIFF
--- a/apps/desktop/src/store/zustand/listener/instance.ts
+++ b/apps/desktop/src/store/zustand/listener/instance.ts
@@ -1,6 +1,9 @@
 import { createListenerStore } from "./index";
 
 type ListenerStoreSingleton = ReturnType<typeof createListenerStore>;
+type ListenerHotData = {
+  [LISTENER_STORE_KEY]?: ListenerStoreSingleton;
+};
 
 const LISTENER_STORE_KEY = "__hypr_listener_store__" as const;
 
@@ -9,9 +12,7 @@ const getListenerStore = (): ListenerStoreSingleton => {
     return createListenerStore();
   }
 
-  const hotData = (import.meta.hot.data ?? {}) as {
-    [LISTENER_STORE_KEY]?: ListenerStoreSingleton;
-  };
+  const hotData = import.meta.hot.data as ListenerHotData;
 
   if (!hotData[LISTENER_STORE_KEY]) {
     hotData[LISTENER_STORE_KEY] = createListenerStore();

--- a/apps/desktop/src/store/zustand/tabs/index.ts
+++ b/apps/desktop/src/store/zustand/tabs/index.ts
@@ -60,6 +60,9 @@ type Actions = BasicActions &
 type Store = State & Actions;
 
 type TabsStoreSingleton = ReturnType<typeof createTabsStore>;
+type TabsHotData = {
+  [TABS_STORE_KEY]?: TabsStoreSingleton;
+};
 
 const TABS_STORE_KEY = "__hypr_tabs_store__" as const;
 
@@ -104,9 +107,7 @@ const getTabsStore = (): TabsStoreSingleton => {
     return createTabsStore();
   }
 
-  const hotData = (import.meta.hot.data ?? {}) as {
-    [TABS_STORE_KEY]?: TabsStoreSingleton;
-  };
+  const hotData = import.meta.hot.data as TabsHotData;
 
   if (!hotData[TABS_STORE_KEY]) {
     hotData[TABS_STORE_KEY] = createTabsStore();


### PR DESCRIPTION
Extract inline type annotations for hot module replacement data into named type definitions. Replace inline type assertions with proper type definitions for TabsHotData and ListenerHotData to improve code readability and maintainability in the Zustand store singleton pattern.