### PR TITLE
fix: refresh content admin drafts after post creation

### DIFF
--- a/apps/web/src/routes/admin/collections/index.tsx
+++ b/apps/web/src/routes/admin/collections/index.tsx
@@ -100,6 +100,8 @@ interface CollectionInfo {
   items: ContentItem[];
 }
 
+const DRAFT_ARTICLES_QUERY_KEY = ["draftArticles"];
+
 interface Tab {
   id: string;
   type: "collection" | "file";
@@ -256,6 +258,19 @@ export const Route = createFileRoute("/admin/collections/")({
   component: CollectionsPage,
 });
 
+async function fetchDraftArticles() {
+  const response = await fetch("/api/admin/content/list-drafts", {
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch drafts");
+  }
+
+  const data = await response.json();
+  return data.drafts as DraftArticle[];
+}
+
 function getFileExtension(filename: string): string {
   const parts = filename.split(".");
   return parts.length > 1 ? parts.pop()?.toLowerCase() || "" : "";
@@ -265,15 +280,8 @@ function CollectionsPage() {
   const queryClient = useQueryClient();
 
   const { data: draftArticles = [] } = useQuery({
-    queryKey: ["draftArticles"],
-    queryFn: async () => {
-      const response = await fetch("/api/admin/content/list-drafts");
-      if (!response.ok) {
-        throw new Error("Failed to fetch drafts");
-      }
-      const data = await response.json();
-      return data.drafts as DraftArticle[];
-    },
+    queryKey: DRAFT_ARTICLES_QUERY_KEY,
+    queryFn: fetchDraftArticles,
     staleTime: 30000,
   });
 
@@ -297,7 +305,10 @@ function CollectionsPage() {
     }
     draftSyncTimerRef.current = setTimeout(() => {
       draftSyncTimerRef.current = null;
-      queryClient.invalidateQueries({ queryKey: ["draftArticles"] });
+      void queryClient.refetchQueries({
+        queryKey: DRAFT_ARTICLES_QUERY_KEY,
+        type: "active",
+      });
     }, 5000);
   }, [queryClient]);
 
@@ -321,14 +332,21 @@ function CollectionsPage() {
     onSuccess: (data, variables) => {
       setEditingItem(null);
       if (data.branch && variables.type === "file") {
-        const slug = variables.name.replace(/\.mdx$/, "");
+        const path = data.path || `${variables.folder}/${variables.name}`;
+        const name = path.split("/").pop() || variables.name;
+        const slug = name.replace(/\.mdx$/, "");
         queryClient.setQueryData(
-          ["draftArticles"],
+          DRAFT_ARTICLES_QUERY_KEY,
           (old: DraftArticle[] = []) => [
-            ...old,
+            ...old.filter(
+              (draft) =>
+                draft.branch !== data.branch &&
+                draft.path !== path &&
+                draft.slug !== slug,
+            ),
             {
-              name: variables.name,
-              path: `${variables.folder}/${variables.name}`,
+              name,
+              path,
               slug,
               branch: data.branch,
             },
@@ -336,7 +354,9 @@ function CollectionsPage() {
         );
         scheduleDraftSync();
       } else {
-        queryClient.invalidateQueries({ queryKey: ["draftArticles"] });
+        void queryClient.invalidateQueries({
+          queryKey: DRAFT_ARTICLES_QUERY_KEY,
+        });
       }
     },
   });
@@ -384,7 +404,9 @@ function CollectionsPage() {
         }
         return filtered;
       });
-      queryClient.invalidateQueries({ queryKey: ["draftArticles"] });
+      void queryClient.invalidateQueries({
+        queryKey: DRAFT_ARTICLES_QUERY_KEY,
+      });
     },
   });
 

--- a/apps/web/src/routes/api/admin/content/list-drafts.ts
+++ b/apps/web/src/routes/api/admin/content/list-drafts.ts
@@ -18,6 +18,11 @@ interface DraftArticle {
   ready_for_review?: boolean;
 }
 
+const NO_STORE_HEADERS = {
+  "Content-Type": "application/json",
+  "Cache-Control": "no-store",
+};
+
 export const Route = createFileRoute("/api/admin/content/list-drafts")({
   server: {
     handlers: {
@@ -28,7 +33,7 @@ export const Route = createFileRoute("/api/admin/content/list-drafts")({
           if (!user?.isAdmin) {
             return new Response(JSON.stringify({ error: "Unauthorized" }), {
               status: 401,
-              headers: { "Content-Type": "application/json" },
+              headers: NO_STORE_HEADERS,
             });
           }
         }
@@ -42,7 +47,7 @@ export const Route = createFileRoute("/api/admin/content/list-drafts")({
               }),
               {
                 status: 500,
-                headers: { "Content-Type": "application/json" },
+                headers: NO_STORE_HEADERS,
               },
             );
           }
@@ -81,14 +86,14 @@ export const Route = createFileRoute("/api/admin/content/list-drafts")({
 
           return new Response(JSON.stringify({ drafts }), {
             status: 200,
-            headers: { "Content-Type": "application/json" },
+            headers: NO_STORE_HEADERS,
           });
         } catch (err) {
           return new Response(
             JSON.stringify({
               error: (err as Error).message,
             }),
-            { status: 500, headers: { "Content-Type": "application/json" } },
+            { status: 500, headers: NO_STORE_HEADERS },
           );
         }
       },


### PR DESCRIPTION
Disable caching for the draft list on both the client fetch and API response. Use the server-returned draft path and branch when updating the query cache, then refetch active draft queries to reconcile state so new posts appear immediately without a manual page refresh.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #4527 
- <kbd>&nbsp;2&nbsp;</kbd> #4526 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #4525 
<!-- GitButler Footer Boundary Bottom -->

