### PR TITLE
fix(ui): align SelectTrigger text to left

### DIFF
--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -220,7 +220,7 @@ export function SelectProviderAndModel() {
                   >
                     <SelectTrigger
                       className={cn([
-                        "bg-white shadow-none focus:ring-0",
+                        "bg-white text-left shadow-none focus:ring-0",
                         "[&>span]:flex [&>span]:w-full [&>span]:items-center [&>span]:justify-between [&>span]:gap-2",
                         isConfigured && "[&>svg:last-child]:hidden",
                       ])}


### PR DESCRIPTION
Add text-left class to SelectTrigger to ensure proper text alignment in the STT provider selection dropdown component.