### PR TITLE
UI: fixes for font sizes in note previews

### DIFF
--- a/apps/desktop/src/session/components/session-preview-card.tsx
+++ b/apps/desktop/src/session/components/session-preview-card.tsx
@@ -20,7 +20,30 @@ import {
   useEnhancedNotes,
 } from "~/session/hooks/useEnhancedNotes";
 import * as main from "~/store/tinybase/store/main";
-import { useTabs } from "~/store/zustand/tabs";
+
+const previewCardComponents: typeof streamdownComponents = {
+  ...streamdownComponents,
+  h1: (props) => (
+    <h1 className="text-md mt-3 mb-1 font-semibold first:mt-0">
+      {props.children}
+    </h1>
+  ),
+  h2: (props) => (
+    <h2 className="mt-3 mb-1 text-sm font-semibold first:mt-0">
+      {props.children}
+    </h2>
+  ),
+  h3: (props) => (
+    <h3 className="mt-2 mb-1 text-xs font-semibold first:mt-0">
+      {props.children}
+    </h3>
+  ),
+  h4: (props) => (
+    <h4 className="mt-2 mb-1 text-xs font-semibold first:mt-0">
+      {props.children}
+    </h4>
+  ),
+};
 
 const MAX_PREVIEW_LENGTH = 200;
 const FOLLOW_RANGE = 16;
@@ -225,9 +248,6 @@ export function SessionPreviewCard({
     dateDisplay,
     participantMappingIds,
   } = useSessionPreviewData(sessionId);
-  const hasPendingCloseConfirmation = useTabs(
-    (state) => state.pendingCloseConfirmationTab !== null,
-  );
 
   const followAxis = side === "right" ? "y" : "x";
   const { triggerRef, handleMouseMove, handleMouseLeave, style } =
@@ -250,7 +270,7 @@ export function SessionPreviewCard({
     setOpenDelay(isWarmedUp() ? OPEN_DELAY_WARM : OPEN_DELAY_COLD);
   }, []);
 
-  if (!enabled || hasPendingCloseConfirmation) {
+  if (!enabled) {
     return <>{children}</>;
   }
 
@@ -288,15 +308,10 @@ export function SessionPreviewCard({
 
           {(previewMarkdown || previewPlainText) && (
             <div className="mt-1 flex flex-col gap-1">
-              {previewLabel && (
-                <div className="text-xs font-medium text-neutral-400">
-                  {previewLabel}
-                </div>
-              )}
               <div className="max-h-24 overflow-hidden [mask-image:linear-gradient(to_bottom,black_60%,transparent)] text-neutral-600">
                 {previewMarkdown ? (
                   <Streamdown
-                    components={streamdownComponents}
+                    components={previewCardComponents}
                     className="flex flex-col text-xs"
                     isAnimating={false}
                   >


### PR DESCRIPTION
Current sizes of headers copied from Streamdown component.

I added rewrites for preview specifically

Before:
<img width="642" height="444" alt="CleanShot 2026-03-12 at 01 11 07@2x" src="https://github.com/user-attachments/assets/fd443e22-f2f6-4f37-9dde-2920e3c5fb07" />


after:
<img width="1192" height="530" alt="CleanShot 2026-03-12 at 01 11 29@2x" src="https://github.com/user-attachments/assets/45ec1f49-5e6b-48ea-ab24-810d26c8917a" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes to hover preview rendering and gating logic; no data, auth, or persistence paths are modified.
> 
> **Overview**
> Session hover preview cards now use a preview-specific `Streamdown` component map that overrides `h1`–`h4` styling to reduce header sizes and improve spacing in note previews.
> 
> The preview no longer blocks rendering based on tab close-confirmation state, and the optional `previewLabel` line is no longer displayed in the hover content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df3469d65d3e3e0d96d67cbf14775de45e9e24ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->