### PR TITLE
fix: emit html underline tags in tiptap markdown

### DIFF
--- a/packages/tiptap/src/shared/extensions/index.ts
+++ b/packages/tiptap/src/shared/extensions/index.ts
@@ -83,6 +83,57 @@ const AttachmentImage = Image.extend({
   },
 });
 
+const MarkdownUnderline = Underline.extend({
+  markdownTokenizer: {
+    name: "underline",
+    level: "inline",
+    start(src) {
+      const plusPlusIndex = src.indexOf("++");
+      const htmlIndex = src.indexOf("<u>");
+
+      if (plusPlusIndex === -1) {
+        return htmlIndex;
+      }
+
+      if (htmlIndex === -1) {
+        return plusPlusIndex;
+      }
+
+      return Math.min(plusPlusIndex, htmlIndex);
+    },
+    tokenize(src, _tokens, lexer) {
+      const plusPlusMatch = /^(\+\+)([\s\S]+?)(\+\+)/.exec(src);
+      if (plusPlusMatch) {
+        const innerContent = plusPlusMatch[2].trim();
+
+        return {
+          type: "underline",
+          raw: plusPlusMatch[0],
+          text: innerContent,
+          tokens: lexer.inlineTokens(innerContent),
+        };
+      }
+
+      const htmlMatch = /^(<u>)([\s\S]+?)(<\/u>)/.exec(src);
+      if (!htmlMatch) {
+        return undefined;
+      }
+
+      const innerContent = htmlMatch[2];
+
+      return {
+        type: "underline",
+        raw: htmlMatch[0],
+        text: innerContent,
+        tokens: lexer.inlineTokens(innerContent),
+      };
+    },
+  },
+  renderMarkdown(node, helpers) {
+    return `<u>${helpers.renderChildren(node)}</u>`;
+  },
+});
+
 const VALID_TLDS = new Set(tldList.map((t: string) => t.toLowerCase()));
 
 function isValidUrl(url: string): boolean {
@@ -116,7 +167,7 @@ export const getExtensions = (
     allowBase64: true,
     HTMLAttributes: { class: "tiptap-image" },
   }),
-  Underline,
+  MarkdownUnderline,
   Placeholder.configure({
     placeholder:
       placeholderComponent ??

--- a/packages/tiptap/src/shared/utils.test.ts
+++ b/packages/tiptap/src/shared/utils.test.ts
@@ -6,6 +6,26 @@ import { getExtensions } from "./extensions";
 import { isValidTiptapContent, json2md, md2json } from "./utils";
 
 describe("json2md", () => {
+  test("renders underline as html tags", () => {
+    const markdown = json2md({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "underlined",
+              marks: [{ type: "underline" }],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(markdown).toBe("<u>underlined</u>");
+  });
+
   test("renders task items without escaping brackets", () => {
     const taskListContent = {
       type: "doc",
@@ -123,6 +143,17 @@ describe("json2md", () => {
 });
 
 describe("md2json", () => {
+  test("converts html underline tags to underline marks", () => {
+    const json = md2json("<u>underlined</u>");
+    const paragraph = json.content?.[0];
+    const textNode = paragraph?.content?.[0];
+
+    expect(paragraph?.type).toBe("paragraph");
+    expect(textNode?.type).toBe("text");
+    expect(textNode?.text).toBe("underlined");
+    expect(textNode?.marks).toEqual([{ type: "underline" }]);
+  });
+
   describe("image handling", () => {
     test("converts standalone image to JSON", () => {
       const markdown = "![alt text](https://example.com/image.png)";


### PR DESCRIPTION
- serialize underline marks as <u>...</u> for downstream blog editor transforms
- parse both <u>...</u> and legacy ++...++ underline syntax into the same mark
- add markdown roundtrip coverage for underline serialization and parsing