### PR TITLE
docs: Replace highlight markup with underlines

### DIFF
--- a/apps/web/content/articles/meeting-productivity-tools.mdx
+++ b/apps/web/content/articles/meeting-productivity-tools.mdx
@@ -31,7 +31,7 @@ Let's get into it.
 
 Most AI meeting tools make the same trade: convenience in exchange for your data living in someone else's database, locked into their format, processed by their AI. Char doesn't make that trade.
 
-++[Char](https://char.com)++ (formerly Hyprnote) is an open-source AI notepad for meetings, built for people who want complete control over their files, their AI stack, and what happens to their data. 
+<u>[Char](https://char.com)</u> (formerly Hyprnote) is an open-source AI notepad for meetings, built for people who want complete control over their files, their AI stack, and what happens to their data. 
 
 Every meeting is saved as a plain .md file on your device. You choose which AI processes it. Nothing is locked behind Char's ecosystem.
 
@@ -70,7 +70,7 @@ Free with local transcription or bring-your-own API keys. Pro is $25/month for t
 
 ![](https://auth.hyprnote.com/storage/v1/object/public/blog/articles/meeting-productivity-tools/image-2-3.png)
 
-You share a link, the other person picks a time, it lands on both calendars. That's the premise, and ++[Calendly](https://calendly.com/)++ executes it cleanly. 
+You share a link, the other person picks a time, it lands on both calendars. That's the premise, and <u>[Calendly](https://calendly.com/)</u> executes it cleanly. 
 
 What makes it more than a booking page is how much complexity it absorbs underneath: multiple calendars, team routing, automated follow-ups, while the person booking sees nothing but a simple interface.
 
@@ -103,7 +103,7 @@ Free plan with one event type. Standard is $12/user/month, Teams is $20/user/mon
 
 ![](https://auth.hyprnote.com/storage/v1/object/public/blog/articles/meeting-productivity-tools/image-3-3.png)
 
-++[Grain](https://grain.com/)++ is a video-first AI note-taker that joins your meetings as a bot, records the video, transcribes it, and gives you a summary with chapters and action items.
+<u>[Grain](https://grain.com/)</u> is a video-first AI note-taker that joins your meetings as a bot, records the video, transcribes it, and gives you a summary with chapters and action items.
 
 #### Key Features
 
@@ -133,7 +133,7 @@ Free plan with unlimited recordings (one Notetaker seat). Starter is $19/user/mo
 
 ![](https://auth.hyprnote.com/storage/v1/object/public/blog/articles/meeting-productivity-tools/image-4-3.png)
 
-If you've ever watched someone share their screen, open a Google Doc, and spend 30 minutes trying to explain something that needed to be drawn, you understand what ++[Miro](https://miro.com/)++ solves. 
+If you've ever watched someone share their screen, open a Google Doc, and spend 30 minutes trying to explain something that needed to be drawn, you understand what <u>[Miro](https://miro.com/)</u> solves. 
 
 It's an infinite collaborative canvas, and the most capable digital replacement for a physical whiteboard that exists right now.
 
@@ -165,7 +165,7 @@ Free plan with three editable boards and unlimited collaborators. Starter is $8/
 
 ![](https://auth.hyprnote.com/storage/v1/object/public/blog/articles/meeting-productivity-tools/image-5-3.png)
 
-You can use every tool on this list correctly and still end up with a week that's wall-to-wall meetings and no time for actual work. That's where ++[Reclaim](https://reclaim.ai/)++ comes in. 
+You can use every tool on this list correctly and still end up with a week that's wall-to-wall meetings and no time for actual work. That's where <u>[Reclaim](https://reclaim.ai/)</u> comes in. 
 
 It sits on top of your Google Calendar or Outlook as an intelligent layer - you tell it your priorities (focus time, lunch, recurring 1:1s), and it finds the best times, marks them appropriately, and reshuffles lower-priority blocks when something more important needs the slot. Your calendar ends up reflecting what you actually want your week to look like.
 

--- a/apps/web/content/articles/otter-ai-review.mdx
+++ b/apps/web/content/articles/otter-ai-review.mdx
@@ -171,7 +171,7 @@ Organizations in regulated industries face particular risks. Individual employee
 
 Some IT security professionals have compared Otter's behavior to malware-like characteristics. Otter automatically sends workspace invitations to colleagues on users' behalf and shares meeting transcripts with external participants without explicit authorization. This can spread throughout organizations before users realize what's happening.
 
-For a detailed analysis of these security concerns and documented incidents, see ++[Is Otter AI Safe: What You Need to Know](https://char.com/blog/is-otter-ai-safe/)++.
+For a detailed analysis of these security concerns and documented incidents, see <u>[Is Otter AI Safe: What You Need to Know](https://char.com/blog/is-otter-ai-safe/)</u>.
 
 ## How much does Otter AI cost
 
@@ -304,7 +304,7 @@ Here's how Otter AI stacks up against competitors:
 | tl;dv            | Video-first teams                 | Free plan available. Paid from $29/user/month    | Unlimited video recordings & clips      |
 
 
-See ++[detailed reviews of all Otter AI competitors](https://char.com/blog/otter-ai-alternatives/)++.
+See <u>[detailed reviews of all Otter AI competitors](https://char.com/blog/otter-ai-alternatives/)</u>.
 
 ### What is the best Otter alternative?
 


### PR DESCRIPTION
Replace custom '++' highlight markup with standard HTML underline tags for better compatibility and consistency across Markdown processors in meeting productivity tools and Otter AI articles.