### PR TITLE
fix: surface admin post creation failures

### DIFF
--- a/apps/web/src/routes/admin/collections/index.tsx
+++ b/apps/web/src/routes/admin/collections/index.tsx
@@ -352,12 +352,20 @@ function CollectionsPage() {
             },
           ],
         );
+        openTab("file", name, path, data.branch);
+        setIsCreatingNewPost(false);
         scheduleDraftSync();
       } else {
+        setIsCreatingNewPost(false);
         void queryClient.invalidateQueries({
           queryKey: DRAFT_ARTICLES_QUERY_KEY,
         });
       }
+    },
+    onError: (error) => {
+      sonnerToast.error("Create failed", {
+        description: error.message,
+      });
     },
   });
 
@@ -561,7 +569,6 @@ function CollectionsPage() {
               name: `${slug}.mdx`,
               type: "file",
             });
-            setIsCreatingNewPost(false);
           }}
           onCancelNewPost={() => setIsCreatingNewPost(false)}
           editingItem={editingItem}


### PR DESCRIPTION
- keep the new post input open until creation succeeds
- show the server error when branch or file creation fails
- auto-open the newly created draft after a successful create