### PR TITLE
fix: improve admin content creation failure handling

### DIFF
--- a/apps/web/src/functions/github-content.ts
+++ b/apps/web/src/functions/github-content.ts
@@ -840,7 +840,18 @@ export async function getBranchSha(
     );
 
     if (!response.ok) {
-      return { success: false, error: `Branch not found: ${branchName}` };
+      let message = `GitHub API error: ${response.status}`;
+      try {
+        const error = await response.json();
+        if (typeof error?.message === "string" && error.message.length > 0) {
+          message = error.message;
+        }
+      } catch {}
+
+      return {
+        success: false,
+        error: `Failed to access branch ref "${branchName}" (${response.status}): ${message}`,
+      };
     }
 
     const data = await response.json();


### PR DESCRIPTION
- keep the new post input open until creation succeeds
- auto-open new drafts after a successful create
- surface the real GitHub ref lookup error instead of claiming main is missing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to error handling for GitHub branch ref lookups; main risk is slightly different error strings affecting any callers/tests relying on exact wording.
> 
> **Overview**
> Improves failure reporting in `getBranchSha` by extracting and returning the GitHub API’s error message (when available) and including the branch name and HTTP status, instead of always reporting the branch as missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31bf15d57313e2dac3a64c09cbc9029371332fb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->