### PR TITLE
fix: preserve animated gifs in blog content

### DIFF
--- a/apps/web/src/components/image.tsx
+++ b/apps/web/src/components/image.tsx
@@ -1,6 +1,14 @@
 import type { ImageProps } from "@unpic/react";
 import { Image as UnpicImage } from "@unpic/react/base";
+import type { ComponentProps } from "react";
 import { transform } from "unpic/providers/netlify";
+
+function isGifSource(src: ImageProps["src"]) {
+  return (
+    typeof src === "string" &&
+    (src.startsWith("data:image/gif") || /\.gif(?:$|[?#])/i.test(src))
+  );
+}
 
 export const Image = ({
   layout = "constrained",
@@ -12,6 +20,22 @@ export const Image = ({
   Pick<ImageProps, "src" | "alt"> & {
     objectFit?: "contain" | "cover" | "fill" | "none" | "scale-down";
   }) => {
+  if (isGifSource(src)) {
+    const imgProps = props as ComponentProps<"img">;
+
+    return (
+      <img
+        {...imgProps}
+        src={src}
+        alt={props.alt}
+        style={{
+          objectFit,
+          ...(imgProps.style || {}),
+        }}
+      />
+    );
+  }
+
   const isExternalUrl =
     typeof src === "string" &&
     (src.startsWith("http://") || src.startsWith("https://"));


### PR DESCRIPTION
- bypass image optimization for gif sources in the shared MDX image wrapper
- render gif assets as plain img tags so animation works in admin previews and published articles