### PR TITLE
fix: restore solid backgrounds for shared popup surfaces

### DIFF
--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -33,7 +33,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn([
-        "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 sm:rounded-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-[hsl(var(--background,0_0%_100%))] p-6 shadow-lg duration-200 sm:rounded-lg",
         className,
       ])}
       {...props}

--- a/packages/ui/src/components/ui/modal.tsx
+++ b/packages/ui/src/components/ui/modal.tsx
@@ -70,7 +70,7 @@ export function Modal({
         aria-modal="true"
         className={cn([
           "fixed top-1/2 left-1/2 z-100 -translate-x-1/2 -translate-y-1/2",
-          "bg-background overflow-clip rounded-lg shadow-lg",
+          "overflow-clip rounded-lg bg-[hsl(var(--background,0_0%_100%))] shadow-lg",
           sizeClasses[size],
           className,
         ])}


### PR DESCRIPTION
- add a white fallback for dialog content backgrounds when the background CSS token is unset
- apply the same fallback to the shared modal container to avoid transparent popup surfaces in web admin views