### PR TITLE
fix: restore admin delete modal styling

### DIFF
--- a/apps/web/src/routes/admin/collections/index.tsx
+++ b/apps/web/src/routes/admin/collections/index.tsx
@@ -418,6 +418,15 @@ function CollectionsPage() {
         queryKey: DRAFT_ARTICLES_QUERY_KEY,
       });
     },
+    onError: (error: unknown) => {
+      if (isAdminSignInRedirectError(error)) {
+        return;
+      }
+
+      sonnerToast.error("Delete failed", {
+        description: error instanceof Error ? error.message : "Delete failed",
+      });
+    },
   });
 
   const duplicateMutation = useMutation({

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -53,6 +53,7 @@
 @import "tailwind-scrollbar-hide/v4";
 @plugin "@tailwindcss/typography";
 
+@source "../../../packages/ui/src";
 @source "../../../packages/tiptap/src";
 @source "../../../packages/transcript/src";
 


### PR DESCRIPTION
- include shared UI package sources in the web Tailwind entry so dialog styles are generated
- surface admin content delete failures with a toast instead of failing silently