### PR TITLE
fix: delete admin draft files from the correct branch

### DIFF
--- a/apps/web/src/functions/github-content.ts
+++ b/apps/web/src/functions/github-content.ts
@@ -42,6 +42,7 @@ interface CommitBody {
   message: string;
   content?: string;
   sha?: string;
+  branch?: string;
   author?: { name: string; email: string };
   committer?: { name: string; email: string };
 }
@@ -49,13 +50,14 @@ interface CommitBody {
 function buildCommitBody(
   message: string,
   author?: { name: string; email: string },
-  options?: { content?: string; sha?: string },
+  options?: { content?: string; sha?: string; branch?: string },
 ): CommitBody {
   const body: CommitBody = {
     message,
   };
   if (options?.content !== undefined) body.content = options.content;
   if (options?.sha) body.sha = options.sha;
+  if (options?.branch) body.branch = options.branch;
   if (author) {
     body.author = author;
     body.committer = author;
@@ -490,6 +492,7 @@ export async function renameContentFile(
 
 export async function deleteContentFile(
   filePath: string,
+  branchName?: string,
 ): Promise<{ success: boolean; error?: string }> {
   if (isDev()) {
     try {
@@ -512,6 +515,7 @@ export async function deleteContentFile(
     return { success: false, error: "GitHub token not configured" };
   }
   const { token: githubToken, author } = credentials;
+  const targetBranch = branchName || GITHUB_BRANCH;
 
   const fullPath = filePath.startsWith("apps/web/content")
     ? filePath
@@ -519,7 +523,7 @@ export async function deleteContentFile(
 
   try {
     const getResponse = await fetch(
-      `https://api.github.com/repos/${GITHUB_REPO}/contents/${fullPath}?ref=${GITHUB_BRANCH}`,
+      `https://api.github.com/repos/${GITHUB_REPO}/contents/${fullPath}?ref=${targetBranch}`,
       {
         headers: {
           Authorization: `Bearer ${githubToken}`,
@@ -548,7 +552,10 @@ export async function deleteContentFile(
           Accept: "application/vnd.github.v3+json",
         },
         body: JSON.stringify(
-          buildCommitBody(`Delete ${filePath} via admin`, author, { sha }),
+          buildCommitBody(`Delete ${filePath} via admin`, author, {
+            sha,
+            branch: targetBranch,
+          }),
         ),
       },
     );

--- a/apps/web/src/routes/admin/collections/index.tsx
+++ b/apps/web/src/routes/admin/collections/index.tsx
@@ -396,7 +396,7 @@ function CollectionsPage() {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: async (params: { path: string }) =>
+    mutationFn: async (params: { path: string; branch?: string }) =>
       postAdminJson<any>(
         "/api/admin/content/delete",
         params,
@@ -620,6 +620,8 @@ function CollectionsPage() {
                   slug: (path.split("/").pop() || "").replace(/\.mdx$/, ""),
                   type: "file",
                   collection: path.split("/")[0] || "articles",
+                  branch:
+                    currentTab?.type === "file" ? currentTab.branch : undefined,
                 },
                 collectionName: path.split("/")[0] || "articles",
               })
@@ -658,6 +660,7 @@ function CollectionsPage() {
                   if (deleteConfirmation) {
                     deleteMutation.mutate({
                       path: deleteConfirmation.item.path,
+                      branch: deleteConfirmation.item.branch,
                     });
                   }
                 }}

--- a/apps/web/src/routes/api/admin/content/delete.ts
+++ b/apps/web/src/routes/api/admin/content/delete.ts
@@ -5,6 +5,7 @@ import { deleteContentFile } from "@/functions/github-content";
 
 interface DeleteRequest {
   path: string;
+  branch?: string;
 }
 
 export const Route = createFileRoute("/api/admin/content/delete")({
@@ -32,7 +33,7 @@ export const Route = createFileRoute("/api/admin/content/delete")({
           });
         }
 
-        const { path } = body;
+        const { path, branch } = body;
 
         if (!path) {
           return new Response(
@@ -41,7 +42,7 @@ export const Route = createFileRoute("/api/admin/content/delete")({
           );
         }
 
-        const result = await deleteContentFile(path);
+        const result = await deleteContentFile(path, branch);
 
         if (!result.success) {
           return new Response(JSON.stringify({ error: result.error }), {


### PR DESCRIPTION
- pass the draft branch through the admin content delete mutation and API
- preserve the current tab branch when deleting from the editor header
- target the correct GitHub ref and DELETE branch in the GitHub content helper