### PR TITLE
fix: clarify desktop auth callback input

### DIFF
--- a/apps/desktop/src/onboarding/account/before-login.tsx
+++ b/apps/desktop/src/onboarding/account/before-login.tsx
@@ -58,22 +58,27 @@ function CallbackUrlInput() {
   const [callbackUrl, setCallbackUrl] = useState("");
 
   return (
-    <div className="relative flex items-center overflow-hidden rounded-full border border-neutral-200 transition-all duration-200 focus-within:border-neutral-400">
-      <input
-        type="text"
-        className="flex-1 bg-white px-4 py-3 font-mono text-xs outline-hidden"
-        placeholder="Paste browser url here, after you've signed in. (Like: http://char.com/callback/auth/?flow=desktop&scheme=hyprnote&access_token=<V>&refresh_token=<V>)"
-        value={callbackUrl}
-        onChange={(e) => setCallbackUrl(e.target.value)}
-      />
-      <button
-        type="button"
-        onClick={() => auth?.handleAuthCallback(callbackUrl)}
-        disabled={!callbackUrl}
-        className="absolute right-0.5 rounded-full bg-neutral-600 px-4 py-2 text-sm text-white transition-all enabled:hover:scale-[1.02] enabled:active:scale-[0.98] disabled:opacity-50"
-      >
-        Submit
-      </button>
+    <div className="flex flex-col gap-2">
+      <div className="relative flex items-center overflow-hidden rounded-full border border-neutral-200 transition-all duration-200 focus-within:border-neutral-400">
+        <input
+          type="text"
+          className="flex-1 bg-white px-4 py-3 font-mono text-xs outline-hidden"
+          placeholder="http://char.com/callback/auth/?flow=desktop&scheme=hyprnote&access_token=<V>&refresh_token=<V>"
+          value={callbackUrl}
+          onChange={(e) => setCallbackUrl(e.target.value)}
+        />
+        <button
+          type="button"
+          onClick={() => auth?.handleAuthCallback(callbackUrl)}
+          disabled={!callbackUrl}
+          className="absolute right-0.5 rounded-full bg-neutral-600 px-4 py-2 text-sm text-white transition-all enabled:hover:scale-[1.02] enabled:active:scale-[0.98] disabled:opacity-50"
+        >
+          Submit
+        </button>
+      </div>
+      <p className="px-4 text-xs text-neutral-500">
+        Paste the browser URL here after you sign in.
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
- Use the example callback URL as the onboarding input placeholder
- Move the sign-in instruction below the input so the field stays easier to scan

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #4583 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #4578 
<!-- GitButler Footer Boundary Bottom -->

