### PR TITLE
feat: add native context menu controls to the audio player

### DIFF
--- a/apps/desktop/src/audio-player/provider.tsx
+++ b/apps/desktop/src/audio-player/provider.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   createContext,
   type ReactNode,
@@ -73,6 +73,8 @@ interface AudioPlayerContextValue {
   audioExists: boolean;
   playbackRate: number;
   setPlaybackRate: (rate: number) => void;
+  deleteRecording: () => Promise<void>;
+  isDeletingRecording: boolean;
 }
 
 const AudioPlayerContext = createContext<AudioPlayerContextValue | null>(null);
@@ -99,6 +101,7 @@ export function AudioPlayerProvider({
   url: string;
   children: ReactNode;
 }) {
+  const queryClient = useQueryClient();
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const [wavesurfer, setWavesurfer] = useState<WaveSurfer | null>(null);
   const [state, setState] = useState<AudioPlayerState>("stopped");
@@ -262,6 +265,25 @@ export function AudioPlayerProvider({
     [wavesurfer],
   );
 
+  const deleteRecordingMutation = useMutation({
+    mutationFn: async () => {
+      const result = await fsSyncCommands.audioDelete(sessionId);
+      if (result.status === "error") {
+        throw new Error(result.error);
+      }
+    },
+    onSuccess: () => {
+      stop();
+      timeStoreRef.current.reset();
+      void queryClient.invalidateQueries({
+        queryKey: ["audio", sessionId, "exist"],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["audio", sessionId, "url"],
+      });
+    },
+  });
+
   const audioExistsValue = Boolean(url) || (audioExists.data ?? false);
 
   const value = useMemo<AudioPlayerContextValue>(
@@ -278,6 +300,8 @@ export function AudioPlayerProvider({
       audioExists: audioExistsValue,
       playbackRate,
       setPlaybackRate,
+      deleteRecording: deleteRecordingMutation.mutateAsync,
+      isDeletingRecording: deleteRecordingMutation.isPending,
     }),
     [
       registerContainer,
@@ -291,6 +315,8 @@ export function AudioPlayerProvider({
       audioExistsValue,
       playbackRate,
       setPlaybackRate,
+      deleteRecordingMutation.mutateAsync,
+      deleteRecordingMutation.isPending,
     ],
   );
 

--- a/apps/desktop/src/audio-player/timeline.tsx
+++ b/apps/desktop/src/audio-player/timeline.tsx
@@ -1,9 +1,11 @@
 import { Pause, Play } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { cn } from "@hypr/utils";
 
 import { useAudioPlayer, useAudioTime } from "./provider";
+
+import { useNativeContextMenu } from "~/shared/hooks/useNativeContextMenu";
 
 const PLAYBACK_RATES = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
 
@@ -14,8 +16,11 @@ export function Timeline() {
     pause,
     resume,
     start,
+    stop,
     playbackRate,
     setPlaybackRate,
+    deleteRecording,
+    isDeletingRecording,
   } = useAudioPlayer();
   const time = useAudioTime();
   const [showRateMenu, setShowRateMenu] = useState(false);
@@ -44,8 +49,50 @@ export function Timeline() {
     }
   };
 
+  const handleDeleteRecording = useCallback(async () => {
+    setShowRateMenu(false);
+    await deleteRecording();
+  }, [deleteRecording]);
+
+  const contextMenu = useMemo(
+    () => [
+      ...(state === "paused"
+        ? [{ id: "resume", text: "Resume", action: resume }]
+        : []),
+      ...(state === "stopped"
+        ? [{ id: "play", text: "Play", action: start }]
+        : []),
+      ...(state === "playing"
+        ? [{ id: "pause", text: "Pause", action: pause }]
+        : []),
+      ...(state !== "stopped"
+        ? [{ id: "stop", text: "Stop", action: stop }]
+        : []),
+      { separator: true as const },
+      {
+        id: "delete-recording",
+        text: "Delete recording",
+        action: () => void handleDeleteRecording(),
+        disabled: isDeletingRecording,
+      },
+    ],
+    [
+      state,
+      resume,
+      start,
+      pause,
+      stop,
+      isDeletingRecording,
+      handleDeleteRecording,
+    ],
+  );
+  const showContextMenu = useNativeContextMenu(contextMenu);
+
   return (
-    <div className="w-full rounded-xl bg-neutral-50">
+    <div
+      className="w-full rounded-xl bg-neutral-50"
+      onContextMenu={showContextMenu}
+    >
       <div className={cn(["flex items-center gap-2 p-2", "w-full max-w-full"])}>
         <button
           onClick={handleClick}


### PR DESCRIPTION
This adds a native right-click context menu to the desktop audio player.

Users can now right-click the player to:

- Play when the recording is stopped
- Resume when playback is paused
- Pause when playback is active
- Stop playback
- Delete the recording

<img width="364" height="135" alt="image" src="https://github.com/user-attachments/assets/809046e2-6c65-4a12-b096-7f27328e44e7" />

<img width="285" height="149" alt="image" src="https://github.com/user-attachments/assets/f5edc1ed-4ea7-4684-b7c6-e8b339b773b4" />

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #4590 
- <kbd>&nbsp;1&nbsp;</kbd> #4589 👈 
<!-- GitButler Footer Boundary Bottom -->

