### PR TITLE
fix: remove unnecessary system audio restart prompt

### DIFF
--- a/apps/desktop/src/onboarding/final.tsx
+++ b/apps/desktop/src/onboarding/final.tsx
@@ -1,5 +1,4 @@
 import { Icon } from "@iconify-icon/react";
-import { message } from "@tauri-apps/plugin-dialog";
 
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
@@ -7,7 +6,6 @@ import { commands as sfxCommands } from "@hypr/plugin-sfx";
 
 import { OnboardingButton } from "./shared";
 
-import { consumePendingSystemAudioStatusChangedMessage } from "~/shared/hooks/usePermissions";
 import { flushAutomaticRelaunch } from "~/store/tinybase/store/save";
 import { commands } from "~/types/tauri.gen";
 
@@ -64,12 +62,6 @@ export async function finishOnboarding(onContinue?: () => void) {
   await commands.setOnboardingNeeded(false).catch(console.error);
   await new Promise((resolve) => setTimeout(resolve, 100));
   await analyticsCommands.event({ event: "onboarding_completed" });
-  if (consumePendingSystemAudioStatusChangedMessage()) {
-    await message("The app will now restart to apply the changes", {
-      kind: "info",
-      title: "System Audio Status Changed",
-    });
-  }
   if (await flushAutomaticRelaunch()) {
     return;
   }

--- a/apps/desktop/src/shared/hooks/usePermissions.ts
+++ b/apps/desktop/src/shared/hooks/usePermissions.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { message } from "@tauri-apps/plugin-dialog";
 import { useState } from "react";
 
 import {
@@ -7,30 +6,6 @@ import {
   commands as permissionsCommands,
   type PermissionStatus,
 } from "@hypr/plugin-permissions";
-
-import { scheduleAutomaticRelaunch } from "~/store/tinybase/store/save";
-
-let pendingSystemAudioStatusChangedMessage = false;
-
-export function consumePendingSystemAudioStatusChangedMessage() {
-  const pending = pendingSystemAudioStatusChangedMessage;
-  pendingSystemAudioStatusChangedMessage = false;
-  return pending;
-}
-
-async function handleSystemAudioPermissionSuccess() {
-  const restartStatus = await scheduleAutomaticRelaunch(2000);
-
-  if (restartStatus === "deferred") {
-    pendingSystemAudioStatusChangedMessage = true;
-    return;
-  }
-
-  void message("The app will now restart to apply the changes", {
-    kind: "info",
-    title: "System Audio Status Changed",
-  });
-}
 
 export function usePermission(type: Permission) {
   const [optimisticStatus, setOptimisticStatus] =
@@ -53,7 +28,6 @@ export function usePermission(type: Permission) {
       if (type === "systemAudio") {
         setOptimisticStatus("authorized");
         setTimeout(() => void status.refetch(), 1000);
-        await handleSystemAudioPermissionSuccess();
         return;
       }
       setOptimisticStatus(null);
@@ -143,8 +117,10 @@ export function usePermissions() {
 
   const systemAudioPermission = useMutation({
     mutationFn: () => permissionsCommands.requestPermission("systemAudio"),
-    onSuccess: async () => {
-      await handleSystemAudioPermissionSuccess();
+    onSuccess: () => {
+      setTimeout(() => {
+        void systemAudioPermissionStatus.refetch();
+      }, 1000);
     },
     onError: console.error,
   });


### PR DESCRIPTION
- stop scheduling a relaunch after successful system audio permission requests
- keep the onboarding permission state updating immediately after grant
- remove the deferred system audio alert from onboarding completion