### PR TITLE
feat: add upload UI to new meeting and empty transcript states

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/screens/empty.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/screens/empty.tsx
@@ -1,5 +1,6 @@
 import { AlertCircleIcon, AudioLinesIcon } from "lucide-react";
 
+import { Button } from "@hypr/ui/components/ui/button";
 import { Spinner } from "@hypr/ui/components/ui/spinner";
 
 export function TranscriptEmptyState({
@@ -54,12 +55,27 @@ export function TranscriptEmptyState({
           <p className="text-sm text-neutral-500">
             {hasAudio ? "Recording available" : "No transcript available"}
           </p>
-          {hasAudio && (
-            <p className="text-xs text-neutral-400">
-              Use the refresh button above to generate a transcript from this
-              recording.
-            </p>
-          )}
+          <p className="text-xs text-neutral-400">
+            {hasAudio
+              ? "Use the refresh button above to generate a transcript, or upload audio or a VTT/SRT file."
+              : "Upload audio or a VTT/SRT transcript to populate this note."}
+          </p>
+          <div className="mt-3 flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-neutral-200 bg-white/90 text-neutral-700 hover:bg-neutral-50"
+            >
+              Upload audio
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="border-neutral-200 bg-white/90 text-neutral-700 hover:bg-neutral-50"
+            >
+              Upload transcript
+            </Button>
+          </div>
         </div>
       )}
     </div>

--- a/apps/desktop/src/shared/main/header-listen-button.tsx
+++ b/apps/desktop/src/shared/main/header-listen-button.tsx
@@ -1,5 +1,19 @@
-import { useCallback } from "react";
+import { ChevronDown } from "lucide-react";
+import {
+  type MouseEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
+import { Button } from "@hypr/ui/components/ui/button";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverTrigger,
+} from "@hypr/ui/components/ui/popover";
 import {
   Tooltip,
   TooltipContent,
@@ -77,26 +91,72 @@ function useHeaderListenState() {
 
 function HeaderListenButtonInner() {
   const { isDisabled, warningMessage } = useHeaderListenState();
+  const [open, setOpen] = useState(false);
+  const [menuWidth, setMenuWidth] = useState<number | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const handleClick = useNewNoteAndListen();
   const openNew = useTabs((state) => state.openNew);
+
+  useEffect(() => {
+    const node = containerRef.current;
+
+    if (!node) {
+      return;
+    }
+
+    const updateWidth = () => {
+      setMenuWidth(node.offsetWidth);
+    };
+
+    updateWidth();
+
+    const observer = new ResizeObserver(updateWidth);
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
 
   const handleConfigure = useCallback(() => {
     openNew({ type: "ai", state: { tab: "transcription" } });
   }, [openNew]);
 
+  const handleMenuMouseDown = useCallback((event: MouseEvent) => {
+    if (event.button === 2) {
+      event.preventDefault();
+    }
+  }, []);
+
+  const handleOpenMenu = useCallback((event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setOpen(true);
+  }, []);
+
+  const handleUploadAudio = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  const handleUploadTranscript = useCallback(() => {
+    setOpen(false);
+  }, []);
+
   const button = (
     <button
       type="button"
       onClick={handleClick}
+      onMouseDown={handleMenuMouseDown}
+      onContextMenu={handleOpenMenu}
       disabled={isDisabled}
       className={cn([
-        "inline-flex items-center justify-center rounded-full text-sm font-medium text-white",
+        "inline-flex items-center justify-center rounded-full text-sm font-medium text-white select-none",
         "gap-2",
-        "h-8 px-4",
+        "h-8 pr-8 pl-4",
         "border-2 border-stone-600 bg-stone-800",
         "transition-all duration-200 ease-out",
         "hover:bg-stone-700",
-        "disabled:pointer-events-none disabled:opacity-50",
+        "disabled:opacity-50",
       ])}
     >
       <RecordingIcon />
@@ -104,22 +164,77 @@ function HeaderListenButtonInner() {
     </button>
   );
 
-  if (!warningMessage) {
-    return button;
-  }
+  const moreButton = (
+    <button
+      type="button"
+      className="absolute inset-y-0 right-0 z-10 inline-flex w-9 cursor-pointer items-center justify-center rounded-r-full bg-transparent text-white/70 transition-colors select-none hover:text-white"
+      onMouseDown={handleMenuMouseDown}
+      onClick={(event) => {
+        event.stopPropagation();
+      }}
+    >
+      <ChevronDown className="size-3.5" />
+      <span className="sr-only">More options</span>
+    </button>
+  );
 
   return (
-    <Tooltip delayDuration={0}>
-      <TooltipTrigger asChild>{button}</TooltipTrigger>
-      <TooltipContent side="bottom">
-        <ActionableTooltipContent
-          message={warningMessage}
-          action={{
-            label: "Configure",
-            handleClick: handleConfigure,
-          }}
-        />
-      </TooltipContent>
-    </Tooltip>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <div
+          ref={containerRef}
+          className="relative flex items-center select-none"
+          onMouseDownCapture={handleMenuMouseDown}
+          onContextMenu={handleOpenMenu}
+        >
+          {warningMessage ? (
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger asChild>
+                <span className="inline-flex">{button}</span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <ActionableTooltipContent
+                  message={warningMessage}
+                  action={{
+                    label: "Configure",
+                    handleClick: handleConfigure,
+                  }}
+                />
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            button
+          )}
+          <PopoverTrigger asChild>{moreButton}</PopoverTrigger>
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        side="bottom"
+        align="end"
+        sideOffset={4}
+        style={menuWidth ? { width: menuWidth } : undefined}
+        className={cn([
+          "overflow-hidden rounded-[1.25rem] border border-white/70 p-1.5 ring-1 ring-black/6 outline-none",
+          "bg-white/68 text-stone-900 shadow-[inset_0_1px_0_rgba(255,255,255,0.7),0_24px_48px_-24px_rgba(48,44,40,0.52),0_8px_18px_rgba(255,255,255,0.28)] backdrop-blur-md backdrop-saturate-150",
+        ])}
+      >
+        <div className="flex flex-col gap-1">
+          <Button
+            variant="ghost"
+            className="h-9 w-full justify-center rounded-[0.95rem] px-3 text-sm text-stone-900 shadow-none hover:bg-black/6 hover:text-stone-950 focus-visible:ring-0 focus-visible:outline-none"
+            onClick={handleUploadAudio}
+          >
+            <span className="text-sm">Upload audio</span>
+          </Button>
+          <Button
+            variant="ghost"
+            className="h-9 w-full justify-center rounded-[0.95rem] px-3 text-sm text-stone-900 shadow-none hover:bg-black/6 hover:text-stone-950 focus-visible:ring-0 focus-visible:outline-none"
+            onClick={handleUploadTranscript}
+          >
+            <span className="text-sm">Upload transcript</span>
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }


### PR DESCRIPTION
- add a chevron menu and glass popover to the header new meeting button
- show upload audio and upload transcript actions in the header menu
- add matching upload buttons to the empty transcript state