### PR TITLE
fix: Update app name from Hyprnote to Char

### DIFF
--- a/.github/workflows/devin_explore_issues.yaml
+++ b/.github/workflows/devin_explore_issues.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           api_key: ${{ secrets.DEVIN_API_KEY }}
           prompt: |
-            A user has submitted an issue via the Hyprnote app. Please explore the codebase and provide helpful context on this issue.
+            A user has submitted an issue via the Char app. Please explore the codebase and provide helpful context on this issue.
 
             ## Issue Details
             - **Title**: {{ title }}

--- a/.github/workflows/devin_triage_issues.yaml
+++ b/.github/workflows/devin_triage_issues.yaml
@@ -16,10 +16,10 @@ jobs:
         with:
           api_key: ${{ secrets.DEVIN_API_KEY }}
           prompt: |
-            You are tasked with triaging open GitHub issues for Hyprnote to determine if they have already been addressed.
+            You are tasked with triaging open GitHub issues for Char to determine if they have already been addressed.
 
             ## Context
-            Hyprnote is a Tauri-based desktop app for AI meeting notes that prioritizes privacy.
+            Char is a Tauri-based desktop app for AI meeting notes that prioritizes privacy.
             Repository: fastrepl/hyprnote
 
             ## Your Task


### PR DESCRIPTION
Replace references to "Hyprnote" with "Char" in GitHub workflow prompts for issue exploration and triage automation to reflect the updated application branding.