### PR TITLE
fix: gate non-essential website tracking behind consent

### DIFF
--- a/apps/web/content/legal/cookies.mdx
+++ b/apps/web/content/legal/cookies.mdx
@@ -1,5 +1,5 @@
 ---
-date: "2026-03-03"
+date: "2026-03-17"
 title: "Cookie Policy"
 summary: "How we use cookies and similar tracking technologies"
 ---
@@ -10,7 +10,7 @@ Cookies are small text files that are placed on your device when you visit a web
 
 ## 2. How We Use Cookies
 
-Char uses cookies and similar tracking technologies to enhance your experience and analyze usage.
+Char uses cookies and similar tracking technologies to enhance your experience and analyze usage. We ask for consent before enabling non-essential web analytics and support technologies on the website.
 
 ## 3. Types of Cookies We Use
 
@@ -77,6 +77,7 @@ Most browsers allow you to control cookies through their settings. You can set y
 
 You can opt out of certain cookie-based tracking:
 
+- **Cookie preferences:** Use the `Cookie preferences` control in the website footer to accept or reject non-essential web tracking.
 - **Browser controls:** Block or clear cookies/local storage from your browser settings.
 - **Analytics providers:** Block analytics domains in your browser or content blocker settings (for example, PostHog/Outlit domains).
 - **Desktop app telemetry:** Use the `Share usage data` toggle in desktop settings (desktop telemetry is not cookie-based).
@@ -85,9 +86,11 @@ You can opt out of certain cookie-based tracking:
 
 Please note that if you disable cookies, some features of the Service may not function properly, and your user experience may be affected.
 
-## 7. Do Not Track Signals
+## 7. Do Not Track Signals and Global Privacy Control
 
-Some browsers include a "Do Not Track" (DNT) feature that signals to websites that you do not want to be tracked. Currently, there is no industry standard for how to respond to DNT signals. We do not currently respond to DNT signals.
+Some browsers include a "Do Not Track" (DNT) feature that signals to websites that you do not want to be tracked. There is no consistent industry standard for DNT, and we do not currently respond to DNT signals.
+
+We do honor Global Privacy Control (GPC) for non-essential website tracking by keeping analytics and similar optional technologies disabled when that signal is present.
 
 ## 8. Changes to This Cookie Policy
 

--- a/apps/web/content/legal/privacy.mdx
+++ b/apps/web/content/legal/privacy.mdx
@@ -1,5 +1,5 @@
 ---
-date: "2026-03-03"
+date: "2026-03-17"
 title: "Privacy Policy"
 summary: "How we collect, use, and protect your personal information"
 ---
@@ -96,7 +96,8 @@ We retain your information for as long as your account is active or as needed to
 ### 7.4 Analytics and Telemetry Controls
 
 - **Desktop app setting:** You can disable desktop usage analytics in Settings (`Share usage data`).
-- **Web tracking controls:** You can manage browser cookies and similar technologies as described in our [Cookie Policy](/legal/cookies).
+- **Web tracking controls:** You can accept or reject non-essential website tracking from the `Cookie preferences` control in the website footer, as described in our [Cookie Policy](/legal/cookies).
+- **Global Privacy Control:** We honor Global Privacy Control (GPC) for non-essential website tracking.
 - **Cloud feature metadata:** Disabling desktop usage analytics does not disable limited server-side operational and billing telemetry required to provide cloud requests (for example, speech-to-text and AI request metadata, and subscription trial status events).
 
 ## 8. International Data Transfers

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@hypr/utils";
 
 import { EmailSubscribeField } from "@/components/email-subscribe-field";
+import { CookiePreferencesButton } from "@/components/privacy-consent";
 
 const vsList = [
   { slug: "otter", name: "Otter.ai" },
@@ -80,6 +81,8 @@ function BrandSection({ currentYear }: { currentYear: number }) {
         >
           Privacy
         </Link>
+        {" · "}
+        <CookiePreferencesButton />
       </p>
     </div>
   );

--- a/apps/web/src/components/privacy-consent.tsx
+++ b/apps/web/src/components/privacy-consent.tsx
@@ -1,0 +1,398 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+import { Button } from "@hypr/ui/components/ui/button";
+import { Checkbox } from "@hypr/ui/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@hypr/ui/components/ui/dialog";
+import { cn } from "@hypr/utils";
+
+const STORAGE_KEY = "char_web_tracking_consent_v1";
+const COOKIE_POLICY_PATH = "/legal/cookies/";
+const PRIVACY_POLICY_PATH = "/legal/privacy/";
+const ACCEPT_CTA_BUTTON_CLASS =
+  "rounded-full border-0 bg-linear-to-t from-stone-600 to-stone-500 text-white shadow-md transition-all hover:scale-[102%] hover:shadow-lg active:scale-[98%]";
+const MUTED_ACTION_BUTTON_CLASS =
+  "border-0 bg-transparent text-neutral-500 shadow-none hover:bg-transparent hover:text-neutral-700";
+
+type ConsentState = {
+  analytics: boolean;
+  source: "user" | "gpc";
+  updatedAt: string;
+};
+
+const PrivacyConsentContext = createContext<{
+  analyticsEnabled: boolean;
+  analyticsChoice: boolean | null;
+  isGpcEnabled: boolean;
+  isReady: boolean;
+  openPreferences: () => void;
+  rejectNonEssential: () => void;
+  saveAnalyticsChoice: (analytics: boolean) => void;
+} | null>(null);
+
+function readStoredConsent(): ConsentState | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const rawValue = window.localStorage.getItem(STORAGE_KEY);
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const parsedValue = JSON.parse(rawValue) as Partial<ConsentState>;
+    if (
+      typeof parsedValue.analytics !== "boolean" ||
+      (parsedValue.source !== "user" && parsedValue.source !== "gpc") ||
+      typeof parsedValue.updatedAt !== "string"
+    ) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return null;
+    }
+
+    return {
+      analytics: parsedValue.analytics,
+      source: parsedValue.source,
+      updatedAt: parsedValue.updatedAt,
+    };
+  } catch {
+    window.localStorage.removeItem(STORAGE_KEY);
+    return null;
+  }
+}
+
+function writeStoredConsent(value: ConsentState) {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+}
+
+function getGlobalPrivacyControlValue() {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  return Boolean(
+    (navigator as Navigator & { globalPrivacyControl?: boolean })
+      .globalPrivacyControl,
+  );
+}
+
+function usePrivacyConsentContext() {
+  const context = useContext(PrivacyConsentContext);
+  if (!context) {
+    throw new Error("Privacy consent context is not available");
+  }
+  return context;
+}
+
+export function usePrivacyConsent() {
+  const context = usePrivacyConsentContext();
+
+  return {
+    analyticsEnabled: context.analyticsEnabled,
+    analyticsChoice: context.analyticsChoice,
+    isGpcEnabled: context.isGpcEnabled,
+    isReady: context.isReady,
+  };
+}
+
+export function CookiePreferencesButton() {
+  const { openPreferences } = usePrivacyConsentContext();
+
+  return (
+    <button
+      type="button"
+      onClick={openPreferences}
+      className={cn([
+        "cursor-pointer bg-transparent p-0 text-sm text-neutral-500 transition-colors",
+        "hover:text-stone-600 hover:underline hover:decoration-dotted",
+      ])}
+    >
+      Cookie preferences
+    </button>
+  );
+}
+
+export function PrivacyConsentProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [consent, setConsent] = useState<ConsentState | null>(null);
+  const [draftAnalytics, setDraftAnalytics] = useState(false);
+  const [isDialogOpen, setDialogOpen] = useState(false);
+  const [isReady, setIsReady] = useState(false);
+  const [isGpcEnabled, setIsGpcEnabled] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const gpcEnabled = getGlobalPrivacyControlValue();
+    setIsGpcEnabled(gpcEnabled);
+
+    let nextConsent = readStoredConsent();
+    if (!nextConsent && gpcEnabled) {
+      nextConsent = {
+        analytics: false,
+        source: "gpc",
+        updatedAt: new Date().toISOString(),
+      };
+      writeStoredConsent(nextConsent);
+    }
+
+    setConsent(nextConsent);
+    setDraftAnalytics(Boolean(nextConsent?.analytics));
+    setIsReady(true);
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== STORAGE_KEY) {
+        return;
+      }
+
+      const updatedConsent = readStoredConsent();
+      setConsent(updatedConsent);
+      setDraftAnalytics(Boolean(updatedConsent?.analytics));
+    };
+
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
+
+  useEffect(() => {
+    if (!isDialogOpen) {
+      return;
+    }
+
+    setDraftAnalytics(Boolean(consent?.analytics));
+  }, [consent, isDialogOpen]);
+
+  const analyticsEnabled =
+    isReady && consent?.analytics === true && !isGpcEnabled;
+
+  const commitConsent = (
+    analytics: boolean,
+    source: ConsentState["source"] = "user",
+  ) => {
+    const nextConsent = {
+      analytics,
+      source,
+      updatedAt: new Date().toISOString(),
+    } satisfies ConsentState;
+
+    writeStoredConsent(nextConsent);
+    setConsent(nextConsent);
+    setDraftAnalytics(analytics);
+  };
+
+  const rejectNonEssential = () => {
+    const shouldReload = consent?.analytics === true;
+    commitConsent(false, isGpcEnabled ? "gpc" : "user");
+    setDialogOpen(false);
+
+    if (shouldReload) {
+      window.location.reload();
+    }
+  };
+
+  const saveAnalyticsChoice = (analytics: boolean) => {
+    if (!analytics) {
+      rejectNonEssential();
+      return;
+    }
+
+    commitConsent(true);
+    setDialogOpen(false);
+  };
+
+  const contextValue = {
+    analyticsChoice: consent?.analytics ?? null,
+    analyticsEnabled,
+    isGpcEnabled,
+    isReady,
+    openPreferences: () => setDialogOpen(true),
+    rejectNonEssential,
+    saveAnalyticsChoice,
+  };
+
+  return (
+    <PrivacyConsentContext.Provider value={contextValue}>
+      {children}
+      <CookieConsentBanner isDialogOpen={isDialogOpen} />
+      <CookiePreferencesDialog
+        analyticsChoice={draftAnalytics}
+        isOpen={isDialogOpen}
+        isGpcEnabled={isGpcEnabled}
+        onAnalyticsChoiceChange={setDraftAnalytics}
+        onOpenChange={setDialogOpen}
+      />
+    </PrivacyConsentContext.Provider>
+  );
+}
+
+function CookieConsentBanner({ isDialogOpen }: { isDialogOpen: boolean }) {
+  const {
+    analyticsChoice,
+    isReady,
+    openPreferences,
+    rejectNonEssential,
+    saveAnalyticsChoice,
+  } = usePrivacyConsentContext();
+
+  if (!isReady || analyticsChoice !== null || isDialogOpen) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none fixed inset-x-4 bottom-4 z-[70] flex justify-center sm:justify-end">
+      <div
+        className={cn([
+          "pointer-events-auto w-full max-w-xl rounded-xs border border-neutral-200 bg-white/95 p-5 shadow-2xl shadow-neutral-900/10 backdrop-blur-md",
+          "sm:p-6",
+        ])}
+      >
+        <div className="flex flex-col gap-4">
+          <div className="space-y-2">
+            <p className="font-serif text-xl font-semibold text-neutral-900">
+              Your data choices
+            </p>
+            <p className="text-sm leading-6 text-neutral-600">
+              We use cookies and similar technologies for site analytics and
+              support tools. You can accept analytics, reject non-essential
+              tracking, or change your choice later from the footer.
+            </p>
+            <p className="text-xs leading-5 text-neutral-500">
+              See our{" "}
+              <a
+                href={COOKIE_POLICY_PATH}
+                className="underline decoration-dotted underline-offset-3"
+              >
+                Cookie Policy
+              </a>{" "}
+              and{" "}
+              <a
+                href={PRIVACY_POLICY_PATH}
+                className="underline decoration-dotted underline-offset-3"
+              >
+                Privacy Policy
+              </a>
+              .
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+            <Button
+              className={MUTED_ACTION_BUTTON_CLASS}
+              variant="ghost"
+              onClick={rejectNonEssential}
+            >
+              Reject non-essential
+            </Button>
+            <Button
+              className={MUTED_ACTION_BUTTON_CLASS}
+              variant="ghost"
+              onClick={openPreferences}
+            >
+              Manage choices
+            </Button>
+            <Button
+              className={ACCEPT_CTA_BUTTON_CLASS}
+              onClick={() => saveAnalyticsChoice(true)}
+            >
+              Accept analytics
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CookiePreferencesDialog({
+  analyticsChoice,
+  isOpen,
+  isGpcEnabled,
+  onAnalyticsChoiceChange,
+  onOpenChange,
+}: {
+  analyticsChoice: boolean;
+  isOpen: boolean;
+  isGpcEnabled: boolean;
+  onAnalyticsChoiceChange: (value: boolean) => void;
+  onOpenChange: (value: boolean) => void;
+}) {
+  const { rejectNonEssential, saveAnalyticsChoice } =
+    usePrivacyConsentContext();
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl rounded-xs border-neutral-200 p-0">
+        <div className="space-y-5 p-6">
+          <DialogHeader>
+            <DialogTitle className="font-serif text-2xl text-neutral-900">
+              Cookie preferences
+            </DialogTitle>
+          </DialogHeader>
+
+          <label className="flex items-start gap-3 text-sm text-neutral-700">
+            <Checkbox
+              checked={isGpcEnabled ? false : analyticsChoice}
+              disabled={isGpcEnabled}
+              onCheckedChange={(checked) =>
+                onAnalyticsChoiceChange(checked === true)
+              }
+              className="mt-0.5 border-neutral-300 data-[state=checked]:border-stone-600 data-[state=checked]:bg-stone-600"
+            />
+            <span className="space-y-1">
+              <span className="block">Analytics and support tools</span>
+              <span className="block text-sm leading-6 text-neutral-500">
+                Includes PostHog, Outlit, and the website support widget.
+              </span>
+            </span>
+          </label>
+
+          {isGpcEnabled && (
+            <div className="text-sm leading-6 text-emerald-900/85">
+              Global Privacy Control is enabled in your browser, so this stays
+              off until that signal is turned off.
+            </div>
+          )}
+
+          <div className="text-sm leading-6 text-neutral-500">
+            For details, review our{" "}
+            <a
+              href={COOKIE_POLICY_PATH}
+              className="underline decoration-dotted underline-offset-3"
+              onClick={() => onOpenChange(false)}
+            >
+              Cookie Policy
+            </a>
+            .
+          </div>
+
+          <DialogFooter>
+            <Button
+              className={MUTED_ACTION_BUTTON_CLASS}
+              variant="ghost"
+              onClick={rejectNonEssential}
+            >
+              Reject non-essential
+            </Button>
+            <Button
+              className={ACCEPT_CTA_BUTTON_CLASS}
+              onClick={() => saveAnalyticsChoice(analyticsChoice)}
+            >
+              Save preferences
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/providers/posthog.tsx
+++ b/apps/web/src/providers/posthog.tsx
@@ -1,22 +1,48 @@
 import { PostHogProvider as PostHogReactProvider } from "@posthog/react";
 import posthog from "posthog-js";
+import { useEffect, useRef, useState } from "react";
 
 import { env } from "../env";
 
 const isDev = import.meta.env.DEV;
 
-if (typeof window !== "undefined" && env.VITE_POSTHOG_API_KEY && !isDev) {
-  posthog.init(env.VITE_POSTHOG_API_KEY, {
-    api_host: env.VITE_POSTHOG_HOST,
-    autocapture: true,
-    capture_pageview: true,
-  });
-}
+export function PostHogProvider({
+  children,
+  enabled,
+}: {
+  children: React.ReactNode;
+  enabled: boolean;
+}) {
+  const didInitRef = useRef(false);
+  const [isInitialized, setIsInitialized] = useState(false);
 
-export function PostHogProvider({ children }: { children: React.ReactNode }) {
-  if (!env.VITE_POSTHOG_API_KEY) {
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      !enabled ||
+      !env.VITE_POSTHOG_API_KEY ||
+      isDev
+    ) {
+      setIsInitialized(false);
+      return;
+    }
+
+    if (!didInitRef.current) {
+      posthog.init(env.VITE_POSTHOG_API_KEY, {
+        api_host: env.VITE_POSTHOG_HOST,
+        autocapture: true,
+        capture_pageview: true,
+      });
+      didInitRef.current = true;
+    }
+
+    setIsInitialized(true);
+  }, [enabled]);
+
+  if (!enabled || !env.VITE_POSTHOG_API_KEY || isDev || !isInitialized) {
     return <>{children}</>;
   }
+
   return (
     <PostHogReactProvider client={posthog}>{children}</PostHogReactProvider>
   );

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -3,13 +3,28 @@ import * as Sentry from "@sentry/tanstackstart-react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createRouter } from "@tanstack/react-router";
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
+import { useEffect } from "react";
 
+import {
+  PrivacyConsentProvider,
+  usePrivacyConsent,
+} from "./components/privacy-consent";
 import { env } from "./env";
 import { PostHogProvider } from "./providers/posthog";
 import { routeTree } from "./routeTree.gen";
 
-function MaybeOutlitProvider({ children }: { children: React.ReactNode }) {
-  if (env.VITE_OUTLIT_PUBLIC_KEY) {
+const ZENDESK_SNIPPET_ID = "ze-snippet";
+const ZENDESK_SNIPPET_SRC =
+  "https://static.zdassets.com/ekr/snippet.js?key=15949e47-ed5a-4e52-846e-200dd0b8f4b9";
+
+function MaybeOutlitProvider({
+  children,
+  enabled,
+}: {
+  children: React.ReactNode;
+  enabled: boolean;
+}) {
+  if (enabled && env.VITE_OUTLIT_PUBLIC_KEY) {
     return (
       <OutlitProvider publicKey={env.VITE_OUTLIT_PUBLIC_KEY} trackPageviews>
         {children}
@@ -17,6 +32,52 @@ function MaybeOutlitProvider({ children }: { children: React.ReactNode }) {
     );
   }
   return <>{children}</>;
+}
+
+function MaybeZendeskWidget({ enabled }: { enabled: boolean }) {
+  useEffect(() => {
+    if (
+      typeof document === "undefined" ||
+      import.meta.env.DEV ||
+      !enabled ||
+      window.location.pathname.startsWith("/admin")
+    ) {
+      return;
+    }
+
+    if (document.getElementById(ZENDESK_SNIPPET_ID)) {
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.id = ZENDESK_SNIPPET_ID;
+    script.src = ZENDESK_SNIPPET_SRC;
+    script.async = true;
+    document.body.appendChild(script);
+  }, [enabled]);
+
+  return null;
+}
+
+function ConsentAwareProviders({
+  children,
+  queryClient,
+}: {
+  children: React.ReactNode;
+  queryClient: QueryClient;
+}) {
+  const { analyticsEnabled } = usePrivacyConsent();
+
+  return (
+    <PostHogProvider enabled={analyticsEnabled}>
+      <MaybeOutlitProvider enabled={analyticsEnabled}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+          <MaybeZendeskWidget enabled={analyticsEnabled} />
+        </QueryClientProvider>
+      </MaybeOutlitProvider>
+    </PostHogProvider>
+  );
 }
 
 export function getRouter() {
@@ -30,13 +91,11 @@ export function getRouter() {
     trailingSlash: "always",
     Wrap: (props: { children: React.ReactNode }) => {
       return (
-        <PostHogProvider>
-          <MaybeOutlitProvider>
-            <QueryClientProvider client={queryClient}>
-              {props.children}
-            </QueryClientProvider>
-          </MaybeOutlitProvider>
-        </PostHogProvider>
+        <PrivacyConsentProvider>
+          <ConsentAwareProviders queryClient={queryClient}>
+            {props.children}
+          </ConsentAwareProviders>
+        </PrivacyConsentProvider>
       );
     },
   });
@@ -48,9 +107,6 @@ export function getRouter() {
         ? `hyprnote-web@${env.VITE_APP_VERSION}`
         : undefined,
       sendDefaultPii: true,
-      integrations: [Sentry.replayIntegration()],
-      replaysSessionSampleRate: 0.1,
-      replaysOnErrorSampleRate: 1.0,
       tracePropagationTargets: [],
     });
   }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -56,25 +56,6 @@ export const Route = createRootRouteWithContext<RouterContext>()({
     ],
     links: [{ rel: "stylesheet", href: appCss }],
   }),
-  scripts: ({ matches }) => {
-    if (import.meta.env.DEV) {
-      return [];
-    }
-
-    const isAdminRoute = matches.some((match) =>
-      match.pathname.startsWith("/admin"),
-    );
-    if (isAdminRoute) {
-      return [];
-    }
-
-    return [
-      {
-        id: "ze-snippet",
-        src: "https://static.zdassets.com/ekr/snippet.js?key=15949e47-ed5a-4e52-846e-200dd0b8f4b9",
-      },
-    ];
-  },
   shellComponent: RootDocument,
   notFoundComponent: NotFoundDocument,
 });


### PR DESCRIPTION
- add a website consent banner and footer preferences dialog for analytics choices
- load PostHog, Outlit, and Zendesk only after analytics consent is granted
- honor Global Privacy Control and align the cookie/privacy policies with the new behavior