### PR TITLE
fix(desktop): support batch transcription for custom STT provider

### DIFF
--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -38,6 +38,7 @@ const BATCH_PROVIDER_MAP: Record<string, BatchParams["provider"]> = {
   elevenlabs: "elevenlabs",
   mistral: "mistral",
   fireworks: "fireworks",
+  custom: "deepgram",
 };
 
 function getBatchProvider(


### PR DESCRIPTION
### Summary
- The "Custom" STT provider was missing from BATCH_PROVIDER_MAP in useRunBatch.ts, causing getBatchProvider() to return null and batch transcription to fail with "Batch transcription is not supported for provider: custom"
- Maps custom to the deepgram adapter since custom endpoints use the Deepgram-compatible protocol                                     
                                                                                                                                        
### Context                                                                                                                                        
When live WebSocket streaming fails (e.g., the custom endpoint only supports HTTP), the app falls back to batch mode and records audio to disk. However, clicking the refresh button to trigger batch transcription threw an error because the custom provider had no batch adapter mapping.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small mapping change that routes `custom` batch requests through the existing Deepgram-compatible adapter, with minimal impact outside batch provider selection.
> 
> **Overview**
> Fixes batch transcription for the `custom` STT provider by adding it to `BATCH_PROVIDER_MAP` in `useRunBatch.ts`, mapping `custom` to the `deepgram` batch adapter so `getBatchProvider()` no longer returns `null`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f85a647203acaf9525afd4ed2b6c97bf57336246. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->