### PR TITLE
fix: force admin media downloads to save instead of preview

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -126,6 +126,7 @@ import { Route as ApiAdminMediaUploadRouteImport } from './routes/api/admin/medi
 import { Route as ApiAdminMediaRegisterRouteImport } from './routes/api/admin/media/register'
 import { Route as ApiAdminMediaMoveRouteImport } from './routes/api/admin/media/move'
 import { Route as ApiAdminMediaListRouteImport } from './routes/api/admin/media/list'
+import { Route as ApiAdminMediaDownloadRouteImport } from './routes/api/admin/media/download'
 import { Route as ApiAdminMediaDeleteRouteImport } from './routes/api/admin/media/delete'
 import { Route as ApiAdminMediaCreateFolderRouteImport } from './routes/api/admin/media/create-folder'
 import { Route as ApiAdminKanbanUpdateRouteImport } from './routes/api/admin/kanban/update'
@@ -751,6 +752,11 @@ const ApiAdminMediaListRoute = ApiAdminMediaListRouteImport.update({
   path: '/api/admin/media/list',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiAdminMediaDownloadRoute = ApiAdminMediaDownloadRouteImport.update({
+  id: '/api/admin/media/download',
+  path: '/api/admin/media/download',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiAdminMediaDeleteRoute = ApiAdminMediaDeleteRouteImport.update({
   id: '/api/admin/media/delete',
   path: '/api/admin/media/delete',
@@ -1050,6 +1056,7 @@ export interface FileRoutesByFullPath {
   '/api/admin/kanban/update': typeof ApiAdminKanbanUpdateRoute
   '/api/admin/media/create-folder': typeof ApiAdminMediaCreateFolderRoute
   '/api/admin/media/delete': typeof ApiAdminMediaDeleteRoute
+  '/api/admin/media/download': typeof ApiAdminMediaDownloadRoute
   '/api/admin/media/list': typeof ApiAdminMediaListRoute
   '/api/admin/media/move': typeof ApiAdminMediaMoveRoute
   '/api/admin/media/register': typeof ApiAdminMediaRegisterRoute
@@ -1193,6 +1200,7 @@ export interface FileRoutesByTo {
   '/api/admin/kanban/update': typeof ApiAdminKanbanUpdateRoute
   '/api/admin/media/create-folder': typeof ApiAdminMediaCreateFolderRoute
   '/api/admin/media/delete': typeof ApiAdminMediaDeleteRoute
+  '/api/admin/media/download': typeof ApiAdminMediaDownloadRoute
   '/api/admin/media/list': typeof ApiAdminMediaListRoute
   '/api/admin/media/move': typeof ApiAdminMediaMoveRoute
   '/api/admin/media/register': typeof ApiAdminMediaRegisterRoute
@@ -1342,6 +1350,7 @@ export interface FileRoutesById {
   '/api/admin/kanban/update': typeof ApiAdminKanbanUpdateRoute
   '/api/admin/media/create-folder': typeof ApiAdminMediaCreateFolderRoute
   '/api/admin/media/delete': typeof ApiAdminMediaDeleteRoute
+  '/api/admin/media/download': typeof ApiAdminMediaDownloadRoute
   '/api/admin/media/list': typeof ApiAdminMediaListRoute
   '/api/admin/media/move': typeof ApiAdminMediaMoveRoute
   '/api/admin/media/register': typeof ApiAdminMediaRegisterRoute
@@ -1491,6 +1500,7 @@ export interface FileRouteTypes {
     | '/api/admin/kanban/update'
     | '/api/admin/media/create-folder'
     | '/api/admin/media/delete'
+    | '/api/admin/media/download'
     | '/api/admin/media/list'
     | '/api/admin/media/move'
     | '/api/admin/media/register'
@@ -1634,6 +1644,7 @@ export interface FileRouteTypes {
     | '/api/admin/kanban/update'
     | '/api/admin/media/create-folder'
     | '/api/admin/media/delete'
+    | '/api/admin/media/download'
     | '/api/admin/media/list'
     | '/api/admin/media/move'
     | '/api/admin/media/register'
@@ -1782,6 +1793,7 @@ export interface FileRouteTypes {
     | '/api/admin/kanban/update'
     | '/api/admin/media/create-folder'
     | '/api/admin/media/delete'
+    | '/api/admin/media/download'
     | '/api/admin/media/list'
     | '/api/admin/media/move'
     | '/api/admin/media/register'
@@ -1832,6 +1844,7 @@ export interface RootRouteChildren {
   ApiAdminKanbanUpdateRoute: typeof ApiAdminKanbanUpdateRoute
   ApiAdminMediaCreateFolderRoute: typeof ApiAdminMediaCreateFolderRoute
   ApiAdminMediaDeleteRoute: typeof ApiAdminMediaDeleteRoute
+  ApiAdminMediaDownloadRoute: typeof ApiAdminMediaDownloadRoute
   ApiAdminMediaListRoute: typeof ApiAdminMediaListRoute
   ApiAdminMediaMoveRoute: typeof ApiAdminMediaMoveRoute
   ApiAdminMediaRegisterRoute: typeof ApiAdminMediaRegisterRoute
@@ -2662,6 +2675,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAdminMediaListRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/admin/media/download': {
+      id: '/api/admin/media/download'
+      path: '/api/admin/media/download'
+      fullPath: '/api/admin/media/download'
+      preLoaderRoute: typeof ApiAdminMediaDownloadRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/admin/media/delete': {
       id: '/api/admin/media/delete'
       path: '/api/admin/media/delete'
@@ -3161,6 +3181,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiAdminKanbanUpdateRoute: ApiAdminKanbanUpdateRoute,
   ApiAdminMediaCreateFolderRoute: ApiAdminMediaCreateFolderRoute,
   ApiAdminMediaDeleteRoute: ApiAdminMediaDeleteRoute,
+  ApiAdminMediaDownloadRoute: ApiAdminMediaDownloadRoute,
   ApiAdminMediaListRoute: ApiAdminMediaListRoute,
   ApiAdminMediaMoveRoute: ApiAdminMediaMoveRoute,
   ApiAdminMediaRegisterRoute: ApiAdminMediaRegisterRoute,

--- a/apps/web/src/routes/admin/media/index.tsx
+++ b/apps/web/src/routes/admin/media/index.tsx
@@ -85,8 +85,62 @@ function formatFileSize(bytes: number): string {
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
 }
 
+function HoverMarqueeText({
+  text,
+  className,
+}: {
+  text: string;
+  className?: string;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const textRef = useRef<HTMLSpanElement>(null);
+  const [overflowWidth, setOverflowWidth] = useState(0);
+  const [isHovered, setIsHovered] = useState(false);
+
+  useEffect(() => {
+    const measure = () => {
+      const containerWidth = containerRef.current?.clientWidth ?? 0;
+      const textWidth = textRef.current?.scrollWidth ?? 0;
+      setOverflowWidth(Math.max(0, textWidth - containerWidth));
+    };
+
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [text]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(["overflow-hidden whitespace-nowrap", className])}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      title={text}
+    >
+      <span
+        ref={textRef}
+        className="inline-block whitespace-nowrap"
+        style={{
+          transform:
+            isHovered && overflowWidth > 0
+              ? `translateX(-${overflowWidth}px)`
+              : "translateX(0)",
+          transitionDuration: `${Math.max(1.8, overflowWidth / 40)}s`,
+          transitionTimingFunction: "linear",
+        }}
+      >
+        {text}
+      </span>
+    </div>
+  );
+}
+
 function getRelativePath(fullPath: string): string {
   return fullPath;
+}
+
+function getAdminMediaDownloadUrl(path: string): string {
+  return `/api/admin/media/download?path=${encodeURIComponent(path)}`;
 }
 
 function MediaLibrary() {
@@ -461,11 +515,10 @@ function MediaLibrary() {
     deleteMutation.mutate(Array.from(selectedItems));
   };
 
-  const handleDownload = (publicUrl: string, filename: string) => {
+  const handleDownload = (path: string, filename: string) => {
     const link = document.createElement("a");
-    link.href = publicUrl;
+    link.href = getAdminMediaDownloadUrl(path);
     link.download = filename;
-    link.target = "_blank";
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -476,7 +529,7 @@ function MediaLibrary() {
     selectedItems.forEach((path) => {
       const item = currentItems.find((i) => i.path === path);
       if (item && item.type === "file") {
-        handleDownload(item.publicUrl, item.name);
+        handleDownload(item.path, item.name);
       }
     });
   };
@@ -1221,7 +1274,7 @@ function ContentPanel({
   items: MediaItem[];
   onToggleSelection: (path: string) => void;
   onCopyToClipboard: (text: string) => void;
-  onDownload: (publicUrl: string, filename: string) => void;
+  onDownload: (path: string, filename: string) => void;
   onReplace: (file: File, path: string) => void;
   onDeleteSingle: (path: string) => void;
   onOpenPreview: (path: string, name: string) => void;
@@ -1302,6 +1355,7 @@ function ContentPanel({
                 selectedItems={selectedItems}
                 onToggleSelection={onToggleSelection}
                 onCopyToClipboard={onCopyToClipboard}
+                onDownload={onDownload}
                 onReplace={onReplace}
                 onDeleteSingle={onDeleteSingle}
                 onOpenPreview={onOpenPreview}
@@ -1566,7 +1620,7 @@ function HeaderBar({
   deletePending: boolean;
   currentFile?: MediaItem;
   onCopyToClipboard: (text: string) => void;
-  onDownload: (publicUrl: string, filename: string) => void;
+  onDownload: (path: string, filename: string) => void;
   onReplace: (file: File, path: string) => void;
   onDeleteSingle: (path: string) => void;
   onCreateFolder: () => void;
@@ -1590,7 +1644,7 @@ function HeaderBar({
 
   return (
     <div className="flex h-10 items-center justify-between border-b border-neutral-200 px-4">
-      <div className="flex items-center gap-1 text-sm text-neutral-500">
+      <div className="flex min-w-0 flex-1 items-center gap-1 text-sm text-neutral-500">
         <div className="mr-2 flex items-center gap-0.5">
           <button
             type="button"
@@ -1655,12 +1709,20 @@ function HeaderBar({
           const isLast = index === breadcrumbs.length - 1;
           const folderPath = breadcrumbs.slice(0, index + 1).join("/");
           const isDropTarget = draggingItem && dropTargetPath === folderPath;
+          const isFileName = currentTab.type === "file" && isLast;
           return (
-            <span key={index} className="flex items-center gap-1">
+            <span key={index} className="flex min-w-0 items-center gap-1">
               <ChevronRightIcon className="size-4 text-neutral-300" />
               {isLast ? (
-                <span className="px-1.5 py-0.5 font-medium text-neutral-700">
-                  {crumb}
+                <span className="min-w-0 px-1.5 py-0.5 font-medium text-neutral-700">
+                  {isFileName ? (
+                    <HoverMarqueeText
+                      text={crumb}
+                      className="max-w-[min(42rem,52vw)]"
+                    />
+                  ) : (
+                    crumb
+                  )}
                 </span>
               ) : (
                 <span
@@ -1694,7 +1756,7 @@ function HeaderBar({
         })}
         {currentFile && (
           <span className="ml-2 text-xs text-neutral-400">
-            {formatFileSize(currentFile.size)} • {currentFile.mimeType}
+            {formatFileSize(currentFile.size)}
           </span>
         )}
       </div>
@@ -1794,7 +1856,7 @@ function HeaderBar({
             <CopyIcon className="size-4" />
           </button>
           <button
-            onClick={() => onDownload(currentFile.publicUrl, currentFile.name)}
+            onClick={() => onDownload(currentFile.path, currentFile.name)}
             className="rounded p-1.5 text-neutral-400 transition-colors hover:text-neutral-600"
             title="Download"
           >
@@ -1844,6 +1906,7 @@ function FolderView({
   selectedItems,
   onToggleSelection,
   onCopyToClipboard,
+  onDownload,
   onReplace,
   onDeleteSingle,
   onOpenPreview,
@@ -1867,6 +1930,7 @@ function FolderView({
   selectedItems: Set<string>;
   onToggleSelection: (path: string) => void;
   onCopyToClipboard: (text: string) => void;
+  onDownload: (path: string, filename: string) => void;
   onReplace: (file: File, path: string) => void;
   onDeleteSingle: (path: string) => void;
   onOpenPreview: (path: string, name: string) => void;
@@ -1920,6 +1984,7 @@ function FolderView({
               isSelected={selectedItems.has(item.path)}
               onSelect={() => onToggleSelection(item.path)}
               onCopyPath={() => onCopyToClipboard(item.publicUrl)}
+              onDownload={() => onDownload(item.path, item.name)}
               onReplace={(file) => onReplace(file, item.path)}
               onDelete={() => onDeleteSingle(item.path)}
               onOpenPreview={() => onOpenPreview(item.path, item.name)}
@@ -1952,6 +2017,7 @@ function MediaItemCard({
   isSelected,
   onSelect,
   onCopyPath,
+  onDownload,
   onReplace,
   onDelete,
   onOpenPreview,
@@ -1970,6 +2036,7 @@ function MediaItemCard({
   isSelected: boolean;
   onSelect: () => void;
   onCopyPath: () => void;
+  onDownload: () => void;
   onReplace: (file: File) => void;
   onDelete: () => void;
   onOpenPreview: () => void;
@@ -2364,15 +2431,16 @@ function MediaItemCard({
                 <CopyIcon className="size-4" />
                 Copy URL
               </button>
-              <a
-                href={item.publicUrl}
-                download={item.name}
-                onClick={() => setShowMenu(false)}
+              <button
+                onClick={() => {
+                  setShowMenu(false);
+                  onDownload();
+                }}
                 className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition-colors hover:bg-neutral-100"
               >
                 <DownloadIcon className="size-4" />
                 Download
-              </a>
+              </button>
               <button
                 onClick={handleReplace}
                 className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition-colors hover:bg-neutral-100"
@@ -2461,15 +2529,16 @@ function MediaItemCard({
               <CopyIcon className="size-4" />
               Copy URL
             </button>
-            <a
-              href={item.publicUrl}
-              download={item.name}
-              onClick={closeContextMenu}
+            <button
+              onClick={() => {
+                closeContextMenu();
+                onDownload();
+              }}
               className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition-colors hover:bg-neutral-100"
             >
               <DownloadIcon className="size-4" />
               Download
-            </a>
+            </button>
             <button
               onClick={() => {
                 closeContextMenu();

--- a/apps/web/src/routes/api/admin/media/download.ts
+++ b/apps/web/src/routes/api/admin/media/download.ts
@@ -1,0 +1,86 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { fetchAdminUser } from "@/functions/admin";
+import { listMediaFiles } from "@/functions/supabase-media";
+import { getMediaFolderFromPath } from "@/lib/media-library";
+
+function getAttachmentDisposition(filename: string) {
+  const encodedFilename = encodeURIComponent(filename);
+  const safeFilename = filename.replace(/["\\]/g, "_");
+
+  return `attachment; filename="${safeFilename}"; filename*=UTF-8''${encodedFilename}`;
+}
+
+export const Route = createFileRoute("/api/admin/media/download")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const isDev = process.env.NODE_ENV === "development";
+        if (!isDev) {
+          const user = await fetchAdminUser();
+          if (!user?.isAdmin) {
+            return new Response(JSON.stringify({ error: "Unauthorized" }), {
+              status: 401,
+              headers: { "Content-Type": "application/json" },
+            });
+          }
+        }
+
+        const url = new URL(request.url);
+        const path = url.searchParams.get("path")?.trim();
+
+        if (!path) {
+          return new Response(JSON.stringify({ error: "Missing path" }), {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        const folder = getMediaFolderFromPath(path);
+        const result = await listMediaFiles(folder);
+
+        if (result.error) {
+          return new Response(JSON.stringify({ error: result.error }), {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        const item = result.items.find(
+          (mediaItem) => mediaItem.type === "file" && mediaItem.path === path,
+        );
+
+        if (!item?.publicUrl) {
+          return new Response(JSON.stringify({ error: "File not found" }), {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        const upstream = await fetch(item.publicUrl);
+
+        if (!upstream.ok) {
+          return new Response(
+            JSON.stringify({ error: "Failed to fetch media asset" }),
+            {
+              status: 502,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        }
+
+        return new Response(upstream.body, {
+          status: 200,
+          headers: {
+            "Cache-Control": "private, no-store",
+            "Content-Disposition": getAttachmentDisposition(item.name),
+            "Content-Type":
+              upstream.headers.get("content-type") ||
+              item.mimeType ||
+              "application/octet-stream",
+          },
+        });
+      },
+    },
+  },
+});


### PR DESCRIPTION
- route admin media downloads through a same-origin attachment endpoint
- switch single and multi-select download actions to use library paths instead of raw public URLs
- align item menus and preview actions with the same download flow