### PR TITLE
fix: preserve pasted images when copying notes to other editors

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -48,6 +48,7 @@
     "overlay:default",
     "notify:default",
     "tantivy:default",
+    "clipboard-manager:allow-write-html",
     "clipboard-manager:allow-write-image",
     "shell:allow-open",
     {

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -6,6 +6,10 @@ import NoteEditor from "@hypr/tiptap/editor";
 import { parseJsonContent } from "@hypr/tiptap/shared";
 
 import { useSearchEngine } from "~/search/contexts/engine";
+import {
+  resolveClipboardImageSrc,
+  writeClipboardHtml,
+} from "~/shared/clipboard-images";
 import { useImageUpload } from "~/shared/hooks/useImageUpload";
 import * as main from "~/store/tinybase/store/main";
 
@@ -93,6 +97,8 @@ export const EnhancedEditor = forwardRef<
       onLinkOpen: (url: string) => {
         void openerCommands.openUrl(url, null);
       },
+      resolveClipboardImageSrc,
+      writeClipboardHtml,
     }),
     [],
   );

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -12,6 +12,10 @@ import {
 } from "@hypr/tiptap/shared";
 
 import { useSearchEngine } from "~/search/contexts/engine";
+import {
+  resolveClipboardImageSrc,
+  writeClipboardHtml,
+} from "~/shared/clipboard-images";
 import { useImageUpload } from "~/shared/hooks/useImageUpload";
 import * as main from "~/store/tinybase/store/main";
 
@@ -125,6 +129,8 @@ export const RawEditor = forwardRef<
       onLinkOpen: (url: string) => {
         void openerCommands.openUrl(url, null);
       },
+      resolveClipboardImageSrc,
+      writeClipboardHtml,
     }),
     [],
   );

--- a/apps/desktop/src/shared/clipboard-images.ts
+++ b/apps/desktop/src/shared/clipboard-images.ts
@@ -1,0 +1,91 @@
+import { invoke } from "@tauri-apps/api/core";
+
+const IMAGE_MIME_TYPES: Record<string, string> = {
+  avif: "image/avif",
+  gif: "image/gif",
+  jpeg: "image/jpeg",
+  jpg: "image/jpeg",
+  png: "image/png",
+  svg: "image/svg+xml",
+  webp: "image/webp",
+};
+
+function isTauriAssetUrl(src: string) {
+  try {
+    const url = new URL(src);
+
+    return (
+      (url.protocol === "asset:" && url.hostname === "localhost") ||
+      ((url.protocol === "http:" || url.protocol === "https:") &&
+        url.hostname === "asset.localhost")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function getAssetPath(src: string) {
+  try {
+    const url = new URL(src);
+    return decodeURIComponent(url.pathname.replace(/^\/+/, "/"));
+  } catch {
+    return null;
+  }
+}
+
+function guessImageMimeType(src: string) {
+  const assetPath = getAssetPath(src) ?? src;
+  const extension = assetPath.split(".").pop()?.toLowerCase();
+
+  return extension ? (IMAGE_MIME_TYPES[extension] ?? null) : null;
+}
+
+function blobToDataUrl(blob: Blob) {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+        return;
+      }
+
+      reject(new Error("Failed to read image as data URL"));
+    };
+    reader.onerror = () =>
+      reject(reader.error ?? new Error("Failed to read image as data URL"));
+    reader.readAsDataURL(blob);
+  });
+}
+
+export async function resolveClipboardImageSrc(src: string) {
+  if (!isTauriAssetUrl(src)) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(src);
+    if (!response.ok) {
+      return null;
+    }
+
+    const blob = await response.blob();
+    const mimeType = blob.type || guessImageMimeType(src);
+    const typedBlob = mimeType
+      ? new Blob([await blob.arrayBuffer()], { type: mimeType })
+      : blob;
+
+    return blobToDataUrl(typedBlob);
+  } catch (error) {
+    console.error("Failed to resolve clipboard image source:", error);
+    return null;
+  }
+}
+
+export async function writeClipboardHtml(html: string, altText: string) {
+  await invoke("plugin:clipboard-manager|write_html", {
+    html,
+    altText,
+    alt_text: altText,
+  });
+}

--- a/packages/tiptap/src/shared/clipboard.test.ts
+++ b/packages/tiptap/src/shared/clipboard.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  rewriteHtmlImageSources,
+  rewriteMarkdownImageSources,
+} from "./clipboard";
+
+describe("rewriteMarkdownImageSources", () => {
+  test("replaces image sources and preserves titles", async () => {
+    const markdown =
+      'Before\n\n![image 1](asset://localhost/%2Ftmp%2Fone.png "Title")\n\nAfter';
+
+    const result = await rewriteMarkdownImageSources(markdown, async (src) =>
+      src.includes("one.png") ? "data:image/png;base64,AAA" : null,
+    );
+
+    expect(result).toContain('![image 1](data:image/png;base64,AAA "Title")');
+    expect(result).toContain("Before");
+    expect(result).toContain("After");
+  });
+
+  test("leaves non-resolved images unchanged", async () => {
+    const markdown = "![image 1](https://example.com/one.png)";
+
+    const result = await rewriteMarkdownImageSources(
+      markdown,
+      async () => null,
+    );
+
+    expect(result).toBe(markdown);
+  });
+});
+
+describe("rewriteHtmlImageSources", () => {
+  test("replaces image sources and adds width styles", async () => {
+    const html =
+      '<p>Before</p><img src="asset://localhost/%2Ftmp%2Fone.png" alt="image 1" data-editor-width="42"><p>After</p>';
+
+    const result = await rewriteHtmlImageSources(html, async (src) =>
+      src.includes("one.png") ? "data:image/png;base64,AAA" : null,
+    );
+
+    expect(result).toContain('src="data:image/png;base64,AAA"');
+    expect(result).toContain('style="width: 42%;"');
+    expect(result).toContain("<p>Before</p>");
+    expect(result).toContain("<p>After</p>");
+  });
+
+  test("merges width styles with existing inline styles", async () => {
+    const html =
+      '<img src="asset://localhost/%2Ftmp%2Fone.png" style="display:block;" data-editor-width="50">';
+
+    const result = await rewriteHtmlImageSources(
+      html,
+      async () => "data:image/png;base64,AAA",
+    );
+
+    expect(result).toContain('src="data:image/png;base64,AAA"');
+    expect(result).toContain('style="display:block; width: 50%;"');
+  });
+});

--- a/packages/tiptap/src/shared/clipboard.ts
+++ b/packages/tiptap/src/shared/clipboard.ts
@@ -2,36 +2,247 @@ import {
   Extension,
   getTextBetween,
   getTextSerializersFromSchema,
+  type Editor,
 } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
 
-export const ClipboardTextSerializer = Extension.create({
+type ResolveClipboardImageSrc = (src: string) => Promise<string | null>;
+type WriteClipboardHtml = (html: string, altText: string) => Promise<void>;
+
+const IMAGE_TAG_REGEX = /<img\b[^>]*>/gi;
+const IMAGE_SRC_REGEX = /\bsrc\s*=\s*(['"])(.*?)\1/i;
+const IMAGE_WIDTH_REGEX = /\bdata-editor-width\s*=\s*(['"])(.*?)\1/i;
+const STYLE_REGEX = /\bstyle\s*=\s*(['"])(.*?)\1/i;
+const MARKDOWN_IMAGE_REGEX = /!\[([^\]]*)\]\((\S+?)(?:\s+"([^"]*)")?\)/g;
+
+function isWholeDocumentSelection(editor: Editor) {
+  const { doc, selection } = editor.state;
+
+  return selection.from <= 1 && selection.to >= doc.content.size - 1;
+}
+
+function getSelectionText(editor: Editor) {
+  const { state, schema } = editor;
+  const { doc, selection } = state;
+  const { ranges } = selection;
+  const from = Math.min(...ranges.map((range) => range.$from.pos));
+  const to = Math.max(...ranges.map((range) => range.$to.pos));
+
+  if (isWholeDocumentSelection(editor)) {
+    return editor.getMarkdown();
+  }
+
+  const textSerializers = getTextSerializersFromSchema(schema);
+  const range = { from, to };
+
+  return getTextBetween(doc, range, {
+    textSerializers,
+  });
+}
+
+function selectionContainsImages(editor: Editor) {
+  const { selection } = editor.state;
+  let hasImage = false;
+
+  editor.state.doc.nodesBetween(selection.from, selection.to, (node) => {
+    if (node.type.name === "image") {
+      hasImage = true;
+      return false;
+    }
+
+    return !hasImage;
+  });
+
+  return hasImage;
+}
+
+function mergeWidthStyle(style: string, width: string) {
+  const withoutWidth = style.replace(/(^|;)\s*width\s*:[^;]+;?/gi, "$1").trim();
+  const normalized =
+    withoutWidth && !withoutWidth.endsWith(";")
+      ? `${withoutWidth};`
+      : withoutWidth;
+
+  return normalized ? `${normalized} width: ${width};` : `width: ${width};`;
+}
+
+function applyImageWidthStyle(tag: string) {
+  const widthMatch = tag.match(IMAGE_WIDTH_REGEX);
+  const widthValue = Number(widthMatch?.[2]);
+
+  if (!Number.isFinite(widthValue) || widthValue <= 0) {
+    return tag;
+  }
+
+  const styleMatch = tag.match(STYLE_REGEX);
+  const nextStyle = mergeWidthStyle(styleMatch?.[2] ?? "", `${widthValue}%`);
+
+  if (!styleMatch) {
+    return tag.replace("<img", `<img style="${nextStyle}"`);
+  }
+
+  return tag.replace(
+    styleMatch[0],
+    `style=${styleMatch[1]}${nextStyle}${styleMatch[1]}`,
+  );
+}
+
+export async function rewriteHtmlImageSources(
+  html: string,
+  resolveImageSrc: ResolveClipboardImageSrc,
+) {
+  const matches = Array.from(html.matchAll(IMAGE_TAG_REGEX));
+
+  if (!matches.length) {
+    return html;
+  }
+
+  let result = "";
+  let lastIndex = 0;
+
+  for (const match of matches) {
+    const index = match.index ?? 0;
+    const tag = match[0];
+    let nextTag = applyImageWidthStyle(tag);
+    const srcMatch = nextTag.match(IMAGE_SRC_REGEX);
+
+    if (srcMatch) {
+      const resolvedSrc = await resolveImageSrc(srcMatch[2]);
+      if (resolvedSrc) {
+        nextTag = nextTag.replace(
+          srcMatch[0],
+          `src=${srcMatch[1]}${resolvedSrc}${srcMatch[1]}`,
+        );
+      }
+    }
+
+    result += html.slice(lastIndex, index);
+    result += nextTag;
+    lastIndex = index + tag.length;
+  }
+
+  return result + html.slice(lastIndex);
+}
+
+export async function rewriteMarkdownImageSources(
+  markdown: string,
+  resolveImageSrc: ResolveClipboardImageSrc,
+) {
+  const matches = Array.from(markdown.matchAll(MARKDOWN_IMAGE_REGEX));
+
+  if (!matches.length) {
+    return markdown;
+  }
+
+  let result = "";
+  let lastIndex = 0;
+
+  for (const match of matches) {
+    const index = match.index ?? 0;
+    const [raw, alt, src, title] = match;
+    const resolvedSrc = await resolveImageSrc(src);
+
+    result += markdown.slice(lastIndex, index);
+    result += resolvedSrc
+      ? title
+        ? `![${alt}](${resolvedSrc} "${title}")`
+        : `![${alt}](${resolvedSrc})`
+      : raw;
+    lastIndex = index + raw.length;
+  }
+
+  return result + markdown.slice(lastIndex);
+}
+
+function handleImageCopy(
+  view: EditorView,
+  editor: Editor,
+  event: ClipboardEvent,
+  resolveImageSrc?: ResolveClipboardImageSrc,
+  writeClipboardHtml?: WriteClipboardHtml,
+) {
+  if (!resolveImageSrc || !selectionContainsImages(editor)) {
+    return false;
+  }
+
+  const { dom, text } = view.serializeForClipboard(
+    view.state.selection.content(),
+  );
+  const html = dom.innerHTML;
+  const altTextPromise = isWholeDocumentSelection(editor)
+    ? rewriteMarkdownImageSources(getSelectionText(editor), resolveImageSrc)
+    : Promise.resolve(text);
+  const htmlPromise = rewriteHtmlImageSources(html, resolveImageSrc);
+
+  if (event.clipboardData) {
+    event.preventDefault();
+    event.clipboardData.clearData();
+    event.clipboardData.setData("text/html", html);
+    event.clipboardData.setData("text/plain", text);
+  }
+
+  if (writeClipboardHtml) {
+    void Promise.all([htmlPromise, altTextPromise])
+      .then(([nextHtml, altText]) => writeClipboardHtml(nextHtml, altText))
+      .catch((error) => {
+        console.error("Failed to write rich clipboard data:", error);
+      });
+    return true;
+  }
+
+  if (typeof ClipboardItem !== "undefined" && navigator.clipboard?.write) {
+    const clipboardItem = new ClipboardItem({
+      "text/plain": altTextPromise.then(
+        (value) => new Blob([value], { type: "text/plain" }),
+      ),
+      "text/html": htmlPromise.then(
+        (value) => new Blob([value], { type: "text/html" }),
+      ),
+    });
+
+    void navigator.clipboard.write([clipboardItem]).catch((error) => {
+      console.error("Failed to write rich clipboard data:", error);
+    });
+    return true;
+  }
+
+  return !!event.clipboardData;
+}
+
+export const ClipboardTextSerializer = Extension.create<{
+  resolveImageSrc?: ResolveClipboardImageSrc;
+  writeClipboardHtml?: WriteClipboardHtml;
+}>({
   name: "hyprnoteClipboardTextSerializer",
+
+  addOptions() {
+    return {
+      resolveImageSrc: undefined,
+      writeClipboardHtml: undefined,
+    };
+  },
 
   addProseMirrorPlugins() {
     return [
       new Plugin({
         key: new PluginKey("hyprnoteClipboardTextSerializer"),
         props: {
-          clipboardTextSerializer: () => {
-            const { editor } = this;
-            const { state, schema } = editor;
-            const { doc, selection } = state;
-            const { ranges } = selection;
-            const from = Math.min(...ranges.map((range) => range.$from.pos));
-            const to = Math.max(...ranges.map((range) => range.$to.pos));
+          clipboardTextSerializer: () => getSelectionText(this.editor),
+          handleDOMEvents: {
+            copy: (view, event) => {
+              if (!(event instanceof ClipboardEvent)) {
+                return false;
+              }
 
-            if (from === 0 && to === doc.content.size) {
-              return editor.getMarkdown();
-            }
-
-            const textSerializers = getTextSerializersFromSchema(schema);
-            const range = { from, to };
-
-            const text = getTextBetween(doc, range, {
-              textSerializers,
-            });
-            return text;
+              return handleImageCopy(
+                view,
+                this.editor,
+                event,
+                this.options.resolveImageSrc,
+                this.options.writeClipboardHtml,
+              );
+            },
           },
         },
       }),

--- a/packages/tiptap/src/shared/extensions/index.ts
+++ b/packages/tiptap/src/shared/extensions/index.ts
@@ -43,6 +43,8 @@ export type FileHandlerConfig = {
 export type ExtensionOptions = {
   imageExtension?: any;
   onLinkOpen?: (url: string) => void;
+  resolveClipboardImageSrc?: (src: string) => Promise<string | null>;
+  writeClipboardHtml?: (html: string, altText: string) => Promise<void>;
 };
 
 const MarkdownUnderline = Underline.extend({
@@ -277,7 +279,10 @@ export const getExtensions = (
   CustomListKeymap,
   ClearMarksOnEnter,
   StreamingAnimation,
-  ClipboardTextSerializer,
+  ClipboardTextSerializer.configure({
+    resolveImageSrc: options?.resolveClipboardImageSrc,
+    writeClipboardHtml: options?.writeClipboardHtml,
+  }),
   SearchAndReplace.configure({
     searchResultClass: "search-result",
     disableRegex: true,


### PR DESCRIPTION
- intercept note copy operations that include images and write rich clipboard payloads
- inline local Tauri attachment images as data URLs for external markdown and rich-text editors
- tighten full-document clipboard markdown serialization and add clipboard rewrite tests