### PR TITLE
feat: add transcript copy action

### DIFF
--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -1,6 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
-import { AlertCircleIcon, PlusIcon, RefreshCwIcon, XIcon } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  AlertCircleIcon,
+  CheckIcon,
+  CopyIcon,
+  PlusIcon,
+  RefreshCwIcon,
+  XIcon,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 import {
@@ -26,6 +33,10 @@ import {
 import { cn } from "@hypr/utils";
 
 import { EditingControls } from "./transcript/editing/controls";
+import {
+  buildTranscriptExportSegments,
+  formatTranscriptExportSegments,
+} from "./transcript/export-data";
 
 import { useAITaskTask } from "~/ai/hooks";
 import { useLanguageModel, useLLMConnectionStatus } from "~/ai/hooks";
@@ -78,10 +89,35 @@ function HeaderTabTranscript({
     sessionMode !== "finalizing" &&
     sessionMode !== "running_batch";
   const store = main.UI.useStore(main.STORE_ID);
+  const transcriptIds =
+    main.UI.useSliceRowIds(
+      main.INDEXES.transcriptBySession,
+      sessionId,
+      main.STORE_ID,
+    ) ?? [];
   const runBatch = useRunBatch(sessionId);
   const [isRedoing, setIsRedoing] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const copiedResetTimeoutRef = useRef<number | null>(null);
 
   const isProcessing = isBatchProcessing || isRedoing;
+  const transcriptText = useMemo(() => {
+    if (!store || transcriptIds.length === 0) {
+      return "";
+    }
+
+    return formatTranscriptExportSegments(
+      buildTranscriptExportSegments(store, transcriptIds),
+    );
+  }, [store, transcriptIds]);
+
+  useEffect(() => {
+    return () => {
+      if (copiedResetTimeoutRef.current !== null) {
+        window.clearTimeout(copiedResetTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const handleRefreshClick = useCallback(
     async (e: React.MouseEvent) => {
@@ -141,8 +177,32 @@ function HeaderTabTranscript({
     },
     [audioExists, isBatchProcessing, runBatch, sessionId, store],
   );
+  const handleCopyClick = useCallback(
+    async (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (!transcriptText) {
+        return;
+      }
+
+      try {
+        await navigator.clipboard.writeText(transcriptText);
+        if (copiedResetTimeoutRef.current !== null) {
+          window.clearTimeout(copiedResetTimeoutRef.current);
+        }
+        setCopied(true);
+        copiedResetTimeoutRef.current = window.setTimeout(() => {
+          setCopied(false);
+          copiedResetTimeoutRef.current = null;
+        }, 2000);
+      } catch {}
+    },
+    [transcriptText],
+  );
 
   const showRefreshButton = audioExists && isActive && isSessionInactive;
+  const showCopyButton = isActive && transcriptText.length > 0;
   const showProgress = audioExists && isActive && isProcessing;
   const refreshButton = (
     <span
@@ -160,10 +220,35 @@ function HeaderTabTranscript({
       <RefreshCwIcon size={12} />
     </span>
   );
+  const copyButton = (
+    <span
+      onClick={(e) => {
+        void handleCopyClick(e);
+      }}
+      className={cn([
+        "inline-flex h-5 w-5 cursor-pointer items-center justify-center rounded-xs transition-colors",
+        copied
+          ? "text-green-500"
+          : ["hover:bg-neutral-200 focus-visible:bg-neutral-200"],
+      ])}
+      aria-label="Copy transcript"
+      role="button"
+    >
+      {copied ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+    </span>
+  );
 
   return (
     <NoteTab isActive={isActive} onClick={onClick}>
       Transcript
+      {showCopyButton && (
+        <Tooltip>
+          <TooltipTrigger asChild>{copyButton}</TooltipTrigger>
+          <TooltipContent>
+            {copied ? "Copied" : "Copy transcript"}
+          </TooltipContent>
+        </Tooltip>
+      )}
       {showRefreshButton &&
         (batchError ? (
           <Tooltip>

--- a/apps/desktop/src/session/components/note-input/transcript/export-data.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/export-data.ts
@@ -1,0 +1,108 @@
+import * as main from "~/store/tinybase/store/main";
+import { buildSegments, SegmentKey } from "~/stt/segment";
+import {
+  defaultRenderLabelContext,
+  SpeakerLabelManager,
+} from "~/stt/segment/shared";
+import { convertStorageHintsToRuntime } from "~/stt/speaker-hints";
+import { parseTranscriptHints, parseTranscriptWords } from "~/stt/utils";
+
+export function buildTranscriptExportSegments(
+  store: NonNullable<ReturnType<typeof main.UI.useStore>>,
+  transcriptIds: string[],
+) {
+  if (transcriptIds.length === 0) {
+    return [];
+  }
+
+  const wordIdToIndex = new Map<string, number>();
+  const collectedWords: Array<{
+    id: string;
+    text: string;
+    start_ms: number;
+    end_ms: number;
+    channel: number;
+  }> = [];
+
+  const firstStartedAt = store.getCell(
+    "transcripts",
+    transcriptIds[0],
+    "started_at",
+  );
+
+  for (const transcriptId of transcriptIds) {
+    const startedAt = store.getCell("transcripts", transcriptId, "started_at");
+    const offset =
+      typeof startedAt === "number" && typeof firstStartedAt === "number"
+        ? startedAt - firstStartedAt
+        : 0;
+
+    const words = parseTranscriptWords(store, transcriptId);
+    for (const word of words) {
+      if (
+        word.text === undefined ||
+        word.start_ms === undefined ||
+        word.end_ms === undefined
+      ) {
+        continue;
+      }
+
+      collectedWords.push({
+        id: word.id,
+        text: word.text,
+        start_ms: word.start_ms + offset,
+        end_ms: word.end_ms + offset,
+        channel: word.channel ?? 0,
+      });
+    }
+  }
+
+  collectedWords.sort((a, b) => a.start_ms - b.start_ms);
+  collectedWords.forEach((word, index) => wordIdToIndex.set(word.id, index));
+
+  const storageHints = transcriptIds.flatMap((transcriptId) =>
+    parseTranscriptHints(store, transcriptId),
+  );
+  const speakerHints = convertStorageHintsToRuntime(
+    storageHints,
+    wordIdToIndex,
+  );
+
+  const segments = buildSegments(collectedWords, [], speakerHints);
+  const ctx = defaultRenderLabelContext(store);
+  const manager = SpeakerLabelManager.fromSegments(segments, ctx);
+
+  return segments.flatMap((segment) => {
+    if (segment.words.length === 0) {
+      return [];
+    }
+
+    const text = segment.words
+      .map((word) => word.text)
+      .join(" ")
+      .trim();
+    if (!text) {
+      return [];
+    }
+
+    const firstWord = segment.words[0];
+    const lastWord = segment.words[segment.words.length - 1];
+
+    return [
+      {
+        text,
+        start_ms: firstWord.start_ms,
+        end_ms: lastWord.end_ms,
+        speaker: SegmentKey.renderLabel(segment.key, ctx, manager),
+      },
+    ];
+  });
+}
+
+export function formatTranscriptExportSegments(
+  segments: Array<{ speaker: string; text: string }>,
+) {
+  return segments
+    .map((segment) => `${segment.speaker}: ${segment.text}`)
+    .join("\n\n");
+}

--- a/apps/desktop/src/session/components/outer-header/overflow/export-transcript.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/export-transcript.tsx
@@ -3,21 +3,12 @@ import { FileTextIcon, Loader2Icon } from "lucide-react";
 import { useMemo } from "react";
 
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
-import {
-  commands as listener2Commands,
-  type VttWord,
-} from "@hypr/plugin-listener2";
+import { commands as listener2Commands } from "@hypr/plugin-listener2";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
 import { DropdownMenuItem } from "@hypr/ui/components/ui/dropdown-menu";
 
+import { buildTranscriptExportSegments } from "~/session/components/note-input/transcript/export-data";
 import * as main from "~/store/tinybase/store/main";
-import { buildSegments, SegmentKey } from "~/stt/segment";
-import {
-  defaultRenderLabelContext,
-  SpeakerLabelManager,
-} from "~/stt/segment/shared";
-import { convertStorageHintsToRuntime } from "~/stt/speaker-hints";
-import { parseTranscriptHints, parseTranscriptWords } from "~/stt/utils";
 
 export function ExportTranscript({ sessionId }: { sessionId: string }) {
   const store = main.UI.useStore(main.STORE_ID);
@@ -33,81 +24,7 @@ export function ExportTranscript({ sessionId }: { sessionId: string }) {
       return [];
     }
 
-    const wordIdToIndex = new Map<string, number>();
-    const collectedWords: Array<{
-      id: string;
-      text: string;
-      start_ms: number;
-      end_ms: number;
-      channel: number;
-    }> = [];
-
-    const firstStartedAt = store.getCell(
-      "transcripts",
-      transcriptIds[0],
-      "started_at",
-    );
-
-    for (const transcriptId of transcriptIds) {
-      const startedAt = store.getCell(
-        "transcripts",
-        transcriptId,
-        "started_at",
-      );
-      const offset =
-        typeof startedAt === "number" && typeof firstStartedAt === "number"
-          ? startedAt - firstStartedAt
-          : 0;
-
-      const words = parseTranscriptWords(store, transcriptId);
-      for (const word of words) {
-        if (
-          word.text === undefined ||
-          word.start_ms === undefined ||
-          word.end_ms === undefined
-        ) {
-          continue;
-        }
-        collectedWords.push({
-          id: word.id,
-          text: word.text,
-          start_ms: word.start_ms + offset,
-          end_ms: word.end_ms + offset,
-          channel: word.channel ?? 0,
-        });
-      }
-    }
-
-    collectedWords.sort((a, b) => a.start_ms - b.start_ms);
-    collectedWords.forEach((w, i) => wordIdToIndex.set(w.id, i));
-
-    const storageHints = transcriptIds.flatMap((id) =>
-      parseTranscriptHints(store, id),
-    );
-    const speakerHints = convertStorageHintsToRuntime(
-      storageHints,
-      wordIdToIndex,
-    );
-
-    const segments = buildSegments(collectedWords, [], speakerHints);
-    const ctx = defaultRenderLabelContext(store);
-    const manager = SpeakerLabelManager.fromSegments(segments, ctx);
-
-    const vttWords: VttWord[] = [];
-    for (const segment of segments) {
-      if (segment.words.length === 0) continue;
-      const speakerLabel = SegmentKey.renderLabel(segment.key, ctx, manager);
-      const firstWord = segment.words[0];
-      const lastWord = segment.words[segment.words.length - 1];
-      vttWords.push({
-        text: segment.words.map((w) => w.text).join(" "),
-        start_ms: firstWord.start_ms,
-        end_ms: lastWord.end_ms,
-        speaker: speakerLabel,
-      });
-    }
-
-    return vttWords;
+    return buildTranscriptExportSegments(store, transcriptIds);
   }, [store, transcriptIds]);
 
   const { mutate, isPending } = useMutation({


### PR DESCRIPTION
- add a copy control to the active Transcript tab that copies speaker-labeled transcript text
- reuse shared transcript serialization for both clipboard copy and VTT export