### PR TITLE
fix: keep editor image resize handles visible

### DIFF
--- a/apps/web/src/components/admin/blog-editor/image-with-alt.tsx
+++ b/apps/web/src/components/admin/blog-editor/image-with-alt.tsx
@@ -2,7 +2,11 @@ import { NodeViewWrapper, ReactNodeViewRenderer } from "@tiptap/react";
 import type { NodeViewProps } from "@tiptap/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { AttachmentImage, normalizeEditorWidth } from "@hypr/tiptap/shared";
+import {
+  AttachmentImage,
+  DEFAULT_EDITOR_WIDTH,
+  normalizeEditorWidth,
+} from "@hypr/tiptap/shared";
 import { cn } from "@hypr/utils";
 
 function ImageNodeView({ node, updateAttributes, selected }: NodeViewProps) {
@@ -129,13 +133,10 @@ function ImageNodeView({ node, updateAttributes, selected }: NodeViewProps) {
   );
 
   const showControls = isHovered || isFocused || selected || isResizing;
+  const editorWidth =
+    normalizeEditorWidth(node.attrs.editorWidth) ?? DEFAULT_EDITOR_WIDTH;
   const imageWidth =
-    draftWidth !== null
-      ? `${draftWidth}px`
-      : node.attrs.editorWidth
-        ? `${node.attrs.editorWidth}%`
-        : undefined;
-  const hasExplicitWidth = imageWidth !== undefined;
+    draftWidth !== null ? `${draftWidth}px` : `${editorWidth}%`;
 
   return (
     <NodeViewWrapper className="relative overflow-visible">
@@ -151,27 +152,24 @@ function ImageNodeView({ node, updateAttributes, selected }: NodeViewProps) {
           src={node.attrs.src}
           alt={node.attrs.alt || ""}
           title={node.attrs.title || undefined}
-          className={cn([
-            "tiptap-image max-w-full",
-            hasExplicitWidth ? "w-full" : "",
-          ])}
+          className={cn(["tiptap-image max-w-full", "w-full"])}
           draggable={false}
         />
         {showControls && (
           <>
             <div
               aria-hidden="true"
-              className="absolute top-0 right-full z-10 h-full w-3"
+              className="absolute top-0 right-0 z-10 h-full w-6"
             />
             <div
               aria-hidden="true"
-              className="absolute top-0 left-full z-10 h-full w-3"
+              className="absolute top-0 left-0 z-10 h-full w-6"
             />
             <button
               type="button"
               aria-label="Resize image from left"
               onPointerDown={(event) => handleResizeStart("left", event)}
-              className="absolute top-1/2 right-full z-20 mr-3 flex h-16 w-4 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border border-neutral-300 bg-white/95 shadow-sm backdrop-blur-sm"
+              className="absolute top-1/2 left-1 z-20 flex h-14 w-4 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border border-neutral-300 bg-white/95 shadow-sm backdrop-blur-sm"
             >
               <span className="h-8 w-1 rounded-full bg-neutral-400" />
             </button>
@@ -179,7 +177,7 @@ function ImageNodeView({ node, updateAttributes, selected }: NodeViewProps) {
               type="button"
               aria-label="Resize image from right"
               onPointerDown={(event) => handleResizeStart("right", event)}
-              className="absolute top-1/2 left-full z-20 ml-3 flex h-16 w-4 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border border-neutral-300 bg-white/95 shadow-sm backdrop-blur-sm"
+              className="absolute top-1/2 right-1 z-20 flex h-14 w-4 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border border-neutral-300 bg-white/95 shadow-sm backdrop-blur-sm"
             >
               <span className="h-8 w-1 rounded-full bg-neutral-400" />
             </button>

--- a/packages/tiptap/src/shared/extensions/image-metadata.ts
+++ b/packages/tiptap/src/shared/extensions/image-metadata.ts
@@ -1,6 +1,7 @@
 const EDITOR_WIDTH_PREFIX = "char-editor-width=";
 const MIN_EDITOR_WIDTH = 15;
 const MAX_EDITOR_WIDTH = 100;
+export const DEFAULT_EDITOR_WIDTH = 80;
 
 function clampEditorWidth(value: number) {
   return Math.min(MAX_EDITOR_WIDTH, Math.max(MIN_EDITOR_WIDTH, value));

--- a/packages/tiptap/src/shared/extensions/image.tsx
+++ b/packages/tiptap/src/shared/extensions/image.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@hypr/utils";
 
 import {
+  DEFAULT_EDITOR_WIDTH,
   normalizeEditorWidth,
   parseImageTitleMetadata,
   serializeImageTitleMetadata,
@@ -120,13 +121,10 @@ function ResizableImageNodeView({
 
   const showControls =
     editor.isEditable && (isHovered || selected || isResizing);
+  const editorWidth =
+    normalizeEditorWidth(node.attrs.editorWidth) ?? DEFAULT_EDITOR_WIDTH;
   const imageWidth =
-    draftWidth !== null
-      ? `${draftWidth}px`
-      : node.attrs.editorWidth
-        ? `${node.attrs.editorWidth}%`
-        : undefined;
-  const hasExplicitWidth = imageWidth !== undefined;
+    draftWidth !== null ? `${draftWidth}px` : `${editorWidth}%`;
 
   return (
     <NodeViewWrapper className="relative overflow-visible">
@@ -145,7 +143,7 @@ function ResizableImageNodeView({
           className={cn([
             "tiptap-image max-w-full",
             selected ? "rounded-md bg-white ring-1 ring-neutral-200" : "",
-            hasExplicitWidth ? "w-full" : "",
+            "w-full",
           ])}
           draggable={false}
         />
@@ -153,17 +151,17 @@ function ResizableImageNodeView({
           <>
             <div
               aria-hidden="true"
-              className="absolute top-0 right-full z-10 h-full w-3"
+              className="absolute top-0 right-0 z-10 h-full w-6"
             />
             <div
               aria-hidden="true"
-              className="absolute top-0 left-full z-10 h-full w-3"
+              className="absolute top-0 left-0 z-10 h-full w-6"
             />
             <button
               type="button"
               aria-label="Resize image from left"
               onPointerDown={(event) => handleResizeStart("left", event)}
-              className="absolute top-1/2 right-full z-20 mr-3 flex h-16 w-4 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border border-neutral-300 bg-white/95 shadow-sm backdrop-blur-sm"
+              className="absolute top-1/2 left-1 z-20 flex h-14 w-4 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border border-neutral-300 bg-white/95 shadow-sm backdrop-blur-sm"
             >
               <span className="h-8 w-1 rounded-full bg-neutral-400" />
             </button>
@@ -171,7 +169,7 @@ function ResizableImageNodeView({
               type="button"
               aria-label="Resize image from right"
               onPointerDown={(event) => handleResizeStart("right", event)}
-              className="absolute top-1/2 left-full z-20 ml-3 flex h-16 w-4 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border border-neutral-300 bg-white/95 shadow-sm backdrop-blur-sm"
+              className="absolute top-1/2 right-1 z-20 flex h-14 w-4 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border border-neutral-300 bg-white/95 shadow-sm backdrop-blur-sm"
             >
               <span className="h-8 w-1 rounded-full bg-neutral-400" />
             </button>
@@ -209,15 +207,17 @@ export const AttachmentImage = Image.extend({
         },
       },
       editorWidth: {
-        default: null,
+        default: DEFAULT_EDITOR_WIDTH,
         parseHTML: (element) => {
           const attr = element.getAttribute("data-editor-width");
           if (attr) {
             return normalizeEditorWidth(Number(attr));
           }
 
-          return parseImageTitleMetadata(element.getAttribute("title"))
-            .editorWidth;
+          return (
+            parseImageTitleMetadata(element.getAttribute("title"))
+              .editorWidth ?? DEFAULT_EDITOR_WIDTH
+          );
         },
         renderHTML: (attributes) => {
           const editorWidth = normalizeEditorWidth(attributes.editorWidth);
@@ -246,7 +246,7 @@ export const AttachmentImage = Image.extend({
         alt: token.text || "",
         title: metadata.title,
         attachmentId: null,
-        editorWidth: metadata.editorWidth,
+        editorWidth: metadata.editorWidth ?? DEFAULT_EDITOR_WIDTH,
       },
     };
   },

--- a/packages/tiptap/src/shared/utils.test.ts
+++ b/packages/tiptap/src/shared/utils.test.ts
@@ -199,6 +199,7 @@ describe("md2json", () => {
       expect(imageNode).toBeDefined();
       expect(imageNode?.attrs?.src).toBe("https://example.com/image.png");
       expect(imageNode?.attrs?.alt).toBe("alt text");
+      expect(imageNode?.attrs?.editorWidth).toBe(80);
     });
 
     test("converts image with title to JSON", () => {
@@ -221,6 +222,7 @@ describe("md2json", () => {
       expect(imageNode?.attrs?.src).toBe("https://example.com/image.png");
       expect(imageNode?.attrs?.alt).toBe("alt text");
       expect(imageNode?.attrs?.title).toBe("Image Title");
+      expect(imageNode?.attrs?.editorWidth).toBe(80);
     });
 
     test("converts image width metadata to JSON attributes", () => {


### PR DESCRIPTION
- default images without stored width metadata to 80% of the editor width
- move shared and blog editor resize handles inside the image frame
- cover the default image width behavior in existing TipTap image tests