### PR TITLE
feat: expose recording deletion in session overflow

### DIFF
--- a/apps/desktop/src/session/components/outer-header/overflow/delete.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/delete.tsx
@@ -1,10 +1,12 @@
-import { TrashIcon } from "lucide-react";
+import { Loader2Icon, TrashIcon } from "lucide-react";
 import { useCallback } from "react";
 
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 import { DropdownMenuItem } from "@hypr/ui/components/ui/dropdown-menu";
+import { cn } from "@hypr/utils";
 
+import { useAudioPlayer } from "~/audio-player";
 import {
   captureSessionData,
   deleteSessionCascade,
@@ -12,6 +14,39 @@ import {
 import * as main from "~/store/tinybase/store/main";
 import { useTabs } from "~/store/zustand/tabs";
 import { useUndoDelete } from "~/store/zustand/undo-delete";
+import { useListener } from "~/stt/contexts";
+
+export function DeleteRecording({ sessionId }: { sessionId: string }) {
+  const { deleteRecording, isDeletingRecording } = useAudioPlayer();
+  const mode = useListener((state) => state.getSessionMode(sessionId));
+  const isDisabled =
+    isDeletingRecording ||
+    mode === "active" ||
+    mode === "finalizing" ||
+    mode === "running_batch";
+
+  const handleDeleteRecording = useCallback(() => {
+    void deleteRecording();
+  }, [deleteRecording]);
+
+  return (
+    <DropdownMenuItem
+      onClick={handleDeleteRecording}
+      disabled={isDisabled}
+      className={cn([
+        "cursor-pointer text-red-600",
+        "hover:bg-red-50 hover:text-red-700",
+      ])}
+    >
+      {isDeletingRecording ? (
+        <Loader2Icon className="animate-spin" />
+      ) : (
+        <TrashIcon />
+      )}
+      <span>{isDeletingRecording ? "Deleting..." : "Delete recording"}</span>
+    </DropdownMenuItem>
+  );
+}
 
 export function DeleteNote({ sessionId }: { sessionId: string }) {
   const store = main.UI.useStore(main.STORE_ID);
@@ -46,7 +81,10 @@ export function DeleteNote({ sessionId }: { sessionId: string }) {
   return (
     <DropdownMenuItem
       onClick={handleDeleteNote}
-      className="cursor-pointer text-red-600 hover:bg-red-50 hover:text-red-700"
+      className={cn([
+        "cursor-pointer text-red-600",
+        "hover:bg-red-50 hover:text-red-700",
+      ])}
     >
       <TrashIcon />
       <span>Delete</span>

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -10,11 +10,12 @@ import {
   DropdownMenuTrigger,
 } from "@hypr/ui/components/ui/dropdown-menu";
 
-import { DeleteNote } from "./delete";
+import { DeleteNote, DeleteRecording } from "./delete";
 import { ExportModal } from "./export-modal";
 import { Listening } from "./listening";
 import { Copy, Folder, ShowInFinder } from "./misc";
 
+import { useAudioPlayer } from "~/audio-player";
 import { useHasTranscript } from "~/session/components/shared";
 import type { EditorView } from "~/store/zustand/tabs/schema";
 
@@ -28,6 +29,7 @@ export function OverflowButton({
   const [open, setOpen] = useState(false);
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
   const hasTranscript = useHasTranscript(sessionId);
+  const { audioExists } = useAudioPlayer();
   const openExportModal = () => {
     setOpen(false);
     requestAnimationFrame(() => setIsExportModalOpen(true));
@@ -59,7 +61,8 @@ export function OverflowButton({
           <Listening sessionId={sessionId} hasTranscript={hasTranscript} />
           <DropdownMenuSeparator />
           <ShowInFinder sessionId={sessionId} />
-          <DropdownMenuSeparator />
+          {audioExists && <DropdownMenuSeparator />}
+          {audioExists && <DeleteRecording sessionId={sessionId} />}
           <DeleteNote sessionId={sessionId} />
         </DropdownMenuContent>
       </DropdownMenu>


### PR DESCRIPTION
- add a recording-only delete action to the session overflow menu
- show the action only when session audio exists
- disable the action while listening or batch processing and show loading feedback while deleting