### PR TITLE
fix: reduce IME glitches and simplify empty-state styling in the raw note editor

### DIFF
--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -144,29 +144,30 @@ export const RawEditor = forwardRef<
   );
 });
 
-const Placeholder: PlaceholderFunction = ({ node, pos }) => {
+const Placeholder: PlaceholderFunction = ({ editor, node, pos }) => {
   "use no memo";
   if (node.type.name !== "paragraph") {
     return "";
   }
 
+  const $pos = editor.state.doc.resolve(pos);
+  for (let depth = $pos.depth; depth > 0; depth--) {
+    const parentName = $pos.node(depth).type.name;
+    if (parentName === "listItem" || parentName === "taskItem") {
+      return "";
+    }
+  }
+
   if (pos === 0) {
     return (
-      <p>
-        <span className="text-neutral-400">
-          <span className="font-semibold">Take notes to guide Char</span>'s
-          meeting notes.
-        </span>{" "}
-        <span className="text-neutral-300">
+      <p className="text-neutral-400">
+        <span>Take notes to guide Char's meeting notes.</span>{" "}
+        <span>
           Press <kbd>/</kbd> for commands.
         </span>
       </p>
     );
   }
 
-  return (
-    <p className="text-neutral-300">
-      Press <kbd>/</kbd> for commands.
-    </p>
-  );
+  return "Press / for commands.";
 };


### PR DESCRIPTION
This change reduces IME-related typing glitches in the raw note editor by making empty-state behavior more conservative around nested list items. Placeholders are no longer rendered inside `listItem` and `taskItem` paragraphs, and the non-primary empty-state UI is simplified to avoid extra inline React-rendered DOM near the caret. The goal is to reduce composition-time DOM churn, which was the most likely cause of duplicated or split CJK input when typing on the first line of a newly nested bullet.