### PR TITLE
fix: prefer session summaries in hover previews

### DIFF
--- a/apps/desktop/src/session/components/session-preview-card.tsx
+++ b/apps/desktop/src/session/components/session-preview-card.tsx
@@ -88,45 +88,6 @@ function markPreviewClosed() {
   lastPreviewClosedAt = Date.now();
 }
 
-function tiptapNodeHasImage(node: unknown): boolean {
-  if (!node || typeof node !== "object") {
-    return false;
-  }
-
-  const content = (node as { content?: unknown }).content;
-  if ((node as { type?: unknown }).type === "image") {
-    return true;
-  }
-
-  if (!Array.isArray(content)) {
-    return false;
-  }
-
-  return content.some(tiptapNodeHasImage);
-}
-
-function sourceHasImages(source: string | undefined): boolean {
-  if (typeof source !== "string") {
-    return false;
-  }
-
-  const trimmed = source.trim();
-  if (!trimmed) {
-    return false;
-  }
-
-  if (trimmed.startsWith("{")) {
-    try {
-      const parsed = JSON.parse(trimmed);
-      if (isValidTiptapContent(parsed)) {
-        return tiptapNodeHasImage(parsed);
-      }
-    } catch {}
-  }
-
-  return MARKDOWN_IMAGE_REGEX.test(trimmed);
-}
-
 function extractPreviewImage(markdown: string | null) {
   if (!markdown) {
     return null;
@@ -194,14 +155,8 @@ function useSessionPreviewData(sessionId: string) {
   );
 
   const hasEnhanced = !!firstEnhancedNoteId && !!enhancedContent;
-  const rawHasImages = useMemo(() => sourceHasImages(rawMd), [rawMd]);
-
   const { previewMarkdown, previewPlainText } = useMemo(() => {
-    const source = rawHasImages
-      ? rawMd
-      : hasEnhanced
-        ? (enhancedContent as string)
-        : rawMd;
+    const source = hasEnhanced ? (enhancedContent as string) : rawMd;
     if (typeof source !== "string" || !source.trim()) {
       return { previewMarkdown: null, previewPlainText: "" };
     }
@@ -227,7 +182,7 @@ function useSessionPreviewData(sessionId: string) {
         ? plain.slice(0, MAX_PREVIEW_LENGTH) + "…"
         : plain;
     return { previewMarkdown: null, previewPlainText: truncated };
-  }, [hasEnhanced, enhancedContent, rawHasImages, rawMd]);
+  }, [hasEnhanced, enhancedContent, rawMd]);
 
   const hasContent = !!previewMarkdown || !!previewPlainText;
 


### PR DESCRIPTION
- Make session preview cards render enhanced summary content whenever a summary exists
- Stop prioritizing raw memo content solely because it contains images
- Remove unused image-detection helpers left behind by the old preview selection logic