### PR TITLE
fix: restore text selection inside note editors

### DIFF
--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -215,8 +215,10 @@
 
   input,
   textarea,
-  [contenteditable="true"] {
+  [contenteditable="true"],
+  [contenteditable="true"] * {
     user-select: text;
+    -webkit-user-select: text;
   }
 }
 


### PR DESCRIPTION
- Re-enable text selection for descendants of contenteditable elements
- Add the WebKit-specific selection rule needed by the desktop editor