### PR TITLE
docs: normalize handbook title casing

### DIFF
--- a/apps/web/content/handbook/about/0.what-char-is.mdx
+++ b/apps/web/content/handbook/about/0.what-char-is.mdx
@@ -1,5 +1,5 @@
 ---
-title: "What Char is"
+title: "What Char Is"
 section: "About"
 summary: "An open-source AI notepad for your meetings. Not a note-taker — a notepad"
 ---

--- a/apps/web/content/handbook/about/3.where-were-heading.mdx
+++ b/apps/web/content/handbook/about/3.where-were-heading.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Where we're heading"
+title: "Where We're Heading"
 section: "About"
 summary: "From AI notepad to AI chief of staff. Three steps"
 ---


### PR DESCRIPTION
- Capitalize inconsistent About section page titles to match the handbook navigation style
- Keep the change scoped to handbook frontmatter so labels update at the content source