### PR TITLE
fix: include the current user in ad-hoc meeting participants

### DIFF
--- a/apps/desktop/src/services/event-listeners.tsx
+++ b/apps/desktop/src/services/event-listeners.tsx
@@ -10,7 +10,7 @@ import { getCurrentWebviewWindowLabel } from "@hypr/plugin-windows";
 
 import * as main from "~/store/tinybase/store/main";
 import {
-  createSession,
+  createAdHocSession,
   getOrCreateSessionForEventId,
 } from "~/store/tinybase/store/sessions";
 import { useTabs } from "~/store/zustand/tabs";
@@ -61,7 +61,7 @@ function useNotificationEvents() {
       pendingAutoStart.current = null;
       const sessionId = eventId
         ? getOrCreateSessionForEventId(store, eventId)
-        : createSession(store);
+        : createAdHocSession(store);
       openNew({
         type: "sessions",
         id: sessionId,
@@ -95,7 +95,7 @@ function useNotificationEvents() {
           }
           const sessionId = eventId
             ? getOrCreateSessionForEventId(currentStore, eventId)
-            : createSession(currentStore);
+            : createAdHocSession(currentStore);
           openNewRef.current({
             type: "sessions",
             id: sessionId,
@@ -117,7 +117,7 @@ function useNotificationEvents() {
                   currentStore,
                   eventIds[selectedIndex],
                 )
-              : createSession(currentStore);
+              : createAdHocSession(currentStore);
 
           openNewRef.current({
             type: "sessions",

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/chip.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/chip.tsx
@@ -10,10 +10,12 @@ import { parseTranscriptHints, updateTranscriptHints } from "~/stt/utils";
 
 export function ParticipantChip({ mappingId }: { mappingId: string }) {
   const details = useParticipantDetails(mappingId);
+  const currentUserId = main.UI.useValue("user_id", main.STORE_ID);
 
   const assignedHumanId = details?.humanId;
   const sessionId = details?.sessionId;
   const source = details?.source;
+  const isCurrentUser = assignedHumanId === currentUserId;
 
   const handleRemove = useRemoveParticipant({
     mappingId,
@@ -35,7 +37,13 @@ export function ParticipantChip({ mappingId }: { mappingId: string }) {
     return null;
   }
 
-  const { humanName } = details;
+  const { humanEmail, humanName } = details;
+  const baseLabel =
+    humanName || humanEmail || (isCurrentUser ? "You" : "Unknown");
+  const label =
+    isCurrentUser && baseLabel !== "You" && !baseLabel.endsWith(" (You)")
+      ? `${baseLabel} (You)`
+      : baseLabel;
 
   return (
     <Badge
@@ -43,7 +51,7 @@ export function ParticipantChip({ mappingId }: { mappingId: string }) {
       className="bg-muted hover:bg-muted/80 flex cursor-pointer items-center gap-1 px-2 py-0.5 text-xs"
       onClick={handleClick}
     >
-      {humanName || "Unknown"}
+      {label}
       <Button
         type="button"
         variant="ghost"

--- a/apps/desktop/src/shared/main/useNewNote.ts
+++ b/apps/desktop/src/shared/main/useNewNote.ts
@@ -7,6 +7,7 @@ import { useShallow } from "zustand/shallow";
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 
 import { id } from "~/shared/utils";
+import { createAdHocSession } from "~/store/tinybase/store/sessions";
 import { useTabs } from "~/store/zustand/tabs";
 import { useListener } from "~/stt/contexts";
 import { setPendingUpload } from "~/stt/pending-upload";
@@ -53,7 +54,7 @@ export function useNewNoteAndListen({
 }: {
   behavior?: "new" | "current";
 } = {}) {
-  const { persistedStore, internalStore } = useRouteContext({
+  const { persistedStore } = useRouteContext({
     from: "__root__",
   });
   const { openNew, openCurrent } = useTabs(
@@ -74,19 +75,9 @@ export function useNewNoteAndListen({
       return;
     }
 
-    const user_id = internalStore?.getValue("user_id");
-    const sessionId = id();
-
-    persistedStore?.setRow("sessions", sessionId, {
-      user_id,
-      created_at: new Date().toISOString(),
-      title: "",
-    });
-
-    void analyticsCommands.event({
-      event: "note_created",
-      has_event_id: false,
-    });
+    const sessionId = persistedStore
+      ? createAdHocSession(persistedStore)
+      : id();
 
     const ff = behavior === "new" ? openNew : openCurrent;
     ff({
@@ -94,15 +85,7 @@ export function useNewNoteAndListen({
       id: sessionId,
       state: { view: null, autoStart: true },
     });
-  }, [
-    status,
-    liveSessionId,
-    persistedStore,
-    internalStore,
-    openNew,
-    openCurrent,
-    behavior,
-  ]);
+  }, [status, liveSessionId, persistedStore, openNew, openCurrent, behavior]);
 
   return handler;
 }

--- a/apps/desktop/src/store/tinybase/store/sessions.test.ts
+++ b/apps/desktop/src/store/tinybase/store/sessions.test.ts
@@ -1,0 +1,70 @@
+import { createMergeableStore } from "tinybase/with-schemas";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { SCHEMA } from "@hypr/store";
+
+import type { Store } from "./main";
+import { createAdHocSession } from "./sessions";
+
+const { analyticsEventMock } = vi.hoisted(() => ({
+  analyticsEventMock: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-analytics", () => ({
+  commands: {
+    event: analyticsEventMock,
+  },
+}));
+
+function createTestStore(): Store {
+  return createMergeableStore()
+    .setTablesSchema(SCHEMA.table)
+    .setValuesSchema(SCHEMA.value) as Store;
+}
+
+describe("createAdHocSession", () => {
+  let store: Store;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    store = createTestStore();
+  });
+
+  test("adds the current user as a participant", () => {
+    store.setValue("user_id", "user-1");
+    store.setRow("humans", "user-1", {
+      user_id: "user-1",
+      name: "John",
+      email: "john@example.com",
+      org_id: "",
+      pinned: false,
+    });
+
+    const sessionId = createAdHocSession(store);
+    const mappingIds = store.getRowIds("mapping_session_participant");
+
+    expect(mappingIds).toHaveLength(1);
+    expect(
+      store.getRow("mapping_session_participant", mappingIds[0]),
+    ).toMatchObject({
+      user_id: "user-1",
+      session_id: sessionId,
+      human_id: "user-1",
+      source: "manual",
+    });
+  });
+
+  test("creates the current user's human row when missing", () => {
+    store.setValue("user_id", "user-1");
+
+    createAdHocSession(store);
+
+    expect(store.getRow("humans", "user-1")).toMatchObject({
+      user_id: "user-1",
+      name: "",
+      email: "",
+      org_id: "",
+      pinned: false,
+    });
+  });
+});

--- a/apps/desktop/src/store/tinybase/store/sessions.ts
+++ b/apps/desktop/src/store/tinybase/store/sessions.ts
@@ -31,6 +31,52 @@ export function createSession(store: Store, title?: string): string {
   return sessionId;
 }
 
+export function createAdHocSession(store: Store, title?: string): string {
+  const sessionId = createSession(store, title);
+  const userId = store.getValue("user_id");
+  if (typeof userId !== "string" || !userId) {
+    return sessionId;
+  }
+
+  if (!store.hasRow("humans", userId)) {
+    store.setRow("humans", userId, {
+      user_id: userId,
+      name: "",
+      email: "",
+      org_id: "",
+      job_title: "",
+      linkedin_username: "",
+      memo: "",
+      pinned: false,
+    } satisfies HumanStorage);
+  }
+
+  let hasParticipant = false;
+  store.forEachRow("mapping_session_participant", (mappingId, _forEachCell) => {
+    const mapping = store.getRow("mapping_session_participant", mappingId);
+    if (
+      mapping?.session_id === sessionId &&
+      mapping.human_id === userId &&
+      mapping.source !== "excluded"
+    ) {
+      hasParticipant = true;
+    }
+  });
+
+  if (hasParticipant) {
+    return sessionId;
+  }
+
+  store.setRow("mapping_session_participant", id(), {
+    user_id: userId,
+    session_id: sessionId,
+    human_id: userId,
+    source: "manual",
+  } satisfies MappingSessionParticipantStorage);
+
+  return sessionId;
+}
+
 export function getOrCreateSessionForEventId(
   store: Store,
   eventId: string,


### PR DESCRIPTION
- add an ad-hoc session creation path that seeds the current user as a manual participant
- route new meeting and notification-driven ad-hoc recording flows through that path
- label the current user's participant chip as `(You)` and cover the session creation behavior with tests