### PR TITLE
fix: increase header recording waveform height

### DIFF
--- a/apps/desktop/src/shared/main/header-listen-button.tsx
+++ b/apps/desktop/src/shared/main/header-listen-button.tsx
@@ -213,7 +213,7 @@ function HeaderListenButtonInner() {
                       1,
                     )}
                     color="#dc2626"
-                    height={20}
+                    height={28}
                     width={72}
                     stickWidth={3}
                     gap={2}


### PR DESCRIPTION
- Raise the max bar height in the header listen button waveform
- Keep the existing width, spacing, and animation behavior unchanged