### PR TITLE
add command for start recording in empty page

### DIFF
--- a/apps/desktop/src/shared/main/empty/index.tsx
+++ b/apps/desktop/src/shared/main/empty/index.tsx
@@ -5,7 +5,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { Kbd } from "@hypr/ui/components/ui/kbd";
 import { cn } from "@hypr/utils";
 
-import { useNewNote } from "../useNewNote";
+import { useNewNote, useNewNoteAndListen } from "../useNewNote";
 import { OpenNoteDialog } from "./open-note-dialog";
 
 import { StandardTabWrapper } from "~/shared/main";
@@ -54,6 +54,7 @@ export function TabContentEmpty({
 
 function EmptyView() {
   const newNote = useNewNote({ behavior: "current" });
+  const newNoteAndListen = useNewNoteAndListen({ behavior: "current" });
   const openCurrent = useTabs((state) => state.openCurrent);
   const [openNoteDialogOpen, setOpenNoteDialogOpen] = useState(false);
 
@@ -89,6 +90,11 @@ function EmptyView() {
     <div className="mb-12 flex h-full flex-col items-center justify-center gap-6 text-neutral-600">
       <div className="flex min-w-[280px] flex-col gap-1 text-center">
         <ActionItem label="New Note" shortcut={["⌘", "N"]} onClick={newNote} />
+        <ActionItem
+          label="Start Recording"
+          shortcut={["⌘", "⇧", "N"]}
+          onClick={newNoteAndListen}
+        />
         <ActionItem
           label="Open Note"
           shortcut={["⌘", "O"]}

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -1032,6 +1032,19 @@ function useTabsShortcuts() {
     [openNew],
   );
 
+  const newNoteAndListen = useNewNoteAndListen();
+
+  useHotkeys(
+    "mod+shift+n",
+    () => newNoteAndListen(),
+    {
+      preventDefault: true,
+      enableOnFormTags: true,
+      enableOnContentEditable: true,
+    },
+    [newNoteAndListen],
+  );
+
   return {};
 }
 


### PR DESCRIPTION
After removing the button from the top right corner and removing auto-recording we moved back to the initial problem: there is no way to quickly start meeting record without meeting itself.

So as simple solution I suggest to add "start recording" button in the empty tab near the "new note". This will not break the usual pattern and with shortcut image could teach user how to start it immediately

<img width="1644" height="1622" alt="CleanShot 2026-03-24 at 12 05 27@2x" src="https://github.com/user-attachments/assets/6cf412fe-ba6f-4dfa-98ec-3df617169963" />
