### PR TITLE
fix: keep tab shortcut badges readable while holding Cmd

### DIFF
--- a/apps/desktop/src/shared/tabs.tsx
+++ b/apps/desktop/src/shared/tabs.tsx
@@ -245,7 +245,14 @@ export function TabItemBase({
           </div>
           <span className="pointer-events-none truncate">{title}</span>
         </div>
-        <div className="relative h-4 w-4 shrink-0">
+        <div
+          className={cn([
+            "relative shrink-0 overflow-visible",
+            showShortcut
+              ? "flex h-5 min-w-fit items-center justify-end"
+              : "h-4 w-4",
+          ])}
+        >
           <div
             className={cn([
               "absolute inset-0 flex items-center justify-center transition-opacity duration-200",
@@ -293,7 +300,7 @@ export function TabItemBase({
             </div>
           )}
           {showShortcut && (
-            <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center">
+            <div className="pointer-events-none flex h-full items-center justify-end">
               <Kbd>⌘ {tabIndex}</Kbd>
             </div>
           )}

--- a/packages/ui/src/components/ui/kbd.tsx
+++ b/packages/ui/src/components/ui/kbd.tsx
@@ -5,7 +5,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
     <kbd
       data-slot="kbd"
       className={cn([
-        "pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded px-1 font-mono text-xs font-medium select-none",
+        "pointer-events-none inline-flex h-5 w-fit min-w-5 shrink-0 items-center justify-center gap-1 rounded px-1 font-mono text-xs leading-none font-medium whitespace-nowrap select-none",
         "border border-neutral-300",
         "bg-linear-to-b from-white to-neutral-100",
         "text-neutral-400",


### PR DESCRIPTION
- let the tab action slot expand to fit the Cmd shortcut badge instead of forcing it into the close-icon box
- tighten shared Kbd sizing so shortcut keycaps keep their height and do not wrap or compress