### PR TITLE
feat: add calendar settings tab

### DIFF
--- a/apps/desktop/src/settings/calendar/index.tsx
+++ b/apps/desktop/src/settings/calendar/index.tsx
@@ -1,0 +1,9 @@
+import { CalendarSidebarContent } from "~/calendar/components/sidebar";
+
+export function SettingsCalendar() {
+  return (
+    <div className="pt-3">
+      <CalendarSidebarContent />
+    </div>
+  );
+}

--- a/apps/desktop/src/settings/index.tsx
+++ b/apps/desktop/src/settings/index.tsx
@@ -1,5 +1,6 @@
 import {
   BellIcon,
+  CalendarCogIcon,
   FlaskConical,
   MonitorIcon,
   SettingsIcon,
@@ -14,6 +15,7 @@ import {
 } from "@hypr/ui/components/ui/scroll-fade";
 import { cn } from "@hypr/utils";
 
+import { SettingsCalendar } from "./calendar";
 import { SettingsApp, SettingsNotifications, SettingsSystem } from "./general";
 import { SettingsLab } from "./lab";
 
@@ -67,6 +69,7 @@ const SECTIONS: {
 }[] = [
   { id: "app", label: "App", icon: SmartphoneIcon },
   { id: "notifications", label: "Notifications", icon: BellIcon },
+  { id: "calendar", label: "Calendar", icon: CalendarCogIcon },
   { id: "system", label: "System", icon: MonitorIcon },
   { id: "lab", label: "Lab", icon: FlaskConical },
 ];
@@ -93,6 +96,8 @@ function SettingsView({ tab }: { tab: Extract<Tab, { type: "settings" }> }) {
         return <SettingsApp />;
       case "notifications":
         return <SettingsNotifications />;
+      case "calendar":
+        return <SettingsCalendar />;
       case "system":
         return <SettingsSystem />;
       case "lab":

--- a/apps/desktop/src/store/zustand/tabs/schema.ts
+++ b/apps/desktop/src/store/zustand/tabs/schema.ts
@@ -36,6 +36,7 @@ export type SettingsTab =
   | "account"
   | "app"
   | "notifications"
+  | "calendar"
   | "system"
   | "lab";
 


### PR DESCRIPTION
- add a dedicated Calendar tab to the settings tab strip
- reuse the existing calendar sidebar content inside a new settings panel
- extend the settings tab state to support the new calendar section