### PR TITLE
fix: launch google calendar connect from empty provider row

### DIFF
--- a/apps/desktop/src/calendar/components/oauth/provider-content.tsx
+++ b/apps/desktop/src/calendar/components/oauth/provider-content.tsx
@@ -245,7 +245,7 @@ function ConnectedContent({
   );
 }
 
-async function openIntegrationUrl(
+export async function openIntegrationUrl(
   nangoIntegrationId: string | undefined,
   connectionId: string | undefined,
   action: "connect" | "reconnect" | "disconnect",

--- a/apps/desktop/src/calendar/components/sidebar.tsx
+++ b/apps/desktop/src/calendar/components/sidebar.tsx
@@ -1,4 +1,5 @@
 import { platform } from "@tauri-apps/plugin-os";
+import { useCallback, type MouseEvent } from "react";
 
 import {
   Accordion,
@@ -10,9 +11,15 @@ import {
 import { AppleCalendarSelection } from "./apple/calendar-selection";
 import { AccessPermissionRow, TroubleShootingLink } from "./apple/permission";
 import { SyncProvider } from "./context";
-import { OAuthProviderContent } from "./oauth/provider-content";
-import { PROVIDERS } from "./shared";
+import {
+  OAuthProviderContent,
+  openIntegrationUrl,
+} from "./oauth/provider-content";
+import { type CalendarProvider, PROVIDERS } from "./shared";
 
+import { useAuth } from "~/auth";
+import { useBillingAccess } from "~/auth/billing";
+import { useConnections } from "~/auth/useConnections";
 import { usePermission } from "~/shared/hooks/usePermissions";
 
 export function CalendarSidebarContent() {
@@ -43,58 +50,99 @@ export function CalendarSidebarContent() {
               )}
             </div>
           ) : (
-            <AccordionItem
+            <ProviderAccordionItem
               key={provider.id}
-              value={provider.id}
-              className="border-none"
-            >
-              <AccordionTrigger className="py-2 hover:no-underline">
-                <div className="flex items-center gap-2">
-                  {provider.icon}
-                  <span className="text-sm font-medium">
-                    {provider.displayName}
-                  </span>
-                  {provider.badge && (
-                    <span className="rounded-full border border-neutral-300 px-2 text-xs font-light text-neutral-500">
-                      {provider.badge}
-                    </span>
-                  )}
-                </div>
-              </AccordionTrigger>
-              <AccordionContent className="pb-2">
-                {provider.id === "apple" && (
-                  <div className="flex flex-col gap-3">
-                    {calendar.status !== "authorized" ? (
-                      <AccessPermissionRow
-                        title="Calendar"
-                        status={calendar.status}
-                        isPending={calendar.isPending}
-                        onOpen={calendar.open}
-                        onRequest={calendar.request}
-                        onReset={calendar.reset}
-                      />
-                    ) : (
-                      <AppleCalendarSelection
-                        leftAction={
-                          <TroubleShootingLink
-                            isPending={calendar.isPending}
-                            onOpen={calendar.open}
-                            onRequest={calendar.request}
-                            onReset={calendar.reset}
-                          />
-                        }
-                      />
-                    )}
-                  </div>
-                )}
-                {provider.nangoIntegrationId && (
-                  <OAuthProviderContent config={provider} />
-                )}
-              </AccordionContent>
-            </AccordionItem>
+              provider={provider}
+              calendar={calendar}
+            />
           ),
         )}
       </Accordion>
     </SyncProvider>
+  );
+}
+
+function ProviderAccordionItem({
+  provider,
+  calendar,
+}: {
+  provider: CalendarProvider;
+  calendar: ReturnType<typeof usePermission>;
+}) {
+  const auth = useAuth();
+  const { isPro } = useBillingAccess();
+  const { data: connections, isPending, isError } = useConnections(isPro);
+  const providerConnections =
+    connections?.filter(
+      (connection) => connection.integration_id === provider.nangoIntegrationId,
+    ) ?? [];
+  const shouldConnectOnClick =
+    !!provider.nangoIntegrationId &&
+    !!auth.session &&
+    isPro &&
+    !isPending &&
+    !isError &&
+    providerConnections.length === 0;
+
+  const handleTriggerClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      if (!shouldConnectOnClick) return;
+      event.preventDefault();
+      void openIntegrationUrl(
+        provider.nangoIntegrationId,
+        undefined,
+        "connect",
+      );
+    },
+    [provider.nangoIntegrationId, shouldConnectOnClick],
+  );
+
+  return (
+    <AccordionItem value={provider.id} className="border-none">
+      <AccordionTrigger
+        className="py-2 hover:no-underline"
+        onClick={handleTriggerClick}
+      >
+        <div className="flex items-center gap-2">
+          {provider.icon}
+          <span className="text-sm font-medium">{provider.displayName}</span>
+          {provider.badge && (
+            <span className="rounded-full border border-neutral-300 px-2 text-xs font-light text-neutral-500">
+              {provider.badge}
+            </span>
+          )}
+        </div>
+      </AccordionTrigger>
+      <AccordionContent className="pb-2">
+        {provider.id === "apple" && (
+          <div className="flex flex-col gap-3">
+            {calendar.status !== "authorized" ? (
+              <AccessPermissionRow
+                title="Calendar"
+                status={calendar.status}
+                isPending={calendar.isPending}
+                onOpen={calendar.open}
+                onRequest={calendar.request}
+                onReset={calendar.reset}
+              />
+            ) : (
+              <AppleCalendarSelection
+                leftAction={
+                  <TroubleShootingLink
+                    isPending={calendar.isPending}
+                    onOpen={calendar.open}
+                    onRequest={calendar.request}
+                    onReset={calendar.reset}
+                  />
+                }
+              />
+            )}
+          </div>
+        )}
+        {provider.nangoIntegrationId && (
+          <OAuthProviderContent config={provider} />
+        )}
+      </AccordionContent>
+    </AccordionItem>
   );
 }


### PR DESCRIPTION
- intercept Google provider clicks when no accounts are connected
- open the existing calendar connect flow instead of expanding an empty accordion
- reuse the shared integration URL helper for sidebar and provider content