### PR TITLE
center meeting countdown over note editor

### DIFF
--- a/apps/desktop/src/session/components/floating/listen.tsx
+++ b/apps/desktop/src/session/components/floating/listen.tsx
@@ -7,6 +7,7 @@ import { ListenActionButton } from "../listen-action";
 import { FloatingButton } from "./shared";
 
 import { useListenButtonState } from "~/session/components/shared";
+import { useEventCountdown } from "~/session/hooks/useEventCountdown";
 import {
   type RemoteMeeting,
   useRemoteMeeting,
@@ -22,9 +23,27 @@ export function ListenButton({
   const { shouldRender } = useListenButtonState(tab.id);
   const loading = useListener((state) => state.live.loading);
   const remote = useRemoteMeeting(tab.id);
+  const countdown = useEventCountdown(tab.id);
 
-  if (!remote || loading) {
+  if (loading) {
     return <ListenActionButton sessionId={tab.id} />;
+  }
+
+  if (!remote) {
+    if (!shouldRender) {
+      return null;
+    }
+
+    return (
+      <div className="flex flex-col items-center gap-2">
+        {countdown.label && (
+          <div className="text-xs whitespace-nowrap text-neutral-500">
+            <span>{countdown.label}</span>
+          </div>
+        )}
+        <ListenActionButton sessionId={tab.id} />
+      </div>
+    );
   }
 
   if (!shouldRender) {
@@ -32,9 +51,16 @@ export function ListenButton({
   }
 
   return (
-    <div className="flex items-center gap-2">
-      <RemoteMeetingButton remote={remote} />
-      <ListenActionButton sessionId={tab.id} />
+    <div className="flex flex-col items-center gap-2">
+      {countdown.label && (
+        <div className="text-xs whitespace-nowrap text-neutral-500">
+          <span>{countdown.label}</span>
+        </div>
+      )}
+      <div className="flex items-center gap-2">
+        <RemoteMeetingButton remote={remote} />
+        <ListenActionButton sessionId={tab.id} />
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/session/components/listen-action.tsx
+++ b/apps/desktop/src/session/components/listen-action.tsx
@@ -6,7 +6,6 @@ import { OptionsMenu } from "./floating/options-menu";
 import { ActionableTooltipContent, FloatingButton } from "./floating/shared";
 import { RecordingIcon, useListenButtonState } from "./shared";
 
-import { useEventCountdown } from "~/session/hooks/useEventCountdown";
 import { useTabs } from "~/store/zustand/tabs";
 import { useListener } from "~/stt/contexts";
 import { useStartListening } from "~/stt/useStartListening";
@@ -20,7 +19,6 @@ export function ListenActionButton({ sessionId }: { sessionId: string }) {
   }));
   const startListening = useStartListening(sessionId);
   const openNew = useTabs((state) => state.openNew);
-  const countdown = useEventCountdown(sessionId);
 
   const handleConfigure = useCallback(() => {
     startListening();
@@ -40,7 +38,7 @@ export function ListenActionButton({ sessionId }: { sessionId: string }) {
   }
 
   return (
-    <div className="relative">
+    <div>
       <OptionsMenu
         sessionId={sessionId}
         disabled={isDisabled}
@@ -73,11 +71,6 @@ export function ListenActionButton({ sessionId }: { sessionId: string }) {
           </span>
         </FloatingButton>
       </OptionsMenu>
-      {countdown.label && (
-        <div className="absolute bottom-full left-1/2 mb-2 -translate-x-1/2 text-xs whitespace-nowrap text-neutral-500">
-          <span>{countdown.label}</span>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
- move the meeting countdown label into the shared floating listen wrapper
- center the countdown over the full floating action group instead of the start button
- remove button-local countdown positioning from the listen action component