### PR TITLE
fix: allow repeated Cmd+Q while holding Command

### DIFF
--- a/crates/intercept/swift-lib/src/QuitInterceptor.swift
+++ b/crates/intercept/swift-lib/src/QuitInterceptor.swift
@@ -56,7 +56,10 @@ final class QuitInterceptor {
       showOverlay()
 
     case .firstPress:
-      break
+      // The first Cmd+Q keydown is swallowed, so macOS may never send us the Q keyup.
+      // Treat a second non-repeat press while Command is still held as confirmation too.
+      state = .idle
+      performQuit()
 
     case .awaiting:
       state = .idle


### PR DESCRIPTION
## Summary
- allow the second Cmd+Q press to confirm quit even if Command is still held
- keep the existing overlay and timeout path for normal key release behavior

## Verification
- cargo check -p intercept
- cargo check -p desktop