### PR TITLE
fix: keep left sidebar open after onboarding

### DIFF
--- a/apps/desktop/src/routes/app/main/_layout.index.tsx
+++ b/apps/desktop/src/routes/app/main/_layout.index.tsx
@@ -39,12 +39,6 @@ function Component() {
   const isChatOpen = chat.mode === "RightPanelOpen";
 
   useEffect(() => {
-    if (isOnboarding && leftsidebar.expanded) {
-      leftsidebar.setExpanded(false);
-    }
-  }, [isOnboarding, leftsidebar]);
-
-  useEffect(() => {
     if (isNavMode) {
       savedExpandedRef.current = leftsidebar.expanded;
       if (!leftsidebar.expanded) {


### PR DESCRIPTION
- stop persisting a collapsed left sidebar state while the onboarding tab is active
- rely on the onboarding layout to hide the sidebar temporarily so it shows again after setup