### PR TITLE
fix: drop empty transcript state

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/state.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/state.ts
@@ -6,7 +6,7 @@ import { useAudioPlayer } from "~/audio-player";
 import * as main from "~/store/tinybase/store/main";
 import { useListener } from "~/stt/contexts";
 import type { Segment } from "~/stt/live-segment";
-import { parseTranscriptWords } from "~/stt/utils";
+import { hasTranscriptWords as hasStoredTranscriptWords } from "~/stt/utils";
 
 type ListeningStatus = "listening" | "finalizing";
 type BatchPhase = "importing" | "transcribing";
@@ -120,8 +120,8 @@ function useTranscriptContent(sessionId: string) {
       return false;
     }
 
-    return transcriptIds.some(
-      (transcriptId) => parseTranscriptWords(store, transcriptId).length > 0,
+    return transcriptIds.some((transcriptId) =>
+      hasStoredTranscriptWords(store, transcriptId),
     );
   }, [store, transcriptIds, transcriptsTable]);
 

--- a/apps/desktop/src/session/components/shared.tsx
+++ b/apps/desktop/src/session/components/shared.tsx
@@ -12,6 +12,7 @@ import type { Tab } from "~/store/zustand/tabs/schema";
 import { type EditorView } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
 import { useSTTConnection } from "~/stt/useSTTConnection";
+import { hasTranscriptWords } from "~/stt/utils";
 
 export { computeCurrentNoteTab } from "./compute-note-tab";
 
@@ -21,14 +22,25 @@ export function useHasTranscript(sessionId: string): boolean {
     sessionId,
     main.STORE_ID,
   );
+  const transcriptsTable = main.UI.useTable("transcripts", main.STORE_ID);
+  const store = main.UI.useStore(main.STORE_ID);
 
-  return !!transcriptIds && transcriptIds.length > 0;
+  return useMemo(() => {
+    if (!store) {
+      return false;
+    }
+
+    return (transcriptIds ?? []).some((transcriptId) =>
+      hasTranscriptWords(store, transcriptId),
+    );
+  }, [store, transcriptIds, transcriptsTable]);
 }
 
 export function useCurrentNoteTab(
   tab: Extract<Tab, { type: "sessions" }>,
 ): EditorView {
   const sessionMode = useListener((state) => state.getSessionMode(tab.id));
+  const hasTranscript = useHasTranscript(tab.id);
   const isListenerStarting = useListener(
     (state) =>
       state.live.loading &&
@@ -45,16 +57,23 @@ export function useCurrentNoteTab(
     tab.id,
     main.STORE_ID,
   );
-  const firstEnhancedNoteId = enhancedNoteIds?.[0];
+  const firstEnhancedNoteId = hasTranscript ? enhancedNoteIds?.[0] : undefined;
+  const resolvedView =
+    !isListenerActive &&
+    (tab.state.view?.type === "transcript" ||
+      tab.state.view?.type === "enhanced") &&
+    !hasTranscript
+      ? null
+      : (tab.state.view ?? null);
 
   return useMemo(
     () =>
       computeCurrentNoteTab(
-        tab.state.view ?? null,
+        resolvedView,
         isListenerActive,
         firstEnhancedNoteId,
       ),
-    [tab.state.view, isListenerActive, firstEnhancedNoteId],
+    [resolvedView, isListenerActive, firstEnhancedNoteId],
   );
 }
 

--- a/apps/desktop/src/store/tinybase/persister/session/load/transcript.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/load/transcript.test.ts
@@ -78,7 +78,7 @@ describe("processTranscriptFile", () => {
           created_at: "2024-01-01T00:00:00Z",
           session_id: "session-1",
           started_at: 0,
-          words: [],
+          words: [{ id: "w1", text: "hello" }],
           speaker_hints: [],
         },
         {
@@ -87,7 +87,7 @@ describe("processTranscriptFile", () => {
           created_at: "2024-01-01T00:00:00Z",
           session_id: "session-1",
           started_at: 100,
-          words: [],
+          words: [{ id: "w2", text: "world" }],
           speaker_hints: [],
         },
       ],
@@ -98,6 +98,27 @@ describe("processTranscriptFile", () => {
     expect(Object.keys(result.transcripts)).toHaveLength(2);
     expect(result.transcripts["transcript-1"]).toBeDefined();
     expect(result.transcripts["transcript-2"]).toBeDefined();
+  });
+
+  test("skips transcript entries without words", () => {
+    const result = createEmptyLoadedSessionData();
+    const content = JSON.stringify({
+      transcripts: [
+        {
+          id: "transcript-empty",
+          user_id: "user-1",
+          created_at: "2024-01-01T00:00:00Z",
+          session_id: "session-1",
+          started_at: 0,
+          words: [],
+          speaker_hints: [],
+        },
+      ],
+    });
+
+    processTranscriptFile("/path/to/transcript.json", content, result);
+
+    expect(result.transcripts).toEqual({});
   });
 
   test("preserves real filesystem hint payload strings with omitted ended_at", () => {

--- a/apps/desktop/src/store/tinybase/persister/session/load/transcript.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/load/transcript.ts
@@ -101,6 +101,11 @@ export function processTranscriptFile(
 
     for (const transcript of data.transcripts ?? []) {
       const { id, words, speaker_hints, ...transcriptData } = transcript;
+      const normalizedWords = words ?? [];
+      if (normalizedWords.length === 0) {
+        continue;
+      }
+
       result.transcripts[id] = {
         ...transcriptData,
         user_id: transcriptData.user_id ?? "",
@@ -117,7 +122,7 @@ export function processTranscriptFile(
           typeof transcriptData.memo_md === "string"
             ? transcriptData.memo_md
             : "",
-        words: JSON.stringify(words ?? []),
+        words: JSON.stringify(normalizedWords),
         speaker_hints: JSON.stringify(speaker_hints ?? []),
       };
     }

--- a/apps/desktop/src/store/tinybase/persister/session/save/note.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/save/note.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { buildNoteSaveOps } from "./note";
+
+import { createTestMainStore } from "~/store/tinybase/persister/testing/mocks";
+
+vi.mock("@tauri-apps/api/path", () => ({
+  sep: () => "/",
+}));
+
+describe("buildNoteSaveOps", () => {
+  const dataDir = "/data";
+
+  test("deletes the summary file when the enhanced note is empty", () => {
+    const store = createTestMainStore();
+    store.setRow("sessions", "session-1", {
+      user_id: "user-1",
+      created_at: "2024-01-01T00:00:00Z",
+      title: "Test Session",
+      folder_id: "",
+      event_json: "",
+      raw_md: "",
+    });
+    store.setRow("enhanced_notes", "note-1", {
+      user_id: "user-1",
+      session_id: "session-1",
+      content: "",
+      template_id: "",
+      position: 1,
+      title: "Summary",
+    });
+
+    const ops = buildNoteSaveOps(
+      store,
+      store.getTables(),
+      dataDir,
+      new Set(["session-1"]),
+    );
+
+    expect(ops).toEqual([
+      {
+        type: "delete",
+        paths: [
+          "/data/sessions/session-1/_summary.md",
+          "/data/sessions/session-1/_memo.md",
+        ],
+      },
+    ]);
+  });
+});

--- a/apps/desktop/src/store/tinybase/persister/session/save/note.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/save/note.ts
@@ -31,45 +31,56 @@ export function buildNoteSaveOps(
 ): WriteOperation[] {
   const ctx: BuildContext = { store, tables, dataDir, changedSessionIds };
 
-  const enhancedNoteItems = collectEnhancedNotes(ctx);
+  const { items: enhancedNoteItems, deletePaths: enhancedNoteDeletePaths } =
+    collectEnhancedNotes(ctx);
   const { items: memoItems, deletePaths: memoDeletePaths } = collectMemos(ctx);
 
-  return buildOperations([...enhancedNoteItems, ...memoItems], memoDeletePaths);
+  return buildOperations(
+    [...enhancedNoteItems, ...memoItems],
+    [...enhancedNoteDeletePaths, ...memoDeletePaths],
+  );
 }
 
-function collectEnhancedNotes(ctx: BuildContext): DocumentItem[] {
+function collectEnhancedNotes(ctx: BuildContext): {
+  items: DocumentItem[];
+  deletePaths: string[];
+} {
   const { store, tables, dataDir, changedSessionIds } = ctx;
+  const items: DocumentItem[] = [];
+  const deletePaths: string[] = [];
 
-  return Array.from(iterateTableRows(tables, "enhanced_notes"))
-    .filter((note) => note.content && note.session_id)
-    .filter(
-      (note) => !changedSessionIds || changedSessionIds.has(note.session_id!),
-    )
-    .map((note) => {
-      const markdown = tryParseAndConvertToMarkdown(note.content!);
-      if (!markdown) return null;
+  for (const note of iterateTableRows(tables, "enhanced_notes")) {
+    if (!note.session_id) continue;
+    if (changedSessionIds && !changedSessionIds.has(note.session_id)) continue;
 
-      const session = tables.sessions?.[note.session_id!];
-      const sessionDir = buildSessionPath(
-        dataDir,
-        note.session_id!,
-        session?.folder_id ?? "",
-      );
-      const path = [sessionDir, getEnhancedNoteFilename(store, note)].join(
-        sep(),
-      );
+    const session = tables.sessions?.[note.session_id];
+    const sessionDir = buildSessionPath(
+      dataDir,
+      note.session_id,
+      session?.folder_id ?? "",
+    );
+    const path = [sessionDir, getEnhancedNoteFilename(store, note)].join(sep());
+    const markdown = note.content
+      ? tryParseAndConvertToMarkdown(note.content)
+      : null;
 
-      const frontmatter: NoteFrontmatter = {
-        id: note.id,
-        session_id: note.session_id!,
-        template_id: note.template_id || undefined,
-        position: note.position,
-        title: note.title || undefined,
-      };
+    if (!markdown) {
+      deletePaths.push(path);
+      continue;
+    }
 
-      return [{ frontmatter, content: markdown }, path] as DocumentItem;
-    })
-    .filter((item): item is DocumentItem => item !== null);
+    const frontmatter: NoteFrontmatter = {
+      id: note.id,
+      session_id: note.session_id,
+      template_id: note.template_id || undefined,
+      position: note.position,
+      title: note.title || undefined,
+    };
+
+    items.push([{ frontmatter, content: markdown }, path]);
+  }
+
+  return { items, deletePaths };
 }
 
 function collectMemos(ctx: BuildContext): {

--- a/apps/desktop/src/store/tinybase/persister/session/save/transcript.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/save/transcript.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { buildTranscriptSaveOps } from "./transcript";
+
+import { createTestMainStore } from "~/store/tinybase/persister/testing/mocks";
+
+vi.mock("@tauri-apps/api/path", () => ({
+  sep: () => "/",
+}));
+
+describe("buildTranscriptSaveOps", () => {
+  const dataDir = "/data";
+
+  test("writes only transcripts with words", () => {
+    const store = createTestMainStore();
+    store.setRow("sessions", "session-1", {
+      user_id: "user-1",
+      created_at: "2024-01-01T00:00:00Z",
+      title: "Test Session",
+      folder_id: "",
+      event_json: "",
+      raw_md: "",
+    });
+    store.setRow("transcripts", "transcript-empty", {
+      user_id: "user-1",
+      created_at: "2024-01-01T00:00:00Z",
+      session_id: "session-1",
+      started_at: 0,
+      ended_at: 10,
+      memo_md: "",
+      words: JSON.stringify([]),
+      speaker_hints: JSON.stringify([]),
+    });
+    store.setRow("transcripts", "transcript-ready", {
+      user_id: "user-1",
+      created_at: "2024-01-01T00:00:01Z",
+      session_id: "session-1",
+      started_at: 10,
+      ended_at: 20,
+      memo_md: "",
+      words: JSON.stringify([{ id: "w1", text: "hello" }]),
+      speaker_hints: JSON.stringify([]),
+    });
+
+    const ops = buildTranscriptSaveOps(store.getTables(), dataDir);
+
+    expect(ops).toEqual([
+      {
+        type: "write-json",
+        path: "/data/sessions/session-1/transcript.json",
+        content: {
+          transcripts: [
+            {
+              id: "transcript-ready",
+              user_id: "user-1",
+              created_at: "2024-01-01T00:00:01Z",
+              session_id: "session-1",
+              started_at: 10,
+              ended_at: 20,
+              memo_md: "",
+              words: [{ id: "w1", text: "hello" }],
+              speaker_hints: [],
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  test("deletes transcript.json when a changed session has no usable transcript content", () => {
+    const store = createTestMainStore();
+    store.setRow("sessions", "session-1", {
+      user_id: "user-1",
+      created_at: "2024-01-01T00:00:00Z",
+      title: "Test Session",
+      folder_id: "",
+      event_json: "",
+      raw_md: "",
+    });
+    store.setRow("transcripts", "transcript-empty", {
+      user_id: "user-1",
+      created_at: "2024-01-01T00:00:00Z",
+      session_id: "session-1",
+      started_at: 0,
+      ended_at: 10,
+      memo_md: "",
+      words: JSON.stringify([]),
+      speaker_hints: JSON.stringify([]),
+    });
+
+    const ops = buildTranscriptSaveOps(
+      store.getTables(),
+      dataDir,
+      new Set(["session-1"]),
+    );
+
+    expect(ops).toEqual([
+      {
+        type: "delete",
+        paths: ["/data/sessions/session-1/transcript.json"],
+      },
+    ]);
+  });
+});

--- a/apps/desktop/src/store/tinybase/persister/session/save/transcript.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/save/transcript.ts
@@ -24,12 +24,7 @@ export function buildTranscriptSaveOps(
   const ctx: BuildContext = { tables, dataDir, changedSessionIds };
 
   const transcriptsBySession = groupTranscriptsBySession(ctx);
-  const sessionsToProcess = filterByChangedSessions(
-    transcriptsBySession,
-    changedSessionIds,
-  );
-
-  return buildOperations(ctx, sessionsToProcess);
+  return buildOperations(ctx, transcriptsBySession);
 }
 
 function groupTranscriptsBySession(
@@ -40,6 +35,7 @@ function groupTranscriptsBySession(
 
   for (const transcript of iterateTableRows(tables, "transcripts")) {
     if (!transcript.session_id) continue;
+    const words = transcript.words ? JSON.parse(transcript.words) : [];
 
     const data: TranscriptWithData = {
       id: transcript.id,
@@ -49,11 +45,12 @@ function groupTranscriptsBySession(
       started_at: transcript.started_at ?? 0,
       memo_md: transcript.memo_md ?? "",
       ended_at: transcript.ended_at,
-      words: transcript.words ? JSON.parse(transcript.words) : [],
+      words,
       speaker_hints: transcript.speaker_hints
         ? JSON.parse(transcript.speaker_hints)
         : [],
     };
+    if (words.length === 0) continue;
 
     const list = grouped.get(transcript.session_id) ?? [];
     list.push(data);
@@ -63,34 +60,58 @@ function groupTranscriptsBySession(
   return grouped;
 }
 
-function filterByChangedSessions(
-  transcriptsBySession: Map<string, TranscriptWithData[]>,
-  changedSessionIds?: Set<string>,
-): Array<[string, TranscriptWithData[]]> {
-  const entries = [...transcriptsBySession];
-  if (!changedSessionIds) return entries;
-  return entries.filter(([id]) => changedSessionIds.has(id));
-}
-
 function buildOperations(
   ctx: BuildContext,
-  sessions: Array<[string, TranscriptWithData[]]>,
+  transcriptsBySession: Map<string, TranscriptWithData[]>,
 ): WriteOperation[] {
   const { tables, dataDir } = ctx;
+  const operations: WriteOperation[] = [];
+  const deletePaths: string[] = [];
 
-  return sessions.map(([sessionId, transcripts]) => {
+  for (const sessionId of getSessionIdsToProcess(ctx, transcriptsBySession)) {
     const session = tables.sessions?.[sessionId];
+    if (!session) continue;
+
     const sessionDir = buildSessionPath(
       dataDir,
       sessionId,
-      session?.folder_id ?? "",
+      session.folder_id ?? "",
     );
+    const path = [sessionDir, SESSION_TRANSCRIPT_FILE].join(sep());
+    const transcripts = transcriptsBySession.get(sessionId) ?? [];
+
+    if (transcripts.length === 0) {
+      deletePaths.push(path);
+      continue;
+    }
 
     const content: TranscriptJson = { transcripts };
-    return {
-      type: "write-json" as const,
-      path: [sessionDir, SESSION_TRANSCRIPT_FILE].join(sep()),
+    operations.push({
+      type: "write-json",
+      path,
       content,
-    };
-  });
+    });
+  }
+
+  if (deletePaths.length > 0) {
+    operations.push({ type: "delete", paths: deletePaths });
+  }
+
+  return operations;
+}
+
+function getSessionIdsToProcess(
+  ctx: BuildContext,
+  transcriptsBySession: Map<string, TranscriptWithData[]>,
+): string[] {
+  if (ctx.changedSessionIds) {
+    return [...ctx.changedSessionIds];
+  }
+
+  const sessionIds = new Set(Object.keys(ctx.tables.sessions ?? {}));
+  for (const sessionId of transcriptsBySession.keys()) {
+    sessionIds.add(sessionId);
+  }
+
+  return [...sessionIds];
 }

--- a/apps/desktop/src/store/tinybase/store/sessions.ts
+++ b/apps/desktop/src/store/tinybase/store/sessions.ts
@@ -13,6 +13,7 @@ import * as main from "./main";
 import { findSessionByEventId } from "~/session/utils";
 import { DEFAULT_USER_ID } from "~/shared/utils";
 import { id } from "~/shared/utils";
+import { hasTranscriptWordsValue } from "~/stt/utils";
 
 type Store = NonNullable<ReturnType<typeof main.UI.useStore>>;
 
@@ -113,7 +114,7 @@ export function isSessionEmpty(store: Store, sessionId: string): boolean {
   let hasTranscript = false;
   store.forEachRow("transcripts", (rowId, _forEachCell) => {
     const row = store.getRow("transcripts", rowId);
-    if (row?.session_id === sessionId) {
+    if (row?.session_id === sessionId && hasTranscriptWordsValue(row.words)) {
       hasTranscript = true;
     }
   });

--- a/apps/desktop/src/stt/utils.ts
+++ b/apps/desktop/src/stt/utils.ts
@@ -18,6 +18,19 @@ interface TranscriptStore {
   ): void;
 }
 
+export function hasTranscriptWordsValue(wordsJson: unknown): boolean {
+  if (typeof wordsJson !== "string" || !wordsJson) {
+    return false;
+  }
+
+  try {
+    const words = JSON.parse(wordsJson) as unknown;
+    return Array.isArray(words) && words.length > 0;
+  } catch {
+    return false;
+  }
+}
+
 export function parseTranscriptWords(
   store: TranscriptStore,
   transcriptId: string,
@@ -32,6 +45,15 @@ export function parseTranscriptWords(
   } catch {
     return [];
   }
+}
+
+export function hasTranscriptWords(
+  store: TranscriptStore,
+  transcriptId: string,
+): boolean {
+  return hasTranscriptWordsValue(
+    store.getCell("transcripts", transcriptId, "words"),
+  );
 }
 
 export function parseTranscriptHints(


### PR DESCRIPTION
- hide transcript-driven tabs unless persisted transcript words exist
- fall back off stale transcript and summary views when transcript content disappears
- delete empty transcript and summary files instead of leaving stale artifacts on disk
- add regression coverage for transcript loading and session save cleanup