### PR TITLE
Keep calendar account actions beside account labels

### DIFF
--- a/apps/desktop/src/calendar/components/calendar-selection.tsx
+++ b/apps/desktop/src/calendar/components/calendar-selection.tsx
@@ -147,12 +147,12 @@ function CalendarGroupAccordionHeader({
     <div
       onContextMenu={hasMenu ? showContextMenu : undefined}
       className={cn([
-        "group -mx-2 grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-1 rounded-md px-2",
+        "group -mx-2 flex items-center gap-1 rounded-md px-2",
         !disableHoverTone && "hover:bg-neutral-50",
       ])}
     >
-      <AccordionHeader className="min-w-0">
-        <AccordionTriggerPrimitive className="flex w-full min-w-0 cursor-pointer items-center py-2 text-left hover:no-underline">
+      <AccordionHeader className="max-w-full min-w-0">
+        <AccordionTriggerPrimitive className="flex max-w-full min-w-0 cursor-pointer items-center py-2 text-left hover:no-underline">
           <span className="truncate text-xs font-medium text-neutral-600">
             {group.sourceName}
           </span>


### PR DESCRIPTION
## Summary

This PR keeps the calendar account row actions visually attached to the account email label in the desktop calendar picker.

## What Changed

- switched the account accordion header from a three-column grid to an inline flex layout
- kept the account source label constrained so the overflow menu and chevron stay next to the email text

## Why

The previous grid layout pushed the more menu and chevron to the far right edge of the row, which made the actions feel disconnected from the account they controlled.

## Validation

- `pnpm exec dprint fmt apps/desktop/src/calendar/components/calendar-selection.tsx`
- `pnpm -F desktop typecheck`
