### PR TITLE
Tighten settings view spacing and add missing page titles

### DIFF
--- a/apps/desktop/src/settings/ai/llm/index.tsx
+++ b/apps/desktop/src/settings/ai/llm/index.tsx
@@ -2,10 +2,13 @@ import { ConfigureProviders } from "./configure";
 import { LlmSettingsProvider } from "./context";
 import { SelectProviderAndModel } from "./select";
 
+import { SettingsPageTitle } from "~/settings/page-title";
+
 export function LLM() {
   return (
     <LlmSettingsProvider>
-      <div className="mt-4 flex flex-col gap-6">
+      <div className="flex flex-col gap-6">
+        <SettingsPageTitle title="Intelligence" />
         <SelectProviderAndModel />
         <ConfigureProviders />
       </div>

--- a/apps/desktop/src/settings/ai/stt/index.tsx
+++ b/apps/desktop/src/settings/ai/stt/index.tsx
@@ -2,10 +2,13 @@ import { ConfigureProviders } from "./configure";
 import { SttSettingsProvider } from "./context";
 import { SelectProviderAndModel } from "./select";
 
+import { SettingsPageTitle } from "~/settings/page-title";
+
 export function STT() {
   return (
     <SttSettingsProvider>
-      <div className="mt-4 flex flex-col gap-6">
+      <div className="flex flex-col gap-6">
+        <SettingsPageTitle title="Transcription" />
         <SelectProviderAndModel />
         <ConfigureProviders />
       </div>

--- a/apps/desktop/src/settings/calendar/index.tsx
+++ b/apps/desktop/src/settings/calendar/index.tsx
@@ -1,5 +1,6 @@
 import { SyncProvider, useSync } from "~/calendar/components/context";
 import { CalendarSidebarContent } from "~/calendar/components/sidebar";
+import { SettingsPageTitle } from "~/settings/page-title";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 
 function SettingsCalendarContent() {
@@ -10,7 +11,8 @@ function SettingsCalendarContent() {
   });
 
   return (
-    <div className="pt-3">
+    <div className="flex flex-col gap-4">
+      <SettingsPageTitle title="Calendar" />
       <CalendarSidebarContent />
     </div>
   );

--- a/apps/desktop/src/settings/dont-use-this/index.tsx
+++ b/apps/desktop/src/settings/dont-use-this/index.tsx
@@ -1,6 +1,7 @@
 import { commands as windowsCommands } from "@hypr/plugin-windows";
 import { Button } from "@hypr/ui/components/ui/button";
 
+import { SettingsPageTitle } from "~/settings/page-title";
 import { useTabs } from "~/store/zustand/tabs";
 
 export function SettingsDontUseThis() {
@@ -11,7 +12,8 @@ export function SettingsDontUseThis() {
   };
 
   return (
-    <div className="flex flex-col gap-4 pt-3">
+    <div className="flex flex-col gap-6">
+      <SettingsPageTitle title="General" />
       <div className="flex items-center justify-between gap-4">
         <div className="flex-1">
           <h3 className="mb-1 text-sm font-medium">Daily Note</h3>

--- a/apps/desktop/src/settings/general/account.tsx
+++ b/apps/desktop/src/settings/general/account.tsx
@@ -104,7 +104,7 @@ export function SettingsAccount() {
   if (!isAuthenticated) {
     if (isPending) {
       return (
-        <div className="flex flex-col gap-8 pt-3">
+        <div className="flex flex-col gap-8">
           <div>
             <h2 className="mb-4 font-serif text-lg font-semibold">Account</h2>
             <Container
@@ -143,7 +143,7 @@ export function SettingsAccount() {
     }
 
     return (
-      <div className="flex flex-col gap-8 pt-3">
+      <div className="flex flex-col gap-8">
         <section className="border-b border-neutral-200 pb-4">
           <div className="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex min-w-0 flex-1 flex-col gap-4">
@@ -175,7 +175,7 @@ export function SettingsAccount() {
   const currentTier = plan === "trial" ? "pro" : plan;
 
   return (
-    <div className="flex flex-col gap-8 pt-3">
+    <div className="flex flex-col gap-8">
       <div>
         <h2 className="mb-4 font-serif text-lg font-semibold">Account</h2>
         <Container

--- a/apps/desktop/src/settings/general/index.tsx
+++ b/apps/desktop/src/settings/general/index.tsx
@@ -120,7 +120,7 @@ export function SettingsApp() {
   const supportedLanguages = supportedLanguagesQuery.data ?? ["en"];
 
   return (
-    <div className="flex flex-col gap-8 pt-3">
+    <div className="flex flex-col gap-8">
       <form.Field name="autostart">
         {(autostartField) => (
           <form.Field name="save_recordings">
@@ -202,7 +202,7 @@ export function SettingsApp() {
 
 export function SettingsNotifications() {
   return (
-    <div className="pt-3">
+    <div>
       <NotificationSettingsView />
     </div>
   );
@@ -210,7 +210,7 @@ export function SettingsNotifications() {
 
 export function SettingsSystem() {
   return (
-    <div className="flex flex-col gap-8 pt-3">
+    <div className="flex flex-col gap-8">
       <Permissions />
       <Audio />
     </div>

--- a/apps/desktop/src/settings/index.tsx
+++ b/apps/desktop/src/settings/index.tsx
@@ -100,7 +100,7 @@ function SettingsView({ tab }: { tab: Extract<Tab, { type: "settings" }> }) {
       <div className="relative w-full flex-1 overflow-hidden">
         <div
           ref={ref}
-          className="scrollbar-hide h-full w-full flex-1 overflow-y-auto px-6 py-6"
+          className="scrollbar-hide h-full w-full flex-1 overflow-y-auto px-6 pt-3 pb-6"
         >
           {renderContent()}
         </div>

--- a/apps/desktop/src/settings/lab/index.tsx
+++ b/apps/desktop/src/settings/lab/index.tsx
@@ -6,9 +6,12 @@ import { commands as openerCommands } from "@hypr/plugin-opener2";
 import { Button } from "@hypr/ui/components/ui/button";
 import { cn } from "@hypr/utils";
 
+import { SettingsPageTitle } from "~/settings/page-title";
+
 export function SettingsLab() {
   return (
-    <div className="flex flex-col gap-4 pt-3">
+    <div className="flex flex-col gap-6">
+      <SettingsPageTitle title="Lab" />
       <DownloadButtons />
     </div>
   );

--- a/apps/desktop/src/settings/memory/index.tsx
+++ b/apps/desktop/src/settings/memory/index.tsx
@@ -1,8 +1,11 @@
 import { CustomVocabularyView } from "./custom-vocabulary";
 
+import { SettingsPageTitle } from "~/settings/page-title";
+
 export function SettingsMemory() {
   return (
-    <div className="mt-4 flex flex-col gap-6">
+    <div className="flex flex-col gap-6">
+      <SettingsPageTitle title="Memory" />
       <CustomVocabularyView />
     </div>
   );

--- a/apps/desktop/src/settings/page-title.tsx
+++ b/apps/desktop/src/settings/page-title.tsx
@@ -1,0 +1,3 @@
+export function SettingsPageTitle({ title }: { title: string }) {
+  return <h2 className="font-serif text-lg font-semibold">{title}</h2>;
+}

--- a/apps/desktop/src/settings/todo/index.tsx
+++ b/apps/desktop/src/settings/todo/index.tsx
@@ -12,9 +12,12 @@ import { cn } from "@hypr/utils";
 import { TodoProviderContent } from "./provider-content";
 import { TODO_PROVIDERS } from "./shared";
 
+import { SettingsPageTitle } from "~/settings/page-title";
+
 export function SettingsTodo() {
   return (
-    <div className="flex flex-col gap-4 pt-3">
+    <div className="flex flex-col gap-6">
+      <SettingsPageTitle title="Ticket" />
       <Accordion type="multiple" className="flex flex-col">
         {TODO_PROVIDERS.map((provider) => (
           <AccordionItem


### PR DESCRIPTION
- reduce extra top padding across settings views so content sits closer to the tab edge
- add explicit page titles to settings panes that previously opened without one