### PR TITLE
fix: restore batch transcript channel assignment

### DIFF
--- a/crates/transcript/src/processor.rs
+++ b/crates/transcript/src/processor.rs
@@ -164,7 +164,7 @@ impl TranscriptProcessor {
     pub fn process_batch_response(response: &BatchResponse) -> TranscriptDelta {
         let mut new_words = Vec::new();
 
-        for channel in &response.results.channels {
+        for (channel_index, channel) in response.results.channels.iter().enumerate() {
             let Some(alt) = channel.alternatives.first() else {
                 continue;
             };
@@ -172,7 +172,7 @@ impl TranscriptProcessor {
                 continue;
             }
 
-            let raw = assemble_batch(&alt.words, &alt.transcript);
+            let raw = assemble_batch(&alt.words, &alt.transcript, channel_index as i32);
             new_words.extend(finalize_words(raw, WordState::Final));
         }
 
@@ -296,6 +296,8 @@ impl PartialSnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use owhisper_interface::batch;
+
     use crate::types::RawWord;
 
     #[test]
@@ -341,5 +343,50 @@ mod tests {
         assert_eq!(snapshot.partials[0].speaker_index, Some(4));
         assert_eq!(snapshot.partials[1].speaker_index, None);
         assert_eq!(snapshot.partials[2].speaker_index, Some(7));
+    }
+
+    #[test]
+    fn process_batch_response_uses_batch_channel_position() {
+        let response = batch::Response {
+            metadata: serde_json::json!({}),
+            results: batch::Results {
+                channels: vec![
+                    batch::Channel {
+                        alternatives: vec![batch::Alternatives {
+                            transcript: "hello".to_string(),
+                            confidence: 0.9,
+                            words: vec![batch::Word {
+                                word: "hello".to_string(),
+                                start: 0.0,
+                                end: 0.5,
+                                confidence: 0.9,
+                                speaker: None,
+                                punctuated_word: Some("hello".to_string()),
+                            }],
+                        }],
+                    },
+                    batch::Channel {
+                        alternatives: vec![batch::Alternatives {
+                            transcript: "world".to_string(),
+                            confidence: 0.9,
+                            words: vec![batch::Word {
+                                word: "world".to_string(),
+                                start: 0.5,
+                                end: 1.0,
+                                confidence: 0.9,
+                                speaker: None,
+                                punctuated_word: Some("world".to_string()),
+                            }],
+                        }],
+                    },
+                ],
+            },
+        };
+
+        let delta = TranscriptProcessor::process_batch_response(&response);
+
+        assert_eq!(delta.new_words.len(), 2);
+        assert_eq!(delta.new_words[0].channel, 0);
+        assert_eq!(delta.new_words[1].channel, 1);
     }
 }

--- a/crates/transcript/src/words/assembly.rs
+++ b/crates/transcript/src/words/assembly.rs
@@ -13,22 +13,20 @@ pub(crate) fn assemble(raw: &[Word], transcript: &str, channel: i32) -> Vec<RawW
             speaker: word.speaker,
         }),
         transcript,
-        channel,
     )
 }
 
-pub(crate) fn assemble_batch(raw: &[batch::Word], transcript: &str) -> Vec<RawWord> {
+pub(crate) fn assemble_batch(raw: &[batch::Word], transcript: &str, channel: i32) -> Vec<RawWord> {
     assemble_words(
         raw.iter().map(|word| AssemblyToken {
             word: word.word.as_str(),
             punctuated_word: word.punctuated_word.as_deref(),
             start_ms: (word.start * 1000.0).round() as i64,
             end_ms: (word.end * 1000.0).round() as i64,
-            channel: word.channel,
+            channel,
             speaker: word.speaker.map(|speaker| speaker as i32),
         }),
         transcript,
-        0,
     )
 }
 
@@ -45,7 +43,6 @@ struct AssemblyToken<'a> {
 fn assemble_words<'a>(
     tokens: impl Iterator<Item = AssemblyToken<'a>>,
     transcript: &str,
-    _channel: i32,
 ) -> Vec<RawWord> {
     let tokens: Vec<AssemblyToken<'a>> = tokens.collect();
     let spaced = spacing_from_slice(
@@ -216,13 +213,8 @@ mod tests {
     #[test]
     fn merges_punctuation_into_previous_word() {
         let mut result = Vec::new();
-        push_assembled_word(
-            &mut result,
-            token("look", None, 0, 100),
-            "look".to_string(),
-            0,
-        );
-        push_assembled_word(&mut result, token(".", None, 100, 110), ".".to_string(), 0);
+        push_assembled_word(&mut result, token("look", None, 0, 100), "look".to_string());
+        push_assembled_word(&mut result, token(".", None, 100, 110), ".".to_string());
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].text, "look.");
@@ -235,13 +227,11 @@ mod tests {
             &mut result,
             token("look", None, 0, 100),
             "look.".to_string(),
-            0,
         );
         push_assembled_word(
             &mut result,
             token("Everyone", None, 110, 200),
             "Everyone".to_string(),
-            0,
         );
 
         assert_eq!(result.len(), 2);
@@ -260,7 +250,6 @@ mod tests {
             ]
             .into_iter(),
             transcript,
-            0,
         );
 
         assert_eq!(words.len(), 3);
@@ -280,7 +269,6 @@ mod tests {
             ]
             .into_iter(),
             transcript,
-            0,
         );
 
         assert_eq!(words.len(), 3);
@@ -292,13 +280,8 @@ mod tests {
     #[test]
     fn merges_contraction_into_previous_word() {
         let mut result = Vec::new();
-        push_assembled_word(&mut result, token("it", None, 0, 100), " it".to_string(), 0);
-        push_assembled_word(
-            &mut result,
-            token("'s", None, 100, 150),
-            "'s".to_string(),
-            0,
-        );
+        push_assembled_word(&mut result, token("it", None, 0, 100), " it".to_string());
+        push_assembled_word(&mut result, token("'s", None, 100, 150), "'s".to_string());
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].text, " it's");
@@ -310,7 +293,6 @@ mod tests {
         let words = assemble_words(
             vec![token("mill", None, 0, 100), token("ions", None, 100, 200)].into_iter(),
             transcript,
-            0,
         );
 
         assert_eq!(words.len(), 1);
@@ -323,7 +305,6 @@ mod tests {
         let words = assemble_words(
             vec![token("한", None, 0, 100), token("국", None, 100, 200)].into_iter(),
             transcript,
-            0,
         );
 
         assert_eq!(words.len(), 1);
@@ -336,7 +317,6 @@ mod tests {
         let words = assemble_words(
             vec![token("3", Some("3."), 0, 100), token("14", None, 100, 200)].into_iter(),
             transcript,
-            0,
         );
 
         assert_eq!(words.len(), 1);
@@ -353,10 +333,29 @@ mod tests {
             ]
             .into_iter(),
             transcript,
-            0,
         );
 
         assert_eq!(words.len(), 1);
         assert_eq!(words[0].text, "example.com");
+    }
+
+    #[test]
+    fn assemble_batch_uses_caller_channel() {
+        let words = assemble_batch(
+            &[batch::Word {
+                word: "hello".to_string(),
+                start: 0.0,
+                end: 0.5,
+                confidence: 0.9,
+                speaker: Some(2),
+                punctuated_word: Some("hello".to_string()),
+            }],
+            "hello",
+            7,
+        );
+
+        assert_eq!(words.len(), 1);
+        assert_eq!(words[0].channel, 7);
+        assert_eq!(words[0].speaker, Some(2));
     }
 }


### PR DESCRIPTION
- pass batch channel position into batch word assembly instead of reading a removed field
- simplify assembly helper signatures and align the local tests
- add regression tests for batch channel propagation