### PR TITLE
Publish: OpenRouter Data Retention Policy Across Providers

### DIFF
--- a/apps/web/content/articles/openrouter-data-retention-policy.mdx
+++ b/apps/web/content/articles/openrouter-data-retention-policy.mdx
@@ -1,8 +1,7 @@
 ---
-meta_title: "OpenRouter Data Retention Policy: What You Need to Know"
+meta_title: "OpenRouter Data Retention Policy Across Providers"
 meta_description: "OpenRouter routes your requests across dozens of AI providers. That means two data retention questions, not one. Here's how to think about both."
 author:
-  - "John Jeong"
   - "Harshika"
 featured: false
 category: "Guides"
@@ -65,7 +64,7 @@ For sensitive work, the two-layer data question requires more active management.
 
 The defaults at OpenRouter are reasonably privacy-conscious. Prompts are not logged out of the box. But the flexibility that makes OpenRouter useful also makes its data handling harder to audit than a direct provider relationship.
 
-## Using OpenRouter Through Char
+## Use OpenRouter to Take AI Notes Through Char
 
 Char supports OpenRouter as an API provider option. When you bring your own OpenRouter API key, your meeting data routes through OpenRouter under your account settings.
 


### PR DESCRIPTION
## Article Ready for Publication

**Title:** OpenRouter Data Retention Policy Across Providers
**Author:** Harshika
**Date:** 2026-03-20
**Category:** Guides

**Branch:** blog/openrouter-data-retention-policy-1774865464842
**File:** apps/web/content/articles/openrouter-data-retention-policy.mdx

---
Auto-generated PR from admin panel.