### PR TITLE
fix: hide chat composer without an LLM

### DIFF
--- a/apps/desktop/src/chat/components/body/empty.tsx
+++ b/apps/desktop/src/chat/components/body/empty.tsx
@@ -75,7 +75,10 @@ export function ChatBodyEmpty({
           </p>
           <button
             onClick={handleGoToSettings}
-            className="inline-flex w-fit items-center gap-1.5 rounded-full border border-neutral-300 bg-white px-3 py-1.5 text-xs text-neutral-700 transition-colors hover:bg-neutral-100"
+            className={cn([
+              "inline-flex w-fit items-center gap-1.5 rounded-full border border-stone-600 bg-stone-800 px-3 py-1.5 text-xs font-medium text-white",
+              "shadow-[0_4px_14px_rgba(87,83,78,0.18)] transition-colors hover:bg-stone-700",
+            ])}
           >
             <SparklesIcon size={12} />
             Open AI Settings

--- a/apps/desktop/src/chat/components/content.tsx
+++ b/apps/desktop/src/chat/components/content.tsx
@@ -51,7 +51,8 @@ export function ChatContent({
   mcpIndicator?: McpIndicator;
   children?: React.ReactNode;
 }) {
-  const disabled = !model || !isSystemPromptReady;
+  const isModelConfigured = !!model;
+  const disabled = !isSystemPromptReady;
   const mergeContextRefs = (contextRefs?: ContextRef[]) =>
     contextRefs ? dedupeByKey([pendingRefs, contextRefs]) : pendingRefs;
 
@@ -63,7 +64,7 @@ export function ChatContent({
           status={status}
           error={error}
           onReload={regenerate}
-          isModelConfigured={!!model}
+          isModelConfigured={isModelConfigured}
           onSendMessage={(content, parts, contextRefs) => {
             handleSendMessage(
               content,
@@ -74,28 +75,32 @@ export function ChatContent({
           }}
         />
       )}
-      <ContextBar
-        entities={contextEntities}
-        onRemoveEntity={onRemoveContextEntity}
-        onAddEntity={onAddContextEntity}
-      />
-      <ChatMessageInput
-        draftKey={sessionId}
-        disabled={disabled}
-        hasContextBar={contextEntities.length > 0}
-        onSendMessage={(content, parts, contextRefs) => {
-          handleSendMessage(
-            content,
-            parts,
-            sendMessage,
-            mergeContextRefs(contextRefs),
-          );
-        }}
-        onContextRefsChange={onDraftContextRefsChange}
-        isStreaming={status === "streaming" || status === "submitted"}
-        onStop={stop}
-        mcpIndicator={mcpIndicator}
-      />
+      {isModelConfigured && (
+        <>
+          <ContextBar
+            entities={contextEntities}
+            onRemoveEntity={onRemoveContextEntity}
+            onAddEntity={onAddContextEntity}
+          />
+          <ChatMessageInput
+            draftKey={sessionId}
+            disabled={disabled}
+            hasContextBar={contextEntities.length > 0}
+            onSendMessage={(content, parts, contextRefs) => {
+              handleSendMessage(
+                content,
+                parts,
+                sendMessage,
+                mergeContextRefs(contextRefs),
+              );
+            }}
+            onContextRefsChange={onDraftContextRefsChange}
+            isStreaming={status === "streaming" || status === "submitted"}
+            onStop={stop}
+            mcpIndicator={mcpIndicator}
+          />
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Keep the Charlie setup prompt visible but remove the context bar and message composer until a language model is configured.