### PR TITLE
fix: default settings to App tab

### DIFF
--- a/apps/desktop/src/settings/index.tsx
+++ b/apps/desktop/src/settings/index.tsx
@@ -64,7 +64,7 @@ export function TabContentSettings({
 }
 
 function SettingsView({ tab }: { tab: Extract<Tab, { type: "settings" }> }) {
-  const activeTab = tab.state.tab ?? "account";
+  const activeTab = tab.state.tab ?? "app";
   const ref = useRef<HTMLDivElement>(null);
   const { atStart, atEnd } = useScrollFade(ref, "vertical", [activeTab]);
 

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -91,9 +91,7 @@ export function SettingsNav() {
   const showDontUseThis = isDev || isStaging;
 
   const activeTab =
-    currentTab?.type === "settings"
-      ? (currentTab.state.tab ?? "account")
-      : "account";
+    currentTab?.type === "settings" ? (currentTab.state.tab ?? "app") : "app";
 
   const setActiveTab = useCallback(
     (tab: SettingsTab) => {

--- a/apps/desktop/src/store/zustand/tabs/basic.test.ts
+++ b/apps/desktop/src/store/zustand/tabs/basic.test.ts
@@ -131,6 +131,18 @@ describe("Basic Tab Actions", () => {
     });
   });
 
+  test("openNew defaults bare settings tabs to app", () => {
+    useTabs.getState().openNew({ type: "settings" });
+
+    expect(useTabs.getState()).toHaveCurrentTab({
+      type: "settings",
+      state: { tab: "app" },
+    });
+    expect(useTabs.getState()).toMatchTabsInOrder([
+      { type: "settings", active: true, state: { tab: "app" } },
+    ]);
+  });
+
   test("select toggles active flag without changing history", () => {
     const tabA = createSessionTab({ active: true });
     const tabB = createSessionTab({ active: false });

--- a/apps/desktop/src/store/zustand/tabs/schema.ts
+++ b/apps/desktop/src/store/zustand/tabs/schema.ts
@@ -214,7 +214,7 @@ export const getDefaultState = (tab: TabInput): Tab => {
       return {
         ...base,
         type: "settings",
-        state: { tab: (tab.state?.tab as SettingsTab) ?? "account" },
+        state: { tab: (tab.state?.tab as SettingsTab) ?? "app" },
       };
     case "chat_support":
       return {


### PR DESCRIPTION
Open new settings tabs on the App section instead of Account and add a regression test for bare settings tabs.