### PR TITLE
fix: notify when summaries finish in background

### DIFF
--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.test.ts
@@ -1,8 +1,25 @@
 import type { LanguageModel } from "ai";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { TaskConfig } from ".";
 import { enhanceSuccess } from "./enhance-success";
+
+const mocks = vi.hoisted(() => ({
+  isFocused: vi.fn().mockResolvedValue(true),
+  showNotification: vi.fn().mockResolvedValue({ status: "ok", data: null }),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    isFocused: mocks.isFocused,
+  }),
+}));
+
+vi.mock("@hypr/plugin-notification", () => ({
+  commands: {
+    showNotification: mocks.showNotification,
+  },
+}));
 
 type EnhanceSuccessParams = Parameters<
   NonNullable<TaskConfig<"enhance">["onSuccess"]>
@@ -35,6 +52,13 @@ function createParams(
 }
 
 describe("enhanceSuccess.onSuccess", () => {
+  beforeEach(() => {
+    mocks.isFocused.mockReset();
+    mocks.isFocused.mockResolvedValue(true);
+    mocks.showNotification.mockReset();
+    mocks.showNotification.mockResolvedValue({ status: "ok", data: null });
+  });
+
   it("persists enhanced note content as TipTap JSON string", async () => {
     const params = createParams();
 
@@ -97,5 +121,45 @@ describe("enhanceSuccess.onSuccess", () => {
     await enhanceSuccess.onSuccess?.(params);
 
     expect(params.startTask).not.toHaveBeenCalled();
+  });
+
+  it("shows a notification when summary generation finishes out of focus", async () => {
+    mocks.isFocused.mockResolvedValue(false);
+    const store = {
+      setPartialRow: vi.fn(),
+      getCell: vi.fn((table: string, _row: string, cell: string) => {
+        if (table === "enhanced_notes" && cell === "title") {
+          return "Summary";
+        }
+        if (table === "sessions" && cell === "title") {
+          return "Weekly sync";
+        }
+        return "";
+      }),
+    } as unknown as EnhanceSuccessParams["store"];
+    const params = createParams({ store });
+
+    await enhanceSuccess.onSuccess?.(params);
+
+    expect(mocks.showNotification).toHaveBeenCalledWith({
+      key: null,
+      title: "Summary ready",
+      message: "Weekly sync",
+      timeout: null,
+      source: null,
+      start_time: null,
+      participants: null,
+      event_details: null,
+      action_label: null,
+      options: null,
+    });
+  });
+
+  it("does not show a notification when the app is focused", async () => {
+    const params = createParams();
+
+    await enhanceSuccess.onSuccess?.(params);
+
+    expect(mocks.showNotification).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-success.ts
@@ -1,8 +1,53 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+import { commands as notificationCommands } from "@hypr/plugin-notification";
 import { md2json } from "@hypr/tiptap/shared";
 
 import { createTaskId, type TaskConfig } from ".";
 
-const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = ({
+async function maybeShowSummaryReadyNotification(
+  store: Parameters<
+    NonNullable<TaskConfig<"enhance">["onSuccess"]>
+  >[0]["store"],
+  args: Parameters<NonNullable<TaskConfig<"enhance">["onSuccess"]>>[0]["args"],
+) {
+  try {
+    const isFocused = await getCurrentWindow().isFocused();
+    if (isFocused) {
+      return;
+    }
+  } catch {
+    return;
+  }
+
+  const rawNoteTitle = store.getCell(
+    "enhanced_notes",
+    args.enhancedNoteId,
+    "title",
+  );
+  const noteTitle =
+    typeof rawNoteTitle === "string" && rawNoteTitle.trim()
+      ? rawNoteTitle.trim()
+      : "Summary";
+  const rawSessionTitle = store.getCell("sessions", args.sessionId, "title");
+  const sessionTitle =
+    typeof rawSessionTitle === "string" ? rawSessionTitle.trim() : "";
+
+  void notificationCommands.showNotification({
+    key: null,
+    title: `${noteTitle} ready`,
+    message: sessionTitle || "Your meeting summary has been generated.",
+    timeout: null,
+    source: null,
+    start_time: null,
+    participants: null,
+    event_details: null,
+    action_label: null,
+    options: null,
+  });
+}
+
+const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = async ({
   text,
   args,
   model,
@@ -23,6 +68,8 @@ const onSuccess: NonNullable<TaskConfig<"enhance">["onSuccess"]> = ({
     console.error("Failed to convert markdown to JSON:", error);
     return;
   }
+
+  await maybeShowSummaryReadyNotification(store, args);
 
   const currentTitle = store.getCell("sessions", args.sessionId, "title");
   const trimmedTitle =


### PR DESCRIPTION
- show a persistent desktop notification when summary generation finishes while the app is out of focus
- cover focused and unfocused behavior in the enhance-success tests

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #4843 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #4837
<!-- GitButler Footer Boundary Bottom -->