### PR TITLE
fix: hide note tags field

### DIFF
--- a/apps/desktop/src/session/components/outer-header/metadata/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/index.tsx
@@ -20,7 +20,6 @@ import {
 
 import { DateEditor } from "./date";
 import { ParticipantsDisplay } from "./participants";
-import { TagsDisplay } from "./tags";
 
 import { useConfigValue } from "~/shared/config";
 import { useSessionEvent } from "~/store/tinybase/hooks";
@@ -108,11 +107,9 @@ function ContentInner({ sessionId }: { sessionId: string }) {
       {eventDisplayData && (
         <EventDisplay event={eventDisplayData}>
           <ParticipantsDisplay sessionId={sessionId} />
-          <TagsDisplay sessionId={sessionId} />
         </EventDisplay>
       )}
       {!eventDisplayData && <ParticipantsDisplay sessionId={sessionId} />}
-      {!eventDisplayData && <TagsDisplay sessionId={sessionId} />}
     </div>
   );
 }


### PR DESCRIPTION
Stop rendering the tags input in the session metadata popover while leaving tag data and persistence intact for later.