### PR TITLE
Fix transcript cutoff after live fallback

### DIFF
--- a/apps/desktop/src/store/zustand/listener/general-live.ts
+++ b/apps/desktop/src/store/zustand/listener/general-live.ts
@@ -139,6 +139,13 @@ const createSessionEventHandlers = <T extends LiveStore>(
 
     const stoppedSessionId = get().live.sessionId;
     const stoppedSeconds = get().live.seconds;
+    const stoppedContext = {
+      requestedTranscriptionMode: get().live.requestedTranscriptionMode,
+      currentTranscriptionMode: get().live.currentTranscriptionMode,
+      recordingMode: get().live.recordingMode,
+      degraded: get().live.degraded,
+      error: payload.error ?? null,
+    };
     const { onStopped } = get();
 
     clearLiveEventUnlisteners(get().live.eventUnlisteners);
@@ -153,7 +160,7 @@ const createSessionEventHandlers = <T extends LiveStore>(
     get().resetTranscript();
 
     if (stoppedSessionId && onStopped) {
-      onStopped(stoppedSessionId, stoppedSeconds);
+      onStopped(stoppedSessionId, stoppedSeconds, stoppedContext);
     }
   },
   progress: (payload) => {

--- a/apps/desktop/src/store/zustand/listener/transcript.ts
+++ b/apps/desktop/src/store/zustand/listener/transcript.ts
@@ -2,9 +2,12 @@ import { create as mutate } from "mutative";
 import type { StoreApi } from "zustand";
 
 import type {
+  DegradedError,
   LiveTranscriptDelta,
   LiveTranscriptSegment,
   LiveTranscriptSegmentDelta,
+  RecordingMode,
+  TranscriptionMode,
 } from "@hypr/plugin-listener";
 
 import type { RuntimeSpeakerHint, WordLike } from "~/stt/segment";
@@ -16,6 +19,14 @@ export type BatchPersistCallback = (
   hints: RuntimeSpeakerHint[],
 ) => void;
 
+export type StoppedSessionContext = {
+  requestedTranscriptionMode: TranscriptionMode | null;
+  currentTranscriptionMode: TranscriptionMode | null;
+  recordingMode: RecordingMode | null;
+  degraded: DegradedError | null;
+  error: string | null;
+};
+
 export type LiveTranscriptPersistCallback = (
   delta: LiveTranscriptDelta,
 ) => void;
@@ -23,6 +34,7 @@ export type LiveTranscriptPersistCallback = (
 export type OnStoppedCallback = (
   sessionId: string,
   durationSeconds: number,
+  context: StoppedSessionContext,
 ) => void;
 
 export type TranscriptState = {

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -7,6 +7,7 @@ import type { TranscriptStorage } from "@hypr/store";
 
 import { useListener } from "./contexts";
 import { useKeywords } from "./useKeywords";
+import { useRunBatch } from "./useRunBatch";
 import { useSTTConnection } from "./useSTTConnection";
 
 import { getEnhancerService } from "~/services/enhancer";
@@ -19,7 +20,11 @@ import type {
   OnStoppedCallback,
 } from "~/store/zustand/listener/transcript";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
-import { applyLiveTranscriptDelta, parseTranscriptWords } from "~/stt/utils";
+import {
+  applyLiveTranscriptDelta,
+  parseTranscriptWords,
+  replaceTranscriptWithBatchResult,
+} from "~/stt/utils";
 
 const MIN_DURATION_SECONDS = 10;
 const MIN_WORD_COUNT = 5;
@@ -40,6 +45,7 @@ export function useStartListening(
 
   const start = useListener((state) => state.start);
   const { conn } = useSTTConnection();
+  const runBatch = useRunBatch(sessionId);
 
   const keywords = useKeywords(sessionId);
   const transcriptionMode = options?.transcriptionMode ?? "live";
@@ -67,7 +73,11 @@ export function useStartListening(
 
     store.setRow("transcripts", transcriptId, transcriptRow);
 
-    const onStopped: OnStoppedCallback = (_sessionId, durationSeconds) => {
+    const onStopped: OnStoppedCallback = (
+      _sessionId,
+      durationSeconds,
+      context,
+    ) => {
       const words = parseTranscriptWords(store, transcriptId);
 
       if (
@@ -101,6 +111,41 @@ export function useStartListening(
             view: null,
           });
         }
+        return;
+      }
+
+      if (
+        context.requestedTranscriptionMode === "live" &&
+        context.currentTranscriptionMode === "batch"
+      ) {
+        void (async () => {
+          const audioPath = await fsSyncCommands.audioPath(sessionId);
+
+          try {
+            if (audioPath.status === "error") {
+              throw new Error(audioPath.error);
+            }
+
+            await runBatch(audioPath.data, {
+              handlePersist: (batchWords, batchHints) => {
+                replaceTranscriptWithBatchResult(
+                  store,
+                  transcriptId,
+                  batchWords,
+                  batchHints,
+                  conn.provider,
+                );
+              },
+            });
+          } catch (error) {
+            console.error(
+              "[listener] failed to rebuild transcript from batch fallback audio",
+              error,
+            );
+          } finally {
+            getEnhancerService()?.queueAutoEnhance(sessionId);
+          }
+        })();
         return;
       }
 
@@ -175,6 +220,7 @@ export function useStartListening(
     indexes,
     sessionId,
     start,
+    runBatch,
     keywords,
     user_id,
     languages,

--- a/apps/desktop/src/stt/utils.test.ts
+++ b/apps/desktop/src/stt/utils.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { upsertSpeakerAssignment } from "./utils";
+import {
+  replaceTranscriptWithBatchResult,
+  upsertSpeakerAssignment,
+} from "./utils";
 
 import type { SegmentKey } from "~/stt/live-segment";
 
@@ -214,6 +217,88 @@ describe("upsertSpeakerAssignment", () => {
         word_id: "speaker-2-word-new",
         type: "user_speaker_assignment",
         value: JSON.stringify({ human_id: "carol" }),
+      },
+    ]);
+  });
+});
+
+describe("replaceTranscriptWithBatchResult", () => {
+  it("replaces existing transcript words and speaker hints with batch output", () => {
+    const store = createStore({
+      words: JSON.stringify([
+        {
+          id: "live-word",
+          text: " partial",
+          start_ms: 0,
+          end_ms: 100,
+          channel: 0,
+        },
+      ]),
+      speaker_hints: JSON.stringify([
+        {
+          id: "live-word:provider_speaker_index",
+          word_id: "live-word",
+          type: "provider_speaker_index",
+          value: JSON.stringify({ channel: 0, speaker_index: 1 }),
+        },
+      ]),
+    });
+
+    let nextId = 0;
+    replaceTranscriptWithBatchResult(
+      store,
+      "transcript-1",
+      [
+        {
+          text: " final",
+          start_ms: 100,
+          end_ms: 200,
+          channel: 0,
+        },
+      ],
+      [
+        {
+          wordIndex: 0,
+          data: {
+            type: "provider_speaker_index",
+            provider: "deepgram",
+            channel: 0,
+            speaker_index: 2,
+          },
+        },
+      ],
+      "deepgram",
+      () => `id-${nextId++}`,
+    );
+
+    expect(
+      JSON.parse(
+        store.getCell("transcripts", "transcript-1", "words") as string,
+      ),
+    ).toEqual([
+      {
+        id: "id-0",
+        text: " final",
+        start_ms: 100,
+        end_ms: 200,
+        channel: 0,
+      },
+    ]);
+
+    expect(
+      JSON.parse(
+        store.getCell("transcripts", "transcript-1", "speaker_hints") as string,
+      ),
+    ).toEqual([
+      {
+        id: "id-1",
+        word_id: "id-0",
+        type: "provider_speaker_index",
+        value: JSON.stringify({
+          provider: "deepgram",
+          channel: 0,
+          speaker_index: 2,
+        }),
       },
     ]);
   });

--- a/apps/desktop/src/stt/utils.ts
+++ b/apps/desktop/src/stt/utils.ts
@@ -3,6 +3,7 @@ import type { LiveTranscriptDelta } from "@hypr/plugin-listener";
 import type { SpeakerHintWithId, WordWithId } from "./types";
 
 import type { SegmentKey } from "~/stt/live-segment";
+import type { RuntimeSpeakerHint, WordLike } from "~/stt/segment";
 
 interface TranscriptStore {
   getCell(
@@ -69,6 +70,51 @@ export function updateTranscriptHints(
     "speaker_hints",
     JSON.stringify(hints),
   );
+}
+
+export function replaceTranscriptWithBatchResult(
+  store: TranscriptStore,
+  transcriptId: string,
+  words: WordLike[],
+  hints: RuntimeSpeakerHint[],
+  provider: string,
+  createId: () => string = () => crypto.randomUUID(),
+): void {
+  const nextWords: WordWithId[] = words.map((word) => ({
+    id: createId(),
+    text: word.text,
+    start_ms: word.start_ms,
+    end_ms: word.end_ms,
+    channel: word.channel,
+  }));
+  const wordIds = nextWords.map((word) => word.id);
+
+  const nextHints: SpeakerHintWithId[] = hints.flatMap((hint) => {
+    if (hint.data.type !== "provider_speaker_index") {
+      return [];
+    }
+
+    const wordId = wordIds[hint.wordIndex];
+    if (!wordId) {
+      return [];
+    }
+
+    return [
+      {
+        id: createId(),
+        word_id: wordId,
+        type: "provider_speaker_index",
+        value: JSON.stringify({
+          provider: hint.data.provider ?? provider,
+          channel: hint.data.channel,
+          speaker_index: hint.data.speaker_index,
+        }),
+      },
+    ];
+  });
+
+  updateTranscriptWords(store, transcriptId, nextWords);
+  updateTranscriptHints(store, transcriptId, nextHints);
 }
 
 export function applyLiveTranscriptDelta(

--- a/crates/listener-core/src/actors/listener/mod.rs
+++ b/crates/listener-core/src/actors/listener/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 use adapters::spawn_rx_task;
 
 pub(super) const LISTEN_STREAM_TIMEOUT: Duration = Duration::from_secs(15 * 60);
-pub(super) const FINALIZE_STREAM_TIMEOUT: Duration = Duration::from_secs(2);
+pub(super) const FINALIZE_STREAM_TIMEOUT: Duration = Duration::from_secs(8);
 pub(super) const DEVICE_FINGERPRINT_HEADER: &str = "x-device-fingerprint";
 
 pub enum ListenerMsg {

--- a/crates/listener-core/src/actors/listener/stream.rs
+++ b/crates/listener-core/src/actors/listener/stream.rs
@@ -31,7 +31,12 @@ pub(super) async fn process_stream<S, E, H>(
                 loop {
                     tokio::select! {
                         _ = &mut finalize_timeout => {
-                            tracing::warn!(hyprnote.timeout.reached = true, "break_timeout");
+                            tracing::warn!(
+                                hyprnote.timeout.reached = true,
+                                finalize_count,
+                                expected_count,
+                                "break_timeout"
+                            );
                             break;
                         }
                         result = listen_stream.next() => {


### PR DESCRIPTION
## Summary
- rerun batch transcription from saved audio before auto-enhance when a live session degrades into batch fallback
- replace the partial live transcript row with the rebuilt batch transcript so summaries use the recovered tail instead of duplicate transcript rows
- increase the live finalize drain timeout to reduce dropped end-of-recording transcript chunks

## Issue
- notes could get summarized from an incomplete transcript after live transcription degraded, so the recording looked like it continued but the resulting note was cut off near the end

## Cause
- the stop path queued auto-enhance as soon as the degraded live session stopped instead of rebuilding the transcript from the saved fallback audio first
- the finalize drain timeout was only 2 seconds, which made it easier to lose the last transcript updates during shutdown