### PR TITLE
fix: restore admin panel resizing

### DIFF
--- a/apps/web/src/routes/admin/collections/index.tsx
+++ b/apps/web/src/routes/admin/collections/index.tsx
@@ -905,7 +905,10 @@ function CollectionsPage() {
   });
 
   return (
-    <ResizablePanelGroup direction="horizontal" className="h-full">
+    <ResizablePanelGroup
+      direction="horizontal"
+      className="h-full min-h-0 min-w-0"
+    >
       <ResizablePanel defaultSize={20} minSize={15} maxSize={30}>
         <Sidebar
           collections={collections}
@@ -966,7 +969,7 @@ function CollectionsPage() {
       </ResizablePanel>
       <ResizableHandle />
       <ResizablePanel defaultSize={80} minSize={50}>
-        <div className="flex h-full flex-col">
+        <div className="flex h-full min-h-0 min-w-0 flex-col">
           <ContentPanel
             tabs={tabs}
             currentTab={currentTab}
@@ -2190,9 +2193,9 @@ function ContentPanel({
   }, [currentTab, getCurrentEditorData, publish]);
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
       {currentTab ? (
-        <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           <EditorHeader
             tabs={tabs}
             currentTab={currentTab}
@@ -4085,9 +4088,12 @@ const FileEditor = React.forwardRef<
     return (
       <>
         {pendingPRBanner}
-        <ResizablePanelGroup direction="horizontal" className="min-h-0 flex-1">
+        <ResizablePanelGroup
+          direction="horizontal"
+          className="min-h-0 min-w-0 flex-1"
+        >
           <ResizablePanel defaultSize={50} minSize={30}>
-            <div className="flex h-full flex-col">
+            <div className="flex h-full min-h-0 min-w-0 flex-col">
               {collection === "articles" ? (
                 <MetadataPanel
                   isExpanded={isMetadataExpanded}
@@ -4127,7 +4133,10 @@ const FileEditor = React.forwardRef<
   return (
     <>
       {pendingPRBanner}
-      <ResizablePanelGroup direction="horizontal" className="min-h-0 flex-1">
+      <ResizablePanelGroup
+        direction="horizontal"
+        className="min-h-0 min-w-0 flex-1"
+      >
         <ResizablePanel defaultSize={70} minSize={50}>
           <BlogEditor
             editor={editor}
@@ -4138,7 +4147,7 @@ const FileEditor = React.forwardRef<
         </ResizablePanel>
         <ResizableHandle className="w-px bg-neutral-200" />
         <ResizablePanel defaultSize={30} minSize={20}>
-          <div className="h-full overflow-y-auto">
+          <div className="h-full min-w-0 overflow-y-auto">
             {collection === "articles" ? (
               <MetadataSidePanel
                 filePath={filePath}

--- a/packages/ui/src/components/ui/resizable.tsx
+++ b/packages/ui/src/components/ui/resizable.tsx
@@ -9,14 +9,22 @@ const ResizablePanelGroup = ({
 }: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) => (
   <ResizablePrimitive.PanelGroup
     className={cn(
-      "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
+      "flex h-full min-h-0 w-full min-w-0 data-[panel-group-direction=vertical]:flex-col",
       className,
     )}
     {...props}
   />
 );
 
-const ResizablePanel = ResizablePrimitive.Panel;
+const ResizablePanel = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.Panel>) => (
+  <ResizablePrimitive.Panel
+    className={cn("min-h-0 min-w-0", className)}
+    {...props}
+  />
+);
 
 const ResizableHandle = ({
   withHandle,
@@ -27,7 +35,7 @@ const ResizableHandle = ({
 }) => (
   <ResizablePrimitive.PanelResizeHandle
     className={cn(
-      "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+      "bg-border focus-visible:ring-ring relative flex w-px cursor-col-resize touch-none items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:cursor-row-resize data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90",
       className,
     )}
     {...props}


### PR DESCRIPTION
Allow the admin collections panels to shrink by clearing flex min-size constraints in the shared resizable primitives and content editor layout.