### PR TITLE
fix: simplify share toast actions

### DIFF
--- a/apps/desktop/src/sidebar/toast/component.tsx
+++ b/apps/desktop/src/sidebar/toast/component.tsx
@@ -9,12 +9,15 @@ import type { DownloadProgress, ToastType } from "./types";
 export function Toast({
   toast,
   onDismiss,
+  alwaysShowDismissButton = false,
 }: {
   toast: ToastType;
-  onDismiss?: () => void;
+  onDismiss?: () => void | Promise<void>;
+  alwaysShowDismissButton?: boolean;
 }) {
   const contentRef = useRef<HTMLDivElement>(null);
   const [height, setHeight] = useState<number | "auto">("auto");
+  const [isAnimatingHeight, setIsAnimatingHeight] = useState(false);
   const contentKey = toast.actions ? "actions" : "default";
 
   useEffect(() => {
@@ -25,6 +28,7 @@ export function Toast({
       }
     };
     measure();
+    setIsAnimatingHeight(true);
     const ro = new ResizeObserver(measure);
     ro.observe(contentRef.current);
     return () => ro.disconnect();
@@ -47,7 +51,9 @@ export function Toast({
             aria-label="Dismiss toast"
             className={cn([
               "absolute top-1.5 right-1.5 z-10 flex size-6 items-center justify-center rounded-full",
-              "opacity-0 group-hover:opacity-50 hover:opacity-100!",
+              alwaysShowDismissButton
+                ? "opacity-100"
+                : "opacity-0 group-hover:opacity-50 hover:opacity-100!",
               "hover:bg-neutral-200",
               "transition-all duration-200",
             ])}
@@ -58,8 +64,10 @@ export function Toast({
 
         <motion.div
           animate={{ height }}
+          onAnimationStart={() => setIsAnimatingHeight(true)}
+          onAnimationComplete={() => setIsAnimatingHeight(false)}
           transition={{ duration: 0.25, ease: "easeInOut" }}
-          style={{ overflow: "hidden" }}
+          style={{ overflow: isAnimatingHeight ? "hidden" : "visible" }}
         >
           <div ref={contentRef}>
             <AnimatePresence mode="wait" initial={false}>
@@ -71,20 +79,24 @@ export function Toast({
                 transition={{ duration: 0.15, ease: "easeInOut" }}
                 className="flex flex-col gap-2"
               >
-                {(toast.icon || toast.title) && (
-                  <div className="flex items-center gap-2">
-                    {toast.icon}
-                    {toast.title && (
-                      <h3 className="text-lg font-bold text-neutral-900">
-                        {toast.title}
-                      </h3>
-                    )}
-                  </div>
-                )}
+                <div
+                  className={cn(["flex flex-col gap-2", onDismiss && "pr-6"])}
+                >
+                  {(toast.icon || toast.title) && (
+                    <div className="flex items-center gap-2">
+                      {toast.icon}
+                      {toast.title && (
+                        <h3 className="text-lg font-bold text-neutral-900">
+                          {toast.title}
+                        </h3>
+                      )}
+                    </div>
+                  )}
 
-                <div className="text-sm">{toast.description}</div>
+                  <div className="text-sm">{toast.description}</div>
+                </div>
 
-                <div className="mt-1 flex flex-col gap-2">
+                <div className="mt-1 flex flex-col gap-2 overflow-visible">
                   {toast.progress !== undefined && (
                     <ProgressBar progress={toast.progress} />
                   )}
@@ -118,7 +130,7 @@ export function Toast({
                       {toast.primaryAction && (
                         <button
                           onClick={toast.primaryAction.onClick}
-                          className="w-full rounded-full border-2 border-stone-600 bg-stone-800 py-2 text-sm font-medium text-white shadow-[0_4px_14px_rgba(87,83,78,0.4)] transition-all duration-200 hover:bg-stone-700"
+                          className="flex h-11 w-full items-center justify-center rounded-full border-2 border-stone-600 bg-stone-800 px-4 text-sm font-medium text-white shadow-[0_2px_6px_rgba(87,83,78,0.22),0_10px_18px_-10px_rgba(87,83,78,0.65)] transition-all duration-200 hover:bg-stone-700"
                         >
                           {toast.primaryAction.label}
                         </button>

--- a/apps/desktop/src/sidebar/toast/index.tsx
+++ b/apps/desktop/src/sidebar/toast/index.tsx
@@ -134,6 +134,10 @@ export function ToastArea({
     setShareExpanded(false);
   }, [dismissToast]);
 
+  const handleShareCollapse = useCallback(() => {
+    setShareExpanded(false);
+  }, []);
+
   const handleShareSocial = useCallback(
     (platform: "x" | "linkedin" | "reddit") => {
       void analyticsCommands.event({
@@ -178,7 +182,6 @@ export function ToastArea({
         onOpenLLMSettings: handleOpenLLMSettings,
         onOpenSTTSettings: handleOpenSTTSettings,
         onShareExpand: handleShareExpand,
-        onShareSnooze: handleShareSnooze,
       }),
     [
       isAuthenticated,
@@ -201,7 +204,6 @@ export function ToastArea({
       handleOpenLLMSettings,
       handleOpenSTTSettings,
       handleShareExpand,
-      handleShareSnooze,
     ],
   );
 
@@ -274,6 +276,15 @@ export function ToastArea({
     return currentToast;
   }, [currentToast, shareExpanded, handleShareSocial, handleShareDone]);
 
+  const dismissAction =
+    displayToast?.id === "share-char"
+      ? shareExpanded
+        ? handleShareCollapse
+        : handleShareSnooze
+      : displayToast?.dismissible
+        ? handleDismiss
+        : undefined;
+
   return (
     <AnimatePresence mode="wait">
       {shouldShowToast && displayToast ? (
@@ -291,13 +302,8 @@ export function ToastArea({
           <div className="pointer-events-auto">
             <Toast
               toast={displayToast}
-              onDismiss={
-                displayToast.dismissible
-                  ? handleDismiss
-                  : displayToast.id === "share-char" && shareExpanded
-                    ? () => setShareExpanded(false)
-                    : undefined
-              }
+              onDismiss={dismissAction}
+              alwaysShowDismissButton={displayToast.id === "share-char"}
             />
           </div>
         </motion.div>

--- a/apps/desktop/src/sidebar/toast/registry.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.tsx
@@ -28,7 +28,6 @@ type ToastRegistryParams = {
   onOpenLLMSettings: () => void;
   onOpenSTTSettings: () => void;
   onShareExpand: () => void;
-  onShareSnooze: () => void;
 };
 
 export function createToastRegistry({
@@ -52,7 +51,6 @@ export function createToastRegistry({
   onOpenLLMSettings,
   onOpenSTTSettings,
   onShareExpand,
-  onShareSnooze,
 }: ToastRegistryParams): ToastRegistryEntry[] {
   const downloadTitle =
     activeDownloads.length === 1
@@ -207,11 +205,7 @@ export function createToastRegistry({
           label: "Share now",
           onClick: onShareExpand,
         },
-        secondaryAction: {
-          label: "I'll do it later",
-          onClick: onShareSnooze,
-        },
-        dismissible: false,
+        dismissible: true,
       },
       condition: () => {
         if (sessionCount < 3) return false;


### PR DESCRIPTION
Remove the secondary share CTA, wire the top-right dismiss icon to the share snooze flow, and add room for the shared toast CTA shadow.