### PR TITLE
Refactor editor state management and stabilize keyboard/plugin handling

### DIFF
--- a/apps/desktop/src/editor/chat/index.tsx
+++ b/apps/desktop/src/editor/chat/index.tsx
@@ -21,16 +21,21 @@ import {
 } from "prosemirror-commands";
 import { history, redo, undo } from "prosemirror-history";
 import { keymap } from "prosemirror-keymap";
-import { Node as PMNode } from "prosemirror-model";
-import { EditorState, Plugin, PluginKey } from "prosemirror-state";
+import { EditorState } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 import { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
 
 import "@hypr/tiptap/styles.css";
 import { cn } from "@hypr/utils";
 
+import { isApplePlatform } from "../keyboard";
 import { AttachmentChipView, MentionNodeView } from "../node-views";
-import { type PlaceholderFunction, placeholderPlugin } from "../plugins";
+import {
+  createDropPasteFileHandlerPlugin,
+  type PlaceholderFunction,
+  placeholderPlugin,
+} from "../plugins";
+import { createEditorState, useManagedEditorState } from "../state";
 import {
   type MentionConfig,
   MentionSuggestion,
@@ -70,6 +75,10 @@ const nodeViews = {
   attachment: AttachmentChipView,
 };
 
+function createEmptyChatDoc() {
+  return chatSchema.node("doc", null, [chatSchema.node("paragraph")]);
+}
+
 function ViewCapture({
   viewRef,
 }: {
@@ -83,29 +92,13 @@ function ViewCapture({
   return null;
 }
 
-const mac =
-  typeof navigator !== "undefined"
-    ? /Mac|iP(hone|[oa]d)/.test(navigator.platform)
-    : false;
+const mac = isApplePlatform();
 
 function fileHandlerPlugin() {
-  return new Plugin({
-    key: new PluginKey("chatFileHandler"),
-    props: {
-      handleDrop(view, event) {
-        const files = Array.from(event.dataTransfer?.files ?? []);
-        if (files.length === 0) return false;
-        event.preventDefault();
-        insertFiles(view, files);
-        return true;
-      },
-      handlePaste(view, event) {
-        const files = Array.from(event.clipboardData?.files ?? []);
-        if (files.length === 0) return false;
-        insertFiles(view, files);
-        return true;
-      },
-    },
+  return createDropPasteFileHandlerPlugin({
+    key: "chatFileHandler",
+    shouldHandleFile: () => true,
+    handleFiles: insertFiles,
   });
 }
 
@@ -169,7 +162,11 @@ export const ChatEditor = forwardRef<ChatEditorHandle, ChatEditorProps>(
     const onSubmitRef = useRef(onSubmit);
     onSubmitRef.current = onSubmit;
     const onUpdateRef = useRef(onUpdate);
+    const placeholderRef = useRef(placeholder);
+    const mentionConfigRef = useRef(mentionConfig);
     onUpdateRef.current = onUpdate;
+    placeholderRef.current = placeholder;
+    mentionConfigRef.current = mentionConfig;
 
     useImperativeHandle(
       ref,
@@ -181,16 +178,14 @@ export const ChatEditor = forwardRef<ChatEditorHandle, ChatEditorProps>(
           return viewRef.current?.state.doc.toJSON() as JSONContent | undefined;
         },
         clearContent() {
-          const view = viewRef.current;
-          if (!view) return;
-          const doc = chatSchema.node("doc", null, [
-            chatSchema.node("paragraph"),
-          ]);
-          const state = EditorState.create({
-            doc,
-            plugins: view.state.plugins,
+          setEditorState((currentState) => {
+            const nextState = createEditorState(
+              createEmptyChatDoc(),
+              currentState.plugins,
+            );
+            onUpdateRef.current?.(nextState.doc.toJSON() as JSONContent);
+            return nextState;
           });
-          view.updateState(state);
         },
       }),
       [],
@@ -204,7 +199,11 @@ export const ChatEditor = forwardRef<ChatEditorHandle, ChatEditorProps>(
           "Mod-Shift-z": redo,
           ...(!mac ? { "Mod-y": redo } : {}),
           "Mod-Enter": (state: EditorState) => {
-            if (mentionConfig && findMention(state, mentionConfig.trigger)) {
+            const currentMentionConfig = mentionConfigRef.current;
+            if (
+              currentMentionConfig &&
+              findMention(state, currentMentionConfig.trigger)
+            ) {
               return false;
             }
             onSubmitRef.current?.();
@@ -234,33 +233,28 @@ export const ChatEditor = forwardRef<ChatEditorHandle, ChatEditorProps>(
           "Mod-a": selectAll,
         }),
         history(),
-        placeholderPlugin(placeholder),
+        placeholderPlugin((props) => placeholderRef.current?.(props) ?? ""),
         ...(mentionConfig ? [mentionSkipPlugin()] : []),
         fileHandlerPlugin(),
       ],
-      [mentionConfig, placeholder],
+      [Boolean(mentionConfig)],
     );
 
-    const defaultState = useMemo(() => {
-      let doc: PMNode;
-      try {
-        doc =
-          initialContent && initialContent.type === "doc"
-            ? PMNode.fromJSON(chatSchema, initialContent)
-            : chatSchema.node("doc", null, [chatSchema.node("paragraph")]);
-      } catch {
-        doc = chatSchema.node("doc", null, [chatSchema.node("paragraph")]);
-      }
-      return EditorState.create({ doc, plugins });
-    }, []);
+    const { editorState, setEditorState } = useManagedEditorState({
+      schema: chatSchema,
+      initialContent,
+      plugins,
+      createEmptyDoc: createEmptyChatDoc,
+      viewRef,
+    });
 
     return (
       <ProseMirror
-        defaultState={defaultState}
+        state={editorState}
         nodeViews={nodeViews}
         dispatchTransaction={function (this: EditorView, tr) {
           const newState = this.state.apply(tr);
-          this.updateState(newState);
+          setEditorState(newState);
           if (tr.docChanged) {
             onUpdateRef.current?.(newState.doc.toJSON() as JSONContent);
           }

--- a/apps/desktop/src/editor/keyboard.test.ts
+++ b/apps/desktop/src/editor/keyboard.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { isApplePlatform, isPlainArrowKey } from "./keyboard";
+
+describe("editor keyboard utilities", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("detects Apple platforms", () => {
+    const userAgentSpy = vi.spyOn(window.navigator, "userAgent", "get");
+    userAgentSpy.mockReturnValue(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15",
+    );
+    expect(isApplePlatform()).toBe(true);
+
+    userAgentSpy.mockReturnValue(
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15",
+    );
+    expect(isApplePlatform()).toBe(true);
+  });
+
+  it("rejects non-Apple platforms", () => {
+    const userAgentSpy = vi.spyOn(window.navigator, "userAgent", "get");
+    userAgentSpy.mockReturnValue("Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
+    expect(isApplePlatform()).toBe(false);
+
+    userAgentSpy.mockReturnValue("Mozilla/5.0 (X11; Linux x86_64)");
+    expect(isApplePlatform()).toBe(false);
+  });
+
+  it("matches only unmodified arrow keys", () => {
+    expect(
+      isPlainArrowKey(
+        {
+          key: "ArrowDown",
+          altKey: false,
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false,
+        },
+        "ArrowDown",
+      ),
+    ).toBe(true);
+
+    expect(
+      isPlainArrowKey(
+        {
+          key: "ArrowDown",
+          altKey: true,
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false,
+        },
+        "ArrowDown",
+      ),
+    ).toBe(false);
+
+    expect(
+      isPlainArrowKey(
+        {
+          key: "ArrowDown",
+          altKey: false,
+          ctrlKey: true,
+          metaKey: false,
+          shiftKey: false,
+        },
+        "ArrowDown",
+      ),
+    ).toBe(false);
+
+    expect(
+      isPlainArrowKey(
+        {
+          key: "ArrowDown",
+          altKey: false,
+          ctrlKey: false,
+          metaKey: true,
+          shiftKey: false,
+        },
+        "ArrowDown",
+      ),
+    ).toBe(false);
+
+    expect(
+      isPlainArrowKey(
+        {
+          key: "ArrowDown",
+          altKey: false,
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: true,
+        },
+        "ArrowDown",
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/editor/keyboard.ts
+++ b/apps/desktop/src/editor/keyboard.ts
@@ -1,0 +1,31 @@
+type KeyboardLikeEvent = Pick<
+  KeyboardEvent,
+  "key" | "altKey" | "ctrlKey" | "metaKey" | "shiftKey"
+>;
+
+type ArrowKey = "ArrowUp" | "ArrowDown" | "ArrowLeft" | "ArrowRight";
+
+export function isApplePlatform() {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  const userAgent = navigator.userAgent.toLowerCase();
+  return (
+    userAgent.includes("macintosh") ||
+    userAgent.includes("mac os x") ||
+    userAgent.includes("iphone") ||
+    userAgent.includes("ipad") ||
+    userAgent.includes("ipod")
+  );
+}
+
+export function isPlainArrowKey(event: KeyboardLikeEvent, key: ArrowKey) {
+  return (
+    event.key === key &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.shiftKey
+  );
+}

--- a/apps/desktop/src/editor/plugins/file-handler.ts
+++ b/apps/desktop/src/editor/plugins/file-handler.ts
@@ -11,6 +11,59 @@ export type FileHandlerConfig = {
 
 const IMAGE_MIME_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
 
+type SharedFileHandlerConfig = {
+  key: string;
+  shouldHandleFile: (file: File) => boolean;
+  onDrop?: (files: File[], pos?: number) => boolean | void;
+  onPaste?: (files: File[]) => boolean | void;
+  handleFiles: (view: EditorView, files: File[], pos?: number) => void;
+};
+
+export function createDropPasteFileHandlerPlugin(
+  config: SharedFileHandlerConfig,
+) {
+  return new Plugin({
+    key: new PluginKey(config.key),
+    props: {
+      handleDrop(view, event) {
+        const files = Array.from(event.dataTransfer?.files ?? []).filter(
+          (file) => config.shouldHandleFile(file),
+        );
+        if (files.length === 0) return false;
+
+        event.preventDefault();
+        const pos = view.posAtCoords({
+          left: event.clientX,
+          top: event.clientY,
+        })?.pos;
+
+        if (config.onDrop) {
+          const result = config.onDrop(files, pos);
+          if (result === false) return false;
+        }
+
+        config.handleFiles(view, files, pos);
+        return true;
+      },
+
+      handlePaste(view, event) {
+        const files = Array.from(event.clipboardData?.files ?? []).filter(
+          (file) => config.shouldHandleFile(file),
+        );
+        if (files.length === 0) return false;
+
+        if (config.onPaste) {
+          const result = config.onPaste(files);
+          if (result === false) return false;
+        }
+
+        config.handleFiles(view, files);
+        return true;
+      },
+    },
+  });
+}
+
 export function fileHandlerPlugin(config: FileHandlerConfig) {
   function insertImage(
     view: EditorView,
@@ -48,44 +101,11 @@ export function fileHandlerPlugin(config: FileHandlerConfig) {
     }
   }
 
-  return new Plugin({
-    key: new PluginKey("fileHandler"),
-    props: {
-      handleDrop(view, event) {
-        const files = Array.from(event.dataTransfer?.files ?? []).filter((f) =>
-          IMAGE_MIME_TYPES.includes(f.type),
-        );
-        if (files.length === 0) return false;
-
-        event.preventDefault();
-        const pos = view.posAtCoords({
-          left: event.clientX,
-          top: event.clientY,
-        })?.pos;
-
-        if (config.onDrop) {
-          const result = config.onDrop(files, pos);
-          if (result === false) return false;
-        }
-
-        handleFiles(view, files, pos);
-        return true;
-      },
-
-      handlePaste(view, event) {
-        const files = Array.from(event.clipboardData?.files ?? []).filter((f) =>
-          IMAGE_MIME_TYPES.includes(f.type),
-        );
-        if (files.length === 0) return false;
-
-        if (config.onPaste) {
-          const result = config.onPaste(files);
-          if (result === false) return false;
-        }
-
-        handleFiles(view, files);
-        return true;
-      },
-    },
+  return createDropPasteFileHandlerPlugin({
+    key: "fileHandler",
+    shouldHandleFile: (file) => IMAGE_MIME_TYPES.includes(file.type),
+    onDrop: config.onDrop,
+    onPaste: config.onPaste,
+    handleFiles,
   });
 }

--- a/apps/desktop/src/editor/plugins/index.ts
+++ b/apps/desktop/src/editor/plugins/index.ts
@@ -7,7 +7,11 @@ export {
   parseYouTubeUrl,
   resolveYouTubeClipUrl,
 } from "./clip-paste";
-export { type FileHandlerConfig, fileHandlerPlugin } from "./file-handler";
+export {
+  createDropPasteFileHandlerPlugin,
+  type FileHandlerConfig,
+  fileHandlerPlugin,
+} from "./file-handler";
 export { findHashtags, hashtagPlugin, hashtagPluginKey } from "./hashtag";
 export { linkBoundaryGuardPlugin } from "./link-boundary-guard";
 export {

--- a/apps/desktop/src/editor/session/index.tsx
+++ b/apps/desktop/src/editor/session/index.tsx
@@ -10,7 +10,6 @@ import {
 import { dropCursor } from "prosemirror-dropcursor";
 import { gapCursor } from "prosemirror-gapcursor";
 import { history } from "prosemirror-history";
-import { Node as PMNode } from "prosemirror-model";
 import {
   EditorState,
   Selection,
@@ -18,14 +17,7 @@ import {
   type Transaction,
 } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
-import {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-} from "react";
+import { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
 import { useDebounceCallback } from "usehooks-ts";
 
 import "@hypr/tiptap/styles.css";
@@ -51,6 +43,7 @@ import {
   searchReplaceCurrent,
   setSearchState,
 } from "../plugins";
+import { useManagedEditorState } from "../state";
 import {
   type MentionConfig,
   MentionSuggestion,
@@ -108,6 +101,10 @@ const nodeViews = {
   "mention-@": MentionNodeView,
   taskItem: TaskItemView,
 };
+
+function createEmptyNoteDoc() {
+  return schema.node("doc", null, [schema.node("paragraph")]);
+}
 
 function ViewCapture({
   viewRef,
@@ -265,9 +262,16 @@ export const NoteEditor = forwardRef<NoteEditorRef, EditorProps>(
       onNavigateToTitle,
     } = props;
 
-    const previousContentRef = useRef<JSONContent | undefined>(initialContent);
     const viewRef = useRef<EditorView | null>(null);
     const commandsRef = useRef<EditorCommands>(noopCommands);
+    const handleChangeRef = useRef(handleChange);
+    const placeholderRef = useRef(placeholderComponent);
+    const fileHandlerConfigRef = useRef(fileHandlerConfig);
+    const onNavigateToTitleRef = useRef(onNavigateToTitle);
+    handleChangeRef.current = handleChange;
+    placeholderRef.current = placeholderComponent;
+    fileHandlerConfigRef.current = fileHandlerConfig;
+    onNavigateToTitleRef.current = onNavigateToTitle;
 
     useImperativeHandle(
       ref,
@@ -282,87 +286,70 @@ export const NoteEditor = forwardRef<NoteEditorRef, EditorProps>(
       [],
     );
 
-    const onUpdate = useDebounceCallback((view: EditorView) => {
-      if (!handleChange) return;
-      handleChange(view.state.doc.toJSON() as JSONContent);
+    const onUpdate = useDebounceCallback((state: EditorState) => {
+      handleChangeRef.current?.(state.doc.toJSON() as JSONContent);
     }, 500);
 
     const plugins = useMemo(
       () => [
         reactKeys(),
         buildInputRules(),
-        buildKeymap(onNavigateToTitle),
+        buildKeymap((pixelWidth) => onNavigateToTitleRef.current?.(pixelWidth)),
         history(),
         dropCursor(),
         gapCursor(),
         hashtagPlugin(),
         searchPlugin(),
-        placeholderPlugin(placeholderComponent),
+        placeholderPlugin((props) => placeholderRef.current?.(props) ?? ""),
         clearMarksOnEnterPlugin(),
         clipPastePlugin(),
         linkBoundaryGuardPlugin(),
         ...(mentionConfig ? [mentionSkipPlugin()] : []),
-        ...(fileHandlerConfig ? [fileHandlerPlugin(fileHandlerConfig)] : []),
+        ...(fileHandlerConfig
+          ? [
+              fileHandlerPlugin({
+                onDrop(files, pos) {
+                  return fileHandlerConfigRef.current?.onDrop?.(files, pos);
+                },
+                onPaste(files) {
+                  return fileHandlerConfigRef.current?.onPaste?.(files);
+                },
+                ...(fileHandlerConfig.onImageUpload
+                  ? {
+                      async onImageUpload(file: File) {
+                        return await fileHandlerConfigRef.current!
+                          .onImageUpload!(file);
+                      },
+                    }
+                  : {}),
+              }),
+            ]
+          : []),
       ],
       [
-        placeholderComponent,
-        fileHandlerConfig,
-        mentionConfig,
-        onNavigateToTitle,
+        Boolean(fileHandlerConfig),
+        Boolean(fileHandlerConfig?.onImageUpload),
+        Boolean(mentionConfig),
       ],
     );
 
-    const defaultState = useMemo(() => {
-      let doc: PMNode;
-      try {
-        doc =
-          initialContent && initialContent.type === "doc"
-            ? PMNode.fromJSON(schema, initialContent)
-            : schema.node("doc", null, [schema.node("paragraph")]);
-      } catch {
-        doc = schema.node("doc", null, [schema.node("paragraph")]);
-      }
-      return EditorState.create({ doc, plugins });
-    }, []);
-
-    useEffect(() => {
-      const view = viewRef.current;
-      if (!view) return;
-      if (previousContentRef.current === initialContent) return;
-      previousContentRef.current = initialContent;
-
-      if (!initialContent || initialContent.type !== "doc") return;
-
-      if (!view.hasFocus()) {
-        try {
-          const doc = PMNode.fromJSON(schema, initialContent);
-          const state = EditorState.create({
-            doc,
-            plugins: view.state.plugins,
-          });
-          view.updateState(state);
-        } catch {
-          // invalid content
-        }
-      }
-    }, [initialContent]);
-
-    const onViewReady = useCallback(
-      (view: EditorView) => {
-        onUpdate(view);
-      },
-      [onUpdate],
-    );
+    const { editorState, setEditorState } = useManagedEditorState({
+      schema,
+      initialContent,
+      plugins,
+      createEmptyDoc: createEmptyNoteDoc,
+      viewRef,
+    });
 
     return (
       <ProseMirror
-        defaultState={defaultState}
+        state={editorState}
         nodeViews={nodeViews}
         dispatchTransaction={function (this: EditorView, tr: Transaction) {
           const newState = this.state.apply(tr);
-          this.updateState(newState);
+          setEditorState(newState);
           if (tr.docChanged) {
-            onUpdate(this);
+            onUpdate(newState);
           }
         }}
         attributes={{
@@ -375,7 +362,12 @@ export const NoteEditor = forwardRef<NoteEditorRef, EditorProps>(
         className="tiptap"
       >
         <ProseMirrorDoc />
-        <ViewCapture viewRef={viewRef} onViewReady={onViewReady} />
+        <ViewCapture
+          viewRef={viewRef}
+          onViewReady={(view) => {
+            onUpdate(view.state);
+          }}
+        />
         <EditorCommandsBridge commandsRef={commandsRef} />
         <SlashCommandMenu />
         {mentionConfig && <MentionSuggestion config={mentionConfig} />}

--- a/apps/desktop/src/editor/session/keymap.ts
+++ b/apps/desktop/src/editor/session/keymap.ts
@@ -37,6 +37,7 @@ import {
   type EditorState,
 } from "prosemirror-state";
 
+import { isApplePlatform } from "../keyboard";
 import { schema } from "./schema";
 
 function isInListItem(state: EditorState): string | null {
@@ -122,10 +123,7 @@ export function buildInputRules() {
 // ---------------------------------------------------------------------------
 // Keymaps
 // ---------------------------------------------------------------------------
-const mac =
-  typeof navigator !== "undefined"
-    ? /Mac|iP(hone|[oa]d)/.test(navigator.platform)
-    : false;
+const mac = isApplePlatform();
 
 export function buildKeymap(onNavigateToTitle?: (pixelWidth?: number) => void) {
   const hardBreak = schema.nodes.hardBreak;

--- a/apps/desktop/src/editor/state.test.ts
+++ b/apps/desktop/src/editor/state.test.ts
@@ -1,0 +1,107 @@
+import { Plugin, PluginKey, TextSelection } from "prosemirror-state";
+import { describe, expect, it } from "vitest";
+
+import { schema } from "./session/schema";
+import {
+  createEditorState,
+  parseEditorDoc,
+  reconcileEditorState,
+} from "./state";
+
+function createEmptyDoc() {
+  return schema.node("doc", null, [schema.node("paragraph")]);
+}
+
+function createPlugin(name: string) {
+  return new Plugin({
+    key: new PluginKey(name),
+  });
+}
+
+describe("editor state helpers", () => {
+  it("falls back to an empty doc for invalid content", () => {
+    const doc = parseEditorDoc(
+      schema,
+      { type: "doc", content: [{ type: "missing-node" }] },
+      createEmptyDoc,
+    );
+
+    expect(doc.toJSON()).toEqual(createEmptyDoc().toJSON());
+  });
+
+  it("reconfigures plugins without replacing the current selection", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("alpha")]),
+    ]);
+    const initialPlugins = [createPlugin("one")];
+    const nextPlugins = [createPlugin("two")];
+    const state = createStateWithSelection(doc, initialPlugins, 3);
+
+    const nextState = reconcileEditorState({
+      currentState: state,
+      nextDoc: doc,
+      plugins: nextPlugins,
+      isViewFocused: true,
+    });
+
+    expect(nextState.doc).toBe(state.doc);
+    expect(nextState.selection.from).toBe(state.selection.from);
+    expect(nextState.plugins).toEqual(nextPlugins);
+  });
+
+  it("replaces the document when external content changes and the view is unfocused", () => {
+    const currentDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("alpha")]),
+    ]);
+    const nextDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("beta")]),
+    ]);
+    const plugins = [createPlugin("shared")];
+    const state = createStateWithSelection(currentDoc, plugins, 3);
+
+    const nextState = reconcileEditorState({
+      currentState: state,
+      nextDoc,
+      plugins,
+      isViewFocused: false,
+    });
+
+    expect(nextState.doc.toJSON()).toEqual(nextDoc.toJSON());
+    expect(nextState.plugins).toEqual(plugins);
+    expect(nextState.selection.from).toBe(1);
+  });
+
+  it("keeps the current doc while focused but still reconfigures plugins", () => {
+    const currentDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("alpha")]),
+    ]);
+    const nextDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("beta")]),
+    ]);
+    const initialPlugins = [createPlugin("one")];
+    const nextPlugins = [createPlugin("two")];
+    const state = createStateWithSelection(currentDoc, initialPlugins, 4);
+
+    const nextState = reconcileEditorState({
+      currentState: state,
+      nextDoc,
+      plugins: nextPlugins,
+      isViewFocused: true,
+    });
+
+    expect(nextState.doc.toJSON()).toEqual(currentDoc.toJSON());
+    expect(nextState.selection.from).toBe(4);
+    expect(nextState.plugins).toEqual(nextPlugins);
+  });
+});
+
+function createStateWithSelection(
+  doc: ReturnType<typeof createEmptyDoc>,
+  plugins: Plugin[],
+  pos: number,
+) {
+  const state = createEditorState(doc, plugins);
+  return state.apply(
+    state.tr.setSelection(TextSelection.create(state.doc, pos)),
+  );
+}

--- a/apps/desktop/src/editor/state.ts
+++ b/apps/desktop/src/editor/state.ts
@@ -1,0 +1,112 @@
+import { Node as PMNode, type Schema } from "prosemirror-model";
+import { EditorState, type Plugin } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+import { type RefObject, useEffect, useMemo, useState } from "react";
+
+type JSONContent = {
+  type?: string;
+  attrs?: Record<string, unknown>;
+  content?: JSONContent[];
+  marks?: { type: string; attrs?: Record<string, unknown> }[];
+  text?: string;
+};
+
+function arePluginsEqual(a: readonly Plugin[], b: readonly Plugin[]) {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+
+  return true;
+}
+
+export function parseEditorDoc(
+  schema: Schema,
+  content: JSONContent | undefined,
+  createEmptyDoc: () => PMNode,
+) {
+  try {
+    if (content?.type === "doc") {
+      return PMNode.fromJSON(schema, content);
+    }
+  } catch {
+    // fall through to the empty document
+  }
+
+  return createEmptyDoc();
+}
+
+export function createEditorState(doc: PMNode, plugins: readonly Plugin[]) {
+  return EditorState.create({ doc, plugins });
+}
+
+export function reconcileEditorState({
+  currentState,
+  nextDoc,
+  plugins,
+  isViewFocused,
+}: {
+  currentState: EditorState;
+  nextDoc: PMNode;
+  plugins: readonly Plugin[];
+  isViewFocused: boolean;
+}) {
+  const docChanged = !nextDoc.eq(currentState.doc);
+  const pluginsChanged = !arePluginsEqual(currentState.plugins, plugins);
+
+  if (!docChanged && !pluginsChanged) {
+    return currentState;
+  }
+
+  if (docChanged && !isViewFocused) {
+    return createEditorState(nextDoc, plugins);
+  }
+
+  if (pluginsChanged) {
+    return currentState.reconfigure({ plugins });
+  }
+
+  return currentState;
+}
+
+export function useManagedEditorState({
+  schema,
+  initialContent,
+  plugins,
+  createEmptyDoc,
+  viewRef,
+}: {
+  schema: Schema;
+  initialContent?: JSONContent;
+  plugins: readonly Plugin[];
+  createEmptyDoc: () => PMNode;
+  viewRef: RefObject<EditorView | null>;
+}) {
+  const parsedDoc = useMemo(
+    () => parseEditorDoc(schema, initialContent, createEmptyDoc),
+    [createEmptyDoc, initialContent, schema],
+  );
+  const [editorState, setEditorState] = useState(() =>
+    createEditorState(parsedDoc, plugins),
+  );
+  const managedState = useMemo(
+    () =>
+      reconcileEditorState({
+        currentState: editorState,
+        nextDoc: parsedDoc,
+        plugins,
+        isViewFocused: viewRef.current?.hasFocus() ?? false,
+      }),
+    [editorState, parsedDoc, plugins, viewRef],
+  );
+
+  useEffect(() => {
+    if (managedState !== editorState) {
+      setEditorState(managedState);
+    }
+  }, [editorState, managedState]);
+
+  return { editorState: managedState, setEditorState };
+}

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -18,6 +18,7 @@ import {
 import { cn } from "@hypr/utils";
 
 import { useTitleGenerating } from "~/ai/hooks";
+import { isPlainArrowKey } from "~/editor/keyboard";
 import * as main from "~/store/tinybase/store/main";
 import { useLiveTitle } from "~/store/zustand/live-title";
 import { type Tab } from "~/store/zustand/tabs";
@@ -217,7 +218,7 @@ const TitleInputInner = memo(
       );
 
       const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === "ArrowUp") {
+        if (isPlainArrowKey(e, "ArrowUp")) {
           e.preventDefault();
           return;
         }
@@ -254,7 +255,7 @@ const TitleInputInner = memo(
             e.preventDefault();
             setTimeout(() => onFocusEditorAtStart?.(), 0);
           }
-        } else if (e.key === "ArrowDown") {
+        } else if (isPlainArrowKey(e, "ArrowDown")) {
           e.preventDefault();
           const input = internalRef.current;
           if (!input) return;


### PR DESCRIPTION
- Centralize ProseMirror state parsing and reconciliation in shared editor helpers
- Move chat and session editors to a controlled `state` flow instead of mixing React state with imperative `view.updateState`
- Preserve selection when only plugin configuration changes, and only replace editor content from props when the editor is unfocused
- Prevent stale callback issues by reading the latest `handleChange`, placeholder, submit, mention, file-handler, and title-navigation props through refs
- Extract shared drop/paste file-handler plumbing so chat and note editors use the same event path
- Unify Apple-platform and plain-arrow-key detection in shared keyboard utilities
- Tighten title input key handling so only unmodified `ArrowUp` / `ArrowDown` presses are intercepted
- Remove deprecated `navigator.platform` usage from the new editor keyboard helper
- Add tests for editor state reconciliation and keyboard utility behavior
