### PR TITLE
fix: add Char template quick actions

### DIFF
--- a/apps/desktop/src/shared/ui/resource-list/preview-header.tsx
+++ b/apps/desktop/src/shared/ui/resource-list/preview-header.tsx
@@ -17,34 +17,47 @@ export function ResourcePreviewHeader({
   actionIcon,
   actionVariant,
   actionClassName,
+  actions,
   children,
 }: {
   title: string;
   description?: string | null;
   category?: string | null;
   targets?: string[] | null;
-  onClone: () => void;
+  onClone?: () => void;
   actionLabel?: string;
   actionIcon?: ReactNode;
   actionVariant?: ButtonProps["variant"];
   actionClassName?: string;
+  actions?: ReactNode;
   children?: ReactNode;
 }) {
+  const actionButton = onClone ? (
+    <Button
+      onClick={onClone}
+      size="sm"
+      variant={actionVariant}
+      className={actionClassName}
+    >
+      {actionIcon === undefined ? (
+        <Copy className="mr-2 h-4 w-4" />
+      ) : (
+        actionIcon
+      )}
+      {actionLabel}
+    </Button>
+  ) : null;
+
   return (
     <div className="pt-1 pr-1 pb-4 pl-3">
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0">
           <TemplateCategoryLabel category={category} />
         </div>
-        <Button
-          onClick={onClone}
-          size="sm"
-          variant={actionVariant}
-          className={actionClassName}
-        >
-          {actionIcon ?? <Copy className="mr-2 h-4 w-4" />}
-          {actionLabel}
-        </Button>
+        <div className="flex items-center gap-0">
+          {actions}
+          {actionButton}
+        </div>
       </div>
       <div className="mt-3 min-w-0 pr-5 pl-3">
         <h2 className="truncate text-lg font-semibold">

--- a/apps/desktop/src/templates/components/details.tsx
+++ b/apps/desktop/src/templates/components/details.tsx
@@ -1,6 +1,16 @@
-import { Pencil } from "lucide-react";
+import { HeartIcon, MoreHorizontalIcon } from "lucide-react";
+import { useState } from "react";
 
 import type { TemplateSection } from "@hypr/store";
+import { Button } from "@hypr/ui/components/ui/button";
+import {
+  AppFloatingPanel,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@hypr/ui/components/ui/dropdown-menu";
+import { cn } from "@hypr/utils";
 
 import { TemplateDetailScrollArea } from "./detail-scroll-area";
 import { SectionsList } from "./sections-editor";
@@ -27,6 +37,8 @@ export function TemplateDetailsColumn({
   handleDeleteTemplate,
   handleDuplicateTemplate,
   handleCloneTemplate,
+  handleFavoriteTemplate,
+  handleSetDefaultTemplate,
 }: {
   isWebMode: boolean;
   selectedMineId: string | null;
@@ -34,6 +46,20 @@ export function TemplateDetailsColumn({
   handleDeleteTemplate: (id: string) => void;
   handleDuplicateTemplate: (id: string) => void;
   handleCloneTemplate: (template: {
+    title: string;
+    description: string;
+    category?: string;
+    targets?: string[];
+    sections: TemplateSection[];
+  }) => void;
+  handleFavoriteTemplate: (template: {
+    title: string;
+    description: string;
+    category?: string;
+    targets?: string[];
+    sections: TemplateSection[];
+  }) => void;
+  handleSetDefaultTemplate: (template: {
     title: string;
     description: string;
     category?: string;
@@ -49,6 +75,8 @@ export function TemplateDetailsColumn({
       <WebTemplatePreview
         template={selectedWebTemplate}
         onClone={handleCloneTemplate}
+        onFavorite={handleFavoriteTemplate}
+        onSetDefault={handleSetDefaultTemplate}
       />
     );
   }
@@ -70,6 +98,8 @@ export function TemplateDetailsColumn({
 function WebTemplatePreview({
   template,
   onClone,
+  onFavorite,
+  onSetDefault,
 }: {
   template: WebTemplate;
   onClone: (template: {
@@ -79,7 +109,30 @@ function WebTemplatePreview({
     targets?: string[];
     sections: TemplateSection[];
   }) => void;
+  onFavorite: (template: {
+    title: string;
+    description: string;
+    category?: string;
+    targets?: string[];
+    sections: TemplateSection[];
+  }) => void;
+  onSetDefault: (template: {
+    title: string;
+    description: string;
+    category?: string;
+    targets?: string[];
+    sections: TemplateSection[];
+  }) => void;
 }) {
+  const nextTemplate = {
+    title: template.title ?? "",
+    description: template.description ?? "",
+    category: template.category,
+    targets: template.targets,
+    sections: template.sections ?? [],
+  };
+  const [actionsOpen, setActionsOpen] = useState(false);
+
   return (
     <div className="flex h-full flex-1 flex-col">
       <ResourcePreviewHeader
@@ -87,18 +140,56 @@ function WebTemplatePreview({
         description={template.description}
         category={template.category}
         targets={template.targets}
-        actionLabel="Edit"
-        actionIcon={<Pencil size={14} className="shrink-0" />}
-        actionVariant="ghost"
-        actionClassName="shrink-0 text-neutral-600 hover:text-black"
-        onClone={() =>
-          onClone({
-            title: template.title ?? "",
-            description: template.description ?? "",
-            category: template.category,
-            targets: template.targets,
-            sections: template.sections ?? [],
-          })
+        actions={
+          <>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => onSetDefault(nextTemplate)}
+              className="shrink-0 text-neutral-600 hover:text-black"
+            >
+              Set as default
+            </Button>
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              onClick={() => onFavorite(nextTemplate)}
+              className="text-neutral-500 hover:text-neutral-800"
+              title="Favorite template"
+              aria-label="Favorite template"
+            >
+              <HeartIcon className="size-4" />
+            </Button>
+            <DropdownMenu open={actionsOpen} onOpenChange={setActionsOpen}>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  className={cn([
+                    "text-neutral-500 hover:text-neutral-800",
+                    actionsOpen &&
+                      "bg-neutral-100 text-neutral-800 hover:bg-neutral-100",
+                  ])}
+                  aria-label="Template actions"
+                >
+                  <MoreHorizontalIcon className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent variant="app" align="end">
+                <AppFloatingPanel className="overflow-hidden p-1">
+                  <DropdownMenuItem
+                    onClick={() => onClone(nextTemplate)}
+                    className="cursor-pointer"
+                  >
+                    Duplicate
+                  </DropdownMenuItem>
+                </AppFloatingPanel>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </>
         }
       />
 

--- a/apps/desktop/src/templates/index.tsx
+++ b/apps/desktop/src/templates/index.tsx
@@ -7,6 +7,7 @@ import { TemplateDetailsColumn } from "./components/details";
 import {
   resolveTemplateTabSelection,
   useCreateTemplate,
+  useToggleTemplateFavorite,
   useUserTemplates,
   type WebTemplate,
 } from "./shared";
@@ -15,6 +16,7 @@ import { StandardTabWrapper } from "~/shared/main";
 import { type TabItem, TabItemBase } from "~/shared/tabs";
 import { useWebResources } from "~/shared/ui/resource-list";
 import * as main from "~/store/tinybase/store/main";
+import * as settings from "~/store/tinybase/store/settings";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 
 export {
@@ -70,7 +72,9 @@ function TemplateView({ tab }: { tab: Extract<Tab, { type: "templates" }> }) {
   const updateTabState = useTabs((state) => state.updateTemplatesTabState);
   const userTemplates = useUserTemplates();
   const createTemplate = useCreateTemplate();
+  const toggleTemplateFavorite = useToggleTemplateFavorite();
   const { data: webTemplates = [] } = useWebResources<WebTemplate>("templates");
+  const settingsStore = settings.UI.useStore(settings.STORE_ID);
 
   const setSelectedMineId = useCallback(
     (id: string | null) => {
@@ -107,6 +111,38 @@ function TemplateView({ tab }: { tab: Extract<Tab, { type: "templates" }> }) {
     [deleteTemplateFromStore, setSelectedMineId],
   );
 
+  const materializeTemplate = useCallback(
+    (
+      template: {
+        title: string;
+        description: string;
+        category?: string;
+        targets?: string[];
+        sections: TemplateSection[];
+      },
+      {
+        title = template.title,
+        onCreate,
+      }: {
+        title?: string;
+        onCreate?: (id: string) => void;
+      } = {},
+    ) => {
+      const id = createTemplate({
+        ...template,
+        title,
+      });
+      if (!id) {
+        return null;
+      }
+
+      onCreate?.(id);
+      setSelectedMineId(id);
+      return id;
+    },
+    [createTemplate, setSelectedMineId],
+  );
+
   const handleCloneTemplate = useCallback(
     (template: {
       title: string;
@@ -115,15 +151,48 @@ function TemplateView({ tab }: { tab: Extract<Tab, { type: "templates" }> }) {
       targets?: string[];
       sections: TemplateSection[];
     }) => {
-      const id = createTemplate({
-        ...template,
+      materializeTemplate(template, {
         title: getTemplateCopyTitle(template.title),
       });
-      if (id) {
-        setSelectedMineId(id);
-      }
     },
-    [createTemplate, setSelectedMineId],
+    [materializeTemplate],
+  );
+
+  const handleFavoriteTemplate = useCallback(
+    (template: {
+      title: string;
+      description: string;
+      category?: string;
+      targets?: string[];
+      sections: TemplateSection[];
+    }) => {
+      materializeTemplate(template, {
+        onCreate: (id) => toggleTemplateFavorite(id),
+      });
+    },
+    [materializeTemplate, toggleTemplateFavorite],
+  );
+
+  const handleSetDefaultTemplate = useCallback(
+    (template: {
+      title: string;
+      description: string;
+      category?: string;
+      targets?: string[];
+      sections: TemplateSection[];
+    }) => {
+      if (!settingsStore) {
+        return;
+      }
+
+      const id = materializeTemplate(template);
+      if (!id) {
+        return;
+      }
+
+      settingsStore.setValue("selected_template_id", id);
+    },
+    [materializeTemplate, settingsStore],
   );
 
   const handleDuplicateTemplate = useCallback(
@@ -151,6 +220,8 @@ function TemplateView({ tab }: { tab: Extract<Tab, { type: "templates" }> }) {
         handleDeleteTemplate={handleDeleteTemplate}
         handleDuplicateTemplate={handleDuplicateTemplate}
         handleCloneTemplate={handleCloneTemplate}
+        handleFavoriteTemplate={handleFavoriteTemplate}
+        handleSetDefaultTemplate={handleSetDefaultTemplate}
       />
     </div>
   );


### PR DESCRIPTION
Let Char template previews create a local copy when they are favorited or set as the default, and extend the shared resource header to render those extra actions alongside Edit.