### PR TITLE
Publish: 7 Best Tactiq Alternatives in 2026

### DIFF
--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -17,16 +17,16 @@ I spent weeks testing alternatives that remove that ceiling in different ways. H
 ## List of the Best Tactiq Alternatives
 
 
-|                  |                                                                            |                                         |
-| ---------------- | -------------------------------------------------------------------------- | --------------------------------------- |
-| **Tool**         | **Best For**                                                               | **Pricing**                             |
-| **Char**         | Developers and tech founders who want control over their data and AI stack | Free (local/BYOK); Pro $25/mo           |
-| **Otter.ai**     | Teams that need cross-meeting search and a mature knowledge base           | Free (300 min/mo); Pro $16.99/mo        |
-| **Granola**      | Individuals who want a notepad-first workflow without a meeting bot        | ~$14/mo (Business)                      |
-| **Fathom**       | Solo users who want unlimited free transcription with fast summaries       | Free (unlimited); Team from $32/user/mo |
-| **Fireflies.ai** | Sales teams that need deep CRM sync and conversation analytics             | Free (800 min/mo); Pro $10/user/mo      |
-| **tl;dv**        | Distributed teams sharing async video clips from meetings                  | Free (unlimited); Pro $29/user/mo       |
-| **Notta**        | International teams needing multilingual transcription and translation     | Free (limited); Pro $13.49/user/mo      |
+|                  |                      |                                                                           |                                         |
+| ---------------- | -------------------- | ------------------------------------------------------------------------- | --------------------------------------- |
+| **Tool**         | **Chrome extension** | **Best For**                                                              | **Pricing**                             |
+| **Char**         | No                   | Developers and tech founder who want control over their data and AI stack | Free (local/BYOK); Pro $25/mo           |
+| **Otter.ai**     | Yes                  | Teams that need cross-meeting search and a mature knowledge base          | Free (300 min/mo); Pro $16.99/mo        |
+| **Granola**      | No                   | Individuals who want a notepad-first workflow without a meeting bot       | ~$14/mo (Business)                      |
+| **Fathom**       | Yes                  | Solo users who want unlimited free transcription with fast summaries      | Free (unlimited); Team from $32/user/mo |
+| **Fireflies.ai** | Yes                  | Sales teams that need deep CRM sync and conversation analytics            | Free (800 min/mo); Pro $10/user/mo      |
+| **tl;dv**        | Yes                  | Distributed teams sharing async video clips from meetings                 | Free (unlimited); Pro $29/user/mo       |
+| **Notta**        | Yes                  | International teams needing multilingual transcription and translation    | Free (limited); Pro $13.49/user/mo      |
 
 
 ## Best Tactiq Alternatives for Meeting Transcription in 2026

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -164,6 +164,8 @@ Free (800 min/mo storage); Pro $10/user/month; Business $19/user/month.
 
 ### 6. tl;dv
 
+![tl;dv vs tactiq](https://auth.hyprnote.com/storage/v1/object/public/blog/blog/image-16.png "char-editor-width=80")
+
 tl;dv takes a different angle than the other tools on this list. The core idea is that most people do not need a full transcript or even a summary. They need the one moment that matters, packaged in a way they can send to someone who was not on the call. 
 
 tl;dv records your meeting, transcribes it, and lets you create timestamped video clips shareable via Slack, Notion, or a direct link. It is built for async-first teams more than for documentation.

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -214,4 +214,4 @@ Free (limited); Pro $13.49/user/month; Business $27.99/user/month.
 
 **Notta** is the strongest option for multilingual teams that need transcription and translation accuracy across dozens of languages.
 
-If you want to try the local-first approach, download Char and try it on your next meeting. 
+If you want to try the local-first approach, [download Char](https://char.com/download/apple-silicon) and try it on your next meeting.

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -33,7 +33,7 @@ I spent weeks testing alternatives that remove that ceiling in different ways. H
 
 ### 1. Char
 
-![](https://auth.hyprnote.com/storage/v1/object/public/blog/blog/image-6.png "char-editor-width=80")
+![char vs tactiq](https://auth.hyprnote.com/storage/v1/object/public/blog/blog/char-summary.png "char-editor-width=80")
 
 Char is an open-source AI notepad for meetings, built for people who want to own their data. 
 
@@ -60,6 +60,8 @@ It transcribes in real time while you take notes in a built-in editor, then comb
 Free with on-device transcription and bring-your-own keys; Lite at $8/month adds cloud transcription and speaker ID; Pro at $25/month adds sync, integrations, and shareable links.
 
 ### 2. Otter.ai
+
+
 
 Otter is the most established name in AI meeting transcription, with over 25 million users. Its OtterPilot bot auto-joins your scheduled meetings on Zoom, Meet, or Teams, transcribes everything, and generates AI summaries with action items. Unlike Tactiq, Otter is a standalone app that works outside the browser.
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -83,14 +83,14 @@ Free (300 min/mo, 30-min cap); Pro $16.99/month ($8.33 annually); Business $30/u
 
 Granola is a desktop app that, like Char, captures system audio and skips the bot. You take notes during the meeting in Granola's notepad, and the AI fills in everything you missed using the transcript. The calendar sync works out of the box, and the note quality is consistently strong.
 
-***What works***
+#### What works
 
 - No bot joins your call. No awkward notifications for other participants.
 - Templates for different meeting types (standup, 1:1, client call) produce well-structured output with minimal setup.
 - Calendar integration is fully automatic. Granola detects meetings and is ready before you are.
 - Works on macOS and Windows, which gives it broader reach than Char's macOS/Linux support.
 
-***What doesn't***
+#### What doesn't
 
 - In March 2026, Granola encrypted its local database, [breaking every agent workflow and third-party tool](https://weekinvoiceai.substack.com/p/week-in-voice-ai12-granola-scramble) that had been reading notes directly from the file system.
 - A [security researcher discovered in May 2025](https://josephthacker.com/hacking/2025/05/08/reverse-engineering-granola-notes.html) that Granola's beta had shipped with a hard-coded AssemblyAI API key, potentially exposing user transcripts. Fixed before public release, but it raised questions about security practices.
@@ -98,11 +98,11 @@ Granola is a desktop app that, like Char, captures system audio and skips the bo
 - Data training is on by default. You have to find and toggle an opt-out in settings.
 - No mobile app. No full transcript bulk export until recently.
 
-***Pricing***
+#### Pricing
 
 Business plan at ~$14/month; requires a Google account to sign up.
 
-**Fathom**
+### 4. Fathom
 
 Fathom has disrupted the pricing model of this entire category by offering unlimited free transcription for individual users. No credit card, no time limits, no catch. It sends a bot into your Zoom, Meet, or Teams call, records everything, and produces AI summaries that are often ready before the meeting ends. The interface is clean and uncluttered, and the highlight clip feature lets you share short video moments with teammates who missed the call.
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -110,7 +110,7 @@ Business plan at ~$14/month; requires a Google account to sign up.
 
 ### 4. Fathom
 
-
+![Fathom vs tactiq](https://auth.hyprnote.com/storage/v1/object/public/blog/blog/image-14.png "char-editor-width=80")
 
 Fathom has disrupted the pricing model of this entire category by offering unlimited free transcription for individual users. No credit card, no time limits, no catch. 
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -33,6 +33,8 @@ I spent weeks testing alternatives that remove that ceiling in different ways. H
 
 ### 1. Char
 
+![](https://auth.hyprnote.com/storage/v1/object/public/blog/blog/image-6.png "char-editor-width=80")
+
 Char is an open-source AI notepad for meetings, built for people who want to own their data. 
 
 Where Tactiq captures text inside Chrome, Char is a desktop app that records system audio from any meeting platform: Zoom, Teams, phone calls, even in-person conversations. 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -85,6 +85,8 @@ Free (300 min/mo, 30-min cap); Pro $16.99/month ($8.33 annually); Business $30/u
 
 ### 3. Granola
 
+![Granola vs tactiq](https://auth.hyprnote.com/storage/v1/object/public/blog/blog/image-13.png "char-editor-width=80")
+
 Granola is a desktop app that, like Char, captures system audio and skips the bot. You take notes during the meeting in Granola's notepad, and the AI fills in everything you missed using the transcript. The calendar sync works out of the box, and the note quality is consistently strong.
 
 #### What works
@@ -107,6 +109,8 @@ Granola is a desktop app that, like Char, captures system audio and skips the bo
 Business plan at ~$14/month; requires a Google account to sign up.
 
 ### 4. Fathom
+
+
 
 Fathom has disrupted the pricing model of this entire category by offering unlimited free transcription for individual users. No credit card, no time limits, no catch. 
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -190,6 +190,8 @@ Free (unlimited recordings and transcriptions); Pro $29/user/month.
 
 ### 7. Notta
 
+
+
 Notta's strongest card is language coverage. It supports 58 languages for transcription and real-time translation for over 50, which is more than any other tool on this list. Tactiq claims 60+ languages for captions, but accuracy drops noticeably with accents and non-native speakers in practice. 
 
 #### What works

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -61,7 +61,7 @@ Free with on-device transcription and bring-your-own keys; Lite at $8/month adds
 
 ### 2. Otter.ai
 
-
+![Otter ai vs tactiq](https://help.otter.ai/hc/article_attachments/8775272002967 "char-editor-width=80")
 
 Otter is the most established name in AI meeting transcription, with over 25 million users. Its OtterPilot bot auto-joins your scheduled meetings on Zoom, Meet, or Teams, transcribes everything, and generates AI summaries with action items. Unlike Tactiq, Otter is a standalone app that works outside the browser.
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -55,23 +55,22 @@ It transcribes in real time while you take notes in a built-in editor, then comb
 
 #### Pricing
 
-Free with unlimited local transcription or bring-your-own API keys; Pro at $25/month adds Char's managed cloud transcription and AI.
+Free with on-device transcription and bring-your-own keys; Lite at $8/month adds cloud transcription and speaker ID; Pro at $25/month adds sync, integrations, and shareable links.
 
-**Otter.ai**
+### 2. Otter.ai
 
-Otter is the most established name in AI meeting transcription, with over 25 million users and [$100 million in annual recurring revenue](https://otter.ai/blog/otter-ai-breaks-100m-arr-barrier-and-transforms-business-meetings) as of March 2025. Its OtterPilot bot auto-joins your scheduled meetings on Zoom, Meet, or Teams, transcribes everything, and generates AI summaries with action items. Unlike Tactiq, Otter is a standalone app that works outside the browser.
+Otter is the most established name in AI meeting transcription, with over 25 million users. Its OtterPilot bot auto-joins your scheduled meetings on Zoom, Meet, or Teams, transcribes everything, and generates AI summaries with action items. Unlike Tactiq, Otter is a standalone app that works outside the browser.
 
-***What works***
+#### What works
 
 - Cross-meeting search is the standout feature. You can ask "What did Sarah say about the Q4 budget?" and get an answer pulled from months of recordings. No other tool on this list does this as well.
 - OtterPilot auto-joins scheduled meetings with zero manual effort.
 - Mature collaboration features: shared notes, highlights, comments, team workspace with usage analytics.
 - Speaker identification works reliably after initial voice training.
 
-***What doesn't***
+#### What doesn't
 
 - A [federal class-action lawsuit filed in August 2025](https://www.npr.org/2025/08/15/nx-s1-5131498/otter-ai-lawsuit-secretly-recording-transcription) accuses Otter of "deceptively and surreptitiously" recording private conversations and using them to train its AI without consent from all meeting participants. The suit alleges the bot records everyone in a call, including people who never signed up for the service.
-- The [University of Massachusetts banned Otter.ai in 2024](https://www.pcmag.com/news/using-otter-notetaker-this-lawsuit-says-it-broke-privacy-laws) for violating its all-party consent law. A Politico journalist raised concerns about data sharing after using Otter to interview a Uyghur human rights activist.
 - The bot ("Otter.ai") joins meetings as a visible participant. Clients notice.
 - AI transcription only works in English, French, and Spanish. Significant gap for international teams.
 - Free tier burns through fast: 300 minutes per month with a 30-minute cap per conversation.

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -10,7 +10,7 @@ date: "2026-04-02"
 
 Tactiq is one of the lighter, smarter approaches to meeting transcription. It runs as a Chrome extension, captures live captions from Google Meet, Zoom, or Teams without sending a bot into the call, and generates AI summaries from the text. Over a million people use it weekly, and for a browser-based tool, it handles the basics well.
 
-But the Chrome dependency is also its ceiling. You have to join meetings through the browser, not the Zoom desktop app or Teams client. There is no audio or video recording, just text. The free plan caps at 10 transcripts per month, and even the $12/month Pro tier limits you to 10 AI credits. If you work across platforms, need to record audio for compliance, or want transcription that works outside Chrome, you hit a wall fast.
+But the Chrome dependency is also its ceiling. You have to join meetings through the browser, not the Zoom desktop app or Teams client. 
 
 I spent weeks testing alternatives that remove that ceiling in different ways. Here are seven tools worth looking at.
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -194,14 +194,24 @@ Notta's strongest card is language coverage. It supports 58 languages for transc
 - Free plan is limited: 120 transcription minutes per month, 10 AI summaries per month.
 - AI summary quality is decent but not as sharp as Fathom's or Granola's in my testing.
 
-***Pricing***
+#### Pricing
 
 Free (limited); Pro $13.49/user/month; Business $27.99/user/month.
 
-**Which Tactiq Alternative Is Right for You?**
+## Which Tactiq Alternative Is Right for You?
 
-No single tool here replaces everything Tactiq does. Tactiq's lightweight Chrome model, its real-time captions without recording audio, and its workflow automation integrations have genuine value. But the Chrome lock-in and limited free tier push a lot of people to look for something that fits their actual workflow better.
+**Char** is the pick if data ownership is non-negotiable: plain markdown files, your choice of AI, fully offline capable. 
 
-**Char** is the pick if data ownership is non-negotiable: plain markdown files, your choice of AI, fully offline capable. **Otter.ai** has the most mature search and knowledge base, but the ongoing consent lawsuit and visible bot make it a harder sell for client-facing work. **Granola** produces excellent notes without a bot, though the recent database encryption incident should give pause to anyone who builds agent workflows around direct file access. **Fathom** is unbeatable for individuals on a budget: unlimited, free, fast. The team pricing is where it gets expensive. **Fireflies.ai** earns its place for sales teams through CRM depth and analytics, but the BIPA lawsuits are a real consideration for organizations with Illinois-based participants. **tl;dv** works best when you need to share moments, not documents, with teammates who were not on the call. And **Notta** is the strongest option for multilingual teams that need transcription and translation accuracy across dozens of languages.
+**Otter.ai** has the most mature search and knowledge base, but the ongoing consent lawsuit and visible bot make it a harder sell for client-facing work. 
+
+**Granola** produces excellent notes without a bot, though the recent database encryption incident should give pause to anyone who builds agent workflows around direct file access. 
+
+**Fathom** is unbeatable for individuals on a budget: unlimited, free, fast. The team pricing is where it gets expensive. 
+
+**Fireflies.ai** earns its place for sales teams through CRM depth and analytics, but the BIPA lawsuits are a real consideration for organizations with Illinois-based participants. 
+
+**tl;dv** works best when you need to share moments, not documents, with teammates who were not on the call. And 
+
+**Notta** is the strongest option for multilingual teams that need transcription and translation accuracy across dozens of languages.
 
 If you want to try the local-first approach, Char is free to download at [char.com](https://char.com). No account required. Install, start a meeting, and your first transcript saves as a markdown file on your machine.

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -79,9 +79,9 @@ Otter is the most established name in AI meeting transcription, with over 25 mil
 
 Free (300 min/mo, 30-min cap); Pro $16.99/month ($8.33 annually); Business $30/user/month.
 
-**Granola**
+### 3. Granola
 
-Granola is a desktop app that, like Char, captures system audio and skips the bot. It launched earlier, grew fast ([1 million+ users, $43 million Series B at a $250 million valuation](https://blog.buildbetter.ai/best-granola-alternatives-private-meeting-notes-2026/)), and built a polished experience around templates and AI-generated summaries. You take notes during the meeting in Granola's notepad, and the AI fills in everything you missed using the transcript. The calendar sync works out of the box, and the note quality is consistently strong.
+Granola is a desktop app that, like Char, captures system audio and skips the bot. You take notes during the meeting in Granola's notepad, and the AI fills in everything you missed using the transcript. The calendar sync works out of the box, and the note quality is consistently strong.
 
 ***What works***
 
@@ -92,7 +92,7 @@ Granola is a desktop app that, like Char, captures system audio and skips the bo
 
 ***What doesn't***
 
-- In March 2026, Granola encrypted its local database, [breaking every agent workflow and third-party tool](https://weekinvoiceai.substack.com/p/week-in-voice-ai12-granola-scramble) that had been reading notes directly from the file system. a16z partner Guido Appenzeller posted a tweet viewed over 337,000 times: "In a world where notes are managed by agents, the app now has zero value." Granola has since committed to a public API, but the incident revealed how dependent users had become on direct file access the company never officially supported.
+- In March 2026, Granola encrypted its local database, [breaking every agent workflow and third-party tool](https://weekinvoiceai.substack.com/p/week-in-voice-ai12-granola-scramble) that had been reading notes directly from the file system.
 - A [security researcher discovered in May 2025](https://josephthacker.com/hacking/2025/05/08/reverse-engineering-granola-notes.html) that Granola's beta had shipped with a hard-coded AssemblyAI API key, potentially exposing user transcripts. Fixed before public release, but it raised questions about security practices.
 - Requires a Google account to sign up, which excludes Microsoft-only organizations.
 - Data training is on by default. You have to find and toggle an opt-out in settings.

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -214,4 +214,4 @@ Free (limited); Pro $13.49/user/month; Business $27.99/user/month.
 
 **Notta** is the strongest option for multilingual teams that need transcription and translation accuracy across dozens of languages.
 
-If you want to try the local-first approach, Char is free to download at [char.com](https://char.com). No account required. Install, start a meeting, and your first transcript saves as a markdown file on your machine.
+If you want to try the local-first approach, download Char and try it on your next meeting. 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -70,7 +70,7 @@ Otter is the most established name in AI meeting transcription, with over 25 mil
 
 #### What doesn't
 
-- A [federal class-action lawsuit filed in August 2025](https://www.npr.org/2025/08/15/nx-s1-5131498/otter-ai-lawsuit-secretly-recording-transcription) accuses Otter of "deceptively and surreptitiously" recording private conversations and using them to train its AI without consent from all meeting participants. The suit alleges the bot records everyone in a call, including people who never signed up for the service.
+- A federal class-action lawsuit filed in August 2025 accuses Otter of "deceptively and surreptitiously" recording private conversations and using them to train its AI without consent from all meeting participants. The suit alleges the bot records everyone in a call, including people who never signed up for the service.
 - The bot ("Otter.ai") joins meetings as a visible participant. Clients notice.
 - AI transcription only works in English, French, and Spanish. Significant gap for international teams.
 - Free tier burns through fast: 300 minutes per month with a 30-minute cap per conversation.

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -166,7 +166,7 @@ Free (800 min/mo storage); Pro $10/user/month; Business $19/user/month.
 
 ![tl;dv vs tactiq](https://auth.hyprnote.com/storage/v1/object/public/blog/blog/image-16.png "char-editor-width=80")
 
-tl;dv takes a different angle than the other tools on this list. The core idea is that most people do not need a full transcript or even a summary. They need the one moment that matters, packaged in a way they can send to someone who was not on the call. 
+[tl;dv](tldv.io) takes a different angle than the other tools on this list. The core idea is that most people do not need a full transcript or even a summary. They need the one moment that matters, packaged in a way they can send to someone who was not on the call. 
 
 tl;dv records your meeting, transcribes it, and lets you create timestamped video clips shareable via Slack, Notion, or a direct link. It is built for async-first teams more than for documentation.
 
@@ -192,7 +192,7 @@ Free (unlimited recordings and transcriptions); Pro $29/user/month.
 
 ![Notta vs tactiq](https://auth.hyprnote.com/storage/v1/object/public/blog/blog/image-18.png "char-editor-width=80")
 
-Notta's strongest card is language coverage. It supports 58 languages for transcription and real-time translation for over 50, which is more than any other tool on this list. Tactiq claims 60+ languages for captions, but accuracy drops noticeably with accents and non-native speakers in practice. 
+[Notta's](notta.ai) strongest card is language coverage. It supports 58 languages for transcription and real-time translation for over 50, which is more than any other tool on this list. Tactiq claims 60+ languages for captions, but accuracy drops noticeably with accents and non-native speakers in practice. 
 
 #### What works
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -190,7 +190,7 @@ Free (unlimited recordings and transcriptions); Pro $29/user/month.
 
 ### 7. Notta
 
-
+![Notta vs tactiq](https://auth.hyprnote.com/storage/v1/object/public/blog/blog/image-18.png "char-editor-width=80")
 
 Notta's strongest card is language coverage. It supports 58 languages for transcription and real-time translation for over 50, which is more than any other tool on this list. Tactiq claims 60+ languages for captions, but accuracy drops noticeably with accents and non-native speakers in practice. 
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -45,7 +45,7 @@ It transcribes in real time while you take notes in a built-in editor, then comb
 
 - Save your notes in your desired folder. If Char disappeared tomorrow, your data would still be exactly where you left it.
 - You choose your own AI stack: Char's managed cloud, your own API keys (OpenAI, Anthropic, Deepgram), or fully local models through Ollama or LM Studio for offline operation.
-- System audio capture means it works with any meeting platform without a or calendar permissions. For teams whose companies have [banned cloud-based tools like Otter or Granola](https://char.com), this is the only option that keeps everything on-device without compromise.
+- System audio capture means it works with any meeting platform without a bot or calendar permissions. For teams whose companies have [banned cloud-based tools like Otter or Granola](https://char.com), this is the only option that keeps everything on-device without compromise.
 - Open-source codebase. Your security team can audit exactly how data is handled.
 - The notepad mode lets you take your own notes during the call. The AI combines your notes with the transcript into structured output, so summaries reflect what you thought was important, not just what the AI picked up.
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -41,11 +41,11 @@ Where Tactiq captures text inside Chrome, Char is a desktop app that records sys
 
 It transcribes in real time while you take notes in a built-in editor, then combines both into a structured summary after the call. No bot joins your meeting and no calendar permissions are required.
 
-***What works***
+#### What works
 
-- Everything is saved as plain markdown files on your device, readable by Obsidian, VS Code, Notion, or any text editor. If Char disappeared tomorrow, your files would still be exactly where you left them.
+- Save your notes in your desired folder. If Char disappeared tomorrow, your data would still be exactly where you left it.
 - You choose your own AI stack: Char's managed cloud, your own API keys (OpenAI, Anthropic, Deepgram), or fully local models through Ollama or LM Studio for offline operation.
-- System audio capture means it works with any meeting platform without requesting OAuth access or calendar permissions. For teams whose companies have [banned cloud-based tools like Otter or Granola](https://char.com), this is the only option that keeps everything on-device without compromise.
+- System audio capture means it works with any meeting platform without a or calendar permissions. For teams whose companies have [banned cloud-based tools like Otter or Granola](https://char.com), this is the only option that keeps everything on-device without compromise.
 - Open-source codebase. Your security team can audit exactly how data is handled.
 - The notepad mode lets you take your own notes during the call. The AI combines your notes with the transcript into structured output, so summaries reflect what you thought was important, not just what the AI picked up.
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -112,7 +112,7 @@ Business plan at ~$14/month; requires a Google account to sign up.
 
 ![Fathom vs tactiq](https://auth.hyprnote.com/storage/v1/object/public/blog/blog/image-14.png "char-editor-width=80")
 
-Fathom has disrupted the pricing model of this entire category by offering unlimited free transcription for individual users. No credit card, no time limits, no catch. 
+[Fathom](fathom.ai) has disrupted the pricing model of this entire category by offering unlimited free transcription for individual users. No credit card, no time limits, no catch. 
 
 It sends a bot into your Zoom, Meet, or Teams call, records everything, and produces AI summaries that are often ready before the meeting ends. 
 
@@ -140,7 +140,7 @@ Free (unlimited individual); Team Standard $32/user/month, Team Pro $39/user/mon
 
 ![Fireflies vs tactiq](https://auth.hyprnote.com/storage/v1/object/public/blog/blog/image-15.png "char-editor-width=80")
 
-Fireflies is built for revenue teams. Where other tools stop at transcription, Fireflies layers on conversation analytics: talk-to-listen ratios, sentiment analysis, topic tracking, and custom vocabulary for industry-specific terminology. 
+[Fireflies](fireflies.ai) is built for revenue teams. Where other tools stop at transcription, Fireflies layers on conversation analytics: talk-to-listen ratios, sentiment analysis, topic tracking, and custom vocabulary for industry-specific terminology. 
 
 The CRM integrations are the deepest I have tested. After connecting HubSpot, every client call automatically logged notes, action items, and summaries to the correct contact record without any manual work.
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -17,25 +17,29 @@ I spent weeks testing alternatives that remove that ceiling in different ways. H
 ## List of the Best Tactiq Alternatives
 
 
-|                  |                                                                        |                                         |
-| ---------------- | ---------------------------------------------------------------------- | --------------------------------------- |
-| **Tool**         | **Best For**                                                           | **Pricing**                             |
-| **Char**         | Developers and tech founders who want control o                        | Free (local/BYOK); Pro $25/mo           |
-| **Otter.ai**     | Teams that need cross-meeting search and a mature knowledge base       | Free (300 min/mo); Pro $16.99/mo        |
-| **Granola**      | Individuals who want a notepad-first workflow without a meeting bot    | ~$14/mo (Business)                      |
-| **Fathom**       | Solo users who want unlimited free transcription with fast summaries   | Free (unlimited); Team from $32/user/mo |
-| **Fireflies.ai** | Sales teams that need deep CRM sync and conversation analytics         | Free (800 min/mo); Pro $10/user/mo      |
-| **tl;dv**        | Distributed teams sharing async video clips from meetings              | Free (unlimited); Pro $29/user/mo       |
-| **Notta**        | International teams needing multilingual transcription and translation | Free (limited); Pro $13.49/user/mo      |
+|                  |                                                                            |                                         |
+| ---------------- | -------------------------------------------------------------------------- | --------------------------------------- |
+| **Tool**         | **Best For**                                                               | **Pricing**                             |
+| **Char**         | Developers and tech founders who want control over their data and AI stack | Free (local/BYOK); Pro $25/mo           |
+| **Otter.ai**     | Teams that need cross-meeting search and a mature knowledge base           | Free (300 min/mo); Pro $16.99/mo        |
+| **Granola**      | Individuals who want a notepad-first workflow without a meeting bot        | ~$14/mo (Business)                      |
+| **Fathom**       | Solo users who want unlimited free transcription with fast summaries       | Free (unlimited); Team from $32/user/mo |
+| **Fireflies.ai** | Sales teams that need deep CRM sync and conversation analytics             | Free (800 min/mo); Pro $10/user/mo      |
+| **tl;dv**        | Distributed teams sharing async video clips from meetings                  | Free (unlimited); Pro $29/user/mo       |
+| **Notta**        | International teams needing multilingual transcription and translation     | Free (limited); Pro $13.49/user/mo      |
 
 
 
 
-**Best Tactiq Alternatives for Meeting Transcription in 2026**
+## Best Tactiq Alternatives for Meeting Transcription in 2026
 
-**Char**
+### 1. Char
 
-Char is an open-source AI notepad for meetings, built for people who want to own their data at the file level. Where Tactiq captures text inside Chrome, Char is a desktop app that records system audio from any meeting platform: Zoom, Teams, phone calls, even in-person conversations. It transcribes in real time while you take notes in a built-in editor, then combines both into a structured summary after the call. No bot joins your meeting and no calendar permissions are required.
+Char is an open-source AI notepad for meetings, built for people who want to own their data. 
+
+Where Tactiq captures text inside Chrome, Char is a desktop app that records system audio from any meeting platform: Zoom, Teams, phone calls, even in-person conversations. 
+
+It transcribes in real time while you take notes in a built-in editor, then combines both into a structured summary after the call. No bot joins your meeting and no calendar permissions are required.
 
 ***What works***
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -176,7 +176,7 @@ tl;dv records your meeting, transcribes it, and lets you create timestamped vide
 
 Free (unlimited recordings and transcriptions); Pro $29/user/month.
 
-**7. Notta**
+### 7. Notta
 
 Notta's strongest card is language coverage. It supports 58 languages for transcription and real-time translation for over 50, which is more than any other tool on this list. Tactiq claims 60+ languages for captions, but accuracy drops noticeably with accents and non-native speakers in practice. 
 
@@ -213,4 +213,4 @@ Free (limited); Pro $13.49/user/month; Business $27.99/user/month.
 
 **Notta** is the strongest option for multilingual teams that need transcription and translation accuracy across dozens of languages.
 
-If you want to try the local-first approach, [download Char](https://char.com/download/apple-silicon) and try it on your next meeting.
+If you want prefer the local-first approach, [download Char](https://char.com/download/apple-silicon) and try it on your next meeting.

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -1,11 +1,199 @@
 ---
-meta_title: ""
-display_title: ""
-meta_description: ""
+meta_title: "7 Best Tactiq Alternatives in 2026"
+meta_description: "For anyone whose workflow has outgrown a Chrome extension: the best alternatives to Tactiq for meeting transcription, AI notes, and real ownership of your data."
 author:
-- "John Jeong"
+  - "John Jeong"
 featured: false
 category: "Product"
 date: "2026-04-02"
 ---
 
+Tactiq is one of the lighter, smarter approaches to meeting transcription. It runs as a Chrome extension, captures live captions from Google Meet, Zoom, or Teams without sending a bot into the call, and generates AI summaries from the text. Over a million people use it weekly, and for a browser-based tool, it handles the basics well.
+
+But the Chrome dependency is also its ceiling. You have to join meetings through the browser, not the Zoom desktop app or Teams client. There is no audio or video recording, just text. The free plan caps at 10 transcripts per month, and even the $12/month Pro tier limits you to 10 AI credits. If you work across platforms, need to record audio for compliance, or want transcription that works outside Chrome, you hit a wall fast.
+
+I spent weeks testing alternatives that remove that ceiling in different ways. Here are seven tools worth looking at, starting with the one that takes the most different approach.
+
+**How These Tactiq Alternatives Compare**
+
+
+|                  |                                                                                   |                                         |
+| ---------------- | --------------------------------------------------------------------------------- | --------------------------------------- |
+| **Tool**         | **Best For**                                                                      | **Pricing**                             |
+| **Char**         | Engineers and privacy-conscious teams who want local files and their own AI stack | Free (local/BYOK); Pro $25/mo           |
+| **Otter.ai**     | Teams that need cross-meeting search and a mature knowledge base                  | Free (300 min/mo); Pro $16.99/mo        |
+| **Granola**      | Individuals who want a notepad-first workflow without a meeting bot               | ~$14/mo (Business)                      |
+| **Fathom**       | Solo users who want unlimited free transcription with fast summaries              | Free (unlimited); Team from $32/user/mo |
+| **Fireflies.ai** | Sales teams that need deep CRM sync and conversation analytics                    | Free (800 min/mo); Pro $10/user/mo      |
+| **tl;dv**        | Distributed teams sharing async video clips from meetings                         | Free (unlimited); Pro $29/user/mo       |
+| **Notta**        | International teams needing multilingual transcription and translation            | Free (limited); Pro $13.49/user/mo      |
+
+
+
+
+**Best Tactiq Alternatives for Meeting Transcription in 2026**
+
+**Char**
+
+Char is an open-source AI notepad for meetings, built for people who want to own their data at the file level. Where Tactiq captures text inside Chrome, Char is a desktop app that records system audio from any meeting platform: Zoom, Teams, phone calls, even in-person conversations. It transcribes in real time while you take notes in a built-in editor, then combines both into a structured summary after the call. No bot joins your meeting and no calendar permissions are required.
+
+***What works***
+
+- Everything is saved as plain markdown files on your device, readable by Obsidian, VS Code, Notion, or any text editor. If Char disappeared tomorrow, your files would still be exactly where you left them.
+- You choose your own AI stack: Char's managed cloud, your own API keys (OpenAI, Anthropic, Deepgram), or fully local models through Ollama or LM Studio for offline operation.
+- System audio capture means it works with any meeting platform without requesting OAuth access or calendar permissions. For teams whose companies have [banned cloud-based tools like Otter or Granola](https://char.com), this is the only option that keeps everything on-device without compromise.
+- Open-source codebase. Your security team can audit exactly how data is handled.
+- The notepad mode lets you take your own notes during the call. The AI combines your notes with the transcript into structured output, so summaries reflect what you thought was important, not just what the AI picked up.
+
+***What doesn't***
+
+- macOS and Linux only. No Windows client yet.
+- No mobile app, no video recording.
+- No built-in CRM integrations. If you need call summaries pushed directly into Salesforce or HubSpot, you will need to build that yourself or use a separate tool.
+- The local-first model means there is no cloud dashboard for team search across meetings. Your notes live in your file system.
+
+***Pricing***
+
+Free with unlimited local transcription or bring-your-own API keys; Pro at $25/month adds Char's managed cloud transcription and AI.
+
+**Otter.ai**
+
+Otter is the most established name in AI meeting transcription, with over 25 million users and [$100 million in annual recurring revenue](https://otter.ai/blog/otter-ai-breaks-100m-arr-barrier-and-transforms-business-meetings) as of March 2025. Its OtterPilot bot auto-joins your scheduled meetings on Zoom, Meet, or Teams, transcribes everything, and generates AI summaries with action items. Unlike Tactiq, Otter is a standalone app that works outside the browser.
+
+***What works***
+
+- Cross-meeting search is the standout feature. You can ask "What did Sarah say about the Q4 budget?" and get an answer pulled from months of recordings. No other tool on this list does this as well.
+- OtterPilot auto-joins scheduled meetings with zero manual effort.
+- Mature collaboration features: shared notes, highlights, comments, team workspace with usage analytics.
+- Speaker identification works reliably after initial voice training.
+
+***What doesn't***
+
+- A [federal class-action lawsuit filed in August 2025](https://www.npr.org/2025/08/15/nx-s1-5131498/otter-ai-lawsuit-secretly-recording-transcription) accuses Otter of "deceptively and surreptitiously" recording private conversations and using them to train its AI without consent from all meeting participants. The suit alleges the bot records everyone in a call, including people who never signed up for the service.
+- The [University of Massachusetts banned Otter.ai in 2024](https://www.pcmag.com/news/using-otter-notetaker-this-lawsuit-says-it-broke-privacy-laws) for violating its all-party consent law. A Politico journalist raised concerns about data sharing after using Otter to interview a Uyghur human rights activist.
+- The bot ("Otter.ai") joins meetings as a visible participant. Clients notice.
+- AI transcription only works in English, French, and Spanish. Significant gap for international teams.
+- Free tier burns through fast: 300 minutes per month with a 30-minute cap per conversation.
+
+***Pricing***
+
+Free (300 min/mo, 30-min cap); Pro $16.99/month ($8.33 annually); Business $30/user/month.
+
+**Granola**
+
+Granola is a desktop app that, like Char, captures system audio and skips the bot. It launched earlier, grew fast ([1 million+ users, $43 million Series B at a $250 million valuation](https://blog.buildbetter.ai/best-granola-alternatives-private-meeting-notes-2026/)), and built a polished experience around templates and AI-generated summaries. You take notes during the meeting in Granola's notepad, and the AI fills in everything you missed using the transcript. The calendar sync works out of the box, and the note quality is consistently strong.
+
+***What works***
+
+- No bot joins your call. No awkward notifications for other participants.
+- Templates for different meeting types (standup, 1:1, client call) produce well-structured output with minimal setup.
+- Calendar integration is fully automatic. Granola detects meetings and is ready before you are.
+- Works on macOS and Windows, which gives it broader reach than Char's macOS/Linux support.
+
+***What doesn't***
+
+- In March 2026, Granola encrypted its local database, [breaking every agent workflow and third-party tool](https://weekinvoiceai.substack.com/p/week-in-voice-ai12-granola-scramble) that had been reading notes directly from the file system. a16z partner Guido Appenzeller posted a tweet viewed over 337,000 times: "In a world where notes are managed by agents, the app now has zero value." Granola has since committed to a public API, but the incident revealed how dependent users had become on direct file access the company never officially supported.
+- A [security researcher discovered in May 2025](https://josephthacker.com/hacking/2025/05/08/reverse-engineering-granola-notes.html) that Granola's beta had shipped with a hard-coded AssemblyAI API key, potentially exposing user transcripts. Fixed before public release, but it raised questions about security practices.
+- Requires a Google account to sign up, which excludes Microsoft-only organizations.
+- Data training is on by default. You have to find and toggle an opt-out in settings.
+- No mobile app. No full transcript bulk export until recently.
+
+***Pricing***
+
+Business plan at ~$14/month; requires a Google account to sign up.
+
+**Fathom**
+
+Fathom has disrupted the pricing model of this entire category by offering unlimited free transcription for individual users. No credit card, no time limits, no catch. It sends a bot into your Zoom, Meet, or Teams call, records everything, and produces AI summaries that are often ready before the meeting ends. The interface is clean and uncluttered, and the highlight clip feature lets you share short video moments with teammates who missed the call.
+
+***What works***
+
+- Unlimited free transcription for individuals is unmatched in this category.
+- Summary speed is the fastest I tested. Usable notes appeared consistently before Otter or Fireflies finished processing.
+- CRM integration pushes notes directly to HubSpot or Salesforce after each call.
+- Highlight clips let you mark key moments during a call and share short video excerpts.
+
+***What doesn't***
+
+- The free tier is individual only. Team features start at $32/user/month (Standard) or $39/user/month (Pro), which is significantly more than Fireflies or Otter at scale.
+- Bot is visible to all meeting participants. For external or client-facing calls, this matters.
+- No offline mode, no local storage. Everything lives in Fathom's cloud.
+- Limited value outside of meeting transcription. No conversation analytics, no sentiment tracking.
+
+***Pricing***
+
+Free (unlimited individual); Team Standard $32/user/month, Team Pro $39/user/month.
+
+**Fireflies.ai**
+
+Fireflies is built for revenue teams. Where other tools stop at transcription, Fireflies layers on conversation analytics: talk-to-listen ratios, sentiment analysis, topic tracking, and custom vocabulary for industry-specific terminology. The CRM integrations are the deepest I have tested. After connecting HubSpot, every client call automatically logged notes, action items, and summaries to the correct contact record without any manual work.
+
+***What works***
+
+- Deepest CRM integrations in the category: native auto-sync with Salesforce, HubSpot, Pipedrive, and Zoho.
+- Conversation analytics (sentiment, talk ratio, topic detection) are genuinely useful for sales coaching and pipeline reviews.
+- Most generous free tier among bot-based tools: 800 minutes per month of storage.
+- Works across Zoom, Meet, Teams, and Webex. Broader platform coverage than most competitors.
+
+***What doesn't***
+
+- Facing two class-action lawsuits under Illinois' BIPA. The first, [Cruz v. Fireflies.AI Corp.](https://www.jdsupra.com/legalnews/lawsuit-alleges-fireflies-ai-corp-8472044), filed December 2025, alleges the bot collected voiceprints from a participant who never created an account. The second, [Fricker v. Fireflies.AI Corp.](https://topclassactions.com/lawsuit-settlements/lawsuit-news/fireflies-ai-sued-over-alleged-unlawful-data-collection-from-meeting-participants/), followed in March 2026 with the same pattern. Both claim the speaker recognition feature creates biometric identifiers without the written consent BIPA requires.
+- Bot ("Fireflies.ai Notetaker") joins every meeting as a visible participant.
+- Dashboard can feel overwhelming. The feature density that makes it great for sales teams makes it noisy for everyone else.
+- Advanced analytics locked behind the Business tier at $19/user/month.
+
+***Pricing***
+
+Free (800 min/mo storage); Pro $10/user/month; Business $19/user/month.
+
+**tl;dv**
+
+tl;dv takes a different angle than the other tools on this list. The core idea is that most people do not need a full transcript or even a summary. They need the one moment that matters, packaged in a way they can send to someone who was not on the call. tl;dv records your meeting, transcribes it, and lets you create timestamped video clips shareable via Slack, Notion, or a direct link. It is built for async-first teams more than for documentation.
+
+***What works***
+
+- Unlimited free recordings and transcriptions with no time cap. One of the most generous free tiers available.
+- Timestamped video clips are the fastest way to share a specific meeting moment with someone who was not there.
+- AI-powered search finds specific moments across all recordings, not just keywords in transcripts.
+- Integrates with Slack, Notion, HubSpot, and project management tools for clip distribution.
+
+***What doesn't***
+
+- Bot joins your call visibly, same friction as Otter and Fireflies.
+- AI summaries are limited on the free plan. You get the recordings but not the intelligence without paying.
+- Pro plan at $29/user/month is steep for small teams, especially when the core value (clips) is available for free.
+- 30+ languages supported, which is solid but behind Notta's 58. No offline mode, no local storage.
+
+***Pricing***
+
+Free (unlimited recordings and transcriptions); Pro $29/user/month.
+
+**Notta**
+
+Notta's strongest card is language coverage. It supports 58 languages for transcription and real-time translation for over 50, which is more than any other tool on this list. Tactiq claims 60+ languages for captions, but accuracy drops noticeably with accents and non-native speakers in practice. Notta's accuracy stayed more consistent in multilingual calls during my testing. It also records audio and video, which Tactiq does not do at all.
+
+***What works***
+
+- 58 languages for transcription with real-time translation for 50+. Best-in-class for international and multilingual teams.
+- Actually records audio and video, so you can replay meetings, verify exact wording, and export files. Essential for compliance-sensitive industries.
+- Exports to DOCX, PDF, SRT, and other formats. Good data portability compared to tools that lock notes in proprietary views.
+- Works on desktop, mobile, and browser. The broadest device coverage on this list.
+
+***What doesn't***
+
+- Notta's policies around AI training are [less clear than competitors](https://fellow.ai/blog/best-meeting-transcription-apps). A secondary review found that Notta may use user data for model training by default, with opt-outs available only on enterprise plans.
+- Bot joins calls visibly, same as Otter and Fireflies.
+- Free plan is limited: 120 transcription minutes per month, 10 AI summaries per month.
+- AI summary quality is decent but not as sharp as Fathom's or Granola's in my testing.
+
+***Pricing***
+
+Free (limited); Pro $13.49/user/month; Business $27.99/user/month.
+
+**Which Tactiq Alternative Is Right for You?**
+
+No single tool here replaces everything Tactiq does. Tactiq's lightweight Chrome model, its real-time captions without recording audio, and its workflow automation integrations have genuine value. But the Chrome lock-in and limited free tier push a lot of people to look for something that fits their actual workflow better.
+
+**Char** is the pick if data ownership is non-negotiable: plain markdown files, your choice of AI, fully offline capable. **Otter.ai** has the most mature search and knowledge base, but the ongoing consent lawsuit and visible bot make it a harder sell for client-facing work. **Granola** produces excellent notes without a bot, though the recent database encryption incident should give pause to anyone who builds agent workflows around direct file access. **Fathom** is unbeatable for individuals on a budget: unlimited, free, fast. The team pricing is where it gets expensive. **Fireflies.ai** earns its place for sales teams through CRM depth and analytics, but the BIPA lawsuits are a real consideration for organizations with Illinois-based participants. **tl;dv** works best when you need to share moments, not documents, with teammates who were not on the call. And **Notta** is the strongest option for multilingual teams that need transcription and translation accuracy across dozens of languages.
+
+If you want to try the local-first approach, Char is free to download at [char.com](https://char.com). No account required. Install, start a meeting, and your first transcript saves as a markdown file on your machine.

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -104,31 +104,37 @@ Business plan at ~$14/month; requires a Google account to sign up.
 
 ### 4. Fathom
 
-Fathom has disrupted the pricing model of this entire category by offering unlimited free transcription for individual users. No credit card, no time limits, no catch. It sends a bot into your Zoom, Meet, or Teams call, records everything, and produces AI summaries that are often ready before the meeting ends. The interface is clean and uncluttered, and the highlight clip feature lets you share short video moments with teammates who missed the call.
+Fathom has disrupted the pricing model of this entire category by offering unlimited free transcription for individual users. No credit card, no time limits, no catch. 
 
-***What works***
+It sends a bot into your Zoom, Meet, or Teams call, records everything, and produces AI summaries that are often ready before the meeting ends. 
+
+The interface is clean and uncluttered, and the highlight clip feature lets you share short video moments with teammates who missed the call.
+
+#### What works
 
 - Unlimited free transcription for individuals is unmatched in this category.
 - Summary speed is the fastest I tested. Usable notes appeared consistently before Otter or Fireflies finished processing.
 - CRM integration pushes notes directly to HubSpot or Salesforce after each call.
 - Highlight clips let you mark key moments during a call and share short video excerpts.
 
-***What doesn't***
+#### What doesn't
 
 - The free tier is individual only. Team features start at $32/user/month (Standard) or $39/user/month (Pro), which is significantly more than Fireflies or Otter at scale.
 - Bot is visible to all meeting participants. For external or client-facing calls, this matters.
 - No offline mode, no local storage. Everything lives in Fathom's cloud.
 - Limited value outside of meeting transcription. No conversation analytics, no sentiment tracking.
 
-***Pricing***
+#### Pricing
 
 Free (unlimited individual); Team Standard $32/user/month, Team Pro $39/user/month.
 
-**Fireflies.ai**
+### 5. Fireflies.ai
 
-Fireflies is built for revenue teams. Where other tools stop at transcription, Fireflies layers on conversation analytics: talk-to-listen ratios, sentiment analysis, topic tracking, and custom vocabulary for industry-specific terminology. The CRM integrations are the deepest I have tested. After connecting HubSpot, every client call automatically logged notes, action items, and summaries to the correct contact record without any manual work.
+Fireflies is built for revenue teams. Where other tools stop at transcription, Fireflies layers on conversation analytics: talk-to-listen ratios, sentiment analysis, topic tracking, and custom vocabulary for industry-specific terminology. 
 
-***What works***
+The CRM integrations are the deepest I have tested. After connecting HubSpot, every client call automatically logged notes, action items, and summaries to the correct contact record without any manual work.
+
+#### ***What works***
 
 - Deepest CRM integrations in the category: native auto-sync with Salesforce, HubSpot, Pipedrive, and Zoho.
 - Conversation analytics (sentiment, talk ratio, topic detection) are genuinely useful for sales coaching and pipeline reviews.

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -29,8 +29,6 @@ I spent weeks testing alternatives that remove that ceiling in different ways. H
 | **Notta**        | International teams needing multilingual transcription and translation     | Free (limited); Pro $13.49/user/mo      |
 
 
-
-
 ## Best Tactiq Alternatives for Meeting Transcription in 2026
 
 ### 1. Char
@@ -45,18 +43,17 @@ It transcribes in real time while you take notes in a built-in editor, then comb
 
 - Save your notes in your desired folder. If Char disappeared tomorrow, your data would still be exactly where you left it.
 - You choose your own AI stack: Char's managed cloud, your own API keys (OpenAI, Anthropic, Deepgram), or fully local models through Ollama or LM Studio for offline operation.
-- System audio capture means it works with any meeting platform without a bot or calendar permissions. For teams whose companies have [banned cloud-based tools like Otter or Granola](https://char.com), this is the only option that keeps everything on-device without compromise.
+- System audio capture means it works with any meeting platform without a bot or calendar permissions. For teams whose companies have banned cloud-based tools like Otter or Granola, this is the only option that keeps everything on-device without compromise.
 - Open-source codebase. Your security team can audit exactly how data is handled.
 - The notepad mode lets you take your own notes during the call. The AI combines your notes with the transcript into structured output, so summaries reflect what you thought was important, not just what the AI picked up.
 
-***What doesn't***
+#### What doesn't
 
 - macOS and Linux only. No Windows client yet.
 - No mobile app, no video recording.
-- No built-in CRM integrations. If you need call summaries pushed directly into Salesforce or HubSpot, you will need to build that yourself or use a separate tool.
-- The local-first model means there is no cloud dashboard for team search across meetings. Your notes live in your file system.
+- No built-in CRM integrations yet.
 
-***Pricing***
+#### Pricing
 
 Free with unlimited local transcription or bring-your-own API keys; Pro at $25/month adds Char's managed cloud transcription and AI.
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -12,21 +12,21 @@ Tactiq is one of the lighter, smarter approaches to meeting transcription. It ru
 
 But the Chrome dependency is also its ceiling. You have to join meetings through the browser, not the Zoom desktop app or Teams client. There is no audio or video recording, just text. The free plan caps at 10 transcripts per month, and even the $12/month Pro tier limits you to 10 AI credits. If you work across platforms, need to record audio for compliance, or want transcription that works outside Chrome, you hit a wall fast.
 
-I spent weeks testing alternatives that remove that ceiling in different ways. Here are seven tools worth looking at, starting with the one that takes the most different approach.
+I spent weeks testing alternatives that remove that ceiling in different ways. Here are seven tools worth looking at.
 
-**How These Tactiq Alternatives Compare**
+## List of the Best Tactiq Alternatives
 
 
-|                  |                                                                                   |                                         |
-| ---------------- | --------------------------------------------------------------------------------- | --------------------------------------- |
-| **Tool**         | **Best For**                                                                      | **Pricing**                             |
-| **Char**         | Engineers and privacy-conscious teams who want local files and their own AI stack | Free (local/BYOK); Pro $25/mo           |
-| **Otter.ai**     | Teams that need cross-meeting search and a mature knowledge base                  | Free (300 min/mo); Pro $16.99/mo        |
-| **Granola**      | Individuals who want a notepad-first workflow without a meeting bot               | ~$14/mo (Business)                      |
-| **Fathom**       | Solo users who want unlimited free transcription with fast summaries              | Free (unlimited); Team from $32/user/mo |
-| **Fireflies.ai** | Sales teams that need deep CRM sync and conversation analytics                    | Free (800 min/mo); Pro $10/user/mo      |
-| **tl;dv**        | Distributed teams sharing async video clips from meetings                         | Free (unlimited); Pro $29/user/mo       |
-| **Notta**        | International teams needing multilingual transcription and translation            | Free (limited); Pro $13.49/user/mo      |
+|                  |                                                                        |                                         |
+| ---------------- | ---------------------------------------------------------------------- | --------------------------------------- |
+| **Tool**         | **Best For**                                                           | **Pricing**                             |
+| **Char**         | Developers and tech founders who want control o                        | Free (local/BYOK); Pro $25/mo           |
+| **Otter.ai**     | Teams that need cross-meeting search and a mature knowledge base       | Free (300 min/mo); Pro $16.99/mo        |
+| **Granola**      | Individuals who want a notepad-first workflow without a meeting bot    | ~$14/mo (Business)                      |
+| **Fathom**       | Solo users who want unlimited free transcription with fast summaries   | Free (unlimited); Team from $32/user/mo |
+| **Fireflies.ai** | Sales teams that need deep CRM sync and conversation analytics         | Free (800 min/mo); Pro $10/user/mo      |
+| **tl;dv**        | Distributed teams sharing async video clips from meetings              | Free (unlimited); Pro $29/user/mo       |
+| **Notta**        | International teams needing multilingual transcription and translation | Free (limited); Pro $13.49/user/mo      |
 
 
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -189,7 +189,6 @@ Notta's strongest card is language coverage. It supports 58 languages for transc
 
 #### What doesn't
 
-- Notta's policies around AI training are [less clear than competitors](https://fellow.ai/blog/best-meeting-transcription-apps). A secondary review found that Notta may use user data for model training by default, with opt-outs available only on enterprise plans.
 - Bot joins calls visibly, same as Otter and Fireflies.
 - Free plan is limited: 120 transcription minutes per month, 10 AI summaries per month.
 - AI summary quality is decent but not as sharp as Fathom's or Granola's in my testing.

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -12,7 +12,7 @@ Tactiq is one of the lighter, smarter approaches to meeting transcription. It ru
 
 But the Chrome dependency is also its ceiling. You have to join meetings through the browser, not the Zoom desktop app or Teams client. 
 
-I spent weeks testing alternatives that remove that ceiling in different ways. Here are seven tools worth looking at.
+I spent weeks testing alternatives that remove that ceiling in different ways. Here are seven tools worth a look.
 
 ## List of the Best Tactiq Alternatives
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -75,7 +75,7 @@ Otter is the most established name in AI meeting transcription, with over 25 mil
 - AI transcription only works in English, French, and Spanish. Significant gap for international teams.
 - Free tier burns through fast: 300 minutes per month with a 30-minute cap per conversation.
 
-***Pricing***
+#### Pricing
 
 Free (300 min/mo, 30-min cap); Pro $16.99/month ($8.33 annually); Business $30/user/month.
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -178,16 +178,16 @@ Free (unlimited recordings and transcriptions); Pro $29/user/month.
 
 **7. Notta**
 
-Notta's strongest card is language coverage. It supports 58 languages for transcription and real-time translation for over 50, which is more than any other tool on this list. Tactiq claims 60+ languages for captions, but accuracy drops noticeably with accents and non-native speakers in practice. Notta's accuracy stayed more consistent in multilingual calls during my testing. It also records audio and video, which Tactiq does not do at all.
+Notta's strongest card is language coverage. It supports 58 languages for transcription and real-time translation for over 50, which is more than any other tool on this list. Tactiq claims 60+ languages for captions, but accuracy drops noticeably with accents and non-native speakers in practice. 
 
-***What works***
+#### What works
 
 - 58 languages for transcription with real-time translation for 50+. Best-in-class for international and multilingual teams.
 - Actually records audio and video, so you can replay meetings, verify exact wording, and export files. Essential for compliance-sensitive industries.
 - Exports to DOCX, PDF, SRT, and other formats. Good data portability compared to tools that lock notes in proprietary views.
 - Works on desktop, mobile, and browser. The broadest device coverage on this list.
 
-***What doesn't***
+#### What doesn't
 
 - Notta's policies around AI training are [less clear than competitors](https://fellow.ai/blog/best-meeting-transcription-apps). A secondary review found that Notta may use user data for model training by default, with opt-outs available only on enterprise plans.
 - Bot joins calls visibly, same as Otter and Fireflies.

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -4,7 +4,7 @@ meta_description: "For anyone whose workflow has outgrown a Chrome extension: th
 author:
   - "John Jeong"
 featured: false
-category: "Product"
+category: "Comparisons"
 date: "2026-04-02"
 ---
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -154,27 +154,29 @@ Free (800 min/mo storage); Pro $10/user/month; Business $19/user/month.
 
 ### 6. tl;dv
 
-tl;dv takes a different angle than the other tools on this list. The core idea is that most people do not need a full transcript or even a summary. They need the one moment that matters, packaged in a way they can send to someone who was not on the call. tl;dv records your meeting, transcribes it, and lets you create timestamped video clips shareable via Slack, Notion, or a direct link. It is built for async-first teams more than for documentation.
+tl;dv takes a different angle than the other tools on this list. The core idea is that most people do not need a full transcript or even a summary. They need the one moment that matters, packaged in a way they can send to someone who was not on the call. 
 
-***What works***
+tl;dv records your meeting, transcribes it, and lets you create timestamped video clips shareable via Slack, Notion, or a direct link. It is built for async-first teams more than for documentation.
+
+#### What works
 
 - Unlimited free recordings and transcriptions with no time cap. One of the most generous free tiers available.
 - Timestamped video clips are the fastest way to share a specific meeting moment with someone who was not there.
 - AI-powered search finds specific moments across all recordings, not just keywords in transcripts.
 - Integrates with Slack, Notion, HubSpot, and project management tools for clip distribution.
 
-***What doesn't***
+#### What doesn't
 
 - Bot joins your call visibly, same friction as Otter and Fireflies.
 - AI summaries are limited on the free plan. You get the recordings but not the intelligence without paying.
 - Pro plan at $29/user/month is steep for small teams, especially when the core value (clips) is available for free.
 - 30+ languages supported, which is solid but behind Notta's 58. No offline mode, no local storage.
 
-***Pricing***
+#### Pricing
 
 Free (unlimited recordings and transcriptions); Pro $29/user/month.
 
-**Notta**
+**7. Notta**
 
 Notta's strongest card is language coverage. It supports 58 languages for transcription and real-time translation for over 50, which is more than any other tool on this list. Tactiq claims 60+ languages for captions, but accuracy drops noticeably with accents and non-native speakers in practice. Notta's accuracy stayed more consistent in multilingual calls during my testing. It also records audio and video, which Tactiq does not do at all.
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -1,0 +1,11 @@
+---
+meta_title: ""
+display_title: ""
+meta_description: ""
+author:
+- "John Jeong"
+featured: false
+category: "Product"
+date: "2026-04-02"
+---
+

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -87,7 +87,7 @@ Free (300 min/mo, 30-min cap); Pro $16.99/month ($8.33 annually); Business $30/u
 
 ![Granola vs tactiq](https://auth.hyprnote.com/storage/v1/object/public/blog/blog/image-13.png "char-editor-width=80")
 
-Granola is a desktop app that, like Char, captures system audio and skips the bot. You take notes during the meeting in Granola's notepad, and the AI fills in everything you missed using the transcript. The calendar sync works out of the box, and the note quality is consistently strong.
+[Granola](granola.ai) is a desktop app that, like Char, captures system audio and skips the bot. You take notes during the meeting in Granola's notepad, and the AI fills in everything you missed using the transcript. The calendar sync works out of the box, and the note quality is consistently strong.
 
 #### What works
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -138,6 +138,8 @@ Free (unlimited individual); Team Standard $32/user/month, Team Pro $39/user/mon
 
 ### 5. Fireflies.ai
 
+![Fireflies vs tactiq](https://auth.hyprnote.com/storage/v1/object/public/blog/blog/image-15.png "char-editor-width=80")
+
 Fireflies is built for revenue teams. Where other tools stop at transcription, Fireflies layers on conversation analytics: talk-to-listen ratios, sentiment analysis, topic tracking, and custom vocabulary for industry-specific terminology. 
 
 The CRM integrations are the deepest I have tested. After connecting HubSpot, every client call automatically logged notes, action items, and summaries to the correct contact record without any manual work.

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -134,25 +134,25 @@ Fireflies is built for revenue teams. Where other tools stop at transcription, F
 
 The CRM integrations are the deepest I have tested. After connecting HubSpot, every client call automatically logged notes, action items, and summaries to the correct contact record without any manual work.
 
-#### ***What works***
+#### What works
 
-- Deepest CRM integrations in the category: native auto-sync with Salesforce, HubSpot, Pipedrive, and Zoho.
+- Native auto-sync with Salesforce, HubSpot, Pipedrive, and Zoho.
 - Conversation analytics (sentiment, talk ratio, topic detection) are genuinely useful for sales coaching and pipeline reviews.
 - Most generous free tier among bot-based tools: 800 minutes per month of storage.
 - Works across Zoom, Meet, Teams, and Webex. Broader platform coverage than most competitors.
 
-***What doesn't***
+#### What doesn't
 
 - Facing two class-action lawsuits under Illinois' BIPA. The first, [Cruz v. Fireflies.AI Corp.](https://www.jdsupra.com/legalnews/lawsuit-alleges-fireflies-ai-corp-8472044), filed December 2025, alleges the bot collected voiceprints from a participant who never created an account. The second, [Fricker v. Fireflies.AI Corp.](https://topclassactions.com/lawsuit-settlements/lawsuit-news/fireflies-ai-sued-over-alleged-unlawful-data-collection-from-meeting-participants/), followed in March 2026 with the same pattern. Both claim the speaker recognition feature creates biometric identifiers without the written consent BIPA requires.
 - Bot ("Fireflies.ai Notetaker") joins every meeting as a visible participant.
 - Dashboard can feel overwhelming. The feature density that makes it great for sales teams makes it noisy for everyone else.
 - Advanced analytics locked behind the Business tier at $19/user/month.
 
-***Pricing***
+#### Pricing
 
 Free (800 min/mo storage); Pro $10/user/month; Business $19/user/month.
 
-**tl;dv**
+### 6. tl;dv
 
 tl;dv takes a different angle than the other tools on this list. The core idea is that most people do not need a full transcript or even a summary. They need the one moment that matters, packaged in a way they can send to someone who was not on the call. tl;dv records your meeting, transcribes it, and lets you create timestamped video clips shareable via Slack, Notion, or a direct link. It is built for async-first teams more than for documentation.
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -35,7 +35,7 @@ I spent weeks testing alternatives that remove that ceiling in different ways. H
 
 ![char vs tactiq](https://auth.hyprnote.com/storage/v1/object/public/blog/blog/char-summary.png "char-editor-width=80")
 
-Char is an open-source AI notepad for meetings, built for people who want to own their data. 
+[Char](char.com) is an open-source AI notepad for meetings, built for people who want to own their data. 
 
 Where Tactiq captures text inside Chrome, Char is a desktop app that records system audio from any meeting platform: Zoom, Teams, phone calls, even in-person conversations. 
 
@@ -63,7 +63,7 @@ Free with on-device transcription and bring-your-own keys; Lite at $8/month adds
 
 ![Otter ai vs tactiq](https://help.otter.ai/hc/article_attachments/8775272002967 "char-editor-width=80")
 
-Otter is the most established name in AI meeting transcription, with over 25 million users. Its OtterPilot bot auto-joins your scheduled meetings on Zoom, Meet, or Teams, transcribes everything, and generates AI summaries with action items. Unlike Tactiq, Otter is a standalone app that works outside the browser.
+[Otter](otter.ai) is the most established name in AI meeting transcription, with over 25 million users. Its OtterPilot bot auto-joins your scheduled meetings on Zoom, Meet, or Teams, transcribes everything, and generates AI summaries with action items. Unlike Tactiq, Otter is a standalone app that works outside the browser.
 
 #### What works
 


### PR DESCRIPTION
## Article Ready for Publication

**Title:** 7 Best Tactiq Alternatives in 2026
**Author:** John Jeong
**Date:** 2026-04-02
**Category:** Comparisons

**Branch:** blog/tactiq-alternatives
**File:** apps/web/content/articles/tactiq-alternatives.mdx

---
Auto-generated PR from admin panel.