### PR TITLE
fix(desktop): align session note scrollbar to panel edge

### DIFF
--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -151,7 +151,7 @@ export const NoteInput = forwardRef<
           }}
           onClick={handleContainerClick}
           className={cn([
-            "h-full px-3",
+            "h-full pr-0 pl-3",
             "scroll-fade-y overflow-auto",
             "pt-2",
             "pb-6",


### PR DESCRIPTION
Remove the note editor right padding from the scroll container so the scrollbar sits flush with the session panel.