### PR TITLE
fix: inline template author byline

### DIFF
--- a/apps/desktop/src/shared/ui/resource-list/preview-header.tsx
+++ b/apps/desktop/src/shared/ui/resource-list/preview-header.tsx
@@ -18,6 +18,8 @@ export function ResourcePreviewHeader({
   actionVariant,
   actionClassName,
   actions,
+  titleMeta,
+  footer,
   children,
 }: {
   title: string;
@@ -30,6 +32,8 @@ export function ResourcePreviewHeader({
   actionVariant?: ButtonProps["variant"];
   actionClassName?: string;
   actions?: ReactNode;
+  titleMeta?: ReactNode;
+  footer?: ReactNode;
   children?: ReactNode;
 }) {
   const actionButton = onClone ? (
@@ -60,9 +64,12 @@ export function ResourcePreviewHeader({
         </div>
       </div>
       <div className="mt-3 min-w-0 pr-5 pl-3">
-        <h2 className="truncate text-lg font-semibold">
-          {title || "Untitled"}
-        </h2>
+        <div className="flex min-w-0 items-baseline gap-2">
+          <h2 className="min-w-0 truncate text-lg font-semibold">
+            {title || "Untitled"}
+          </h2>
+          {titleMeta}
+        </div>
         {description && (
           <p className="mt-1 text-sm text-neutral-500">{description}</p>
         )}
@@ -78,9 +85,13 @@ export function ResourcePreviewHeader({
             ))}
           </div>
         )}
-        <p className="mt-2 text-xs text-neutral-400">
-          {getTemplateCreatorLabel({ isUserTemplate: false })}
-        </p>
+        {footer === undefined ? (
+          <p className="mt-2 text-xs text-neutral-400">
+            {getTemplateCreatorLabel({ isUserTemplate: false })}
+          </p>
+        ) : (
+          footer
+        )}
       </div>
       {children}
     </div>

--- a/apps/desktop/src/templates/components/details.tsx
+++ b/apps/desktop/src/templates/components/details.tsx
@@ -12,6 +12,7 @@ import {
 } from "@hypr/ui/components/ui/dropdown-menu";
 import { cn } from "@hypr/utils";
 
+import { getTemplateCreatorByline } from "../shared";
 import { TemplateDetailScrollArea } from "./detail-scroll-area";
 import { SectionsList } from "./sections-editor";
 import { TemplateForm } from "./template-form";
@@ -140,6 +141,12 @@ function WebTemplatePreview({
         description={template.description}
         category={template.category}
         targets={template.targets}
+        titleMeta={
+          <span className="shrink-0 text-sm font-normal whitespace-nowrap text-neutral-400">
+            {getTemplateCreatorByline({ isUserTemplate: false })}
+          </span>
+        }
+        footer={null}
         actions={
           <>
             <Button

--- a/apps/desktop/src/templates/components/template-form.tsx
+++ b/apps/desktop/src/templates/components/template-form.tsx
@@ -16,7 +16,7 @@ import { Textarea } from "@hypr/ui/components/ui/textarea";
 import { cn } from "@hypr/utils";
 
 import {
-  getTemplateCreatorLabel,
+  getTemplateCreatorByline,
   useTemplateCreatorName,
   useToggleTemplateFavorite,
 } from "../shared";
@@ -228,12 +228,28 @@ export function TemplateForm({
         <div className="mt-3 min-w-0 pr-5 pl-3">
           <form.Field name="title">
             {(field) => (
-              <Input
-                value={field.state.value}
-                onChange={(e) => field.handleChange(e.target.value)}
-                placeholder="Enter template title"
-                className="h-auto border-0 px-0 py-0 text-lg font-semibold shadow-none focus-visible:ring-0 md:text-lg"
-              />
+              <div className="flex min-w-0 items-baseline gap-2">
+                <div className="relative max-w-full min-w-0">
+                  <span
+                    aria-hidden="true"
+                    className="invisible block px-0 py-0 text-lg font-semibold whitespace-pre md:text-lg"
+                  >
+                    {(field.state.value || " ") + " "}
+                  </span>
+                  <Input
+                    value={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    placeholder="Enter template title"
+                    className="absolute inset-0 h-auto w-full max-w-full min-w-0 border-0 px-0 py-0 text-lg font-semibold shadow-none focus-visible:ring-0 md:text-lg"
+                  />
+                </div>
+                <span className="shrink-0 text-sm font-normal whitespace-nowrap text-neutral-400">
+                  {getTemplateCreatorByline({
+                    isUserTemplate: true,
+                    creatorName,
+                  })}
+                </span>
+              </div>
             )}
           </form.Field>
           <form.Field name="description">
@@ -299,12 +315,6 @@ export function TemplateForm({
               );
             }}
           </form.Field>
-          <p className="mt-2 text-xs text-neutral-400">
-            {getTemplateCreatorLabel({
-              isUserTemplate: true,
-              creatorName,
-            })}
-          </p>
         </div>
       </div>
 

--- a/apps/desktop/src/templates/shared.ts
+++ b/apps/desktop/src/templates/shared.ts
@@ -127,6 +127,16 @@ export function getTemplateCreatorLabel({
     : "Created by Char";
 }
 
+export function getTemplateCreatorByline({
+  isUserTemplate,
+  creatorName,
+}: {
+  isUserTemplate: boolean;
+  creatorName?: string | null;
+}) {
+  return isUserTemplate ? `by ${creatorName?.trim() || "user"}` : "by Char";
+}
+
 export function useCreateTemplate() {
   const { user_id } = main.UI.useValues(main.STORE_ID);
 


### PR DESCRIPTION
Move template author text beside the title in the template preview and editor, and keep the shared preview header change opt-in for other resources.