### PR TITLE
fix: remove undo-delete keyboard shortcut

### DIFF
--- a/apps/desktop/src/shared/main-app-layout.tsx
+++ b/apps/desktop/src/shared/main-app-layout.tsx
@@ -9,10 +9,7 @@ import { useNewNote } from "./main/useNewNote";
 import { AuthProvider } from "~/auth";
 import { BillingProvider } from "~/auth/billing";
 import { NetworkProvider } from "~/contexts/network";
-import {
-  UndoDeleteKeyboardHandler,
-  UndoDeleteToast,
-} from "~/sidebar/toast/undo-delete-toast";
+import { UndoDeleteToast } from "~/sidebar/toast/undo-delete-toast";
 import { isTabInputSupported, useTabs } from "~/store/zustand/tabs";
 
 export default function MainAppLayout() {
@@ -33,7 +30,6 @@ function MainAppContent() {
   return (
     <>
       <Outlet />
-      <UndoDeleteKeyboardHandler />
       <UndoDeleteToast />
     </>
   );

--- a/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
+++ b/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
@@ -2,7 +2,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
-import { useHotkeys } from "react-hotkeys-hook";
 
 import { cn } from "@hypr/utils";
 
@@ -170,33 +169,6 @@ function useGroupCountdown(group: ToastGroup) {
   }, [earliest, isPaused, frozenRemaining]);
 
   return Math.ceil(remaining / 1000);
-}
-
-export function UndoDeleteKeyboardHandler() {
-  const groups = useToastGroups();
-  const restoreGroup = useRestoreGroup();
-
-  const latestGroup = useMemo(() => {
-    if (groups.length === 0) return null;
-    return groups[groups.length - 1];
-  }, [groups]);
-
-  useHotkeys(
-    "mod+z",
-    () => {
-      if (latestGroup) {
-        restoreGroup(latestGroup);
-      }
-    },
-    {
-      preventDefault: true,
-      enableOnFormTags: true,
-      enableOnContentEditable: true,
-    },
-    [latestGroup, restoreGroup],
-  );
-
-  return null;
 }
 
 export function UndoDeleteToast() {


### PR DESCRIPTION
Remove the global mod+z undo-delete handler so native text undo works in desktop inputs again.