### PR TITLE
Merge spoken languages into language settings

### DIFF
--- a/apps/desktop/src/settings/general/index.tsx
+++ b/apps/desktop/src/settings/general/index.tsx
@@ -172,12 +172,6 @@ export function SettingsApp() {
           </form.Field>
           <TimezoneSelector />
           <WeekStartSelector />
-        </div>
-      </div>
-
-      <div>
-        <h2 className="mb-4 font-serif text-lg font-semibold">Transcription</h2>
-        <div className="flex flex-col gap-6">
           <form.Field name="spoken_languages">
             {(field) => (
               <SpokenLanguagesView


### PR DESCRIPTION
Remove the separate transcription heading in app settings and keep spoken languages under the existing Language & Region section.