### PR TITLE
fix(web): use `arguments` instead of rest params in gtag shim

### DIFF
--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -43,8 +43,8 @@ function MaybeGoogleAnalytics({ enabled }: { enabled: boolean }) {
     analyticsWindow.dataLayer = analyticsWindow.dataLayer ?? [];
     analyticsWindow.gtag =
       analyticsWindow.gtag ??
-      function gtag(...args) {
-        analyticsWindow.dataLayer?.push(args);
+      function gtag() {
+        analyticsWindow.dataLayer?.push(arguments);
       };
     analyticsWindow.gtag("js", new Date());
     analyticsWindow.gtag("config", GOOGLE_ANALYTICS_ID);


### PR DESCRIPTION
## Summary

- The gtag shim was using `dataLayer.push(args)` with rest parameters, which pushes a plain `Array` into the data layer
- gtag.js only recognizes `Arguments` objects as commands — plain arrays are silently ignored
- This caused **zero hits** to be sent to Google Analytics (confirmed via Tag Assistant: "No hits were sent by this tag")
- Fix: replace `...args` / `push(args)` with `arguments` / `push(arguments)` to match the [official gtag.js snippet](https://developers.google.com/tag-platform/gtagjs/install)

## Verification

1. Opened https://char.com with Tag Assistant connected
2. Confirmed "No hits were sent by this tag" on all events
3. Ran in browser console:
   ```js
   // Official arguments pattern → hit sent ✅
   function testGtag(){dataLayer.push(arguments);}
   testGtag('event', 'test_ping');
   ```
4. Confirmed a collect request (`/a?id=G-4CDGPKJ8JB&...`) was sent to Google Analytics

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change isolated to the Google Analytics shim, primarily affecting whether analytics events are recorded.
> 
> **Overview**
> Fixes the Google Analytics `gtag` shim in `apps/web/src/router.tsx` to push an `arguments` object into `dataLayer` instead of a rest-parameter array.
> 
> This aligns the shim with the expected gtag.js command format so `gtag("js"/"config"/events)` calls are actually processed and hits are sent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d45c5de6ac0c67064bdfc4648e6cd374fdbc395. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->