### PR TITLE
Publish: 5 Best Local AI Meeting Notetakers in 2026

### DIFF
--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -179,22 +179,22 @@ If you want to start with local AI meeting notes that give you full ownership, [
 
 ## Frequently Asked Questions
 
-**1. Are local AI meeting notes as accurate as cloud-based tools?**
+### 1. Are local AI meeting notes as accurate as cloud-based tools?
 
 It depends on the model and your hardware. Cloud transcription services like Deepgram still have an edge on messy audio, heavy accents, and cross-talk. But local models like Parakeet and Whisper Large V3 have closed the gap significantly, especially on clear audio from a decent microphone. For most one-on-one and small group calls, the difference is negligible.
 
-**2. Can I use these tools for in-person meetings?**
+### 2. Can I use these tools for in-person meetings?
 
 Yes. Tools that capture microphone input (Char, Meetily, Talat, Screenpipe) work for in-person conversations. Place your laptop near the speakers and let the mic pick up the room. Speaker diarization accuracy varies since it was primarily designed for virtual calls with separate audio channels.
 
-**3. Do local meeting notetakers work offline?**
+### 3. Do local meeting notetakers work offline?
 
 If both transcription and summarization use local models, yes. Char with Ollama, Meetily with Parakeet + Ollama, Talat with its built-in LLM, and Screenpipe with local Whisper all work without an internet connection. Shadow's transcription works offline but the AI summary features need a connection.
 
-**What hardware do I need to run local transcription?**
+### 4. What hardware do I need to run local transcription?
 
 Most tools work on any Mac from the last five years. Apple Silicon (M1 or later) gives the best performance due to the Neural Engine. Intel Macs are supported by Meetily and Screenpipe but transcription will be slower. Talat requires M-series specifically. On Windows, a modern multi-core processor with 8+ GB RAM handles Whisper fine. A dedicated GPU (NVIDIA with CUDA) speeds things up significantly for Meetily and Screenpipe.
 
-**Is it legal to record meetings without telling participants?**
+### 5. Is it legal to record meetings without telling participants?
 
 Recording laws vary by jurisdiction. In many US states and most of Europe, you need consent from all parties to record a conversation. The fact that these tools do not send a bot into the meeting makes them less visible, but that does not remove your legal obligation to inform participants. Always tell the people on your call that you are recording.

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -120,7 +120,7 @@ Free for unlimited transcription and 25 lifetime meetings for AI features. Plus,
 
 ### 4. Talat
 
-
+![talat notetaker review](/api/assets/blog/blog/image-25.png "char-editor-width=80")
 
 [Talat](https://talat.app) runs transcription and summarization entirely on your Mac's Neural Engine. It captures both sides of your call (system audio and microphone), transcribes in real time with speaker identification, and generates summaries using a local LLM (Qwen3-4B-4bit by default). The whole app is 20 MB. It detects when a conferencing app grabs your microphone and starts recording in the background.
 
@@ -147,6 +147,8 @@ If you never configure a cloud LLM, nothing leaves your machine. Talat was [feat
 $49 one-time purchase (pre-release price). $99 at version 1.0. 10 hours of free recordings to try before buying.
 
 ### 5. Screenpipe
+
+
 
 [Screenpipe](https://screenpi.pe) records your screen and audio 24/7, transcribes everything locally with Whisper, and indexes it in a searchable local database. 
 

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -110,11 +110,9 @@ Shadow is local for capture but not fully local for intelligence. The AI feature
 
 #### Pricing
 
-Free for unlimited transcription, 25 lifetime meetings for AI features.
+Free for unlimited transcription and 25 lifetime meetings for AI features. Plus, at $8/month, billed annually.
 
-- Plus: $8/month billed annually.
-
-**Talat**
+### 4. Talat
 
 [Talat](https://talat.app) runs transcription and summarization entirely on your Mac's Neural Engine. It captures both sides of your call (system audio and microphone), transcribes in real time with speaker identification, and generates summaries using a local LLM (Qwen3-4B-4bit by default). The whole app is 20 MB. It detects when a conferencing app grabs your microphone and starts recording in the background.
 

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -148,7 +148,7 @@ $49 one-time purchase (pre-release price). $99 at version 1.0. 10 hours of free 
 
 ### 5. Screenpipe
 
-
+![screenpipe review](/api/assets/blog/blog/image-26.png "char-editor-width=80")
 
 [Screenpipe](https://screenpi.pe) records your screen and audio 24/7, transcribes everything locally with Whisper, and indexes it in a searchable local database. 
 
@@ -218,6 +218,3 @@ Recording laws vary by jurisdiction. In many US states and most of Europe, you n
 ### 6. Are local AI meeting notes as accurate as cloud-based tools?
 
 It depends on the model and your hardware. Cloud transcription services like Deepgram still have an edge on messy audio, heavy accents, and cross-talk. But local models like Parakeet and Whisper Large V3 have closed the gap significantly, especially on clear audio from a decent microphone. For most one-on-one and small group calls, the difference is negligible.
-
-![](/api/assets/blog/blog/image-21.png "char-editor-width=80")
-

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -25,7 +25,7 @@ I tested six tools that take different positions on this spectrum. For each one,
 | **Shadow**     | Client-facing roles who need screen capture alongside audio        | Free transcription, Plus $8/mo |
 | **Talat**      | People who want Granola's UX without the cloud, for a one-time fee | $49 pre-release, $99 at 1.0    |
 | **Screenpipe** | Developers who want meeting notes as part of full desktop memory   | $400 lifetime                  |
-| **Granola**    | People already in its ecosystem who accept cloud processing        | Free tier, Business $14/mo     |
+|                |                                                                    |                                |
 
 
 ## 6 Tools for Local AI Meeting Notes: A Closer Look
@@ -167,60 +167,27 @@ It captures what audio-only tools miss: the URL someone dropped in the Zoom chat
 
 $400 lifetime (one-time). All features, all future updates. $600 lifetime + 1 year of Pro (cloud sync, priority support).
 
-### 6. Granola
-
-[Granola](https://granola.ai) captures system audio without a bot and produces AI summaries in a notepad-style interface where you can type your own notes during the call. The AI weaves your notes together with the transcript into polished output. It integrates with your calendar, detects meetings automatically, and works on macOS, Windows, and iOS. It is the most popular tool in this category, with over a million users and a [$250 million valuation](https://techcrunch.com/2026/03/24/talats-ai-meeting-notes-stay-on-your-machine-not-in-the-cloud/).
-
-It is also the only tool on this list that is not local-first. I am including it because most people reading this are comparing local tools against Granola, and skipping it would leave a gap.
-
-***How local is it actually***
-
-- Transcription: cloud. Audio processed through Deepgram's API.
-- Summarization: cloud. GPT-4o and Claude via cloud APIs.
-- Storage: AWS servers in the US. Encrypted at rest and in transit.
-- Notes are shareable via link. By default, anyone with the link can view them.
-
-Two incidents in early 2026 are worth knowing about:
-
-In March, Granola [encrypted its local database](https://weekinvoiceai.substack.com/p/week-in-voice-ai12-granola-scramble), breaking every agent workflow that read meeting data locally. An a16z partner posted that "in a world where notes are managed by agents, the app now has zero value." The post got 337,000 views.
-
-In April, [The Verge reported](https://www.theverge.com/ai-artificial-intelligence/906253/granola-note-links-ai-training-psa) that notes were viewable to anyone with a link by default, despite the security page claiming "private by default." Non-enterprise data is used for AI training unless you manually opt out.
-
-***Where it falls short***
-
-- Not local. Everything is cloud-processed and cloud-stored.
-- Requires a Google account to sign up.
-- No audio saved. You cannot replay meetings or verify exact wording.
-- No offline mode.
-- Data portability issues after the encrypted database change.
-
-***Pricing***
-
-- Free tier: limited features.
-- Business: $14/month per user.
-- Enterprise: custom pricing. AI training disabled by default on this tier only.
-
 **Which Local AI Meeting Notetaker Is Right for You?**
 
 Local processing means accepting tradeoffs. Local models are not as accurate as cloud transcription on messy audio, speaker diarization is still maturing across the board, and most of these tools are macOS-only or macOS-first. The gap is closing fast, though, and for anyone handling sensitive conversations, the architectural guarantee that your audio never left your device is worth more than a privacy policy that can change with a terms-of-service update.
 
 Char is the strongest choice if you want complete control: open-source, your choice of AI provider, and data that lives on your device in a format you own. Meetily is the best open-source option if you need Windows support or want a free polished app. Shadow is the only tool that captures what is on screen alongside what is said. Talat is for people who loved Granola but could not accept cloud dependency, and it is the only one-time purchase purpose-built meeting tool here.
 
-Screenpipe is the power user's option: not just meeting notes but a searchable memory of your entire workday. Granola remains the most polished experience if you accept cloud processing, but check your settings. The defaults are not as private as the marketing suggests.
+Screenpipe is the power user's option: not just meeting notes but a searchable memory of your entire workday. 
 
 If you want to start with local AI meeting notes that give you full ownership, [try Char](https://char.com). It is free, open-source, and works offline with local models. Your first meeting's notes will land on your device, readable by any tool you already use.
 
-**Frequently Asked Questions**
+## Frequently Asked Questions
 
-**Are local AI meeting notes as accurate as cloud-based tools?**
+**1. Are local AI meeting notes as accurate as cloud-based tools?**
 
 It depends on the model and your hardware. Cloud transcription services like Deepgram still have an edge on messy audio, heavy accents, and cross-talk. But local models like Parakeet and Whisper Large V3 have closed the gap significantly, especially on clear audio from a decent microphone. For most one-on-one and small group calls, the difference is negligible.
 
-**Can I use these tools for in-person meetings?**
+**2. Can I use these tools for in-person meetings?**
 
 Yes. Tools that capture microphone input (Char, Meetily, Talat, Screenpipe) work for in-person conversations. Place your laptop near the speakers and let the mic pick up the room. Speaker diarization accuracy varies since it was primarily designed for virtual calls with separate audio channels.
 
-**Do local meeting notetakers work offline?**
+**3. Do local meeting notetakers work offline?**
 
 If both transcription and summarization use local models, yes. Char with Ollama, Meetily with Parakeet + Ollama, Talat with its built-in LLM, and Screenpipe with local Whisper all work without an internet connection. Shadow's transcription works offline but the AI summary features need a connection.
 

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -17,26 +17,28 @@ I tested six tools that take different positions on this spectrum. For each one,
 ## How These Local AI Meeting Notetakers Compare
 
 
-|                |                                                                               |                                |
-| -------------- | ----------------------------------------------------------------------------- | ------------------------------ |
-| **Tool**       | **Best For**                                                                  | **Pricing**                    |
-| **Char**       | Engineers and Obsidian users who want complete control over data and AI stack | Free (local/BYOK), Pro $25/mo  |
-| **Meetily**    | Teams on Windows or Mac who want a polished open-source option                | Community free, Pro $10/mo     |
-| **Shadow**     | Client-facing roles who need screen capture alongside audio                   | Free transcription, Plus $8/mo |
-| **Talat**      | People who want Granola's UX without the cloud, for a one-time fee            | $49 pre-release, $99 at 1.0    |
-| **Screenpipe** | Developers who want meeting notes as part of full desktop memory              | $400 lifetime                  |
-| **Granola**    | People already in its ecosystem who accept cloud processing                   | Free tier, Business $14/mo     |
+|                |                                                                    |                                |
+| -------------- | ------------------------------------------------------------------ | ------------------------------ |
+| **Tool**       | **Best For**                                                       | **Pricing**                    |
+| **Char**       | Users who want complete control over data and AI stack             | Free (local/BYOK), Pro $25/mo  |
+| **Meetily**    | Teams on Windows or Mac who want a polished open-source option     | Community free, Pro $10/mo     |
+| **Shadow**     | Client-facing roles who need screen capture alongside audio        | Free transcription, Plus $8/mo |
+| **Talat**      | People who want Granola's UX without the cloud, for a one-time fee | $49 pre-release, $99 at 1.0    |
+| **Screenpipe** | Developers who want meeting notes as part of full desktop memory   | $400 lifetime                  |
+| **Granola**    | People already in its ecosystem who accept cloud processing        | Free tier, Business $14/mo     |
 
 
-**6 Tools for Local AI Meeting Notes: A Closer Look**
+## 6 Tools for Local AI Meeting Notes: A Closer Look
 
-**Char**
+### 1. Char
 
-[Char](https://char.com) is an open-source AI notepad for meetings, built for people who want complete control over their data and AI stack. It captures system audio from any meeting platform without joining your call and without requiring calendar permissions. You can take notes during the meeting in Char's built-in editor while it transcribes in the background, and the AI combines both into a structured summary after the call. Or skip the manual notes entirely and let it generate output from the transcript alone.
+[Char](https://char.com) is an open-source AI notepad for meetings, built for people who want complete control over their data and AI stack. It captures system audio from any meeting platform without joining your call and without requiring calendar permissions. 
+
+You can take notes during the meeting in Char's built-in editor while it transcribes in the background, and the AI combines both into a structured summary after the call. 
 
 The AI stack is yours to choose: Char's managed cloud service, your own API keys from OpenAI, Anthropic, or Deepgram, or fully local models through Ollama or LM Studio for offline operation. Every audio file, transcript, and note lives on your computer. You decide if data ever leaves your device.
 
-***How local is it actually***
+#### How local is it actually
 
 - Transcription: local or BYOK. Supports Ollama and LM Studio for fully on-device processing.
 - Summarization: your choice. Managed cloud, BYOK API keys, or local models. You control the boundary.
@@ -45,7 +47,7 @@ The AI stack is yours to choose: Char's managed cloud service, your own API keys
 
 If you run Char with local models, nothing leaves your machine. If you plug in an API key, only the transcript goes to that provider for summarization. For companies that have banned cloud-based meeting tools, Char is one of the few options where "local-first" means exactly what it says.
 
-***Where it falls short***
+#### *Where it falls short*
 
 - macOS and Linux only. No Windows client yet.
 - No mobile app, no video recording.

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -84,18 +84,15 @@ The team is transparent that local model summarization does not match cloud qual
 
 #### Pricing
 
-Community Edition is free forever.
+Community Edition is free forever. Pro is at $10/month, billed annually, includes enhanced accuracy models, auto-meeting detection, PDF/DOCX export, and custom templates.
 
-- Pro: $10/month billed annually ($120/year). 14-day free trial, no credit card.
-- Pro adds: enhanced accuracy models, auto-meeting detection, PDF/DOCX export, custom templates.
-
-**Shadow**
+### 3. Shadow
 
 [Shadow](https://shadow.do) captures both channels of a meeting: what is said and what is shown on screen. It runs on macOS, records system audio without a bot, and automatically takes timestamped screenshots of whatever is displayed during your call: slides, code, dashboards, design mockups. Those screenshots are embedded directly in your notes alongside the transcript.
 
 This matters the moment someone says "look at the numbers on slide four" and you need to know what those numbers were. Every other tool on this list captures audio only. Shadow also has autopilot mode that detects meetings and starts recording without you pressing anything, real-time speaker identification, and custom post-meeting AI "Skills" that run automatically.
 
-***How local is it actually***
+#### How local is it actually
 
 - Transcription: local. Audio never leaves your Mac.
 - Screen capture: local. Screenshots stored on device.
@@ -104,16 +101,17 @@ This matters the moment someone says "look at the numbers on slide four" and you
 
 Shadow is local for capture but not fully local for intelligence. The AI features route through external APIs. You can turn them off and keep just the transcript and screenshots, but then you lose the analysis layer.
 
-***Where it falls short***
+#### Where it falls short
 
 - macOS only.
 - AI features use cloud APIs, so not fully local end-to-end.
 - Free tier caps AI-powered features at 25 lifetime meetings.
 - No real-time collaborative editing.
 
-***Pricing***
+#### Pricing
 
-- Free: unlimited transcription, 25 lifetime meetings for AI features.
+Free for unlimited transcription, 25 lifetime meetings for AI features.
+
 - Plus: $8/month billed annually.
 
 **Talat**

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -1,5 +1,5 @@
 ---
-meta_title: "6 Best Local AI Meeting Notetakers in 2026"
+meta_title: "5 Best Local AI Meeting Notetakers in 2026"
 meta_description: "Local AI meeting notes tools that transcribe and summarize on your device. For engineers, legal teams, and anyone whose company banned cloud recording tools."
 author:
   - "John Jeong"
@@ -12,7 +12,7 @@ Every meeting notetaker calls itself "local" or "private" now. The word has beco
 
 Some tools transcribe on your device but send the transcript to a cloud LLM for summarization. Some store notes locally but make them accessible via a shareable link by default. Some process everything on-device but only work on one operating system, or only on recent hardware. And some are fully local until you look at the fine print and discover your data trains their models unless you opt out.
 
-I tested six tools that take different positions on this spectrum. For each one, I dug into what "local" actually means in practice: what stays on your machine, what leaves, what the tradeoffs are, and what it costs.
+I tested five tools that take different positions on this spectrum. For each one, I dug into what "local" actually means in practice: what stays on your machine, what leaves, what the tradeoffs are, and what it costs.
 
 ## How These Local AI Meeting Notetakers Compare
 

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -1,11 +1,239 @@
 ---
-meta_title: ""
-display_title: ""
-meta_description: ""
 author:
-- "John Jeong"
+  - "John Jeong"
 featured: false
 category: "Product"
 date: "2026-04-10"
 ---
 
+**Title:** 6 Best Local AI Meeting Notetakers in 2026  
+**Meta description:** Local AI meeting notes tools that transcribe and summarize on your device. For engineers, legal teams, and anyone whose company banned cloud recording tools.  
+**Category:** Comparisons  
+**Date:** April 10, 2026
+
+**6 Best Local AI Meeting Notetakers in 2026**
+
+Every meeting notetaker calls itself "local" or "private" now. The word has become a marketing checkbox. But local means wildly different things depending on which tool you pick.
+
+Some tools transcribe on your device but send the transcript to a cloud LLM for summarization. Some store notes locally but make them accessible via a shareable link by default. Some process everything on-device but only work on one operating system, or only on recent hardware. And some are fully local until you look at the fine print and discover your data trains their models unless you opt out.
+
+I tested six tools that take different positions on this spectrum. For each one, I dug into what "local" actually means in practice: what stays on your machine, what leaves, what the tradeoffs are, and what it costs.
+
+**How These Local AI Meeting Notetakers Compare**
+
+
+|                |                                                                               |                                |
+| -------------- | ----------------------------------------------------------------------------- | ------------------------------ |
+| **Tool**       | **Best For**                                                                  | **Pricing**                    |
+| **Char**       | Engineers and Obsidian users who want complete control over data and AI stack | Free (local/BYOK), Pro $25/mo  |
+| **Meetily**    | Teams on Windows or Mac who want a polished open-source option                | Community free, Pro $10/mo     |
+| **Shadow**     | Client-facing roles who need screen capture alongside audio                   | Free transcription, Plus $8/mo |
+| **Talat**      | People who want Granola's UX without the cloud, for a one-time fee            | $49 pre-release, $99 at 1.0    |
+| **Screenpipe** | Developers who want meeting notes as part of full desktop memory              | $400 lifetime                  |
+| **Granola**    | People already in its ecosystem who accept cloud processing                   | Free tier, Business $14/mo     |
+
+
+**6 Tools for Local AI Meeting Notes: A Closer Look**
+
+**Char**
+
+[Char](https://char.com) is an open-source AI notepad for meetings, built for people who want complete control over their data and AI stack. It captures system audio from any meeting platform without joining your call and without requiring calendar permissions. You can take notes during the meeting in Char's built-in editor while it transcribes in the background, and the AI combines both into a structured summary after the call. Or skip the manual notes entirely and let it generate output from the transcript alone.
+
+The AI stack is yours to choose: Char's managed cloud service, your own API keys from OpenAI, Anthropic, or Deepgram, or fully local models through Ollama or LM Studio for offline operation. Every audio file, transcript, and note lives on your computer. You decide if data ever leaves your device.
+
+***How local is it actually***
+
+- Transcription: local or BYOK. Supports Ollama and LM Studio for fully on-device processing.
+- Summarization: your choice. Managed cloud, BYOK API keys, or local models. You control the boundary.
+- Storage: all data stored locally on your device. Your files, your folder structure, zero lock-in.
+- Open-source codebase. Your security team can audit exactly how data is handled.
+
+If you run Char with local models, nothing leaves your machine. If you plug in an API key, only the transcript goes to that provider for summarization. For companies that have banned cloud-based meeting tools, Char is one of the few options where "local-first" means exactly what it says.
+
+***Where it falls short***
+
+- macOS and Linux only. No Windows client yet.
+- No mobile app, no video recording.
+- No built-in CRM integrations. If you need notes pushed into Salesforce, you will need to build that yourself.
+- No team dashboard or cross-meeting cloud search. Your notes live in your file system.
+
+***Pricing***
+
+- Free: unlimited local transcription or BYOK API keys. 45+ languages.
+- Pro: $25/month for managed cloud transcription and AI.
+
+**Meetily**
+
+[Meetily](https://meetily.ai) is an open-source meeting assistant (MIT license) that runs transcription entirely on your device using Whisper or Parakeet models. It captures system audio without a bot, works with Zoom, Teams, Meet, and anything else that produces audio on your machine. Parakeet is the default engine and runs significantly faster than Whisper with lower resource usage, with GPU acceleration built in for Apple Silicon, NVIDIA, and AMD hardware.
+
+Summaries are pluggable: use Ollama for fully local processing, or connect your own API key to Claude, Groq, or OpenRouter. The app is built in Rust with a Next.js frontend and ships as a single installer for macOS and Windows. Linux users can build from source.
+
+***How local is it actually***
+
+- Transcription: 100% local. Whisper or Parakeet models running on your hardware.
+- Summarization: pluggable. Ollama for fully local, or BYOK with cloud providers.
+- Storage: local SQLite database. Audio files stored on your device.
+- GPU acceleration: Apple Silicon (Metal), NVIDIA (CUDA), AMD/Intel (Vulkan).
+
+The team is transparent that local model summarization does not match cloud quality yet, especially on longer meetings. They document the tradeoffs in their blog and are actively working on closing the gap.
+
+***Where it falls short***
+
+- Speaker diarization is still in development.
+- Local summarization quality lags cloud on long meetings.
+- Linux requires building from source.
+- No mobile app.
+
+***Pricing***
+
+- Community Edition: free forever, MIT licensed, no restrictions.
+- Pro: $10/month billed annually ($120/year). 14-day free trial, no credit card.
+- Pro adds: enhanced accuracy models, auto-meeting detection, PDF/DOCX export, custom templates.
+
+**Shadow**
+
+[Shadow](https://shadow.do) captures both channels of a meeting: what is said and what is shown on screen. It runs on macOS, records system audio without a bot, and automatically takes timestamped screenshots of whatever is displayed during your call: slides, code, dashboards, design mockups. Those screenshots are embedded directly in your notes alongside the transcript.
+
+This matters the moment someone says "look at the numbers on slide four" and you need to know what those numbers were. Every other tool on this list captures audio only. Shadow also has autopilot mode that detects meetings and starts recording without you pressing anything, real-time speaker identification, and custom post-meeting AI "Skills" that run automatically.
+
+***How local is it actually***
+
+- Transcription: local. Audio never leaves your Mac.
+- Screen capture: local. Screenshots stored on device.
+- Summarization: cloud LLM APIs by default. Can be disabled, but you lose summaries, action items, and the "Ask Shadow" chatbot.
+- Export: .md files to a local folder. Works with Obsidian out of the box, webhooks for Zapier/Make/n8n.
+
+Shadow is local for capture but not fully local for intelligence. The AI features route through external APIs. You can turn them off and keep just the transcript and screenshots, but then you lose the analysis layer.
+
+***Where it falls short***
+
+- macOS only.
+- AI features use cloud APIs, so not fully local end-to-end.
+- Free tier caps AI-powered features at 25 lifetime meetings.
+- No real-time collaborative editing.
+
+***Pricing***
+
+- Free: unlimited transcription, 25 lifetime meetings for AI features.
+- Plus: $8/month billed annually.
+
+**Talat**
+
+[Talat](https://talat.app) runs transcription and summarization entirely on your Mac's Neural Engine. It captures both sides of your call (system audio and microphone), transcribes in real time with speaker identification, and generates summaries using a local LLM (Qwen3-4B-4bit by default). The whole app is 20 MB. It detects when a conferencing app grabs your microphone and starts recording in the background.
+
+The focus is configurability. You choose your LLM provider: the built-in local model, OpenAI, Anthropic, OpenRouter, or Ollama. You can write custom summarization prompts, auto-export notes to Obsidian, fire webhooks when a meeting ends, and run an MCP server so AI coding tools can query your meeting history. No analytics, no telemetry, no data collection.
+
+***How local is it actually***
+
+- Transcription: 100% on-device via FluidAudio on Apple's Neural Engine. Audio never leaves your Mac.
+- Summarization: local by default (Qwen3-4B-4bit). Optional BYOK with OpenAI, Anthropic, OpenRouter, or Ollama.
+- Storage: local database. Auto-export to Obsidian, webhooks, MCP server.
+- Zero analytics, zero telemetry.
+
+If you never configure a cloud LLM, nothing leaves your machine. Talat was [featured in TechCrunch](https://techcrunch.com/2026/03/24/talats-ai-meeting-notes-stay-on-your-machine-not-in-the-cloud/) in March 2026 and is a one-time purchase from a bootstrapped two-person team.
+
+***Where it falls short***
+
+- macOS only, M-series chips only (M1 or later).
+- Pre-release software. Speaker diarization is rough.
+- Local LLM summarization can be hit or miss on longer meetings.
+- No calendar integration yet (planned).
+
+***Pricing***
+
+- $49 one-time purchase (pre-release price). $99 at version 1.0.
+- 10 hours of free recordings to try before buying.
+- No subscription. Every future update included.
+
+**Screenpipe**
+
+[Screenpipe](https://screenpi.pe) records your screen and audio 24/7, transcribes everything locally with Whisper, and indexes it in a searchable local database. It is not a meeting tool. It is an open-source AI memory layer for your entire desktop that happens to be very good at meeting notes, because meeting notes are a side effect of it always running.
+
+After a call, you ask the AI: "Summarize my meeting from 2 to 3pm and list action items." Screenpipe searches your audio transcripts and screen content from that time window. It captures what audio-only tools miss: the URL someone dropped in the Zoom chat, the spreadsheet someone shared, the code someone walked through in a terminal. It also runs as an MCP server, so Cursor, Claude Code, and Cline can query your meeting history directly.
+
+***How local is it actually***
+
+- Transcription: local Whisper by default. Optional Deepgram (cloud) for faster processing.
+- Summarization: any model. Ollama for local, or connect cloud models.
+- Storage: local SQLite database in ~/.screenpipe/data/.
+- Screen capture: local. Accessibility APIs + OCR fallback.
+- Runs on macOS, Windows, and Linux. MIT-licensed open source.
+
+***Where it falls short***
+
+- Not purpose-built for meetings. Always running, always capturing.
+- Higher resource usage (~5-10% CPU, ~20 GB storage/month).
+- Setup is more involved: configuring audio devices, transcription engines, pipe automations.
+- $400 is steep if you only want meeting notes.
+
+***Pricing***
+
+- $400 lifetime (one-time). All features, all future updates.
+- $600 lifetime + 1 year of Pro (cloud sync, priority support).
+- Pro subscription: $39/month.
+- CLI is free and MIT-licensed.
+
+**Granola**
+
+[Granola](https://granola.ai) captures system audio without a bot and produces AI summaries in a notepad-style interface where you can type your own notes during the call. The AI weaves your notes together with the transcript into polished output. It integrates with your calendar, detects meetings automatically, and works on macOS, Windows, and iOS. It is the most popular tool in this category, with over a million users and a [$250 million valuation](https://techcrunch.com/2026/03/24/talats-ai-meeting-notes-stay-on-your-machine-not-in-the-cloud/).
+
+It is also the only tool on this list that is not local-first. I am including it because most people reading this are comparing local tools against Granola, and skipping it would leave a gap.
+
+***How local is it actually***
+
+- Transcription: cloud. Audio processed through Deepgram's API.
+- Summarization: cloud. GPT-4o and Claude via cloud APIs.
+- Storage: AWS servers in the US. Encrypted at rest and in transit.
+- Notes are shareable via link. By default, anyone with the link can view them.
+
+Two incidents in early 2026 are worth knowing about:
+
+In March, Granola [encrypted its local database](https://weekinvoiceai.substack.com/p/week-in-voice-ai12-granola-scramble), breaking every agent workflow that read meeting data locally. An a16z partner posted that "in a world where notes are managed by agents, the app now has zero value." The post got 337,000 views.
+
+In April, [The Verge reported](https://www.theverge.com/ai-artificial-intelligence/906253/granola-note-links-ai-training-psa) that notes were viewable to anyone with a link by default, despite the security page claiming "private by default." Non-enterprise data is used for AI training unless you manually opt out.
+
+***Where it falls short***
+
+- Not local. Everything is cloud-processed and cloud-stored.
+- Requires a Google account to sign up.
+- No audio saved. You cannot replay meetings or verify exact wording.
+- No offline mode.
+- Data portability issues after the encrypted database change.
+
+***Pricing***
+
+- Free tier: limited features.
+- Business: $14/month per user.
+- Enterprise: custom pricing. AI training disabled by default on this tier only.
+
+**Which Local AI Meeting Notetaker Is Right for You?**
+
+Local processing means accepting tradeoffs. Local models are not as accurate as cloud transcription on messy audio, speaker diarization is still maturing across the board, and most of these tools are macOS-only or macOS-first. The gap is closing fast, though, and for anyone handling sensitive conversations, the architectural guarantee that your audio never left your device is worth more than a privacy policy that can change with a terms-of-service update.
+
+Char is the strongest choice if you want complete control: open-source, your choice of AI provider, and data that lives on your device in a format you own. Meetily is the best open-source option if you need Windows support or want a free polished app. Shadow is the only tool that captures what is on screen alongside what is said. Talat is for people who loved Granola but could not accept cloud dependency, and it is the only one-time purchase purpose-built meeting tool here.
+
+Screenpipe is the power user's option: not just meeting notes but a searchable memory of your entire workday. Granola remains the most polished experience if you accept cloud processing, but check your settings. The defaults are not as private as the marketing suggests.
+
+If you want to start with local AI meeting notes that give you full ownership, [try Char](https://char.com). It is free, open-source, and works offline with local models. Your first meeting's notes will land on your device, readable by any tool you already use.
+
+**Frequently Asked Questions**
+
+**Are local AI meeting notes as accurate as cloud-based tools?**
+
+It depends on the model and your hardware. Cloud transcription services like Deepgram still have an edge on messy audio, heavy accents, and cross-talk. But local models like Parakeet and Whisper Large V3 have closed the gap significantly, especially on clear audio from a decent microphone. For most one-on-one and small group calls, the difference is negligible.
+
+**Can I use these tools for in-person meetings?**
+
+Yes. Tools that capture microphone input (Char, Meetily, Talat, Screenpipe) work for in-person conversations. Place your laptop near the speakers and let the mic pick up the room. Speaker diarization accuracy varies since it was primarily designed for virtual calls with separate audio channels.
+
+**Do local meeting notetakers work offline?**
+
+If both transcription and summarization use local models, yes. Char with Ollama, Meetily with Parakeet + Ollama, Talat with its built-in LLM, and Screenpipe with local Whisper all work without an internet connection. Shadow's transcription works offline but the AI summary features need a connection.
+
+**What hardware do I need to run local transcription?**
+
+Most tools work on any Mac from the last five years. Apple Silicon (M1 or later) gives the best performance due to the Neural Engine. Intel Macs are supported by Meetily and Screenpipe but transcription will be slower. Talat requires M-series specifically. On Windows, a modern multi-core processor with 8+ GB RAM handles Whisper fine. A dedicated GPU (NVIDIA with CUDA) speeds things up significantly for Meetily and Screenpipe.
+
+**Is it legal to record meetings without telling participants?**
+
+Recording laws vary by jurisdiction. In many US states and most of Europe, you need consent from all parties to record a conversation. The fact that these tools do not send a bot into the meeting makes them less visible, but that does not remove your legal obligation to inform participants. Always tell the people on your call that you are recording.

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -62,6 +62,8 @@ Free for unlimited loacl transcription and AI. A lite plan at $8/month with Char
 
 ### 2. Meetily
 
+![meetily review](/api/assets/blog/blog/image-20.png "char-editor-width=80")
+
 [Meetily](https://meetily.ai) is an open-source meeting assistant (MIT license) that runs transcription entirely on your device using Whisper or Parakeet models. 
 
 It captures system audio without a bot, works with Zoom, Teams, Meet, and anything else that produces audio on your machine. Parakeet is the default engine and runs significantly faster than Whisper with lower resource usage, with GPU acceleration built in for Apple Silicon, NVIDIA, and AMD hardware.
@@ -89,6 +91,8 @@ The team is transparent that local model summarization does not match cloud qual
 Community Edition is free forever. Pro is at $10/month, billed annually, includes enhanced accuracy models, auto-meeting detection, PDF/DOCX export, and custom templates.
 
 ### 3. Shadow
+
+
 
 [Shadow](https://shadow.do) captures both channels of a meeting: what is said and what is shown on screen. It runs on macOS, records system audio without a bot, and automatically takes timestamped screenshots of whatever is displayed during your call: slides, code, dashboards, design mockups. Those screenshots are embedded directly in your notes alongside the transcript.
 
@@ -210,6 +214,3 @@ Recording laws vary by jurisdiction. In many US states and most of Europe, you n
 ### 6. Are local AI meeting notes as accurate as cloud-based tools?
 
 It depends on the model and your hardware. Cloud transcription services like Deepgram still have an edge on messy audio, heavy accents, and cross-talk. But local models like Parakeet and Whisper Large V3 have closed the gap significantly, especially on clear audio from a decent microphone. For most one-on-one and small group calls, the difference is negligible.
-
-
-

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -8,20 +8,13 @@ category: "Comparisons"
 date: "2026-04-10"
 ---
 
-**Title:** 6 Best Local AI Meeting Notetakers in 2026  
-**Meta description:** Local AI meeting notes tools that transcribe and summarize on your device. For engineers, legal teams, and anyone whose company banned cloud recording tools.  
-**Category:** Comparisons  
-**Date:** April 10, 2026
-
-**6 Best Local AI Meeting Notetakers in 2026**
-
 Every meeting notetaker calls itself "local" or "private" now. The word has become a marketing checkbox. But local means wildly different things depending on which tool you pick.
 
 Some tools transcribe on your device but send the transcript to a cloud LLM for summarization. Some store notes locally but make them accessible via a shareable link by default. Some process everything on-device but only work on one operating system, or only on recent hardware. And some are fully local until you look at the fine print and discover your data trains their models unless you opt out.
 
 I tested six tools that take different positions on this spectrum. For each one, I dug into what "local" actually means in practice: what stays on your machine, what leaves, what the tradeoffs are, and what it costs.
 
-**How These Local AI Meeting Notetakers Compare**
+## How These Local AI Meeting Notetakers Compare
 
 
 |                |                                                                               |                                |

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -185,9 +185,9 @@ If you want to start with local AI meeting notes that give you full ownership, [
 
 ## Frequently Asked Questions
 
-### 1. Are local AI meeting notes as accurate as cloud-based tools?
+### 1. Is Granola a local AI notetaker?
 
-It depends on the model and your hardware. Cloud transcription services like Deepgram still have an edge on messy audio, heavy accents, and cross-talk. But local models like Parakeet and Whisper Large V3 have closed the gap significantly, especially on clear audio from a decent microphone. For most one-on-one and small group calls, the difference is negligible.
+No. Granola captures system audio locally, which is why it gets grouped with local tools, but the similarity ends there. Your audio is sent to Deepgram for transcription, your transcript is processed through GPT-4o or Claude for summarization, and your notes are stored on AWS servers. There is no offline mode and no option to run local models. Granola is a cloud tool with a local audio capture step. 
 
 ### 2. Can I use these tools for in-person meetings?
 
@@ -204,3 +204,10 @@ Most tools work on any Mac from the last five years. Apple Silicon (M1 or later)
 ### 5. Is it legal to record meetings without telling participants?
 
 Recording laws vary by jurisdiction. In many US states and most of Europe, you need consent from all parties to record a conversation. The fact that these tools do not send a bot into the meeting makes them less visible, but that does not remove your legal obligation to inform participants. Always tell the people on your call that you are recording.
+
+### 6. Are local AI meeting notes as accurate as cloud-based tools?
+
+It depends on the model and your hardware. Cloud transcription services like Deepgram still have an edge on messy audio, heavy accents, and cross-talk. But local models like Parakeet and Whisper Large V3 have closed the gap significantly, especially on clear audio from a decent microphone. For most one-on-one and small group calls, the difference is negligible.
+
+
+

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -92,7 +92,7 @@ Community Edition is free forever. Pro is at $10/month, billed annually, include
 
 ### 3. Shadow
 
-![shadow ai notetaker reviw](/api/assets/blog/blog/image-22.png "char-editor-width=80")
+![shadow.do review](/api/assets/blog/blog/Screenshot-2026-04-10-at-7.43.38-PM.png "char-editor-width=80")
 
 [Shadow](https://shadow.do) captures both channels of a meeting: what is said and what is shown on screen. It runs on macOS, records system audio without a bot, and automatically takes timestamped screenshots of whatever is displayed during your call: slides, code, dashboards, design mockups. Those screenshots are embedded directly in your notes alongside the transcript.
 
@@ -119,6 +119,8 @@ Shadow is local for capture but not fully local for intelligence. The AI feature
 Free for unlimited transcription and 25 lifetime meetings for AI features. Plus, at $8/month, billed annually.
 
 ### 4. Talat
+
+
 
 [Talat](https://talat.app) runs transcription and summarization entirely on your Mac's Neural Engine. It captures both sides of your call (system audio and microphone), transcribes in real time with speaker identification, and generates summaries using a local LLM (Qwen3-4B-4bit by default). The whole app is 20 MB. It detects when a conferencing app grabs your microphone and starts recording in the background.
 

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -118,7 +118,7 @@ Free for unlimited transcription and 25 lifetime meetings for AI features. Plus,
 
 The focus is configurability. You choose your LLM provider: the built-in local model, OpenAI, Anthropic, OpenRouter, or Ollama. You can write custom summarization prompts, auto-export notes to Obsidian, fire webhooks when a meeting ends, and run an MCP server so AI coding tools can query your meeting history. No analytics, no telemetry, no data collection.
 
-***How local is it actually***
+#### How local is it actually
 
 - Transcription: 100% on-device via FluidAudio on Apple's Neural Engine. Audio never leaves your Mac.
 - Summarization: local by default (Qwen3-4B-4bit). Optional BYOK with OpenAI, Anthropic, OpenRouter, or Ollama.
@@ -127,26 +127,28 @@ The focus is configurability. You choose your LLM provider: the built-in local m
 
 If you never configure a cloud LLM, nothing leaves your machine. Talat was [featured in TechCrunch](https://techcrunch.com/2026/03/24/talats-ai-meeting-notes-stay-on-your-machine-not-in-the-cloud/) in March 2026 and is a one-time purchase from a bootstrapped two-person team.
 
-***Where it falls short***
+#### Where it falls short
 
 - macOS only, M-series chips only (M1 or later).
 - Pre-release software. Speaker diarization is rough.
 - Local LLM summarization can be hit or miss on longer meetings.
 - No calendar integration yet (planned).
 
-***Pricing***
+#### Pricing
 
-- $49 one-time purchase (pre-release price). $99 at version 1.0.
-- 10 hours of free recordings to try before buying.
-- No subscription. Every future update included.
+$49 one-time purchase (pre-release price). $99 at version 1.0. 10 hours of free recordings to try before buying.
 
-**Screenpipe**
+### 5. Screenpipe
 
-[Screenpipe](https://screenpi.pe) records your screen and audio 24/7, transcribes everything locally with Whisper, and indexes it in a searchable local database. It is not a meeting tool. It is an open-source AI memory layer for your entire desktop that happens to be very good at meeting notes, because meeting notes are a side effect of it always running.
+[Screenpipe](https://screenpi.pe) records your screen and audio 24/7, transcribes everything locally with Whisper, and indexes it in a searchable local database. 
 
-After a call, you ask the AI: "Summarize my meeting from 2 to 3pm and list action items." Screenpipe searches your audio transcripts and screen content from that time window. It captures what audio-only tools miss: the URL someone dropped in the Zoom chat, the spreadsheet someone shared, the code someone walked through in a terminal. It also runs as an MCP server, so Cursor, Claude Code, and Cline can query your meeting history directly.
+It is not a meeting tool. It is an open-source AI memory layer for your entire desktop that happens to be very good at meeting notes, because meeting notes are a side effect of it always running.
 
-***How local is it actually***
+After a call, you ask the AI: "Summarize my meeting from 2 to 3pm and list action items." Screenpipe searches your audio transcripts and screen content from that time window. 
+
+It captures what audio-only tools miss: the URL someone dropped in the Zoom chat, the spreadsheet someone shared, the code someone walked through in a terminal. It also runs as an MCP server, so Cursor, Claude Code, and Cline can query your meeting history directly.
+
+#### How local is it actually
 
 - Transcription: local Whisper by default. Optional Deepgram (cloud) for faster processing.
 - Summarization: any model. Ollama for local, or connect cloud models.
@@ -154,7 +156,7 @@ After a call, you ask the AI: "Summarize my meeting from 2 to 3pm and list actio
 - Screen capture: local. Accessibility APIs + OCR fallback.
 - Runs on macOS, Windows, and Linux. MIT-licensed open source.
 
-***Where it falls short***
+#### Where it falls short
 
 - Not purpose-built for meetings. Always running, always capturing.
 - Higher resource usage (~5-10% CPU, ~20 GB storage/month).

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -171,7 +171,13 @@ $400 lifetime (one-time). All features, all future updates. $600 lifetime + 1 ye
 
 Local processing means accepting tradeoffs. Local models are not as accurate as cloud transcription on messy audio, speaker diarization is still maturing across the board, and most of these tools are macOS-only or macOS-first. The gap is closing fast, though, and for anyone handling sensitive conversations, the architectural guarantee that your audio never left your device is worth more than a privacy policy that can change with a terms-of-service update.
 
-Char is the strongest choice if you want complete control: open-source, your choice of AI provider, and data that lives on your device in a format you own. Meetily is the best open-source option if you need Windows support or want a free polished app. Shadow is the only tool that captures what is on screen alongside what is said. Talat is for people who loved Granola but could not accept cloud dependency, and it is the only one-time purchase purpose-built meeting tool here.
+Char is the strongest choice if you want complete control: open-source, your choice of AI provider, and data that lives on your device in a format you own. 
+
+Meetily is the best open-source option if you need Windows support or want a free polished app. 
+
+Shadow is the only tool that captures what is on screen alongside what is said. 
+
+Talat is for people who loved Granola but could not accept cloud dependency, and it is the only one-time purchase purpose-built meeting tool here.
 
 Screenpipe is the power user's option: not just meeting notes but a searchable memory of your entire workday. 
 

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -2,7 +2,7 @@
 meta_title: "5 Best Local AI Meeting Notetakers in 2026"
 meta_description: "Local AI meeting notes tools that transcribe and summarize on your device. For engineers, legal teams, and anyone whose company banned cloud recording tools."
 author:
-  - "John Jeong"
+  - "Harshika"
 featured: false
 category: "Comparisons"
 date: "2026-04-10"

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -92,7 +92,7 @@ Community Edition is free forever. Pro is at $10/month, billed annually, include
 
 ### 3. Shadow
 
-
+![shadow ai notetaker reviw](/api/assets/blog/blog/image-22.png "char-editor-width=80")
 
 [Shadow](https://shadow.do) captures both channels of a meeting: what is said and what is shown on screen. It runs on macOS, records system audio without a bot, and automatically takes timestamped screenshots of whatever is displayed during your call: slides, code, dashboards, design mockups. Those screenshots are embedded directly in your notes alongside the transcript.
 
@@ -214,3 +214,6 @@ Recording laws vary by jurisdiction. In many US states and most of Europe, you n
 ### 6. Are local AI meeting notes as accurate as cloud-based tools?
 
 It depends on the model and your hardware. Cloud transcription services like Deepgram still have an edge on messy audio, heavy accents, and cross-talk. But local models like Parakeet and Whisper Large V3 have closed the gap significantly, especially on clear audio from a decent microphone. For most one-on-one and small group calls, the difference is negligible.
+
+![](/api/assets/blog/blog/image-21.png "char-editor-width=80")
+

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -32,6 +32,8 @@ I tested five tools that take different positions on this spectrum. For each one
 
 ### 1. Char
 
+![](/api/assets/blog/blog/char-summary.png "char-editor-width=80")
+
 [Char](https://char.com) is an open-source AI notepad for meetings, built for people who want complete control over their data and AI stack. It captures system audio from any meeting platform without joining your call and without requiring calendar permissions. 
 
 You can take notes during the meeting in Char's built-in editor while it transcribes in the background, and the AI combines both into a structured summary after the call. 

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -1,0 +1,11 @@
+---
+meta_title: ""
+display_title: ""
+meta_description: ""
+author:
+- "John Jeong"
+featured: false
+category: "Product"
+date: "2026-04-10"
+---
+

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -56,15 +56,17 @@ If you run Char with local models, nothing leaves your machine. If you plug in a
 
 #### Pricing
 
-Free for unlimited loacl transcription and AI. A lite plan at $8/month with Char cloud and pro at $25/month for managed cloud transcription and AI.
+Free for unlimited loacl transcription and AI. A lite plan at $8/month with Char cloud and pro at $25/month for integrations, advanced templates, and more.
 
-**2. Meetily**
+### 2. Meetily
 
-[Meetily](https://meetily.ai) is an open-source meeting assistant (MIT license) that runs transcription entirely on your device using Whisper or Parakeet models. It captures system audio without a bot, works with Zoom, Teams, Meet, and anything else that produces audio on your machine. Parakeet is the default engine and runs significantly faster than Whisper with lower resource usage, with GPU acceleration built in for Apple Silicon, NVIDIA, and AMD hardware.
+[Meetily](https://meetily.ai) is an open-source meeting assistant (MIT license) that runs transcription entirely on your device using Whisper or Parakeet models. 
+
+It captures system audio without a bot, works with Zoom, Teams, Meet, and anything else that produces audio on your machine. Parakeet is the default engine and runs significantly faster than Whisper with lower resource usage, with GPU acceleration built in for Apple Silicon, NVIDIA, and AMD hardware.
 
 Summaries are pluggable: use Ollama for fully local processing, or connect your own API key to Claude, Groq, or OpenRouter. The app is built in Rust with a Next.js frontend and ships as a single installer for macOS and Windows. Linux users can build from source.
 
-***How local is it actually***
+#### How local is it actually
 
 - Transcription: 100% local. Whisper or Parakeet models running on your hardware.
 - Summarization: pluggable. Ollama for fully local, or BYOK with cloud providers.
@@ -73,16 +75,17 @@ Summaries are pluggable: use Ollama for fully local processing, or connect your 
 
 The team is transparent that local model summarization does not match cloud quality yet, especially on longer meetings. They document the tradeoffs in their blog and are actively working on closing the gap.
 
-***Where it falls short***
+#### Where it falls short
 
 - Speaker diarization is still in development.
 - Local summarization quality lags cloud on long meetings.
 - Linux requires building from source.
 - No mobile app.
 
-***Pricing***
+#### Pricing
 
-- Community Edition: free forever, MIT licensed, no restrictions.
+Community Edition is free forever.
+
 - Pro: $10/month billed annually ($120/year). 14-day free trial, no credit card.
 - Pro adds: enhanced accuracy models, auto-meeting detection, PDF/DOCX export, custom templates.
 

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -47,19 +47,20 @@ The AI stack is yours to choose: Char's managed cloud service, your own API keys
 
 If you run Char with local models, nothing leaves your machine. If you plug in an API key, only the transcript goes to that provider for summarization. For companies that have banned cloud-based meeting tools, Char is one of the few options where "local-first" means exactly what it says.
 
-#### *Where it falls short*
+#### Where it falls short
 
 - macOS and Linux only. No Windows client yet.
 - No mobile app, no video recording.
 - No built-in CRM integrations. If you need notes pushed into Salesforce, you will need to build that yourself.
 - No team dashboard or cross-meeting cloud search. Your notes live in your file system.
 
-***Pricing***
+#### Pricing
 
-- Free: unlimited local transcription or BYOK API keys. 45+ languages.
+Free for unlimited loacl transcription and AI. A lit plan at $8/month 
+
 - Pro: $25/month for managed cloud transcription and AI.
 
-**Meetily**
+**2. Meetily**
 
 [Meetily](https://meetily.ai) is an open-source meeting assistant (MIT license) that runs transcription entirely on your device using Whisper or Parakeet models. It captures system audio without a bot, works with Zoom, Teams, Meet, and anything else that produces audio on your machine. Parakeet is the default engine and runs significantly faster than Whisper with lower resource usage, with GPU acceleration built in for Apple Silicon, NVIDIA, and AMD hardware.
 

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -28,7 +28,7 @@ I tested five tools that take different positions on this spectrum. For each one
 |                |                                                                    |                                |
 
 
-## 6 Tools for Local AI Meeting Notes: A Closer Look
+## 5 Tools for Local AI Meeting Notes: A Closer Look
 
 ### 1. Char
 

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -1,8 +1,10 @@
 ---
+meta_title: "6 Best Local AI Meeting Notetakers in 2026"
+meta_description: "Local AI meeting notes tools that transcribe and summarize on your device. For engineers, legal teams, and anyone whose company banned cloud recording tools."
 author:
   - "John Jeong"
 featured: false
-category: "Product"
+category: "Comparisons"
 date: "2026-04-10"
 ---
 

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -163,14 +163,11 @@ It captures what audio-only tools miss: the URL someone dropped in the Zoom chat
 - Setup is more involved: configuring audio devices, transcription engines, pipe automations.
 - $400 is steep if you only want meeting notes.
 
-***Pricing***
+#### Pricing
 
-- $400 lifetime (one-time). All features, all future updates.
-- $600 lifetime + 1 year of Pro (cloud sync, priority support).
-- Pro subscription: $39/month.
-- CLI is free and MIT-licensed.
+$400 lifetime (one-time). All features, all future updates. $600 lifetime + 1 year of Pro (cloud sync, priority support).
 
-**Granola**
+### 6. Granola
 
 [Granola](https://granola.ai) captures system audio without a bot and produces AI summaries in a notepad-style interface where you can type your own notes during the call. The AI weaves your notes together with the transcript into polished output. It integrates with your calendar, detects meetings automatically, and works on macOS, Windows, and iOS. It is the most popular tool in this category, with over a million users and a [$250 million valuation](https://techcrunch.com/2026/03/24/talats-ai-meeting-notes-stay-on-your-machine-not-in-the-cloud/).
 

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -56,9 +56,7 @@ If you run Char with local models, nothing leaves your machine. If you plug in a
 
 #### Pricing
 
-Free for unlimited loacl transcription and AI. A lit plan at $8/month 
-
-- Pro: $25/month for managed cloud transcription and AI.
+Free for unlimited loacl transcription and AI. A lite plan at $8/month with Char cloud and pro at $25/month for managed cloud transcription and AI.
 
 **2. Meetily**
 


### PR DESCRIPTION
## Article Ready for Publication

**Title:** 5 Best Local AI Meeting Notetakers in 2026
**Author:** Harshika
**Date:** 2026-04-10
**Category:** Comparisons

**Branch:** blog/local-ai-meeting-notes
**File:** apps/web/content/articles/local-ai-meeting-notes.mdx

---
Auto-generated PR from admin panel.