### PR TITLE
fix: harden GitHub repo stats fallback

### DIFF
--- a/apps/web/src/functions/github.ts
+++ b/apps/web/src/functions/github.ts
@@ -4,62 +4,136 @@ import { createServerFn } from "@tanstack/react-start";
 import { env } from "../env";
 
 const GITHUB_ORG_REPO = "fastrepl/char";
+const GITHUB_REPO_URL = `https://github.com/${GITHUB_ORG_REPO}`;
+const GITHUB_REPO_API_URL = `https://api.github.com/repos/${GITHUB_ORG_REPO}`;
 const CACHE_TTL = HOUR;
 
-function getGitHubHeaders(): Record<string, string> {
+type GitHubStats = {
+  stars: number | null;
+  forks: number | null;
+};
+
+function getGitHubHeaders(accept = "application/vnd.github+json") {
   const headers: Record<string, string> = {
-    Accept: "application/vnd.github.v3+json",
+    Accept: accept,
     "User-Agent": "Char-Web",
+    "X-GitHub-Api-Version": "2022-11-28",
   };
   if (env.GITHUB_TOKEN) {
-    headers["Authorization"] = `token ${env.GITHUB_TOKEN}`;
+    headers.Authorization = `Bearer ${env.GITHUB_TOKEN}`;
   }
   return headers;
 }
 
-async function fetchGitHub(url: string): Promise<Response> {
+async function fetchGitHub(url: string, accept?: string): Promise<Response> {
   return fetchWithCache(
     url,
-    { headers: getGitHubHeaders() },
+    { headers: getGitHubHeaders(accept) },
     { ttl: CACHE_TTL, durable: true },
   );
 }
 
+function parseGitHubCounter(value: string | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = Number(value.replaceAll(",", "").trim());
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function extractGitHubCounter(html: string, patterns: RegExp[]) {
+  for (const pattern of patterns) {
+    const value = parseGitHubCounter(pattern.exec(html)?.[1]);
+    if (value !== null) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+async function fetchGitHubStatsFromApi(): Promise<GitHubStats | null> {
+  try {
+    const response = await fetchGitHub(GITHUB_REPO_API_URL);
+
+    if (!response.ok) {
+      console.error("Failed to fetch GitHub repo stats:", response.status);
+      return null;
+    }
+
+    const data = (await response.json()) as {
+      stargazers_count?: unknown;
+      forks_count?: unknown;
+    };
+
+    const stars =
+      typeof data.stargazers_count === "number" ? data.stargazers_count : null;
+    const forks =
+      typeof data.forks_count === "number" ? data.forks_count : null;
+
+    if (stars === null || forks === null) {
+      console.error(
+        "GitHub repo stats response did not include numeric counts",
+      );
+      return null;
+    }
+
+    return { stars, forks };
+  } catch (error) {
+    console.error("Failed to fetch GitHub repo stats from API:", error);
+    return null;
+  }
+}
+
+async function fetchGitHubStatsFromRepoPage(): Promise<GitHubStats | null> {
+  try {
+    const response = await fetchGitHub(
+      GITHUB_REPO_URL,
+      "text/html,application/xhtml+xml",
+    );
+
+    if (!response.ok) {
+      console.error("Failed to fetch GitHub repo page:", response.status);
+      return null;
+    }
+
+    const html = await response.text();
+    const stars = extractGitHubCounter(html, [
+      /id="repo-stars-counter-star"[^>]*title="([^"]+)"/,
+      /id="repo-stars-counter-star"[^>]*aria-label="([0-9,]+)\s+users starred this repository"/,
+    ]);
+    const forks = extractGitHubCounter(html, [
+      /id="repo-network-counter"[^>]*title="([^"]+)"/,
+      /href="\/fastrepl\/char\/forks"[\s\S]{0,250}?<strong>([0-9,]+)<\/strong>/,
+    ]);
+
+    if (stars === null || forks === null) {
+      console.error("Failed to parse GitHub repo counts from repo page");
+      return null;
+    }
+
+    return { stars, forks };
+  } catch (error) {
+    console.error("Failed to fetch GitHub repo stats from repo page:", error);
+    return null;
+  }
+}
+
 export const getGitHubStats = createServerFn({ method: "GET" }).handler(
   async () => {
-    try {
-      const response = await fetchGitHub(
-        `https://api.github.com/repos/${GITHUB_ORG_REPO}`,
-      );
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch repo info: ${response.status}`);
-      }
-
-      const data = await response.json();
-      return {
-        stars: data.stargazers_count ?? 0,
-        forks: data.forks_count ?? 0,
-      };
-    } catch {
-      return { stars: 0, forks: 0 };
-    }
+    return (
+      (await fetchGitHubStatsFromApi()) ??
+      (await fetchGitHubStatsFromRepoPage()) ?? { stars: null, forks: null }
+    );
   },
 );
 
 export const getStargazers = createServerFn({ method: "GET" }).handler(
   async () => {
     try {
-      const repoResponse = await fetchGitHub(
-        `https://api.github.com/repos/${GITHUB_ORG_REPO}`,
-      );
-
-      if (!repoResponse.ok) {
-        throw new Error(`Failed to fetch repo info: ${repoResponse.status}`);
-      }
-
-      const repoData = await repoResponse.json();
-      const totalStars = repoData.stargazers_count ?? 0;
+      const repoStats = await fetchGitHubStatsFromApi();
+      const totalStars = repoStats?.stars ?? 0;
 
       if (totalStars === 0) {
         return [];

--- a/apps/web/src/queries.ts
+++ b/apps/web/src/queries.ts
@@ -3,8 +3,8 @@ import { useQuery } from "@tanstack/react-query";
 import { getGitHubStats, getStargazers } from "./functions/github";
 
 const ORG_REPO = "fastrepl/char";
-const LAST_SEEN_STARS = 7032;
-const LAST_SEEN_FORKS = 432;
+const LAST_SEEN_STARS = 8173;
+const LAST_SEEN_FORKS = 582;
 
 export function useGitHubStats() {
   return useQuery({
@@ -12,8 +12,8 @@ export function useGitHubStats() {
     queryFn: async () => {
       const stats = await getGitHubStats();
       return {
-        stars: stats.stars || LAST_SEEN_STARS,
-        forks: stats.forks || LAST_SEEN_FORKS,
+        stars: stats.stars ?? LAST_SEEN_STARS,
+        forks: stats.forks ?? LAST_SEEN_FORKS,
       };
     },
     staleTime: 1000 * 60 * 60,


### PR DESCRIPTION
Use the repo API first, parse repo-page counters as a fallback, and refresh the last-seen stars and forks values.