### PR TITLE
fix: move media upload toast closer to the corner

### DIFF
--- a/apps/web/src/hooks/use-media-api.tsx
+++ b/apps/web/src/hooks/use-media-api.tsx
@@ -80,6 +80,7 @@ export type { MediaItem } from "@/lib/media-library";
 
 const MEDIA_ITEMS_QUERY_STALE_TIME = 30_000;
 const MEDIA_ITEMS_QUERY_GC_TIME = 5 * 60_000;
+const UPLOAD_TOAST_NUDGE_PX = 12;
 
 export function getMediaItemsQueryKey(path: string) {
   return ["mediaItems", path] as const;
@@ -191,6 +192,10 @@ export function useMediaApi({
           {
             id: toastId,
             duration: done || error ? 3000 : Infinity,
+            style: {
+              marginBottom: -UPLOAD_TOAST_NUDGE_PX,
+              marginRight: -UPLOAD_TOAST_NUDGE_PX,
+            },
           },
         );
       };


### PR DESCRIPTION
Nudge the admin media upload progress toast toward the bottom-right edge without changing other web toasts.