### PR TITLE
fix: unblock homepage styles on first paint

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -20,6 +20,20 @@ interface RouterContext {
   queryClient: QueryClient;
 }
 
+const FONT_PRECONNECTS = [
+  { rel: "preconnect", href: "https://fonts.googleapis.com" },
+  {
+    rel: "preconnect",
+    href: "https://fonts.gstatic.com",
+    crossOrigin: "anonymous" as const,
+  },
+] as const;
+
+const FONT_STYLESHEETS = [
+  "https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&family=Instrument+Serif:ital@1&family=Lora:wght@400;500;600;700&display=swap",
+  "https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&display=swap",
+] as const;
+
 export const Route = createRootRouteWithContext<RouterContext>()({
   head: () => ({
     meta: [
@@ -55,6 +69,11 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       },
     ],
     links: [
+      ...FONT_PRECONNECTS,
+      ...FONT_STYLESHEETS.map((href) => ({
+        rel: "stylesheet" as const,
+        href,
+      })),
       { rel: "icon", href: "/favicon.svg", type: "image/svg+xml" },
       { rel: "icon", href: "/favicon.ico", sizes: "32x32" },
       { rel: "stylesheet", href: appCss },

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&family=Lora:wght@400;500;600;700&family=Instrument+Serif:ital@1&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&display=swap");
 @font-face {
   font-family: "Redaction";
   src: url("/fonts/Redaction-Regular.otf") format("opentype");


### PR DESCRIPTION
Move Google font loading out of the render-critical stylesheet so the root styles can apply without waiting on @import requests.