### PR TITLE
refactor: turn prompt editor into a split workbench

### DIFF
--- a/apps/desktop/src/ai/prompts/assistant.tsx
+++ b/apps/desktop/src/ai/prompts/assistant.tsx
@@ -1,0 +1,321 @@
+import type { ChatStatus } from "ai";
+import { tool } from "ai";
+import { ChevronDownIcon, SparklesIcon, WandSparklesIcon } from "lucide-react";
+import { useCallback, useMemo } from "react";
+import { z } from "zod";
+
+import { Button } from "@hypr/ui/components/ui/button";
+import { cn } from "@hypr/utils";
+
+import { useLanguageModel } from "~/ai/hooks";
+import { ChatBodyNonEmpty } from "~/chat/components/body/non-empty";
+import { useChatAutoScroll } from "~/chat/components/body/use-chat-auto-scroll";
+import { ChatMessageInput } from "~/chat/components/input";
+import { ChatSession } from "~/chat/components/session-provider";
+import type { HyprUIMessage } from "~/chat/types";
+import { id } from "~/shared/utils";
+import type { TaskType } from "~/store/tinybase/store/prompts";
+
+const PROMPT_ASSISTANT_SUGGESTIONS = {
+  enhance: [
+    "Make this prompt more action-item focused.",
+    "Tighten the structure so the instructions feel shorter and clearer.",
+    "Rewrite this so the output reads more executive and less verbose.",
+  ],
+  title: [
+    "Make the title guidance punchier and less generic.",
+    "Bias the title toward decisions instead of broad meeting names.",
+    "Shorten the title output to four or five words max.",
+  ],
+} satisfies Record<TaskType, string[]>;
+
+export function PromptAssistantPanel({
+  selectedTask,
+  taskLabel,
+  taskDescription,
+  variables,
+  filters,
+  draftContent,
+  hasCustomPrompt,
+  onApplyTemplate,
+}: {
+  selectedTask: TaskType;
+  taskLabel: string;
+  taskDescription: string;
+  variables: string[];
+  filters: string[];
+  draftContent: string;
+  hasCustomPrompt: boolean;
+  onApplyTemplate: (content: string) => void;
+}) {
+  const model = useLanguageModel("chat");
+  const sessionId = useMemo(() => id(), [selectedTask]);
+
+  const assistantPrompt = useMemo(
+    () =>
+      [
+        "You are helping the user edit a custom Jinja template for Char.",
+        `Task: ${taskLabel}`,
+        `Description: ${taskDescription}`,
+        "",
+        "This editor controls the custom override surface rendered with renderCustom(...).",
+        "Do not refer to internal Askama macros or hidden template helpers.",
+        "",
+        `Saved state: ${hasCustomPrompt ? "custom override" : "default behavior with no override saved yet"}`,
+        `Available variables: ${variables.join(", ") || "none"}`,
+        `Available filters: ${filters.join(", ") || "none"}`,
+        "",
+        "Rules:",
+        "- Keep responses concise.",
+        "- Explain changes briefly before or after applying them.",
+        "- When the user asks for a concrete change, call update_prompt_template with the full next template.",
+        "- Do not say the draft was updated unless you actually call the tool.",
+        "- Preserve valid Jinja syntax.",
+        "",
+        "<current_template>",
+        draftContent,
+        "</current_template>",
+      ].join("\n"),
+    [
+      draftContent,
+      filters,
+      hasCustomPrompt,
+      taskDescription,
+      taskLabel,
+      variables,
+    ],
+  );
+
+  const extraTools = useMemo(
+    () => ({
+      update_prompt_template: tool({
+        description:
+          "Replace the current prompt draft with a complete updated Jinja template.",
+        inputSchema: z.object({
+          content: z
+            .string()
+            .describe("The full updated prompt template in Jinja syntax."),
+          summary: z
+            .string()
+            .optional()
+            .describe("A short note about what changed in the draft."),
+        }),
+        execute: async ({
+          content,
+          summary,
+        }: {
+          content: string;
+          summary?: string;
+        }) => {
+          const nextContent = content.trim();
+          onApplyTemplate(nextContent);
+
+          return {
+            status: "applied",
+            message:
+              summary ??
+              "Draft updated in the editor. Review and save to make it live.",
+            lineCount: nextContent.split("\n").length,
+          };
+        },
+      }),
+    }),
+    [onApplyTemplate],
+  );
+
+  const handleSendMessage = useCallback(
+    (
+      _content: string,
+      parts: HyprUIMessage["parts"],
+      sendMessage: (message: HyprUIMessage) => void,
+    ) => {
+      sendMessage({
+        id: id(),
+        role: "user",
+        parts,
+        metadata: {
+          createdAt: Date.now(),
+        },
+      });
+    },
+    [],
+  );
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-stone-50">
+      <div className="border-b border-neutral-200 px-4 py-4">
+        <div className="flex items-center gap-2 text-sm font-medium text-neutral-900">
+          <WandSparklesIcon className="h-4 w-4 text-neutral-500" />
+          Prompt Assistant
+        </div>
+        <p className="mt-1 text-xs leading-5 text-neutral-600">
+          Ask Charlie to rewrite the draft, tighten the language, or reshape the
+          structure. Applied changes land back in the editor so you can review
+          them before saving.
+        </p>
+      </div>
+
+      <ChatSession
+        key={selectedTask}
+        sessionId={sessionId}
+        modelOverride={model ?? undefined}
+        extraTools={extraTools}
+        systemPromptOverride={assistantPrompt}
+      >
+        {(sessionProps) => (
+          <div className="flex min-h-0 flex-1 flex-col">
+            <PromptAssistantBody
+              messages={sessionProps.messages}
+              status={sessionProps.status}
+              error={sessionProps.error}
+              regenerate={sessionProps.regenerate}
+              isModelConfigured={!!model}
+              selectedTask={selectedTask}
+              onSendPrompt={(prompt) => {
+                handleSendMessage(
+                  prompt,
+                  [{ type: "text", text: prompt }],
+                  sessionProps.sendMessage,
+                );
+              }}
+            />
+
+            {model ? (
+              <ChatMessageInput
+                draftKey={sessionProps.sessionId}
+                disabled={!sessionProps.isSystemPromptReady}
+                onSendMessage={(content, parts) => {
+                  handleSendMessage(content, parts, sessionProps.sendMessage);
+                }}
+                isStreaming={
+                  sessionProps.status === "streaming" ||
+                  sessionProps.status === "submitted"
+                }
+                onStop={sessionProps.stop}
+              />
+            ) : (
+              <div className="border-t border-neutral-200 px-4 py-3 text-xs text-neutral-500">
+                Configure a chat model in AI settings to edit prompts from chat.
+              </div>
+            )}
+          </div>
+        )}
+      </ChatSession>
+    </div>
+  );
+}
+
+function PromptAssistantBody({
+  messages,
+  status,
+  error,
+  regenerate,
+  isModelConfigured,
+  selectedTask,
+  onSendPrompt,
+}: {
+  messages: HyprUIMessage[];
+  status: ChatStatus;
+  error?: Error;
+  regenerate: () => void;
+  isModelConfigured: boolean;
+  selectedTask: TaskType;
+  onSendPrompt: (prompt: string) => void;
+}) {
+  const {
+    contentRef,
+    isAtBottom,
+    scrollRef,
+    scrollToBottom,
+    showGoToRecent,
+    updateAutoScrollState,
+    handleWheel,
+  } = useChatAutoScroll(status);
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      <div
+        ref={scrollRef}
+        onScroll={updateAutoScrollState}
+        onWheel={handleWheel}
+        className="flex min-h-0 flex-1 flex-col overflow-y-auto"
+      >
+        <div
+          ref={contentRef}
+          className="flex min-h-full flex-1 flex-col px-3 py-3"
+        >
+          <div className="flex-1" />
+          {messages.length === 0 ? (
+            <PromptAssistantEmpty
+              isModelConfigured={isModelConfigured}
+              selectedTask={selectedTask}
+              onSendPrompt={onSendPrompt}
+            />
+          ) : (
+            <ChatBodyNonEmpty
+              messages={messages}
+              status={status}
+              error={error}
+              onReload={regenerate}
+            />
+          )}
+        </div>
+      </div>
+
+      {messages.length > 0 && showGoToRecent && !isAtBottom ? (
+        <Button
+          onClick={scrollToBottom}
+          size="sm"
+          className="absolute bottom-3 left-1/2 z-20 flex -translate-x-1/2 items-center gap-1 rounded-full border border-neutral-200 bg-white text-neutral-700 shadow-xs hover:bg-neutral-50"
+          variant="outline"
+        >
+          <ChevronDownIcon size={12} />
+          <span className="text-xs">Go to recent</span>
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+function PromptAssistantEmpty({
+  isModelConfigured,
+  selectedTask,
+  onSendPrompt,
+}: {
+  isModelConfigured: boolean;
+  selectedTask: TaskType;
+  onSendPrompt: (prompt: string) => void;
+}) {
+  return (
+    <div className="flex justify-start pb-1">
+      <div className="flex w-full flex-col">
+        <div className="mb-2 flex items-center gap-2">
+          <SparklesIcon className="h-4 w-4 text-neutral-500" />
+          <span className="text-sm font-medium text-neutral-800">Charlie</span>
+        </div>
+        <p className="mb-3 text-sm leading-6 text-neutral-700">
+          {isModelConfigured
+            ? "I can rewrite the active draft, preserve the Jinja structure, and apply the updated template back into the editor."
+            : "Set up a chat model to rewrite the active draft from this pane."}
+        </p>
+        {isModelConfigured ? (
+          <div className="flex flex-wrap gap-1.5">
+            {PROMPT_ASSISTANT_SUGGESTIONS[selectedTask].map((prompt) => (
+              <button
+                key={prompt}
+                type="button"
+                onClick={() => onSendPrompt(prompt)}
+                className={cn([
+                  "rounded-full border border-neutral-300 bg-white px-2.5 py-1 text-left text-[11px] text-neutral-700",
+                  "transition-colors hover:bg-neutral-100",
+                ])}
+              >
+                {prompt}
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/ai/prompts/defaults.ts
+++ b/apps/desktop/src/ai/prompts/defaults.ts
@@ -1,0 +1,60 @@
+import type { TaskType } from "~/store/tinybase/store/prompts";
+
+const ENHANCE_STARTER_TEMPLATE = `
+# Context
+
+{% if session.title %}
+Title: {{ session.title }}
+{% endif %}
+{% if session.startedAt %}
+Date: {{ session.startedAt }}
+{% endif %}
+
+{% if participants %}
+Participants:
+{% for participant in participants %}
+- {{ participant.name }}{% if participant.jobTitle %} - {{ participant.jobTitle }}{% endif %}
+{% endfor %}
+{% endif %}
+
+{% if pre_meeting_memo %}
+# Pre-Meeting Notes
+
+{{ pre_meeting_memo }}
+{% endif %}
+
+{% if post_meeting_memo %}
+# Meeting Notes
+
+{{ post_meeting_memo }}
+{% endif %}
+
+# Transcript
+
+{{ content | transcript }}
+
+{% if template and template.sections %}
+# Output Template
+
+{% for section in template.sections %}
+{{ loop.index }}. {{ section.title }}{% if section.description %} - {{ section.description }}{% endif %}
+{% endfor %}
+{% endif %}
+`.trim();
+
+const TITLE_STARTER_TEMPLATE = `
+<note>
+{{ enhanced_note }}
+</note>
+
+Give me a super concise meeting title. Focus only on the topic and return title text only.
+`.trim();
+
+const DEFAULT_PROMPT_TEMPLATES = {
+  enhance: ENHANCE_STARTER_TEMPLATE,
+  title: TITLE_STARTER_TEMPLATE,
+} satisfies Record<TaskType, string>;
+
+export function getDefaultPromptTemplate(taskType: TaskType): string {
+  return DEFAULT_PROMPT_TEMPLATES[taskType];
+}

--- a/apps/desktop/src/ai/prompts/details.tsx
+++ b/apps/desktop/src/ai/prompts/details.tsx
@@ -1,9 +1,19 @@
-import { useCallback, useEffect, useState } from "react";
+import { useForm } from "@tanstack/react-form";
+import { CircleDotIcon, RotateCcwIcon, SaveIcon } from "lucide-react";
+import { type ReactNode, useCallback, useMemo, useRef } from "react";
 
-import { commands as templateCommands } from "@hypr/plugin-template";
 import { Button } from "@hypr/ui/components/ui/button";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@hypr/ui/components/ui/resizable";
+import { cn } from "@hypr/utils";
 
-import { PromptEditor } from "./editor";
+import { PromptAssistantPanel } from "./assistant";
+import { getDefaultPromptTemplate } from "./defaults";
+import { PromptEditor, type PromptEditorHandle } from "./editor";
+import { PromptInsertChip, PromptTemplatePreview } from "./preview";
 
 import * as main from "~/store/tinybase/store/main";
 import {
@@ -19,17 +29,29 @@ export function PromptDetailsColumn({
 }: {
   selectedTask: TaskType | null;
 }) {
+  const customContent = main.UI.useCell(
+    "prompts",
+    selectedTask ?? "",
+    "content",
+    main.STORE_ID,
+  );
+
   if (!selectedTask) {
     return (
       <div className="flex h-full items-center justify-center">
         <p className="text-sm text-neutral-500">
-          Select a meeting-note task to view or customize its instructions
+          Select a meeting-note task to inspect or customize its prompt.
         </p>
       </div>
     );
   }
 
-  return <PromptDetails key={selectedTask} selectedTask={selectedTask} />;
+  return (
+    <PromptDetails
+      key={`${selectedTask}:${customContent ?? "__default__"}`}
+      selectedTask={selectedTask}
+    />
+  );
 }
 
 function PromptDetails({ selectedTask }: { selectedTask: TaskType }) {
@@ -40,166 +62,273 @@ function PromptDetails({ selectedTask }: { selectedTask: TaskType }) {
     "content",
     main.STORE_ID,
   );
+  const editorRef = useRef<PromptEditorHandle>(null);
 
-  const [defaultContent, setDefaultContent] = useState("");
-  const [localValue, setLocalValue] = useState(customContent || "");
-  const [isLoading, setIsLoading] = useState(true);
-
-  const taskConfig = TASK_CONFIGS.find((c) => c.type === selectedTask);
-  const variables = taskConfig?.variables ?? [];
-
-  useEffect(() => {
-    setIsLoading(true);
-
-    const template: Parameters<typeof templateCommands.render>[0] =
-      selectedTask === "enhance"
-        ? {
-            enhanceUser: {
-              session: {
-                event: null,
-                title: null,
-                startedAt: null,
-                endedAt: null,
-              },
-              participants: [],
-              template: null,
-              transcripts: [],
-              preMeetingMemo: "",
-              postMeetingMemo: "",
-            },
-          }
-        : { titleUser: { enhancedNote: "" } };
-
-    void templateCommands
-      .render(template)
-      .then((result) => {
-        if (result.status === "ok") {
-          setDefaultContent(result.data);
-        }
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-  }, [selectedTask]);
-
-  useEffect(() => {
-    setLocalValue(customContent || "");
-  }, [customContent, selectedTask]);
-
-  const handleSave = useCallback(() => {
-    if (!store) return;
-    const trimmed = localValue.trim();
-    if (trimmed) {
-      setCustomPrompt(store, selectedTask, trimmed);
-    } else {
-      deleteCustomPrompt(store, selectedTask);
-    }
-  }, [store, selectedTask, localValue]);
-
-  const handleReset = useCallback(() => {
-    if (!store) return;
-    deleteCustomPrompt(store, selectedTask);
-    setLocalValue("");
-  }, [store, selectedTask]);
-
-  const hasChanges = localValue !== (customContent || "");
+  const taskConfig = TASK_CONFIGS.find(
+    (config) => config.type === selectedTask,
+  );
+  const defaultTemplate = getDefaultPromptTemplate(selectedTask);
+  const savedContent = customContent || defaultTemplate;
   const hasCustomPrompt = !!customContent;
+  const variables = useMemo(
+    () => [...(taskConfig?.variables ?? [])],
+    [taskConfig?.variables],
+  );
+  const filters = useMemo(() => [...AVAILABLE_FILTERS], []);
+
+  const form = useForm({
+    defaultValues: {
+      content: savedContent,
+    },
+    onSubmit: ({ value }) => {
+      if (!store) {
+        return;
+      }
+
+      const nextContent = value.content.trim();
+      const normalizedDefault = defaultTemplate.trim();
+
+      if (!nextContent || nextContent === normalizedDefault) {
+        deleteCustomPrompt(store, selectedTask);
+        return;
+      }
+
+      setCustomPrompt(store, selectedTask, nextContent);
+    },
+  });
+
+  const handleInsertSnippet = useCallback((snippet: string) => {
+    editorRef.current?.insertText(snippet);
+  }, []);
+
+  if (!taskConfig) {
+    return null;
+  }
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="border-b border-neutral-200 px-6 py-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <h2 className="text-lg font-semibold">{taskConfig?.label}</h2>
-            <p className="mt-1 text-sm text-neutral-500">
-              {taskConfig?.description}
-            </p>
-          </div>
-          <div className="flex gap-2">
-            {hasCustomPrompt && (
-              <Button variant="outline" size="sm" onClick={handleReset}>
-                Reset to Default
-              </Button>
-            )}
-            <Button size="sm" onClick={handleSave} disabled={!hasChanges}>
-              Save
-            </Button>
-          </div>
-        </div>
-      </div>
+    <form.Field name="content">
+      {(field) => {
+        const draftContent = field.state.value;
+        const hasChanges = draftContent !== savedContent;
 
-      <div className="border-b border-neutral-200 bg-neutral-50 px-6 py-3">
-        <h3 className="mb-2 text-xs font-medium text-neutral-600">
-          Available Variables
-        </h3>
-        <div className="flex flex-wrap gap-1.5">
-          {variables.map((variable) => (
-            <code
-              key={variable}
-              className="rounded-xs border border-neutral-200 bg-white px-2 py-0.5 font-mono text-xs"
-            >
-              {"{{ "}
-              {variable}
-              {" }}"}
-            </code>
-          ))}
-        </div>
-        <div className="mt-2 text-xs text-neutral-500">
-          <span className="font-medium">Filters:</span>{" "}
-          {AVAILABLE_FILTERS.map((filter, i) => (
-            <span key={filter}>
-              <code className="rounded-xs border border-neutral-200 bg-white px-1">
-                {filter}
-              </code>
-              {i < AVAILABLE_FILTERS.length - 1 && ", "}
-            </span>
-          ))}
-        </div>
-      </div>
+        return (
+          <div className="flex h-full min-h-0 flex-col">
+            <div className="border-b border-neutral-200 px-6 py-4">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <div className="flex items-center gap-2 text-xs text-neutral-500">
+                    <CircleDotIcon className="h-3.5 w-3.5" />
+                    <span>
+                      {hasCustomPrompt ? "Custom override" : "Default behavior"}
+                    </span>
+                  </div>
+                  <h2 className="mt-2 text-lg font-semibold text-neutral-900">
+                    {taskConfig.label}
+                  </h2>
+                  <p className="mt-1 text-sm text-neutral-500">
+                    {taskConfig.description}
+                  </p>
+                </div>
 
-      <div className="flex flex-1 flex-col overflow-hidden">
-        <div className="flex-1 p-6">
-          <div className="h-full overflow-hidden rounded-lg border border-neutral-200">
-            <PromptEditor
-              value={localValue}
-              onChange={setLocalValue}
-              placeholder="Enter custom meeting-note instructions using Jinja2 syntax..."
-              variables={variables as string[]}
-              filters={[...AVAILABLE_FILTERS]}
-            />
-          </div>
-        </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      field.handleChange(savedContent);
+                      editorRef.current?.focus();
+                    }}
+                    disabled={!hasChanges}
+                  >
+                    <RotateCcwIcon className="h-3.5 w-3.5" />
+                    Revert Draft
+                  </Button>
+                  {hasCustomPrompt ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        if (!store) {
+                          return;
+                        }
 
-        <div className="border-t border-neutral-200">
-          <details className="group">
-            <summary className="flex cursor-pointer list-none items-center gap-2 px-6 py-3 text-sm font-medium text-neutral-600 hover:bg-neutral-50">
-              <svg
-                className="h-4 w-4 transition-transform group-open:rotate-90"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 5l7 7-7 7"
-                />
-              </svg>
-              Default Template Reference
-            </summary>
-            <div className="max-h-64 overflow-auto px-6 pb-4">
-              {isLoading ? (
-                <div className="text-sm text-neutral-500">Loading...</div>
-              ) : (
-                <pre className="rounded-lg border border-neutral-200 bg-neutral-50 p-4 font-mono text-xs whitespace-pre-wrap text-neutral-600">
-                  {defaultContent || "No default template available"}
-                </pre>
-              )}
+                        deleteCustomPrompt(store, selectedTask);
+                      }}
+                    >
+                      Reset to Default
+                    </Button>
+                  ) : null}
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => {
+                      void form.handleSubmit();
+                    }}
+                    disabled={!hasChanges}
+                  >
+                    <SaveIcon className="h-3.5 w-3.5" />
+                    Save
+                  </Button>
+                </div>
+              </div>
             </div>
-          </details>
-        </div>
+
+            <ResizablePanelGroup
+              direction="horizontal"
+              className="min-h-0 flex-1"
+            >
+              <ResizablePanel defaultSize={60} minSize={42}>
+                <div className="flex h-full min-h-0 flex-col">
+                  <div className="border-b border-neutral-200 px-6 py-4">
+                    <div className="rounded-xl border border-neutral-200 bg-stone-50 px-4 py-3">
+                      <p className="text-xs leading-5 text-neutral-600">
+                        The built-in prompt uses internal helpers. This editor
+                        works on the supported custom-Jinja surface that becomes
+                        active after you save an override.
+                      </p>
+                    </div>
+
+                    <div className="mt-4 flex flex-col gap-3">
+                      <PromptLibraryRow
+                        label="Variables"
+                        helper="Click to insert or drag into the editor."
+                      >
+                        {variables.map((variable) => (
+                          <PromptInsertChip
+                            key={variable}
+                            label={variable}
+                            snippet={`{{ ${variable} }}`}
+                            kind="variable"
+                            onInsert={handleInsertSnippet}
+                          />
+                        ))}
+                      </PromptLibraryRow>
+
+                      <PromptLibraryRow
+                        label="Filters"
+                        helper="Use these inside an expression like {{ content | transcript }}."
+                      >
+                        {filters.map((filter) => (
+                          <PromptInsertChip
+                            key={filter}
+                            label={filter}
+                            snippet={`| ${filter}`}
+                            kind="filter"
+                            onInsert={handleInsertSnippet}
+                          />
+                        ))}
+                      </PromptLibraryRow>
+                    </div>
+                  </div>
+
+                  <ResizablePanelGroup
+                    direction="vertical"
+                    className="min-h-0 flex-1"
+                  >
+                    <ResizablePanel defaultSize={42} minSize={24}>
+                      <PromptSection
+                        title="Formatted View"
+                        description="A cleaner read of the active draft. Inline chips can be dragged or inserted back into the editor."
+                      >
+                        <PromptTemplatePreview
+                          content={draftContent}
+                          onInsert={handleInsertSnippet}
+                        />
+                      </PromptSection>
+                    </ResizablePanel>
+                    <ResizableHandle />
+                    <ResizablePanel defaultSize={58} minSize={32}>
+                      <PromptSection
+                        title="Template Source"
+                        description="Edit the Jinja draft directly, or let Charlie rewrite it from the chat pane."
+                        flush
+                      >
+                        <div className="min-h-0 flex-1 overflow-hidden rounded-xl border border-neutral-200">
+                          <PromptEditor
+                            ref={editorRef}
+                            value={draftContent}
+                            onChange={field.handleChange}
+                            placeholder="Write a custom prompt override, drag chips into place, or ask Charlie to rewrite the draft."
+                            variables={variables}
+                            filters={filters}
+                          />
+                        </div>
+                      </PromptSection>
+                    </ResizablePanel>
+                  </ResizablePanelGroup>
+                </div>
+              </ResizablePanel>
+
+              <ResizableHandle />
+
+              <ResizablePanel defaultSize={40} minSize={28}>
+                <PromptAssistantPanel
+                  selectedTask={selectedTask}
+                  taskLabel={taskConfig.label}
+                  taskDescription={taskConfig.description}
+                  variables={variables}
+                  filters={filters}
+                  draftContent={draftContent}
+                  hasCustomPrompt={hasCustomPrompt}
+                  onApplyTemplate={(content) => {
+                    field.handleChange(content);
+                    editorRef.current?.focus();
+                  }}
+                />
+              </ResizablePanel>
+            </ResizablePanelGroup>
+          </div>
+        );
+      }}
+    </form.Field>
+  );
+}
+
+function PromptLibraryRow({
+  label,
+  helper,
+  children,
+}: {
+  label: string;
+  helper: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs font-medium text-neutral-700">{label}</span>
+        <span className="text-[11px] text-neutral-500">{helper}</span>
       </div>
+      <div className="flex flex-wrap gap-1.5">{children}</div>
+    </div>
+  );
+}
+
+function PromptSection({
+  title,
+  description,
+  children,
+  flush = false,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+  flush?: boolean;
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div
+        className={cn([
+          "border-b border-neutral-200 px-6 py-4",
+          flush && "pb-3",
+        ])}
+      >
+        <h3 className="text-sm font-medium text-neutral-900">{title}</h3>
+        <p className="mt-1 text-xs leading-5 text-neutral-500">{description}</p>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col px-6 py-4">{children}</div>
     </div>
   );
 }

--- a/apps/desktop/src/ai/prompts/editor.tsx
+++ b/apps/desktop/src/ai/prompts/editor.tsx
@@ -2,13 +2,24 @@ import { EditorState, type Extension } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import CodeMirror from "@uiw/react-codemirror";
 import readOnlyRangesExtension from "codemirror-readonly-ranges";
-import { useCallback, useMemo } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from "react";
 
 import { jinjaLanguage, jinjaLinter, readonlyVisuals } from "./jinja";
 
 export interface ReadOnlyRange {
   from: number;
   to: number;
+}
+
+export interface PromptEditorHandle {
+  focus: () => void;
+  insertText: (value: string) => void;
 }
 
 interface PromptEditorProps {
@@ -21,120 +32,163 @@ interface PromptEditorProps {
   filters?: string[];
 }
 
-export function PromptEditor({
-  value,
-  onChange,
-  placeholder,
-  readOnly = false,
-  readOnlyRanges = [],
-  variables = [],
-  filters = [],
-}: PromptEditorProps) {
-  const getReadOnlyRanges = useCallback(
-    (_state: EditorState) => {
-      if (readOnly || readOnlyRanges.length === 0) {
-        return [];
+export const PromptEditor = forwardRef<PromptEditorHandle, PromptEditorProps>(
+  function PromptEditor(
+    {
+      value,
+      onChange,
+      placeholder,
+      readOnly = false,
+      readOnlyRanges = [],
+      variables = [],
+      filters = [],
+    },
+    ref,
+  ) {
+    const viewRef = useRef<EditorView | null>(null);
+
+    const getReadOnlyRanges = useCallback(
+      (_state: EditorState) => {
+        if (readOnly || readOnlyRanges.length === 0) {
+          return [];
+        }
+
+        return readOnlyRanges.map((range) => ({
+          from: range.from,
+          to: range.to,
+        }));
+      },
+      [readOnly, readOnlyRanges],
+    );
+
+    const getRangesForVisuals = useCallback(() => {
+      return readOnlyRanges;
+    }, [readOnlyRanges]);
+
+    const extensions = useMemo(() => {
+      const exts: Extension[] = [
+        jinjaLanguage(variables, filters),
+        jinjaLinter(),
+      ];
+
+      if (!readOnly && readOnlyRanges.length > 0) {
+        exts.push(readOnlyRangesExtension(getReadOnlyRanges));
+        exts.push(readonlyVisuals(getRangesForVisuals));
       }
 
-      return readOnlyRanges.map((range) => ({
-        from: range.from,
-        to: range.to,
-      }));
-    },
-    [readOnly, readOnlyRanges],
-  );
+      return exts;
+    }, [
+      readOnly,
+      readOnlyRanges,
+      getReadOnlyRanges,
+      getRangesForVisuals,
+      variables,
+      filters,
+    ]);
 
-  const getRangesForVisuals = useCallback(() => {
-    return readOnlyRanges;
-  }, [readOnlyRanges]);
+    const theme = useMemo(
+      () =>
+        EditorView.theme({
+          "&": {
+            height: "100%",
+            fontFamily:
+              "var(--font-mono, 'Menlo', 'Monaco', 'Courier New', monospace)",
+            fontSize: "13px",
+            lineHeight: "1.6",
+          },
+          ".cm-content": {
+            padding: "8px 0",
+          },
+          ".cm-line": {
+            padding: "0 12px",
+          },
+          ".cm-scroller": {
+            overflow: "auto",
+          },
+          "&.cm-focused": {
+            outline: "none",
+          },
+          ".cm-placeholder": {
+            color: "#999",
+            fontStyle: "italic",
+          },
+          ".cm-readonly-region": {
+            backgroundColor: "rgba(0, 0, 0, 0.04)",
+            borderRadius: "2px",
+          },
+          ".cm-tooltip-autocomplete": {
+            border: "1px solid #e5e7eb",
+            borderRadius: "6px",
+            boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
+            backgroundColor: "#fff",
+          },
+          ".cm-tooltip-autocomplete ul li": {
+            padding: "4px 8px",
+          },
+          ".cm-tooltip-autocomplete ul li[aria-selected]": {
+            backgroundColor: "#f3f4f6",
+          },
+          ".cm-diagnostic-error": {
+            borderBottom: "2px wavy #ef4444",
+          },
+          ".cm-lintPoint-error:after": {
+            borderBottomColor: "#ef4444",
+          },
+        }),
+      [],
+    );
 
-  const extensions = useMemo(() => {
-    const exts: Extension[] = [
-      jinjaLanguage(variables, filters),
-      jinjaLinter(),
-    ];
+    useImperativeHandle(
+      ref,
+      () => ({
+        focus: () => {
+          viewRef.current?.focus();
+        },
+        insertText: (text: string) => {
+          const view = viewRef.current;
+          if (!view || readOnly) {
+            return;
+          }
 
-    if (!readOnly && readOnlyRanges.length > 0) {
-      exts.push(readOnlyRangesExtension(getReadOnlyRanges));
-      exts.push(readonlyVisuals(getRangesForVisuals));
-    }
+          const selection = view.state.selection.main;
+          const nextCursor = selection.from + text.length;
 
-    return exts;
-  }, [
-    readOnly,
-    readOnlyRanges,
-    getReadOnlyRanges,
-    getRangesForVisuals,
-    variables,
-    filters,
-  ]);
+          view.dispatch({
+            changes: {
+              from: selection.from,
+              to: selection.to,
+              insert: text,
+            },
+            selection: {
+              anchor: nextCursor,
+              head: nextCursor,
+            },
+          });
 
-  const theme = useMemo(
-    () =>
-      EditorView.theme({
-        "&": {
-          height: "100%",
-          fontFamily:
-            "var(--font-mono, 'Menlo', 'Monaco', 'Courier New', monospace)",
-          fontSize: "13px",
-          lineHeight: "1.6",
-        },
-        ".cm-content": {
-          padding: "8px 0",
-        },
-        ".cm-line": {
-          padding: "0 12px",
-        },
-        ".cm-scroller": {
-          overflow: "auto",
-        },
-        "&.cm-focused": {
-          outline: "none",
-        },
-        ".cm-placeholder": {
-          color: "#999",
-          fontStyle: "italic",
-        },
-        ".cm-readonly-region": {
-          backgroundColor: "rgba(0, 0, 0, 0.04)",
-          borderRadius: "2px",
-        },
-        ".cm-tooltip-autocomplete": {
-          border: "1px solid #e5e7eb",
-          borderRadius: "6px",
-          boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
-          backgroundColor: "#fff",
-        },
-        ".cm-tooltip-autocomplete ul li": {
-          padding: "4px 8px",
-        },
-        ".cm-tooltip-autocomplete ul li[aria-selected]": {
-          backgroundColor: "#f3f4f6",
-        },
-        ".cm-diagnostic-error": {
-          borderBottom: "2px wavy #ef4444",
-        },
-        ".cm-lintPoint-error:after": {
-          borderBottomColor: "#ef4444",
+          view.focus();
         },
       }),
-    [],
-  );
+      [readOnly],
+    );
 
-  return (
-    <CodeMirror
-      value={value}
-      onChange={onChange}
-      placeholder={placeholder}
-      readOnly={readOnly}
-      basicSetup={{
-        lineNumbers: false,
-        foldGutter: false,
-        highlightActiveLineGutter: false,
-        highlightActiveLine: false,
-      }}
-      extensions={[theme, ...extensions]}
-      height="100%"
-    />
-  );
-}
+    return (
+      <CodeMirror
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        onCreateEditor={(view) => {
+          viewRef.current = view;
+        }}
+        readOnly={readOnly}
+        basicSetup={{
+          lineNumbers: false,
+          foldGutter: false,
+          highlightActiveLineGutter: false,
+          highlightActiveLine: false,
+        }}
+        extensions={[theme, ...extensions]}
+        height="100%"
+      />
+    );
+  },
+);

--- a/apps/desktop/src/ai/prompts/index.tsx
+++ b/apps/desktop/src/ai/prompts/index.tsx
@@ -71,14 +71,14 @@ function PromptView({ tab }: { tab: Extract<Tab, { type: "prompts" }> }) {
 
   return (
     <ResizablePanelGroup direction="horizontal" className="h-full">
-      <ResizablePanel defaultSize={30} minSize={20} maxSize={40}>
+      <ResizablePanel defaultSize={24} minSize={18} maxSize={32}>
         <PromptsListColumn
           selectedTask={selectedTask as TaskType | null}
           setSelectedTask={setSelectedTask}
         />
       </ResizablePanel>
       <ResizableHandle />
-      <ResizablePanel defaultSize={70} minSize={50}>
+      <ResizablePanel defaultSize={76} minSize={48}>
         <PromptDetailsColumn selectedTask={selectedTask as TaskType | null} />
       </ResizablePanel>
     </ResizablePanelGroup>

--- a/apps/desktop/src/ai/prompts/preview.tsx
+++ b/apps/desktop/src/ai/prompts/preview.tsx
@@ -1,0 +1,194 @@
+import { GripVerticalIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@hypr/utils";
+
+type PromptTokenKind = "expression" | "statement" | "variable" | "filter";
+
+const INLINE_TOKEN_REGEX = /({{.*?}}|{#.*?#})/g;
+
+export function PromptTemplatePreview({
+  content,
+  onInsert,
+}: {
+  content: string;
+  onInsert: (snippet: string) => void;
+}) {
+  const lines = content.split("\n");
+
+  return (
+    <div className="rounded-xl border border-neutral-200 bg-stone-50 p-4">
+      <div className="flex flex-col gap-2">
+        {lines.map((line, index) => (
+          <PromptPreviewLine
+            key={`${index}-${line}`}
+            line={line}
+            onInsert={onInsert}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function PromptInsertChip({
+  label,
+  snippet,
+  kind,
+  onInsert,
+  className,
+}: {
+  label: string;
+  snippet: string;
+  kind: PromptTokenKind;
+  onInsert: (snippet: string) => void;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      draggable
+      onClick={() => onInsert(snippet)}
+      onDragStart={(event) => {
+        event.dataTransfer.setData("text/plain", snippet);
+        event.dataTransfer.effectAllowed = "copy";
+      }}
+      className={cn([
+        "group inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs font-medium transition-colors",
+        kind === "expression" && [
+          "border-sky-200 bg-sky-50 text-sky-900",
+          "hover:border-sky-300 hover:bg-sky-100",
+        ],
+        kind === "statement" && [
+          "border-amber-200 bg-amber-50 text-amber-900",
+          "hover:border-amber-300 hover:bg-amber-100",
+        ],
+        kind === "variable" && [
+          "border-neutral-200 bg-white text-neutral-700",
+          "hover:border-neutral-300 hover:bg-neutral-50",
+        ],
+        kind === "filter" && [
+          "border-emerald-200 bg-emerald-50 text-emerald-900",
+          "hover:border-emerald-300 hover:bg-emerald-100",
+        ],
+        className,
+      ])}
+      title="Click to insert or drag into the editor"
+    >
+      <GripVerticalIcon className="h-3 w-3 opacity-40 transition-opacity group-hover:opacity-70" />
+      <span className="truncate">{label}</span>
+    </button>
+  );
+}
+
+function PromptPreviewLine({
+  line,
+  onInsert,
+}: {
+  line: string;
+  onInsert: (snippet: string) => void;
+}) {
+  const trimmed = line.trim();
+
+  if (!trimmed) {
+    return <div className="h-2" />;
+  }
+
+  const statement = getStatementToken(trimmed);
+  if (statement) {
+    return (
+      <div className="flex">
+        <PromptInsertChip
+          label={statement.label}
+          snippet={statement.snippet}
+          kind="statement"
+          onInsert={onInsert}
+        />
+      </div>
+    );
+  }
+
+  const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
+  if (headingMatch) {
+    const level = headingMatch[1].length;
+    const headingClass =
+      level === 1
+        ? "text-base font-semibold text-neutral-900"
+        : level === 2
+          ? "text-sm font-semibold text-neutral-900"
+          : "text-sm font-medium text-neutral-800";
+
+    return (
+      <div className={cn(["whitespace-pre-wrap", headingClass])}>
+        {renderInlineTokens(headingMatch[2], onInsert)}
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-sm whitespace-pre-wrap text-neutral-700">
+      {renderInlineTokens(line, onInsert)}
+    </div>
+  );
+}
+
+function renderInlineTokens(
+  line: string,
+  onInsert: (snippet: string) => void,
+): ReactNode[] {
+  const tokens: ReactNode[] = [];
+  let lastIndex = 0;
+
+  for (const match of line.matchAll(INLINE_TOKEN_REGEX)) {
+    if (match.index === undefined) {
+      continue;
+    }
+
+    if (match.index > lastIndex) {
+      tokens.push(
+        <span key={`text-${match.index}`}>
+          {line.slice(lastIndex, match.index)}
+        </span>,
+      );
+    }
+
+    const snippet = match[0];
+    tokens.push(
+      <PromptInsertChip
+        key={`token-${match.index}`}
+        label={formatExpressionLabel(snippet)}
+        snippet={snippet}
+        kind="expression"
+        onInsert={onInsert}
+        className="mx-1 align-middle"
+      />,
+    );
+
+    lastIndex = match.index + snippet.length;
+  }
+
+  if (lastIndex < line.length) {
+    tokens.push(<span key={`tail-${lastIndex}`}>{line.slice(lastIndex)}</span>);
+  }
+
+  return tokens.length > 0 ? tokens : [<span key="line">{line}</span>];
+}
+
+function getStatementToken(line: string) {
+  if (!line.startsWith("{%") || !line.endsWith("%}")) {
+    return null;
+  }
+
+  return {
+    label: line.slice(2, -2).trim(),
+    snippet: line,
+  };
+}
+
+function formatExpressionLabel(snippet: string) {
+  if (snippet.startsWith("{{")) {
+    return snippet.slice(2, -2).trim();
+  }
+
+  return snippet.slice(2, -2).trim();
+}

--- a/apps/desktop/src/chat/components/message/tool/index.tsx
+++ b/apps/desktop/src/chat/components/message/tool/index.tsx
@@ -6,6 +6,7 @@ import { ToolGeneric } from "./generic";
 import { ToolListSubscriptions } from "./list-subscriptions";
 import { ToolSearchSessions } from "./search";
 import { ToolSearchIssues } from "./search-issues";
+import { ToolUpdatePromptTemplate } from "./update-prompt-template";
 
 import type { Part } from "~/chat/components/message/types";
 
@@ -19,6 +20,7 @@ const toolRegistry: Record<string, ToolComponent> = {
   "tool-list_subscriptions": ToolListSubscriptions as ToolComponent,
   "tool-create_billing_portal_session": ToolBillingPortal as ToolComponent,
   "tool-edit_summary": ToolEditSummary as ToolComponent,
+  "tool-update_prompt_template": ToolUpdatePromptTemplate as ToolComponent,
 };
 
 export function Tool({ part }: { part: Part }) {

--- a/apps/desktop/src/chat/components/message/tool/update-prompt-template.tsx
+++ b/apps/desktop/src/chat/components/message/tool/update-prompt-template.tsx
@@ -1,0 +1,49 @@
+import { WandSparklesIcon } from "lucide-react";
+
+import { defineTool } from "./define-tool";
+import { ToolCardBody, ToolCardFooterError, ToolCardFooters } from "./shared";
+
+type UpdatePromptTemplateOutput = {
+  status?: string;
+  message?: string;
+  lineCount?: number;
+};
+
+function parseUpdatePromptTemplateOutput(
+  output: unknown,
+): UpdatePromptTemplateOutput | null {
+  if (output && typeof output === "object") {
+    return output as UpdatePromptTemplateOutput;
+  }
+
+  return null;
+}
+
+export const ToolUpdatePromptTemplate = defineTool({
+  icon: <WandSparklesIcon />,
+  parseFn: parseUpdatePromptTemplateOutput,
+  isDone: (parsed) => parsed?.status === "applied",
+  label: ({ running, failed, parsed }) => {
+    if (running) return "Updating prompt draft";
+    if (failed) return "Prompt update failed";
+    if (parsed?.status === "applied") return "Prompt draft updated";
+    return "Update prompt draft";
+  },
+  renderBody: (input) =>
+    typeof input?.content === "string" ? (
+      <ToolCardBody>
+        <pre className="max-h-48 overflow-auto rounded-md border border-neutral-200 bg-neutral-50 p-3 font-mono text-[11px] whitespace-pre-wrap text-neutral-700">
+          {input.content}
+        </pre>
+      </ToolCardBody>
+    ) : null,
+  renderFooter: ({ failed, errorText, parsed }) => (
+    <ToolCardFooters failed={failed} errorText={errorText} rawText={null}>
+      {parsed?.status === "error" ? (
+        <ToolCardFooterError text={parsed.message ?? "Unknown error"} />
+      ) : parsed?.message ? (
+        <p className="text-xs text-neutral-600">{parsed.message}</p>
+      ) : null}
+    </ToolCardFooters>
+  ),
+});

--- a/apps/desktop/src/settings/personalization/index.tsx
+++ b/apps/desktop/src/settings/personalization/index.tsx
@@ -202,7 +202,7 @@ export function SettingsPersonalization() {
 
         <ActionSettingRow
           title="Advanced editor"
-          description="Fine-tune the templates used to generate meeting notes."
+          description="Fine-tune meeting-note templates in a split editor with a built-in prompt assistant."
           actionLabel="Open editor"
           onAction={openMeetingNotesEditor}
         />


### PR DESCRIPTION
Add a formatted Jinja draft view, draggable insert chips, and a scoped prompt assistant to the advanced meeting-note editor.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #4998 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #4995 
<!-- GitButler Footer Boundary Bottom -->

