### PR TITLE
fix: eliminate FOUC on cookie accept and custom font load

### DIFF
--- a/apps/web/src/hooks/use-posthog.ts
+++ b/apps/web/src/hooks/use-posthog.ts
@@ -1,45 +1,51 @@
 import { usePostHog } from "@posthog/react";
 import { useCallback } from "react";
 
+import { usePostHogReady } from "@/providers/posthog";
+
 export { usePostHog };
 
 /**
- * Hook for type-safe PostHog event tracking
+ * Hook for type-safe PostHog event tracking.
+ * All callbacks are stable references that update when PostHog initializes,
+ * so mount-time useEffects depending on them will re-run after init.
  */
 export function useAnalytics() {
   const posthog = usePostHog();
+  const analyticsReady = usePostHogReady();
 
   const track = useCallback(
     (eventName: string, properties?: Record<string, any>) => {
-      if (!posthog) {
+      if (!analyticsReady || !posthog) {
         return;
       }
       posthog.capture(eventName, properties);
     },
-    [posthog],
+    [posthog, analyticsReady],
   );
 
   const identify = useCallback(
     (userId: string, properties?: Record<string, any>) => {
-      if (!posthog) {
+      if (!analyticsReady || !posthog) {
         return;
       }
       posthog.identify(userId, properties);
     },
-    [posthog],
+    [posthog, analyticsReady],
   );
 
   const reset = useCallback(() => {
-    if (!posthog) {
+    if (!analyticsReady || !posthog) {
       return;
     }
     posthog.reset();
-  }, [posthog]);
+  }, [posthog, analyticsReady]);
 
   return {
     track,
     identify,
     reset,
     posthog,
+    analyticsReady,
   };
 }

--- a/apps/web/src/providers/posthog.tsx
+++ b/apps/web/src/providers/posthog.tsx
@@ -27,18 +27,21 @@ export function PostHogProvider({
       typeof window === "undefined" ||
       !enabled ||
       !env.VITE_POSTHOG_API_KEY ||
-      isDev ||
-      didInitRef.current
+      isDev
     ) {
+      setIsInitialized(false);
       return;
     }
 
-    posthog.init(env.VITE_POSTHOG_API_KEY, {
-      api_host: env.VITE_POSTHOG_HOST,
-      autocapture: true,
-      capture_pageview: true,
-    });
-    didInitRef.current = true;
+    if (!didInitRef.current) {
+      posthog.init(env.VITE_POSTHOG_API_KEY, {
+        api_host: env.VITE_POSTHOG_HOST,
+        autocapture: true,
+        capture_pageview: true,
+      });
+      didInitRef.current = true;
+    }
+
     setIsInitialized(true);
   }, [enabled]);
 

--- a/apps/web/src/providers/posthog.tsx
+++ b/apps/web/src/providers/posthog.tsx
@@ -1,6 +1,6 @@
 import { PostHogProvider as PostHogReactProvider } from "@posthog/react";
 import posthog from "posthog-js";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 
 import { env } from "../env";
 
@@ -14,32 +14,27 @@ export function PostHogProvider({
   enabled: boolean;
 }) {
   const didInitRef = useRef(false);
-  const [isInitialized, setIsInitialized] = useState(false);
 
   useEffect(() => {
     if (
       typeof window === "undefined" ||
       !enabled ||
       !env.VITE_POSTHOG_API_KEY ||
-      isDev
+      isDev ||
+      didInitRef.current
     ) {
-      setIsInitialized(false);
       return;
     }
 
-    if (!didInitRef.current) {
-      posthog.init(env.VITE_POSTHOG_API_KEY, {
-        api_host: env.VITE_POSTHOG_HOST,
-        autocapture: true,
-        capture_pageview: true,
-      });
-      didInitRef.current = true;
-    }
-
-    setIsInitialized(true);
+    posthog.init(env.VITE_POSTHOG_API_KEY, {
+      api_host: env.VITE_POSTHOG_HOST,
+      autocapture: true,
+      capture_pageview: true,
+    });
+    didInitRef.current = true;
   }, [enabled]);
 
-  if (!enabled || !env.VITE_POSTHOG_API_KEY || isDev || !isInitialized) {
+  if (!env.VITE_POSTHOG_API_KEY || isDev) {
     return <>{children}</>;
   }
 

--- a/apps/web/src/providers/posthog.tsx
+++ b/apps/web/src/providers/posthog.tsx
@@ -1,10 +1,16 @@
 import { PostHogProvider as PostHogReactProvider } from "@posthog/react";
 import posthog from "posthog-js";
-import { useEffect, useRef } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 
 import { env } from "../env";
 
 const isDev = import.meta.env.DEV;
+
+const PostHogReadyContext = createContext(false);
+
+export function usePostHogReady() {
+  return useContext(PostHogReadyContext);
+}
 
 export function PostHogProvider({
   children,
@@ -14,6 +20,7 @@ export function PostHogProvider({
   enabled: boolean;
 }) {
   const didInitRef = useRef(false);
+  const [isInitialized, setIsInitialized] = useState(false);
 
   useEffect(() => {
     if (
@@ -32,13 +39,20 @@ export function PostHogProvider({
       capture_pageview: true,
     });
     didInitRef.current = true;
+    setIsInitialized(true);
   }, [enabled]);
 
   if (!env.VITE_POSTHOG_API_KEY || isDev) {
-    return <>{children}</>;
+    return (
+      <PostHogReadyContext.Provider value={isInitialized}>
+        {children}
+      </PostHogReadyContext.Provider>
+    );
   }
 
   return (
-    <PostHogReactProvider client={posthog}>{children}</PostHogReactProvider>
+    <PostHogReadyContext.Provider value={isInitialized}>
+      <PostHogReactProvider client={posthog}>{children}</PostHogReactProvider>
+    </PostHogReadyContext.Provider>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3,6 +3,7 @@
   src: url("/fonts/Redaction-Regular.otf") format("opentype");
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -10,6 +11,7 @@
   src: url("/fonts/Redaction35-Regular.otf") format("opentype");
   font-weight: 350;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -17,6 +19,7 @@
   src: url("/fonts/Redaction70-Regular.otf") format("opentype");
   font-weight: 700;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -24,6 +27,7 @@
   src: url("/fonts/SF-Pro-Text-Regular.otf") format("opentype");
   font-weight: 400;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -31,6 +35,7 @@
   src: url("/fonts/SF-Pro-Text-Medium.otf") format("opentype");
   font-weight: 500;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -38,6 +43,7 @@
   src: url("/fonts/SF-Pro-Text-Semibold.otf") format("opentype");
   font-weight: 600;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -45,6 +51,7 @@
   src: url("/fonts/SF-Pro-Text-Bold.otf") format("opentype");
   font-weight: 700;
   font-style: normal;
+  font-display: swap;
 }
 
 @import "tailwindcss";


### PR DESCRIPTION
## Summary

- Remove `isInitialized` state from `PostHogProvider` so the React wrapper type stays stable (`PostHogReactProvider` in prod with an API key). Previously, accepting cookie consent triggered a `Fragment → PostHogReactProvider` wrapper swap that unmounted and remounted the entire page, causing a brief flash of unstyled content.
- Add `font-display: swap` to all `@font-face` rules (Redaction, SF Pro) so custom fonts swap in without blocking render.

## Root cause

`PostHogProvider` conditionally rendered `<>{children}</>` or `<PostHogReactProvider>` based on an `isInitialized` state that started as `false`. On consent accept, React saw a component type change and remounted all children — visible as FOUC.

## Safety verification

Verified against `posthog-js` v1.367.0 source: all `capture()` / `identify()` calls are silent no-ops before `init()` via the `!this.__loaded` guard. Rendering `PostHogReactProvider` with an uninitialized client sets no cookies, makes no network requests, and queues no events.

## Test plan

- [ ] Accept cookie consent on char.com — no FOUC flash
- [ ] Reject cookie consent — page reloads cleanly (existing behavior unchanged)
- [ ] PostHog events still fire after accepting consent
- [ ] Custom fonts (Redaction, SF Pro) render without layout shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the top-level `PostHogProvider` wrapper and analytics gating; a mistake could break event capture or consent-driven initialization across the app. Font CSS changes are low risk but can affect perceived rendering/layout timing.
> 
> **Overview**
> Prevents remount-driven flashes by keeping the `PostHogReactProvider` wrapper stable in production and moving PostHog initialization to an effect guarded by `enabled` and a `didInitRef`.
> 
> Adds a `PostHogReadyContext` (`usePostHogReady`) and updates `useAnalytics` to no-op until analytics is initialized, exposing `analyticsReady` to callers.
> 
> Improves font loading behavior by adding `font-display: swap` to all custom `@font-face` declarations to avoid render-blocking/FOUT/FOUC during font fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 879178f35ed8b4003e1aff58f35596a62ed9a428. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->