### PR TITLE
chore: add cloud VM environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,3 +59,22 @@ Naming rules:
 ## Misc
 
 - Do not create summary docs or example code files unless requested.
+
+## Cursor Cloud specific instructions
+
+### Services
+
+| Service | Start command | Notes |
+|---|---|---|
+| Web app | `SKIP_NETLIFY=1 pnpm -F @hypr/web dev` | Runs on port 3000. Use `SKIP_NETLIFY=1` in Cloud VMs to avoid the Netlify plugin. No `.env` file needed for basic dev — all `requiredInProd` vars are optional in dev mode. |
+| Desktop app | `pnpm -F @hypr/desktop tauri:dev` | Requires macOS or a full GUI + Tauri system deps. Not runnable in headless Cloud VMs. |
+| API server | `CXX=g++ CC=gcc cargo run -p api` | Needs `.env` with Supabase, Stripe, Nango keys. Use `CXX=g++ CC=gcc` on Linux to avoid clang/libc++ issues. |
+
+### Caveats
+
+- **Rust `cargo check` on full workspace fails on Linux x86_64** because `cactus-sys` contains ARM-specific SIMD instructions (Apple Silicon targets). Use `cargo check -p api` or `cargo check -p cli` to check individual crates instead.
+- **`CXX=g++ CC=gcc`** must be set for Rust builds involving `whisper-rs-sys` or `cactus-sys` on Linux, because the default clang compiler cannot find `<array>` and other C++ headers.
+- **dprint fmt** will emit errors for `.swift` files on Linux (Swift formatter not available). These are safe to ignore.
+- **`pnpm-workspace.yaml`** controls `onlyBuiltDependencies`. If builds fail due to missing native deps (esbuild, @swc/core, sharp, etc.), check that the package is listed there.
+- **Desktop tests** (`pnpm -F @hypr/desktop test`): All 650 unit tests pass; 2 test files report CSS plugin errors related to PostCSS config loading — these are pre-existing and do not affect test results.
+- **Lint** (`pnpm lint`): There are 8 pre-existing lint errors (mostly `@tanstack/query` rules). These are in the existing codebase.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,9 @@ packages:
 onlyBuiltDependencies:
   - supabase
   - "@infisical/cli"
+  - esbuild
+  - "@swc/core"
+  - "@parcel/watcher"
+  - sharp
+  - dprint
+  - protobufjs


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for Cursor Cloud agents.

### Changes

- **`pnpm-workspace.yaml`**: Added critical packages to `onlyBuiltDependencies` (esbuild, @swc/core, @parcel/watcher, sharp, dprint, protobufjs) so their postinstall scripts run and Vite/build tools work correctly.
- **`AGENTS.md`**: Added `## Cursor Cloud specific instructions` section with:
  - Service startup commands (web app, desktop app, API server)
  - Platform-specific caveats (cargo check ARM failures on x86_64, C++ compiler flags, dprint Swift errors)
  - Pre-existing lint/test status notes

### Verification

- Web app dev server runs on port 3000 with `SKIP_NETLIFY=1 pnpm -F @hypr/web dev`
- TypeScript typecheck passes (`pnpm -F @hypr/web typecheck`)
- Rust cargo check passes for `api` and `cli` crates
- Desktop unit tests: 650/650 pass
- Lint runs successfully (8 pre-existing errors in codebase)

[web_app_demo.mp4](https://cursor.com/agents/bc-f39ba243-c7fb-4074-8cfb-441f7ddef19d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_app_demo.mp4)

[Web app homepage](https://cursor.com/agents/bc-f39ba243-c7fb-4074-8cfb-441f7ddef19d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_app_homepage.webp)
[Web app templates page](https://cursor.com/agents/bc-f39ba243-c7fb-4074-8cfb-441f7ddef19d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_app_templates.webp)
[Web app download page](https://cursor.com/agents/bc-f39ba243-c7fb-4074-8cfb-441f7ddef19d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_app_download.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f39ba243-c7fb-4074-8cfb-441f7ddef19d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f39ba243-c7fb-4074-8cfb-441f7ddef19d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

