### PR TITLE
feat: restore announcement bar on homepage

### DIFF
--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -214,7 +214,7 @@ export function Sidebar() {
   return (
     <>
       {/* ===== MOBILE: top bar + dropdown menu (<md / <768px) ===== */}
-      <div className="fixed top-0 right-0 left-0 z-50 flex h-14 items-center justify-between border-b border-neutral-100 bg-white/80 px-4 backdrop-blur-xs md:hidden">
+      <div className="fixed right-0 left-0 top-[var(--announcement-bar-h,0px)] z-50 flex h-14 items-center justify-between border-b border-neutral-100 bg-white/80 px-4 backdrop-blur-xs md:hidden">
         <Link to="/">
           <CharLogo className="text-fg h-5 w-auto" />
         </Link>
@@ -241,7 +241,7 @@ export function Sidebar() {
             className="fixed inset-0 z-40 md:hidden"
             onClick={() => setIsMobileOpen(false)}
           />
-          <div className="animate-in slide-in-from-top fixed top-14 right-0 left-0 z-50 max-h-[calc(100vh-56px)] overflow-y-auto border-b border-neutral-100 bg-white/80 shadow-lg backdrop-blur-xs duration-300 md:hidden">
+          <div className="animate-in slide-in-from-top fixed right-0 left-0 top-[calc(theme(spacing.14)+var(--announcement-bar-h,0px))] z-50 max-h-[calc(100vh-56px-var(--announcement-bar-h,0px))] overflow-y-auto border-b border-neutral-100 bg-white/80 shadow-lg backdrop-blur-xs duration-300 md:hidden">
             <nav className="mx-auto max-w-6xl px-4 py-6">
               <div className="flex flex-col gap-6">
                 <MobileMenuLinks
@@ -262,7 +262,7 @@ export function Sidebar() {
       )}
 
       {/* ===== TABLET: horizontal header bar (md to xl / 768-1280px) ===== */}
-      <header className="fixed top-0 right-0 left-0 z-50 hidden border-b border-neutral-100 bg-white/80 backdrop-blur-xs md:block xl:hidden">
+      <header className="fixed right-0 left-0 top-[var(--announcement-bar-h,0px)] z-50 hidden border-b border-neutral-100 bg-white/80 backdrop-blur-xs md:block xl:hidden">
         <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
           <div className="flex items-center gap-6">
             <Link to="/" className="mr-2">

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -214,7 +214,7 @@ export function Sidebar() {
   return (
     <>
       {/* ===== MOBILE: top bar + dropdown menu (<md / <768px) ===== */}
-      <div className="fixed right-0 left-0 top-[var(--announcement-bar-h,0px)] z-50 flex h-14 items-center justify-between border-b border-neutral-100 bg-white/80 px-4 backdrop-blur-xs md:hidden">
+      <div className="fixed top-[var(--announcement-bar-h,0px)] right-0 left-0 z-50 flex h-14 items-center justify-between border-b border-neutral-100 bg-white/80 px-4 backdrop-blur-xs md:hidden">
         <Link to="/">
           <CharLogo className="text-fg h-5 w-auto" />
         </Link>
@@ -241,7 +241,7 @@ export function Sidebar() {
             className="fixed inset-0 z-40 md:hidden"
             onClick={() => setIsMobileOpen(false)}
           />
-          <div className="animate-in slide-in-from-top fixed right-0 left-0 top-[calc(theme(spacing.14)+var(--announcement-bar-h,0px))] z-50 max-h-[calc(100vh-56px-var(--announcement-bar-h,0px))] overflow-y-auto border-b border-neutral-100 bg-white/80 shadow-lg backdrop-blur-xs duration-300 md:hidden">
+          <div className="animate-in slide-in-from-top fixed top-[calc(theme(spacing.14)+var(--announcement-bar-h,0px))] right-0 left-0 z-50 max-h-[calc(100vh-56px-var(--announcement-bar-h,0px))] overflow-y-auto border-b border-neutral-100 bg-white/80 shadow-lg backdrop-blur-xs duration-300 md:hidden">
             <nav className="mx-auto max-w-6xl px-4 py-6">
               <div className="flex flex-col gap-6">
                 <MobileMenuLinks
@@ -262,7 +262,7 @@ export function Sidebar() {
       )}
 
       {/* ===== TABLET: horizontal header bar (md to xl / 768-1280px) ===== */}
-      <header className="fixed right-0 left-0 top-[var(--announcement-bar-h,0px)] z-50 hidden border-b border-neutral-100 bg-white/80 backdrop-blur-xs md:block xl:hidden">
+      <header className="fixed top-[var(--announcement-bar-h,0px)] right-0 left-0 z-50 hidden border-b border-neutral-100 bg-white/80 backdrop-blur-xs md:block xl:hidden">
         <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
           <div className="flex items-center gap-6">
             <Link to="/" className="mr-2">

--- a/apps/web/src/routes/_view/index.tsx
+++ b/apps/web/src/routes/_view/index.tsx
@@ -137,7 +137,6 @@ function Component() {
   return (
     <main className="min-h-screen flex-1 overflow-x-hidden px-2 md:px-8">
       <div className="">
-        {/* <AnnouncementBanner /> */}
         <HeroSection
           onVideoExpand={setExpandedVideo}
           heroInputRef={heroInputRef}

--- a/apps/web/src/routes/_view/route.tsx
+++ b/apps/web/src/routes/_view/route.tsx
@@ -1,11 +1,15 @@
 import {
   createFileRoute,
+  Link,
   Outlet,
   useMatchRoute,
   useRouterState,
 } from "@tanstack/react-router";
 import { allHandbooks } from "content-collections";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { XIcon } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { cn } from "@hypr/utils";
 
 import { Footer } from "@/components/footer";
 import { NotFoundContent } from "@/components/not-found";
@@ -91,6 +95,7 @@ function Component() {
               }}
             >
               <div className="relative flex min-h-screen flex-col">
+                {isHomePage && <AnnouncementBanner />}
                 {!isResourcePage && !isAppPage && (
                   <>
                     <div
@@ -117,7 +122,10 @@ function Component() {
                 )}
 
                 {/* Mobile top bar spacer */}
-                <div className="h-14 xl:hidden" />
+                <div
+                  className="xl:hidden"
+                  style={{ height: "calc(3.5rem + var(--announcement-bar-h, 0px))" }}
+                />
 
                 {/* Sidebar + content in a centered container */}
                 <div className="relative z-10 mx-auto flex w-full max-w-[1800px]">
@@ -285,6 +293,61 @@ function MobileHandbookDrawer({
           />
         </div>
       </div>
+    </>
+  );
+}
+
+const ANNOUNCEMENT_STORAGE_KEY = "char_announcement_dismissed";
+
+const ANNOUNCEMENT_BAR_HEIGHT = "36px";
+
+function AnnouncementBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const isDismissed =
+      window.localStorage.getItem(ANNOUNCEMENT_STORAGE_KEY) === "true";
+    if (!isDismissed) {
+      setVisible(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty(
+      "--announcement-bar-h",
+      visible ? ANNOUNCEMENT_BAR_HEIGHT : "0px",
+    );
+  }, [visible]);
+
+  if (!visible) return null;
+
+  return (
+    <>
+      <Link
+        to="/blog/$slug/"
+        params={{ slug: "hyprnote-is-now-char" }}
+        className={cn([
+          "fixed inset-x-0 top-0 z-[60] flex items-center justify-center",
+          "bg-stone-800 px-10 py-2",
+          "font-serif text-sm text-stone-200",
+          "transition-colors hover:bg-stone-700",
+        ])}
+      >
+        <span>Hyprnote is now <strong>Char</strong>.</span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            window.localStorage.setItem(ANNOUNCEMENT_STORAGE_KEY, "true");
+            setVisible(false);
+          }}
+          className="absolute right-4 cursor-pointer text-stone-400 transition-colors hover:text-white"
+        >
+          <XIcon size={14} />
+        </button>
+      </Link>
+      <div style={{ height: ANNOUNCEMENT_BAR_HEIGHT }} />
     </>
   );
 }

--- a/apps/web/src/routes/_view/route.tsx
+++ b/apps/web/src/routes/_view/route.tsx
@@ -124,7 +124,9 @@ function Component() {
                 {/* Mobile top bar spacer */}
                 <div
                   className="xl:hidden"
-                  style={{ height: "calc(3.5rem + var(--announcement-bar-h, 0px))" }}
+                  style={{
+                    height: "calc(3.5rem + var(--announcement-bar-h, 0px))",
+                  }}
                 />
 
                 {/* Sidebar + content in a centered container */}
@@ -333,7 +335,9 @@ function AnnouncementBanner() {
           "transition-colors hover:bg-stone-700",
         ])}
       >
-        <span>Hyprnote is now <strong>Char</strong>.</span>
+        <span>
+          Hyprnote is now <strong>Char</strong>.
+        </span>
         <button
           type="button"
           onClick={(e) => {


### PR DESCRIPTION
## Summary

- Restore the "Hyprnote is now **Char**." announcement bar at the top of the homepage, above the navigation
- Full strip is clickable and links to `/blog/hyprnote-is-now-char/`
- Dismissible via X button (persisted in localStorage)
- Fixed positioning (`z-[60]`) so bar + nav move together on mobile overscroll
- SSR-safe: renders only after client hydration — no flash for returning users who already dismissed

## Changes

- `apps/web/src/routes/_view/route.tsx` — Add `AnnouncementBanner` component with fixed bar + spacer div, CSS variable `--announcement-bar-h` for sidebar offset coordination
- `apps/web/src/components/sidebar.tsx` — Update mobile/tablet fixed headers to use `top-[var(--announcement-bar-h,0px)]` instead of `top-0`
- `apps/web/src/routes/_view/index.tsx` — Remove stale commented-out `<AnnouncementBanner />` reference

## Test plan

- [ ] Homepage shows announcement bar above nav on desktop, tablet, and mobile
- [ ] Clicking the bar navigates to `/blog/hyprnote-is-now-char/`
- [ ] X button dismisses the bar, persists across page reloads
- [ ] Dismissed users never see the bar flash on load
- [ ] Mobile: bar stays fixed on scroll, no gap with nav on overscroll
- [ ] Non-homepage routes do not show the bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)