### PR TITLE
fix: move stylesheets before HeadContent to prevent FOUC

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -20,15 +20,6 @@ interface RouterContext {
   queryClient: QueryClient;
 }
 
-const FONT_PRECONNECTS = [
-  { rel: "preconnect", href: "https://fonts.googleapis.com" },
-  {
-    rel: "preconnect",
-    href: "https://fonts.gstatic.com",
-    crossOrigin: "anonymous" as const,
-  },
-] as const;
-
 const FONT_STYLESHEETS = [
   "https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&family=Instrument+Serif:ital@1&family=Lora:wght@400;500;600;700&display=swap",
   "https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&display=swap",
@@ -68,15 +59,13 @@ export const Route = createRootRouteWithContext<RouterContext>()({
         content: DEFAULT_OG_IMAGE_URL,
       },
     ],
+    // Render-blocking stylesheets are placed directly in the shell JSX
+    // (RootDocument) before <HeadContent /> so the browser discovers them
+    // before TanStack Router's 70+ modulepreload links. Only non-blocking
+    // links belong here.
     links: [
-      ...FONT_PRECONNECTS,
-      ...FONT_STYLESHEETS.map((href) => ({
-        rel: "stylesheet" as const,
-        href,
-      })),
       { rel: "icon", href: "/favicon.svg", type: "image/svg+xml" },
       { rel: "icon", href: "/favicon.ico", sizes: "32x32" },
-      { rel: "stylesheet", href: appCss },
     ],
   }),
   shellComponent: RootDocument,
@@ -87,6 +76,16 @@ function RootDocument({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        {FONT_STYLESHEETS.map((href) => (
+          <link key={href} rel="stylesheet" href={href} />
+        ))}
+        <link rel="stylesheet" href={appCss} />
         <HeadContent />
       </head>
       <body>


### PR DESCRIPTION
## Summary

- Move preconnect, Google Fonts, and app CSS `<link>` tags from TanStack Router's `head()` config into the shell JSX, **before** `<HeadContent />`
- This ensures the browser discovers CSS at the top of `<head>`, before the 70+ `<link rel="modulepreload">` tags that `HeadContent` emits from the route manifest

## Root cause

TanStack Router's `HeadContent` component renders route manifest modulepreloads **before** user-defined links from `head()`. This meant CSS stylesheets appeared after 70+ modulepreload entries in the HTML, delaying stylesheet discovery and causing a flash of unstyled content on first paint and refresh.

**Before (HTML output order):**
```
image preloads → meta → modulepreload (70+) → preconnect → CSS ❌
```

**After:**
```
preconnect → CSS → meta → modulepreload (70+) ✅
```

## Test plan

- [ ] No FOUC on first load of char.com
- [ ] No FOUC on hard refresh (Ctrl+Shift+R)
- [ ] Fonts load correctly (Geist, Geist Mono, Instrument Serif, Lora, Fraunces)
- [ ] All pages render with correct styles (homepage, blog, docs, pricing)
- [ ] View source confirms CSS links appear before modulepreload links in `<head>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)