### PR TITLE
fix tab area

### DIFF
--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -18,9 +18,9 @@ export function ClassicMainBody() {
   }
 
   return (
-    <div className="relative flex h-full flex-1 flex-col gap-1">
+    <div className="relative flex h-full flex-1 flex-col">
       <ClassicMainTabChrome tabs={tabs} />
-      <div className="flex-1 overflow-auto">
+      <div className="min-h-0 flex-1 overflow-auto">
         <ClassicMainTabContent
           key={uniqueIdfromTab(currentTab)}
           tab={currentTab as Tab}

--- a/apps/desktop/src/main/tab-chrome.tsx
+++ b/apps/desktop/src/main/tab-chrome.tsx
@@ -123,7 +123,7 @@ export function ClassicMainTabChrome({ tabs }: { tabs: Tab[] }) {
     <div
       data-tauri-drag-region
       className={cn([
-        "flex h-8 w-full items-center",
+        "flex h-12 w-full items-center",
         isSidebarHidden && (isLinux ? "pl-3" : "pl-20"),
       ])}
       data-testid="main-tab-chrome"
@@ -205,7 +205,7 @@ export function ClassicMainTabChrome({ tabs }: { tabs: Tab[] }) {
             axis="x"
             values={regularTabs}
             onReorder={reorder}
-            className="flex h-full w-max gap-1"
+            className="flex h-full w-max items-center gap-1"
           >
             {regularTabs.map((tab, index) => {
               const isLastTab = index === regularTabs.length - 1;
@@ -228,7 +228,7 @@ export function ClassicMainTabChrome({ tabs }: { tabs: Tab[] }) {
                   as="div"
                   ref={(el) => setTabRef(tab, el)}
                   style={{ position: "relative" }}
-                  className="z-10 h-full"
+                  className="z-10 flex h-full items-center"
                   transition={{ layout: { duration: 0.15 } }}
                 >
                   <ClassicMainTabItem

--- a/apps/desktop/src/main/tab-chrome.tsx
+++ b/apps/desktop/src/main/tab-chrome.tsx
@@ -123,7 +123,7 @@ export function ClassicMainTabChrome({ tabs }: { tabs: Tab[] }) {
     <div
       data-tauri-drag-region
       className={cn([
-        "flex h-12 w-full items-center",
+        "flex h-10 w-full items-center",
         isSidebarHidden && (isLinux ? "pl-3" : "pl-20"),
       ])}
       data-testid="main-tab-chrome"

--- a/apps/desktop/src/main/tab-chrome.tsx
+++ b/apps/desktop/src/main/tab-chrome.tsx
@@ -123,7 +123,7 @@ export function ClassicMainTabChrome({ tabs }: { tabs: Tab[] }) {
     <div
       data-tauri-drag-region
       className={cn([
-        "flex h-9 w-full items-center",
+        "flex h-8 w-full items-center",
         isSidebarHidden && (isLinux ? "pl-3" : "pl-20"),
       ])}
       data-testid="main-tab-chrome"

--- a/apps/desktop/src/main2/profile-menu.tsx
+++ b/apps/desktop/src/main2/profile-menu.tsx
@@ -130,8 +130,7 @@ export function ProfileMenu() {
                 {menuItems.map((item, index) => (
                   <div key={item.label}>
                     <MenuItem {...item} />
-                    {(index === (isPro ? 2 : 1) ||
-                      index === (isPro ? 4 : 3)) && (
+                    {index === (isPro ? 2 : 1) && (
                       <div className="my-1 border-t border-neutral-100" />
                     )}
                   </div>

--- a/apps/desktop/src/main2/shell.tsx
+++ b/apps/desktop/src/main2/shell.tsx
@@ -180,7 +180,7 @@ export function Main2Shell() {
       <div className="flex h-full min-w-0 flex-1 flex-col">
         <div
           data-tauri-drag-region
-          className="flex h-12 w-full min-w-0 shrink-0 items-center gap-1 pr-1 pl-3"
+          className="flex h-10 w-full min-w-0 shrink-0 items-center gap-1 pr-1 pl-3"
         >
           <div
             className={cn([

--- a/apps/desktop/src/main2/shell.tsx
+++ b/apps/desktop/src/main2/shell.tsx
@@ -180,7 +180,7 @@ export function Main2Shell() {
       <div className="flex h-full min-w-0 flex-1 flex-col">
         <div
           data-tauri-drag-region
-          className="flex h-8 w-full min-w-0 shrink-0 items-center gap-1 pr-1 pl-3"
+          className="flex h-12 w-full min-w-0 shrink-0 items-center gap-1 pr-1 pl-3"
         >
           <div
             className={cn([
@@ -240,7 +240,7 @@ export function Main2Shell() {
                 axis="x"
                 values={tabs}
                 onReorder={reorder}
-                className="flex h-full w-max gap-1"
+                className="flex h-full w-max items-center gap-1"
               >
                 {tabs.map((tab) => (
                   <Reorder.Item
@@ -249,7 +249,7 @@ export function Main2Shell() {
                     as="div"
                     ref={(el) => setTabRef(tab, el)}
                     style={{ position: "relative" }}
-                    className="z-10 h-full"
+                    className="z-10 flex h-full items-center"
                     transition={{ layout: { duration: 0.15 } }}
                   >
                     <MainTabItem

--- a/apps/desktop/src/main2/shell.tsx
+++ b/apps/desktop/src/main2/shell.tsx
@@ -35,6 +35,7 @@ import {
   useCustomSidebarEffect,
 } from "~/sidebar/use-custom-sidebar";
 import { uniqueIdfromTab, useTabs } from "~/store/zustand/tabs";
+import { useListener } from "~/stt/contexts";
 
 export function Main2Shell() {
   const currentPlatform = platform();
@@ -93,6 +94,13 @@ export function Main2Shell() {
   const isHomeActive = currentTab === null;
   const isChatOpen =
     chat.mode === "FloatingOpen" || chat.mode === "RightPanelOpen";
+  const liveSessionId = useListener((state) => state.live.sessionId);
+  const liveStatus = useListener((state) => state.live.status);
+  const showAdHocButton = !(
+    currentTab?.type === "sessions" &&
+    currentTab.id === liveSessionId &&
+    liveStatus === "active"
+  );
 
   useMain2TabsShortcuts();
 
@@ -172,7 +180,7 @@ export function Main2Shell() {
       <div className="flex h-full min-w-0 flex-1 flex-col">
         <div
           data-tauri-drag-region
-          className="flex h-9 w-full min-w-0 shrink-0 items-center gap-1 px-3"
+          className="flex h-8 w-full min-w-0 shrink-0 items-center gap-1 pr-1 pl-3"
         >
           <div
             className={cn([
@@ -264,15 +272,22 @@ export function Main2Shell() {
             </div>
           </div>
 
-          <div className="ml-auto flex shrink-0 items-center gap-1">
-            <button
-              type="button"
-              onClick={handleAdHoc}
-              title="New ad-hoc session"
-              className="relative h-3.5 w-3.5 overflow-hidden rounded-full border border-red-500/60 bg-linear-to-b from-red-400 to-red-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.22),0_1px_2px_rgba(127,29,29,0.14)] hover:brightness-110"
-            >
-              <span className="pointer-events-none absolute top-[1px] left-1/2 h-[22%] w-[68%] -translate-x-1/2 rounded-full bg-white/18" />
-            </button>
+          <div className="ml-auto flex shrink-0 items-center gap-2">
+            {showAdHocButton && (
+              <Button
+                type="button"
+                onClick={handleAdHoc}
+                title="New ad-hoc session"
+                aria-label="New ad-hoc session"
+                variant="ghost"
+                size="icon"
+                className="group shrink-0"
+              >
+                <span className="relative h-3.5 w-3.5 overflow-hidden rounded-full border border-red-500/60 bg-linear-to-b from-red-400 to-red-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.22),0_1px_2px_rgba(127,29,29,0.14)] transition-[filter] group-hover:brightness-110">
+                  <span className="pointer-events-none absolute top-[1px] left-1/2 h-[22%] w-[68%] -translate-x-1/2 rounded-full bg-white/18" />
+                </span>
+              </Button>
+            )}
             <Button
               onClick={() => setOpenNoteDialogOpen(true)}
               variant="ghost"

--- a/apps/desktop/src/session/components/session-preview-card.tsx
+++ b/apps/desktop/src/session/components/session-preview-card.tsx
@@ -346,7 +346,7 @@ export function SessionPreviewCard({
           onMouseMove={handleMouseMove}
           onMouseLeave={handleMouseLeave}
           onMouseEnter={handleMouseEnter}
-          className={side === "bottom" ? "h-full" : ""}
+          className={side === "bottom" ? "flex h-full items-center" : ""}
         >
           {children}
         </div>

--- a/apps/desktop/src/shared/main/shell-scaffold.tsx
+++ b/apps/desktop/src/shared/main/shell-scaffold.tsx
@@ -11,7 +11,7 @@ export function MainShellScaffold({ children }: { children: React.ReactNode }) {
   return (
     <SyncWrapper>
       <div
-        className="flex h-full gap-1 overflow-hidden bg-stone-50 p-1"
+        className="flex h-full gap-1 overflow-hidden bg-stone-50 px-1 pb-1"
         data-testid="main-app-shell"
       >
         {children}

--- a/apps/desktop/src/shared/tabs.tsx
+++ b/apps/desktop/src/shared/tabs.tsx
@@ -275,7 +275,7 @@ export function TabItemBase({
     <div
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
-      className="relative h-full"
+      className="relative h-9"
     >
       <InteractiveButton
         asChild
@@ -284,7 +284,7 @@ export function TabItemBase({
         onMouseDown={handleMouseDown}
         className={cn([
           "relative flex items-center gap-1",
-          "h-full w-[160px] px-2",
+          "h-9 w-[160px] px-2",
           "rounded-xl border",
           "group cursor-pointer",
           "transition-colors duration-200",

--- a/apps/desktop/src/shared/tabs.tsx
+++ b/apps/desktop/src/shared/tabs.tsx
@@ -275,7 +275,7 @@ export function TabItemBase({
     <div
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
-      className="relative h-9"
+      className="relative h-8"
     >
       <InteractiveButton
         asChild
@@ -284,7 +284,7 @@ export function TabItemBase({
         onMouseDown={handleMouseDown}
         className={cn([
           "relative flex items-center gap-1",
-          "h-9 w-[160px] px-2",
+          "h-8 w-[160px] px-2",
           "rounded-xl border",
           "group cursor-pointer",
           "transition-colors duration-200",

--- a/apps/desktop/src/sidebar/index.tsx
+++ b/apps/desktop/src/sidebar/index.tsx
@@ -65,7 +65,7 @@ export function LeftSidebar() {
         data-tauri-drag-region
         className={cn([
           "flex flex-row items-center",
-          "h-9 w-full py-1",
+          "h-10 w-full",
           isLinux ? "justify-between pl-3" : "justify-end pl-20",
           "shrink-0",
         ])}


### PR DESCRIPTION
- Match ad-hoc button hitbox with toolbar controls by wrapping the session dot in a shared 28px icon button
- Tighten classic tab chrome height to align active tabs closer to content pane
- Establish 48px vertical rhythm for tab chrome with 36px tabs centered in the row
- Remove extra tab chrome spacing and align shell variants with new spacing
- Remove shell top padding and classic chrome/content gap for consistent titlebar alignment