### PR TITLE
polish transcript panel and chat

### DIFF
--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -10,8 +10,10 @@ import { useShell } from "~/contexts/shell";
 
 export function PersistentChatPanel({
   panelContainerRef,
+  floatingContainerRef,
 }: {
   panelContainerRef: React.RefObject<HTMLDivElement | null>;
+  floatingContainerRef: React.RefObject<HTMLDivElement | null>;
 }) {
   const { chat } = useShell();
   const mode = chat.mode;
@@ -20,8 +22,9 @@ export function PersistentChatPanel({
   const isVisible = isFloating || isPanel;
 
   const [hasBeenOpened, setHasBeenOpened] = useState(false);
-  const [panelRect, setPanelRect] = useState<DOMRect | null>(null);
+  const [containerRect, setContainerRect] = useState<DOMRect | null>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
+  const activeContainerRef = isPanel ? panelContainerRef : floatingContainerRef;
 
   useEffect(() => {
     if (isVisible && !hasBeenOpened) {
@@ -54,15 +57,19 @@ export function PersistentChatPanel({
   );
 
   useLayoutEffect(() => {
-    if (!isPanel || !panelContainerRef.current) {
-      setPanelRect(null);
+    const container = activeContainerRef.current;
+
+    if (!isVisible || !container) {
+      setContainerRect(null);
       return;
     }
-    setPanelRect(panelContainerRef.current.getBoundingClientRect());
-  }, [isPanel, panelContainerRef]);
+    setContainerRect(container.getBoundingClientRect());
+  }, [activeContainerRef, isVisible]);
 
   useEffect(() => {
-    if (!isPanel || !panelContainerRef.current) {
+    const container = activeContainerRef.current;
+
+    if (!isVisible || !container) {
       if (observerRef.current) {
         observerRef.current.disconnect();
         observerRef.current = null;
@@ -70,13 +77,12 @@ export function PersistentChatPanel({
       return;
     }
 
-    const el = panelContainerRef.current;
     const updateRect = () => {
-      setPanelRect(el.getBoundingClientRect());
+      setContainerRect(container.getBoundingClientRect());
     };
 
     observerRef.current = new ResizeObserver(updateRect);
-    observerRef.current.observe(el);
+    observerRef.current.observe(container);
     window.addEventListener("resize", updateRect);
 
     return () => {
@@ -84,7 +90,7 @@ export function PersistentChatPanel({
       observerRef.current = null;
       window.removeEventListener("resize", updateRect);
     };
-  }, [isPanel, panelContainerRef]);
+  }, [activeContainerRef, isVisible]);
 
   if (!hasBeenOpened) {
     return null;
@@ -95,12 +101,12 @@ export function PersistentChatPanel({
       <div
         className="pointer-events-none fixed z-100"
         style={
-          panelRect
+          containerRect
             ? {
-                top: panelRect.top,
-                left: panelRect.left,
-                width: panelRect.width,
-                height: panelRect.height,
+                top: containerRect.top,
+                left: containerRect.left,
+                width: containerRect.width,
+                height: containerRect.height,
               }
             : { display: "none" }
         }
@@ -116,31 +122,45 @@ export function PersistentChatPanel({
     <AnimatePresence>
       {isFloating && (
         <motion.div
-          className="fixed inset-0 z-100 flex items-end justify-center px-4 pb-4"
-          onClick={(event) => {
-            if (event.target === event.currentTarget) {
-              chat.sendEvent({ type: "CLOSE" });
-            }
-          }}
+          className="pointer-events-none fixed z-100"
+          style={
+            containerRect
+              ? {
+                  top: containerRect.top,
+                  left: containerRect.left,
+                  width: containerRect.width,
+                  height: containerRect.height,
+                }
+              : { display: "none" }
+          }
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.2 }}
         >
-          <motion.div
-            className={cn([
-              "relative flex flex-col overflow-hidden",
-              "max-h-[70vh] w-full max-w-[640px]",
-              "rounded-2xl bg-white shadow-2xl",
-              "border border-neutral-200",
-            ])}
-            initial={{ y: 40, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            exit={{ y: 40, opacity: 0 }}
-            transition={{ duration: 0.25, ease: [0.32, 0.72, 0, 1] }}
+          <div
+            className="pointer-events-auto flex h-full items-end justify-center px-4 pb-4"
+            onClick={(event) => {
+              if (event.target === event.currentTarget) {
+                chat.sendEvent({ type: "CLOSE" });
+              }
+            }}
           >
-            <ChatView />
-          </motion.div>
+            <motion.div
+              className={cn([
+                "relative flex flex-col overflow-hidden",
+                "max-h-[70vh] w-full max-w-[640px]",
+                "rounded-2xl bg-white shadow-2xl",
+                "border border-neutral-200",
+              ])}
+              initial={{ y: 40, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={{ y: 40, opacity: 0 }}
+              transition={{ duration: 0.25, ease: [0.32, 0.72, 0, 1] }}
+            >
+              <ChatView />
+            </motion.div>
+          </div>
         </motion.div>
       )}
     </AnimatePresence>

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -24,7 +24,18 @@ export function PersistentChatPanel({
   const [hasBeenOpened, setHasBeenOpened] = useState(false);
   const [containerRect, setContainerRect] = useState<DOMRect | null>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
-  const activeContainerRef = isPanel ? panelContainerRef : floatingContainerRef;
+
+  const getActiveContainer = () => {
+    if (isPanel) {
+      return panelContainerRef.current;
+    }
+
+    return (
+      floatingContainerRef.current?.querySelector<HTMLDivElement>(
+        "[data-chat-floating-anchor]",
+      ) ?? floatingContainerRef.current
+    );
+  };
 
   useEffect(() => {
     if (isVisible && !hasBeenOpened) {
@@ -57,17 +68,17 @@ export function PersistentChatPanel({
   );
 
   useLayoutEffect(() => {
-    const container = activeContainerRef.current;
+    const container = getActiveContainer();
 
     if (!isVisible || !container) {
       setContainerRect(null);
       return;
     }
     setContainerRect(container.getBoundingClientRect());
-  }, [activeContainerRef, isVisible]);
+  }, [isVisible, isPanel, panelContainerRef, floatingContainerRef]);
 
   useEffect(() => {
-    const container = activeContainerRef.current;
+    const container = getActiveContainer();
 
     if (!isVisible || !container) {
       if (observerRef.current) {
@@ -84,13 +95,15 @@ export function PersistentChatPanel({
     observerRef.current = new ResizeObserver(updateRect);
     observerRef.current.observe(container);
     window.addEventListener("resize", updateRect);
+    window.addEventListener("scroll", updateRect, true);
 
     return () => {
       observerRef.current?.disconnect();
       observerRef.current = null;
       window.removeEventListener("resize", updateRect);
+      window.removeEventListener("scroll", updateRect, true);
     };
-  }, [activeContainerRef, isVisible]);
+  }, [isVisible, isPanel, panelContainerRef, floatingContainerRef]);
 
   if (!hasBeenOpened) {
     return null;

--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -3,8 +3,6 @@ import { useMemo, useRef } from "react";
 
 import { cn } from "@hypr/utils";
 
-import { ExpandToggle } from "./expand-toggle";
-
 import { getSegmentColor } from "~/session/components/note-input/transcript/renderer/utils";
 import * as main from "~/store/tinybase/store/main";
 import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
@@ -23,12 +21,10 @@ export function DuringSessionAccessory({
   sessionId,
   isFinalizing = false,
   isExpanded = false,
-  onToggleExpand,
 }: {
   sessionId: string;
   isFinalizing?: boolean;
   isExpanded?: boolean;
-  onToggleExpand?: () => void;
 }) {
   if (isFinalizing) {
     return (
@@ -44,23 +40,15 @@ export function DuringSessionAccessory({
     );
   }
 
-  return (
-    <LiveTranscriptFooter
-      sessionId={sessionId}
-      isExpanded={isExpanded}
-      onToggleExpand={onToggleExpand}
-    />
-  );
+  return <LiveTranscriptFooter sessionId={sessionId} isExpanded={isExpanded} />;
 }
 
 function LiveTranscriptFooter({
   sessionId,
   isExpanded = false,
-  onToggleExpand,
 }: {
   sessionId: string;
   isExpanded?: boolean;
-  onToggleExpand?: () => void;
 }) {
   const store = main.UI.useStore(main.STORE_ID);
   const segments = useLiveTranscriptSegments(sessionId);
@@ -98,15 +86,7 @@ function LiveTranscriptFooter({
   const previewText = useMemo(() => getTranscriptPreview(segments), [segments]);
 
   return (
-    <div className="relative w-full pt-3 select-none">
-      {mode.kind === "live" && onToggleExpand && (
-        <ExpandToggle
-          isExpanded={isExpanded}
-          onToggle={onToggleExpand}
-          label="Live"
-        />
-      )}
-
+    <div className="w-full select-none">
       <div className="rounded-xl bg-neutral-50">
         {mode.kind === "record_only" ? (
           <RecordOnlyFooter isFallbackFromLive={mode.isFallbackFromLive} />

--- a/apps/desktop/src/session/components/bottom-accessory/expand-toggle.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/expand-toggle.tsx
@@ -7,11 +7,13 @@ export function ExpandToggle({
   onToggle,
   label,
   showExpandedCloseIcon = false,
+  collapsedClassName,
 }: {
   isExpanded: boolean;
   onToggle: () => void;
   label?: string;
   showExpandedCloseIcon?: boolean;
+  collapsedClassName?: string;
 }) {
   const hasLabel = Boolean(label);
 
@@ -24,7 +26,8 @@ export function ExpandToggle({
         "relative flex h-5 items-center justify-center gap-1",
         hasLabel ? "px-3" : "w-10",
         "rounded-t-[10px] rounded-b-none border-x border-t border-neutral-200",
-        "bg-neutral-50 text-neutral-400",
+        "text-neutral-400",
+        isExpanded ? "bg-white" : (collapsedClassName ?? "bg-white"),
         "transition-colors hover:bg-neutral-100 hover:text-neutral-600",
         "hover:cursor-pointer",
       ])}

--- a/apps/desktop/src/session/components/bottom-accessory/expand-toggle.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/expand-toggle.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { X } from "lucide-react";
 
 import { cn } from "@hypr/utils";
 
@@ -6,32 +6,36 @@ export function ExpandToggle({
   isExpanded,
   onToggle,
   label,
+  showExpandedCloseIcon = false,
 }: {
   isExpanded: boolean;
   onToggle: () => void;
   label?: string;
+  showExpandedCloseIcon?: boolean;
 }) {
+  const hasLabel = Boolean(label);
+
   return (
     <button
       type="button"
       onClick={onToggle}
       className={cn([
-        "absolute top-0 left-1/2 z-10 -translate-x-1/2 -translate-y-1/2",
-        "flex h-6 items-center justify-center gap-1 rounded-full",
-        label && !isExpanded ? "px-3" : "w-10",
-        "border border-neutral-200 bg-white text-neutral-400 shadow-xs",
-        "transition-colors hover:bg-neutral-50 hover:text-neutral-600",
+        "absolute left-3 z-10",
+        "relative flex h-5 items-center justify-center gap-1",
+        hasLabel ? "px-3" : "w-10",
+        "rounded-t-[10px] rounded-b-none border-x border-t border-neutral-200",
+        "bg-neutral-50 text-neutral-400",
+        "transition-colors hover:bg-neutral-100 hover:text-neutral-600",
+        "hover:cursor-pointer",
       ])}
-      aria-label={isExpanded ? "Collapse" : `Expand ${label ?? ""}`}
+      aria-label={
+        isExpanded ? `Collapse ${label ?? ""}`.trim() : `Expand ${label ?? ""}`
+      }
     >
-      {isExpanded ? (
-        <ChevronDown size={14} />
-      ) : (
-        <>
-          <ChevronUp size={14} />
-          {label && <span className="text-[10px] font-medium">{label}</span>}
-        </>
-      )}
+      {label ? <span className="text-[10px] font-medium">{label}</span> : null}
+      {isExpanded && showExpandedCloseIcon ? (
+        <X size={10} className="shrink-0" />
+      ) : null}
     </button>
   );
 }

--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -1,0 +1,149 @@
+import { act, renderHook } from "@testing-library/react";
+import { isValidElement } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  hotkeys: new Map<
+    string,
+    {
+      handler: () => void;
+      options?: {
+        enabled?: boolean;
+      };
+    }
+  >(),
+}));
+
+vi.mock("react-hotkeys-hook", () => ({
+  useHotkeys: (
+    keys: string,
+    handler: () => void,
+    options?: {
+      enabled?: boolean;
+    },
+  ) => {
+    hoisted.hotkeys.set(keys, { handler, options });
+  },
+}));
+
+vi.mock("./during-session", () => ({
+  DuringSessionAccessory: () => null,
+}));
+
+vi.mock("./post-session", () => ({
+  PostSessionAccessory: () => null,
+}));
+
+vi.mock("~/stt/contexts", () => ({
+  useListener: (
+    selector: (state: {
+      live: {
+        requestedLiveTranscription: boolean | null;
+        liveTranscriptionActive: boolean | null;
+      };
+    }) => unknown,
+  ) =>
+    selector({
+      live: {
+        requestedLiveTranscription: true,
+        liveTranscriptionActive: true,
+      },
+    }),
+}));
+
+const { useShellMock } = vi.hoisted(() => ({
+  useShellMock: vi.fn(),
+}));
+
+vi.mock("~/contexts/shell", () => ({
+  useShell: useShellMock,
+}));
+
+import { useSessionBottomAccessory } from "./index";
+
+describe("useSessionBottomAccessory", () => {
+  beforeEach(() => {
+    hoisted.hotkeys.clear();
+    useShellMock.mockReturnValue({
+      chat: {
+        mode: "Closed",
+      },
+    });
+  });
+
+  it("collapses the post-session transcript panel on escape", () => {
+    const { result } = renderHook(() =>
+      useSessionBottomAccessory({
+        sessionId: "session-1",
+        sessionMode: "inactive",
+        audioUrl: "file:///session.wav",
+        hasTranscript: true,
+      }),
+    );
+
+    expect(result.current.bottomAccessoryState).toEqual({
+      mode: "playback",
+      expanded: false,
+    });
+    expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(false);
+
+    const toggle = result.current.bottomBorderHandle;
+    expect(isValidElement<{ onToggle: () => void }>(toggle)).toBe(true);
+    if (!isValidElement<{ onToggle: () => void }>(toggle)) {
+      return;
+    }
+
+    act(() => {
+      toggle.props.onToggle();
+    });
+
+    expect(result.current.bottomAccessoryState).toEqual({
+      mode: "playback",
+      expanded: true,
+    });
+    expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(true);
+
+    act(() => {
+      hoisted.hotkeys.get("esc")?.handler();
+    });
+
+    expect(result.current.bottomAccessoryState).toEqual({
+      mode: "playback",
+      expanded: false,
+    });
+    expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(false);
+  });
+
+  it("defers transcript escape handling while chat is open", () => {
+    useShellMock.mockReturnValue({
+      chat: {
+        mode: "RightPanelOpen",
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useSessionBottomAccessory({
+        sessionId: "session-1",
+        sessionMode: "inactive",
+        audioUrl: "file:///session.wav",
+        hasTranscript: true,
+      }),
+    );
+
+    const toggle = result.current.bottomBorderHandle;
+    expect(isValidElement<{ onToggle: () => void }>(toggle)).toBe(true);
+    if (!isValidElement<{ onToggle: () => void }>(toggle)) {
+      return;
+    }
+
+    act(() => {
+      toggle.props.onToggle();
+    });
+
+    expect(result.current.bottomAccessoryState).toEqual({
+      mode: "playback",
+      expanded: true,
+    });
+    expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(false);
+  });
+});

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import { DuringSessionAccessory } from "./during-session";
+import { ExpandToggle } from "./expand-toggle";
 import { PostSessionAccessory } from "./post-session";
 
 import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
@@ -23,6 +24,7 @@ export function useSessionBottomAccessory({
   hasTranscript: boolean;
 }): {
   bottomAccessory: ReactNode;
+  bottomBorderHandle: ReactNode;
   bottomAccessoryState: BottomAccessoryState;
 } {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -75,11 +77,16 @@ export function useSessionBottomAccessory({
           sessionId={sessionId}
           isFinalizing={isFinalizing}
           isExpanded={effectiveExpanded}
-          onToggleExpand={
-            canExpandLiveTranscript ? () => setIsExpanded((v) => !v) : undefined
-          }
         />
       ),
+      bottomBorderHandle:
+        canExpandLiveTranscript && !isFinalizing ? (
+          <ExpandToggle
+            isExpanded={effectiveExpanded}
+            onToggle={() => setIsExpanded((v) => !v)}
+            label="Live"
+          />
+        ) : null,
       bottomAccessoryState,
     };
   }
@@ -92,7 +99,14 @@ export function useSessionBottomAccessory({
           hasAudio={hasAudio}
           hasTranscript={hasTranscript}
           isTranscriptExpanded={isExpanded}
-          onToggleTranscript={() => setIsExpanded((v) => !v)}
+        />
+      ),
+      bottomBorderHandle: (
+        <ExpandToggle
+          isExpanded={isExpanded}
+          onToggle={() => setIsExpanded((v) => !v)}
+          label="Transcript"
+          showExpandedCloseIcon
         />
       ),
       bottomAccessoryState,
@@ -101,6 +115,7 @@ export function useSessionBottomAccessory({
 
   return {
     bottomAccessory: null,
+    bottomBorderHandle: null,
     bottomAccessoryState,
   };
 }

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -127,6 +127,7 @@ export function useSessionBottomAccessory({
           onToggle={() => setIsExpanded((v) => !v)}
           label="Transcript"
           showExpandedCloseIcon
+          collapsedClassName="bg-neutral-50"
         />
       ),
       bottomAccessoryState,

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 
 import { DuringSessionAccessory } from "./during-session";
 import { ExpandToggle } from "./expand-toggle";
 import { PostSessionAccessory } from "./post-session";
 
+import { useShell } from "~/contexts/shell";
 import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
 import { useListener } from "~/stt/contexts";
 
@@ -34,10 +36,13 @@ export function useSessionBottomAccessory({
   const isInactive = sessionMode === "inactive" || isBatching;
   const hasAudio = Boolean(audioUrl) && isInactive;
   const live = useListener((state) => state.live);
+  const { chat } = useShell();
   const liveCaptureMode = getLiveCaptureUiMode(live);
   const canExpandLiveTranscript = isLive && liveCaptureMode === "live";
   const effectiveExpanded =
     isLive && !canExpandLiveTranscript ? false : isExpanded;
+  const isChatVisible =
+    chat.mode === "FloatingOpen" || chat.mode === "RightPanelOpen";
 
   const prevLive = useRef(isLive);
   useEffect(() => {
@@ -55,6 +60,21 @@ export function useSessionBottomAccessory({
 
   const showPostSession =
     isInactive && (isBatching || hasAudio || hasTranscript);
+
+  useHotkeys(
+    "esc",
+    () => {
+      setIsExpanded(false);
+    },
+    {
+      enabled: showPostSession && isExpanded && !isChatVisible,
+      preventDefault: true,
+      enableOnFormTags: true,
+      enableOnContentEditable: true,
+    },
+    [showPostSession, isExpanded, isChatVisible],
+  );
+
   const mode: NonNullable<BottomAccessoryState>["mode"] | null = isLive
     ? "live"
     : isFinalizing

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -56,6 +56,11 @@ vi.mock("~/audio-player", () => ({
   TimelineMeta: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   ),
+  useAudioPlayer: () => ({
+    audioExists: true,
+    deleteRecording: vi.fn(),
+    isDeletingRecording: false,
+  }),
 }));
 
 vi.mock("~/session/components/note-input/transcript", () => ({

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -48,16 +48,6 @@ vi.mock("@hypr/ui/components/ui/tooltip", () => ({
   ),
 }));
 
-vi.mock("./expand-toggle", () => ({
-  ExpandToggle: ({
-    label,
-  }: {
-    isExpanded: boolean;
-    onToggle: () => void;
-    label: string;
-  }) => <div>{label}</div>,
-}));
-
 vi.mock("~/audio-player", () => ({
   Timeline: () => <div data-testid="timeline" />,
   TimelineShell: ({ children }: { children?: React.ReactNode }) => (
@@ -132,7 +122,6 @@ describe("PostSessionAccessory", () => {
         hasAudio
         hasTranscript
         isTranscriptExpanded
-        onToggleTranscript={vi.fn()}
       />,
     );
 

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -1,5 +1,11 @@
-import { Pencil, RefreshCw, SquareIcon } from "lucide-react";
-import { useCallback, useRef } from "react";
+import {
+  Loader2Icon,
+  Pencil,
+  RefreshCw,
+  SquareIcon,
+  TrashIcon,
+} from "lucide-react";
+import { type ReactNode, useCallback, useRef } from "react";
 
 import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 import { Button } from "@hypr/ui/components/ui/button";
@@ -10,8 +16,6 @@ import {
   TooltipTrigger,
 } from "@hypr/ui/components/ui/tooltip";
 import { cn } from "@hypr/utils";
-
-import { ExpandToggle } from "./expand-toggle";
 
 import * as AudioPlayer from "~/audio-player";
 import { Transcript } from "~/session/components/note-input/transcript";
@@ -25,30 +29,51 @@ export function PostSessionAccessory({
   hasAudio,
   hasTranscript,
   isTranscriptExpanded,
-  onToggleTranscript,
 }: {
   sessionId: string;
   hasAudio: boolean;
   hasTranscript: boolean;
   isTranscriptExpanded: boolean;
-  onToggleTranscript: () => void;
 }) {
   const screen = useTranscriptScreen({ sessionId });
+  const hasTranscriptPanel = isTranscriptExpanded;
+  const timeline =
+    screen.kind === "running_batch" ? (
+      <BatchProgressTimeline sessionId={sessionId} screen={screen} />
+    ) : hasAudio ? (
+      <AudioPlayer.Timeline />
+    ) : null;
+
+  if (!hasTranscriptPanel && !timeline) {
+    return null;
+  }
+
+  const shouldBalanceCollapsedTimeline =
+    !hasTranscriptPanel && Boolean(timeline);
 
   return (
-    <div className="flex flex-col gap-1">
-      <TranscriptPanel
-        sessionId={sessionId}
-        screen={screen}
-        hasTranscript={hasTranscript}
-        isExpanded={isTranscriptExpanded}
-        onToggleExpand={onToggleTranscript}
-      />
-      {screen.kind === "running_batch" ? (
-        <BatchProgressTimeline sessionId={sessionId} screen={screen} />
-      ) : hasAudio ? (
-        <AudioPlayer.Timeline />
+    <div
+      className={cn([
+        "flex flex-col",
+        isTranscriptExpanded && "gap-1",
+        shouldBalanceCollapsedTimeline && "relative -mt-[6px] pb-1",
+      ])}
+    >
+      {shouldBalanceCollapsedTimeline ? (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute top-[-4px] right-0 left-0 h-px bg-neutral-50"
+        />
       ) : null}
+      {hasTranscriptPanel ? (
+        <TranscriptPanel
+          sessionId={sessionId}
+          screen={screen}
+          hasTranscript={hasTranscript}
+          isExpanded={isTranscriptExpanded}
+        />
+      ) : null}
+      {timeline}
     </div>
   );
 }
@@ -58,13 +83,11 @@ function TranscriptPanel({
   screen,
   hasTranscript,
   isExpanded,
-  onToggleExpand,
 }: {
   sessionId: string;
   screen: ReturnType<typeof useTranscriptScreen>;
   hasTranscript: boolean;
   isExpanded: boolean;
-  onToggleExpand: () => void;
 }) {
   if (screen.kind === "running_batch") {
     return (
@@ -73,28 +96,17 @@ function TranscriptPanel({
         screen={screen}
         hasTranscript={hasTranscript}
         isExpanded={isExpanded}
-        onToggleExpand={onToggleExpand}
       />
     );
   }
 
   if (hasTranscript) {
     return (
-      <TranscriptReadyPanel
-        sessionId={sessionId}
-        isExpanded={isExpanded}
-        onToggleExpand={onToggleExpand}
-      />
+      <TranscriptReadyPanel sessionId={sessionId} isExpanded={isExpanded} />
     );
   }
 
-  return (
-    <TranscriptEmptyPanel
-      sessionId={sessionId}
-      isExpanded={isExpanded}
-      onToggleExpand={onToggleExpand}
-    />
-  );
+  return <TranscriptEmptyPanel sessionId={sessionId} isExpanded={isExpanded} />;
 }
 
 function useRegenerateTranscript(sessionId: string) {
@@ -124,7 +136,6 @@ function BatchingTranscriptPanel({
   screen,
   hasTranscript,
   isExpanded,
-  onToggleExpand,
 }: {
   sessionId: string;
   screen: {
@@ -134,7 +145,6 @@ function BatchingTranscriptPanel({
   };
   hasTranscript: boolean;
   isExpanded: boolean;
-  onToggleExpand: () => void;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const stopTranscription = useListener((state) => state.stopTranscription);
@@ -145,54 +155,46 @@ function BatchingTranscriptPanel({
   const phaseLabel = phase === "importing" ? "Importing..." : "Transcribing...";
   const canStopTranscription = phase !== "importing";
 
+  if (!isExpanded) {
+    return null;
+  }
+
   return (
-    <div className="relative w-full pt-1 select-none">
-      <ExpandToggle
-        isExpanded={isExpanded}
-        onToggle={onToggleExpand}
-        label="Transcript"
-      />
-
-      {isExpanded && (
-        <div className="rounded-xl bg-neutral-50">
-          <div className="flex items-center justify-between rounded-t-xl border-b border-neutral-200 bg-neutral-100 px-3 py-1.5">
-            <span className="text-xs font-medium text-neutral-500">
-              Transcript
-            </span>
-            <div className="flex items-center gap-1 px-1 py-0.5">
-              <Spinner size={10} />
-              <span className="text-[11px] text-neutral-500">
-                {phaseLabel}
-                {typeof percentage === "number" && percentage > 0 && (
-                  <span className="ml-1 text-neutral-400 tabular-nums">
-                    {Math.round(percentage * 100)}%
-                  </span>
-                )}
+    <TranscriptCard>
+      <div className="flex items-center justify-between px-3 py-1.5">
+        <span className="text-xs font-medium text-neutral-500">Transcript</span>
+        <div className="flex items-center gap-1 px-1 py-0.5">
+          <Spinner size={10} />
+          <span className="text-[11px] text-neutral-500">
+            {phaseLabel}
+            {typeof percentage === "number" && percentage > 0 && (
+              <span className="ml-1 text-neutral-400 tabular-nums">
+                {Math.round(percentage * 100)}%
               </span>
-              {canStopTranscription ? (
-                <StopTranscriptionButton onClick={handleStop} compact />
-              ) : null}
-            </div>
-          </div>
+            )}
+          </span>
+          {canStopTranscription ? (
+            <StopTranscriptionButton onClick={handleStop} compact />
+          ) : null}
+        </div>
+      </div>
 
-          {hasTranscript ? (
-            <div className="h-[300px] overflow-y-auto px-3">
-              <Transcript sessionId={sessionId} scrollRef={scrollRef} />
-            </div>
-          ) : (
-            <div className="flex h-[120px] flex-col items-center justify-center gap-2">
-              <Spinner size={24} />
-              {typeof percentage === "number" && percentage > 0 && (
-                <p className="text-xl font-medium text-neutral-500 tabular-nums">
-                  {Math.round(percentage * 100)}%
-                </p>
-              )}
-              <p className="text-sm text-neutral-400">{phaseLabel}</p>
-            </div>
+      {hasTranscript ? (
+        <div className="h-[300px] overflow-y-auto px-3">
+          <Transcript sessionId={sessionId} scrollRef={scrollRef} />
+        </div>
+      ) : (
+        <div className="flex h-[120px] flex-col items-center justify-center gap-2">
+          <Spinner size={24} />
+          {typeof percentage === "number" && percentage > 0 && (
+            <p className="text-xl font-medium text-neutral-500 tabular-nums">
+              {Math.round(percentage * 100)}%
+            </p>
           )}
+          <p className="text-sm text-neutral-400">{phaseLabel}</p>
         </div>
       )}
-    </div>
+    </TranscriptCard>
   );
 }
 
@@ -293,81 +295,90 @@ function StopTranscriptionButton({
 function TranscriptReadyPanel({
   sessionId,
   isExpanded,
-  onToggleExpand,
 }: {
   sessionId: string;
   isExpanded: boolean;
-  onToggleExpand: () => void;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const regenerate = useRegenerateTranscript(sessionId);
+  const { audioExists, deleteRecording, isDeletingRecording } =
+    AudioPlayer.useAudioPlayer();
+
+  if (!isExpanded) {
+    return null;
+  }
 
   return (
-    <div className="relative w-full pt-1 select-none">
-      <ExpandToggle
-        isExpanded={isExpanded}
-        onToggle={onToggleExpand}
-        label="Transcript"
-      />
-
-      {isExpanded && (
-        <div className="rounded-xl bg-neutral-50">
-          <div className="flex items-center justify-between rounded-t-xl border-b border-neutral-200 bg-neutral-100 px-3 py-1.5">
-            <span className="text-xs font-medium text-neutral-500">
-              Transcript
-            </span>
-            <div className="flex items-center gap-1">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    disabled
-                    className={cn([
-                      "flex items-center gap-1 rounded px-1.5 py-0.5",
-                      "text-[11px] font-medium text-neutral-300",
-                      "cursor-not-allowed",
-                    ])}
-                  >
-                    <Pencil size={10} />
-                    Edit
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  <p>Coming soon</p>
-                </TooltipContent>
-              </Tooltip>
+    <TranscriptCard>
+      <div className="flex items-center justify-between px-3 py-1.5">
+        <div className="flex items-center gap-1">
+          <Tooltip>
+            <TooltipTrigger asChild>
               <button
                 type="button"
-                onClick={regenerate}
+                disabled
                 className={cn([
                   "flex items-center gap-1 rounded px-1.5 py-0.5",
-                  "text-[11px] font-medium text-neutral-500",
-                  "transition-colors hover:bg-neutral-200/60 hover:text-neutral-700",
+                  "text-[11px] font-medium text-neutral-300",
+                  "cursor-not-allowed",
                 ])}
               >
-                <RefreshCw size={10} />
-                Regenerate
+                <Pencil size={10} />
+                Edit
               </button>
-            </div>
-          </div>
-
-          <div className="h-[300px] overflow-y-auto px-3">
-            <Transcript sessionId={sessionId} scrollRef={scrollRef} />
-          </div>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p>Coming soon</p>
+            </TooltipContent>
+          </Tooltip>
+          <button
+            type="button"
+            onClick={regenerate}
+            className={cn([
+              "flex items-center gap-1 rounded px-1.5 py-0.5",
+              "text-[11px] font-medium text-neutral-500",
+              "transition-colors hover:bg-neutral-200/60 hover:text-neutral-700",
+            ])}
+          >
+            <RefreshCw size={10} />
+            Regenerate
+          </button>
         </div>
-      )}
-    </div>
+        {audioExists ? (
+          <button
+            type="button"
+            onClick={() => void deleteRecording()}
+            disabled={isDeletingRecording}
+            className={cn([
+              "flex items-center gap-1 rounded px-1.5 py-0.5",
+              "text-[11px] font-medium text-red-600",
+              "transition-colors hover:bg-red-50 hover:text-red-700",
+              "disabled:cursor-not-allowed disabled:text-red-300",
+            ])}
+          >
+            {isDeletingRecording ? (
+              <Loader2Icon size={10} className="animate-spin" />
+            ) : (
+              <TrashIcon size={10} />
+            )}
+            {isDeletingRecording ? "Deleting..." : "Delete recording"}
+          </button>
+        ) : null}
+      </div>
+
+      <div className="h-[300px] overflow-y-auto px-3">
+        <Transcript sessionId={sessionId} scrollRef={scrollRef} />
+      </div>
+    </TranscriptCard>
   );
 }
 
 function TranscriptEmptyPanel({
   sessionId,
   isExpanded,
-  onToggleExpand,
 }: {
   sessionId: string;
   isExpanded: boolean;
-  onToggleExpand: () => void;
 }) {
   const screen = useTranscriptScreen({ sessionId });
   const { uploadAudio } = useUploadFile(sessionId);
@@ -376,49 +387,49 @@ function TranscriptEmptyPanel({
   const error = screen.kind === "empty" ? screen.error : null;
   const hasAudio = screen.kind === "empty" ? screen.hasAudio : false;
 
+  if (!isExpanded) {
+    return null;
+  }
+
   return (
-    <div className="relative w-full pt-1 select-none">
-      <ExpandToggle
-        isExpanded={isExpanded}
-        onToggle={onToggleExpand}
-        label="Transcript"
-      />
+    <TranscriptCard>
+      <div className="flex items-center justify-between px-4 py-3">
+        {error ? (
+          <span className="text-xs text-red-500">{error}</span>
+        ) : (
+          <span className="text-xs text-neutral-400">No transcript yet</span>
+        )}
 
-      {isExpanded && (
-        <div className="rounded-xl bg-neutral-50">
-          <div className="flex items-center justify-between px-4 py-3">
-            {error ? (
-              <span className="text-xs text-red-500">{error}</span>
-            ) : (
-              <span className="text-xs text-neutral-400">
-                No transcript yet
-              </span>
-            )}
-
-            <div className="flex items-center gap-1.5">
-              {hasAudio && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 gap-1.5 text-xs text-neutral-500"
-                  onClick={regenerate}
-                >
-                  <RefreshCw size={12} />
-                  Generate
-                </Button>
-              )}
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-7 text-xs text-neutral-500"
-                onClick={uploadAudio}
-              >
-                Upload audio
-              </Button>
-            </div>
-          </div>
+        <div className="flex items-center gap-1.5">
+          {hasAudio && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1.5 text-xs text-neutral-500"
+              onClick={regenerate}
+            >
+              <RefreshCw size={12} />
+              Generate
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs text-neutral-500"
+            onClick={uploadAudio}
+          >
+            Upload audio
+          </Button>
         </div>
-      )}
+      </div>
+    </TranscriptCard>
+  );
+}
+
+function TranscriptCard({ children }: { children: ReactNode }) {
+  return (
+    <div className="overflow-hidden rounded-b-xl border-x border-b border-neutral-200 bg-white">
+      {children}
     </div>
   );
 }

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -10,8 +10,10 @@ import { useListener } from "~/stt/contexts";
 
 export function FloatingActionButton({
   tab,
+  chatOpenMode = "floating",
 }: {
   tab: Extract<Tab, { type: "sessions" }>;
+  chatOpenMode?: "floating" | "right-panel";
 }) {
   const shouldShowListen = useShouldShowListeningFab(tab);
   const shouldShowChat = useShouldShowChatFab(tab);
@@ -22,7 +24,11 @@ export function FloatingActionButton({
 
   return (
     <div className="absolute bottom-4 left-1/2 z-20 -translate-x-1/2">
-      {shouldShowListen ? <ListenButton tab={tab} /> : <ChatCTA />}
+      {shouldShowListen ? (
+        <ListenButton tab={tab} />
+      ) : (
+        <ChatCTA openMode={chatOpenMode} />
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
@@ -23,9 +23,8 @@ export function SegmentHeader({
   const label = useSpeakerLabel(segment.key, speakerLabelManager);
   const timestamp = getTimestampRange(segment);
   const headerClassName = cn([
-    "bg-background sticky top-0 z-20",
+    "sticky top-0 z-20 bg-neutral-50",
     "-mx-3 px-3 py-1",
-    "border-b border-neutral-200",
     "text-xs font-light",
     "flex items-center justify-between",
   ]);

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
@@ -125,7 +125,7 @@ const SegmentsList = memo(
         {segments.map((segment, index) => (
           <div
             key={createSegmentKey(segment, transcriptId, index)}
-            className={cn([index > 0 && "pt-8"])}
+            className={cn([index > 0 && "pt-4"])}
           >
             <SegmentRenderer
               segment={segment}

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
@@ -46,6 +46,7 @@ export function useScrollDetection(
     };
 
     element.addEventListener("scroll", handleScroll);
+    handleScroll();
     return () => element.removeEventListener("scroll", handleScroll);
   }, [containerRef]);
 

--- a/apps/desktop/src/session/components/session-surface.tsx
+++ b/apps/desktop/src/session/components/session-surface.tsx
@@ -5,18 +5,24 @@ export function SessionSurface({
   title,
   children,
   afterBorder,
+  bottomBorderHandle,
   floatingButton,
+  mergeAfterBorder,
 }: {
   header?: React.ReactNode;
   title?: React.ReactNode;
   children: React.ReactNode;
   afterBorder?: React.ReactNode;
+  bottomBorderHandle?: React.ReactNode;
   floatingButton?: React.ReactNode;
+  mergeAfterBorder?: boolean;
 }) {
   return (
     <StandardTabWrapper
       afterBorder={afterBorder}
+      bottomBorderHandle={bottomBorderHandle}
       floatingButton={floatingButton}
+      mergeAfterBorder={mergeAfterBorder}
     >
       <div className="flex h-full flex-col">
         {header ? <div className="pr-1 pl-2">{header}</div> : null}

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -191,12 +191,13 @@ function TabContentNoteInner({
   useAutoFocusTitle({ sessionId, titleInputRef });
   usePendingUpload(sessionId);
 
-  const { bottomAccessory, bottomAccessoryState } = useSessionBottomAccessory({
-    sessionId,
-    sessionMode,
-    audioUrl,
-    hasTranscript,
-  });
+  const { bottomAccessory, bottomBorderHandle, bottomAccessoryState } =
+    useSessionBottomAccessory({
+      sessionId,
+      sessionMode,
+      audioUrl,
+      hasTranscript,
+    });
 
   const handleNavigateToTitle = React.useCallback((pixelWidth?: number) => {
     if (pixelWidth !== undefined) {
@@ -240,6 +241,7 @@ function TabContentNoteInner({
         />
       }
       afterBorder={bottomAccessory}
+      bottomBorderHandle={bottomBorderHandle}
       floatingButton={<FloatingActionButton tab={tab} />}
     >
       <NoteInput

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -231,6 +231,10 @@ function TabContentNoteInner({
 
   const chatOpenMode =
     bottomAccessoryState?.expanded === true ? "right-panel" : "floating";
+  const mergeTranscriptSurface =
+    bottomAccessoryState?.expanded === true &&
+    (bottomAccessoryState.mode === "playback" ||
+      bottomAccessoryState.mode === "transcript_only");
 
   useEffect(() => {
     if (bottomAccessoryState?.expanded !== true) {
@@ -259,6 +263,7 @@ function TabContentNoteInner({
       }
       afterBorder={bottomAccessory}
       bottomBorderHandle={bottomBorderHandle}
+      mergeAfterBorder={mergeTranscriptSurface}
       floatingButton={
         <FloatingActionButton tab={tab} chatOpenMode={chatOpenMode} />
       }

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -21,6 +21,7 @@ import { getSessionTabStatus } from "./tab-visual-state";
 
 import { useTitleGeneration } from "~/ai/hooks";
 import * as AudioPlayer from "~/audio-player";
+import { useShell } from "~/contexts/shell";
 import { useSessionStatusBanner } from "~/shared/main";
 import { type TabItem, TabItemBase } from "~/shared/tabs";
 import * as main from "~/store/tinybase/store/main";
@@ -179,6 +180,7 @@ function TabContentNoteInner({
 }) {
   const titleInputRef = React.useRef<TitleInputHandle>(null);
   const noteInputRef = React.useRef<NoteInputHandle>(null);
+  const { chat } = useShell();
 
   const currentView = useCurrentNoteTab(tab);
   const { generateTitle } = useTitleGeneration(tab);
@@ -227,6 +229,21 @@ function TabContentNoteInner({
     bottomAccessoryState,
   });
 
+  const chatOpenMode =
+    bottomAccessoryState?.expanded === true ? "right-panel" : "floating";
+
+  useEffect(() => {
+    if (bottomAccessoryState?.expanded !== true) {
+      return;
+    }
+
+    if (chat.mode !== "FloatingOpen") {
+      return;
+    }
+
+    chat.sendEvent({ type: "OPEN_RIGHT_PANEL" });
+  }, [bottomAccessoryState?.expanded, chat]);
+
   return (
     <SessionSurface
       header={<OuterHeader sessionId={tab.id} currentView={currentView} />}
@@ -242,7 +259,9 @@ function TabContentNoteInner({
       }
       afterBorder={bottomAccessory}
       bottomBorderHandle={bottomBorderHandle}
-      floatingButton={<FloatingActionButton tab={tab} />}
+      floatingButton={
+        <FloatingActionButton tab={tab} chatOpenMode={chatOpenMode} />
+      }
     >
       <NoteInput
         ref={noteInputRef}

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -4,16 +4,33 @@ import { useShell } from "~/contexts/shell";
 
 export function ChatCTA({
   label = "Ask about this session",
+  openMode = "remember",
 }: {
   label?: string;
+  openMode?: "remember" | "floating" | "right-panel";
 }) {
   const { chat } = useShell();
+  const isChatOpen =
+    chat.mode === "FloatingOpen" || chat.mode === "RightPanelOpen";
 
   const handleClick = useCallback(() => {
-    const isChatOpen =
-      chat.mode === "FloatingOpen" || chat.mode === "RightPanelOpen";
-    chat.sendEvent(isChatOpen ? { type: "TOGGLE" } : { type: "OPEN" });
-  }, [chat]);
+    if (isChatOpen) {
+      chat.sendEvent({ type: "TOGGLE" });
+      return;
+    }
+
+    chat.sendEvent(
+      openMode === "floating"
+        ? { type: "OPEN_FLOATING" }
+        : openMode === "right-panel"
+          ? { type: "OPEN_RIGHT_PANEL" }
+          : { type: "OPEN" },
+    );
+  }, [chat, isChatOpen, openMode]);
+
+  if (isChatOpen) {
+    return null;
+  }
 
   return (
     <button

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -26,6 +26,7 @@ export function MainChatPanels({
   const previousModeRef = useRef(rightPanelMode);
   const bodyPanelRef = useRef<ImperativePanelHandle>(null);
   const chatPanelContainerRef = useRef<HTMLDivElement>(null);
+  const bodyPanelContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const isOpeningRightPanel =
@@ -61,7 +62,9 @@ export function MainChatPanels({
           ref={bodyPanelRef}
           className="min-h-0 flex-1 overflow-hidden"
         >
-          {children}
+          <div ref={bodyPanelContainerRef} className="h-full min-h-0">
+            {children}
+          </div>
         </ResizablePanel>
         {isRightPanelOpen && (
           <>
@@ -82,7 +85,10 @@ export function MainChatPanels({
         )}
       </ResizablePanelGroup>
 
-      <PersistentChatPanel panelContainerRef={chatPanelContainerRef} />
+      <PersistentChatPanel
+        panelContainerRef={chatPanelContainerRef}
+        floatingContainerRef={bodyPanelContainerRef}
+      />
     </>
   );
 }

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -32,6 +32,7 @@ export function StandardTabWrapper({
     <div className="flex h-full flex-col">
       <div className="relative flex min-h-0 flex-1 flex-col">
         <div
+          data-chat-floating-anchor
           className={cn([
             "relative flex min-h-0 flex-1 flex-col overflow-hidden bg-white",
             mergeAfterBorder && afterBorder

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -16,26 +16,41 @@ export { useScrollActiveTabIntoView } from "./tab-scroll";
 export function StandardTabWrapper({
   children,
   afterBorder,
+  bottomBorderHandle,
   floatingButton,
   noBorder = false,
 }: {
   children: React.ReactNode;
   afterBorder?: React.ReactNode;
+  bottomBorderHandle?: React.ReactNode;
   floatingButton?: React.ReactNode;
   noBorder?: boolean;
 }) {
   return (
     <div className="flex h-full flex-col">
-      <div
-        className={cn([
-          "relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl bg-white",
-          !noBorder && "border border-neutral-200",
-        ])}
-      >
-        {children}
-        {floatingButton}
+      <div className="relative flex min-h-0 flex-1 flex-col">
+        <div
+          className={cn([
+            "relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl bg-white",
+            !noBorder && "border border-neutral-200",
+          ])}
+        >
+          {children}
+          {floatingButton}
+        </div>
+        {bottomBorderHandle ? (
+          <div className="pointer-events-none absolute right-0 bottom-0 left-0 z-20">
+            <div className="pointer-events-auto relative">
+              {bottomBorderHandle}
+            </div>
+          </div>
+        ) : null}
       </div>
-      {afterBorder && <div className="mt-1">{afterBorder}</div>}
+      {afterBorder ? (
+        <div className={cn([bottomBorderHandle ? "pt-[10px]" : "mt-1"])}>
+          {afterBorder}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -18,12 +18,14 @@ export function StandardTabWrapper({
   afterBorder,
   bottomBorderHandle,
   floatingButton,
+  mergeAfterBorder = false,
   noBorder = false,
 }: {
   children: React.ReactNode;
   afterBorder?: React.ReactNode;
   bottomBorderHandle?: React.ReactNode;
   floatingButton?: React.ReactNode;
+  mergeAfterBorder?: boolean;
   noBorder?: boolean;
 }) {
   return (
@@ -31,8 +33,14 @@ export function StandardTabWrapper({
       <div className="relative flex min-h-0 flex-1 flex-col">
         <div
           className={cn([
-            "relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl bg-white",
-            !noBorder && "border border-neutral-200",
+            "relative flex min-h-0 flex-1 flex-col overflow-hidden bg-white",
+            mergeAfterBorder && afterBorder
+              ? "rounded-t-xl rounded-b-none"
+              : "rounded-xl",
+            !noBorder &&
+              (mergeAfterBorder && afterBorder
+                ? "border border-b-0 border-neutral-200"
+                : "border border-neutral-200"),
           ])}
         >
           {children}
@@ -47,7 +55,11 @@ export function StandardTabWrapper({
         ) : null}
       </div>
       {afterBorder ? (
-        <div className={cn([bottomBorderHandle ? "pt-[10px]" : "mt-1"])}>
+        <div
+          className={cn([
+            !mergeAfterBorder && (bottomBorderHandle ? "pt-[10px]" : "mt-1"),
+          ])}
+        >
           {afterBorder}
         </div>
       ) : null}

--- a/apps/desktop/src/store/zustand/tabs/chat-mode.test.ts
+++ b/apps/desktop/src/store/zustand/tabs/chat-mode.test.ts
@@ -33,6 +33,16 @@ describe("Chat Mode", () => {
     expect(useTabs.getState().chatMode).toBe("RightPanelOpen");
   });
 
+  test("OPEN_FLOATING from FloatingClosed → FloatingOpen", () => {
+    useTabs.getState().transitionChatMode({ type: "OPEN_FLOATING" });
+    expect(useTabs.getState().chatMode).toBe("FloatingOpen");
+  });
+
+  test("OPEN_RIGHT_PANEL from FloatingClosed → RightPanelOpen", () => {
+    useTabs.getState().transitionChatMode({ type: "OPEN_RIGHT_PANEL" });
+    expect(useTabs.getState().chatMode).toBe("RightPanelOpen");
+  });
+
   test("OPEN_TAB transitions to FullTab", () => {
     useTabs.getState().transitionChatMode({ type: "OPEN_TAB" });
     expect(useTabs.getState().chatMode).toBe("FullTab");

--- a/apps/desktop/src/store/zustand/tabs/chat-mode.ts
+++ b/apps/desktop/src/store/zustand/tabs/chat-mode.ts
@@ -10,6 +10,8 @@ export type ChatMode =
 
 export type ChatEvent =
   | { type: "OPEN" }
+  | { type: "OPEN_FLOATING" }
+  | { type: "OPEN_RIGHT_PANEL" }
   | { type: "CLOSE" }
   | { type: "SHIFT" }
   | { type: "TOGGLE" }
@@ -31,6 +33,9 @@ const computeNextChatMode = (
 ): ChatMode => {
   switch (state) {
     case "RightPanelOpen":
+      if (event.type === "OPEN_FLOATING") {
+        return "FloatingOpen";
+      }
       if (event.type === "CLOSE" || event.type === "TOGGLE") {
         return "FloatingClosed";
       }
@@ -45,11 +50,20 @@ const computeNextChatMode = (
       if (event.type === "OPEN" || event.type === "TOGGLE") {
         return lastOpenMode;
       }
+      if (event.type === "OPEN_FLOATING") {
+        return "FloatingOpen";
+      }
+      if (event.type === "OPEN_RIGHT_PANEL") {
+        return "RightPanelOpen";
+      }
       if (event.type === "OPEN_TAB") {
         return "FullTab";
       }
       return state;
     case "FloatingOpen":
+      if (event.type === "OPEN_RIGHT_PANEL") {
+        return "RightPanelOpen";
+      }
       if (event.type === "CLOSE" || event.type === "TOGGLE") {
         return "FloatingClosed";
       }
@@ -61,6 +75,12 @@ const computeNextChatMode = (
       }
       return state;
     case "FullTab":
+      if (event.type === "OPEN_FLOATING") {
+        return "FloatingOpen";
+      }
+      if (event.type === "OPEN_RIGHT_PANEL") {
+        return "RightPanelOpen";
+      }
       if (event.type === "CLOSE" || event.type === "TOGGLE") {
         return "FloatingClosed";
       }


### PR DESCRIPTION
- Polish transcript panel chrome with borders instead of fills and refine handle borders for unified appearance
- Center floating session chat panel over notes and hide CTA while open
- Merge transcript panel into note surface by removing seam and collapsing wrapper gap
- Add Esc key to collapse expanded transcript panel with focused tests
- Adjust transcript handle background color (neutral-50 when collapsed, white when expanded)
- Anchor floating session chat to note surface to maintain proper positioning and spacing