### PR TITLE
fix: move unsigned hero char.com link to copy

### DIFF
--- a/apps/unsigned-web/src/pages/index.mdx
+++ b/apps/unsigned-web/src/pages/index.mdx
@@ -7,18 +7,32 @@ export const UNSIGNED_CHAR_RELEASES_URL =
   `https://github.com/${UNSIGNED_CHAR_REPO}/releases/latest`;
 
 <section class="flex w-full flex-col items-center justify-center gap-8 text-center">
-  <a
-    href="https://char.com"
-    target="_blank"
-    rel="noopener noreferrer"
-    aria-label="Open char.com"
-    class="stagger-1 block w-full max-w-[720px]"
-  >
+  <div class="stagger-1 block w-full max-w-[720px]">
     <img src="/logo.svg" alt="Unsigned Char" class="w-full" />
-  </a>
+  </div>
 
   <div class="stagger-2 flex max-w-2xl flex-col items-center gap-4">
-    <p class="max-w-2xl font-serif text-[30px] leading-snug text-neutral-950 sm:text-[38px]">Unsigned Char is a bot-free meeting note taker for macOS that runs fully on device. It&apos;s <a href="https://github.com/fastrepl/unsigned-char" target="_blank" rel="noopener noreferrer" class="underline decoration-neutral-950 decoration-[1.5px] underline-offset-4">open source</a> and free to use forever.</p>
+    <p class="max-w-2xl font-serif text-[30px] leading-snug text-neutral-950 sm:text-[38px]">
+      Unsigned{" "}
+      <a
+        href="https://char.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="underline decoration-neutral-950 decoration-[1.5px] underline-offset-4"
+      >
+        Char
+      </a>{" "}
+      is a bot-free meeting note taker for macOS that runs fully on device. It&apos;s{" "}
+      <a
+        href="https://github.com/fastrepl/unsigned-char"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="underline decoration-neutral-950 decoration-[1.5px] underline-offset-4"
+      >
+        open source
+      </a>{" "}
+      and free to use forever.
+    </p>
   </div>
 
   <a


### PR DESCRIPTION
Remove the hero logo link and attach the char.com target to the linked Char text in the unsigned landing page copy.