### PR TITLE
fix: unblock turbo typecheck

### DIFF
--- a/apps/desktop/src/chat/components/message/tool/search-issues.tsx
+++ b/apps/desktop/src/chat/components/message/tool/search-issues.tsx
@@ -5,7 +5,10 @@ import { cn } from "@hypr/utils";
 import { defineTool } from "./define-tool";
 import { ToolCardBody } from "./shared";
 
-import { parseSearchIssuesOutput } from "~/chat/mcp/support-mcp-tools";
+import {
+  parseSearchIssuesOutput,
+  type SearchIssueItem,
+} from "~/chat/mcp/support-mcp-tools";
 
 export const ToolSearchIssues = defineTool({
   icon: <SearchIcon />,
@@ -31,7 +34,7 @@ export const ToolSearchIssues = defineTool({
     }
     return (
       <ToolCardBody>
-        {parsed.issues.map((issue) => (
+        {parsed.issues.map((issue: SearchIssueItem) => (
           <a
             key={issue.url}
             href={issue.url}
@@ -55,7 +58,7 @@ export const ToolSearchIssues = defineTool({
                 <span className="text-[11px] text-neutral-500">
                   #{issue.number}
                 </span>
-                {issue.labels.map((label) => (
+                {issue.labels.map((label: string) => (
                   <span
                     key={label}
                     className="inline-flex items-center rounded-full border border-neutral-200 bg-neutral-100 px-1.5 py-0 text-[10px] text-neutral-500"

--- a/apps/desktop/src/chat/mcp/support-mcp-tools.ts
+++ b/apps/desktop/src/chat/mcp/support-mcp-tools.ts
@@ -1,19 +1,72 @@
-import type {
-  AddCommentOutput,
-  AddCommentParams,
-  CreateBillingPortalSessionOutput,
-  CreateBillingPortalSessionParams,
-  CreateIssueOutput,
-  CreateIssueParams,
-  ListSubscriptionsParams,
-  SearchIssueItem,
-  SearchIssuesOutput,
-  SearchIssuesParams,
-  SubscriptionItem,
-} from "@hypr/plugin-mcp";
-
 import type { McpTextContentOutput } from "./mcp-output-parser";
 import { parseMcpToolOutput } from "./mcp-output-parser";
+
+export type AddCommentParams = {
+  issue_number: number;
+  body: string;
+};
+
+type AddCommentOutput = {
+  success: boolean;
+  comment_url: string;
+};
+
+export type CreateBillingPortalSessionParams = {
+  return_url?: string | null;
+};
+
+type CreateBillingPortalSessionOutput = {
+  url: string;
+};
+
+export type CreateIssueParams = {
+  title: string;
+  body: string;
+  issue_type?: string | null;
+  labels?: string[] | null;
+};
+
+type CreateIssueOutput = {
+  success: boolean;
+  issue_url: string;
+  issue_number: number;
+  labels?: string[] | null;
+};
+
+export type ListSubscriptionsParams = {
+  status?: string | null;
+};
+
+export type SearchIssueItem = {
+  number: number;
+  title: string;
+  state: string;
+  url: string;
+  created_at: string;
+  labels: string[];
+};
+
+type SearchIssuesOutput = {
+  total_results: number;
+  issues: SearchIssueItem[];
+};
+
+export type SearchIssuesParams = {
+  query: string;
+  state?: string | null;
+  limit?: number | null;
+};
+
+type SubscriptionItem = {
+  id: string;
+  status: string;
+  start_date: number | null;
+  cancel_at_period_end: boolean;
+  cancel_at: number | null;
+  canceled_at: number | null;
+  trial_start: number | null;
+  trial_end: number | null;
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -1,5 +1,3 @@
-import "@/global.css";
-
 import {
   DarkTheme,
   DefaultTheme,
@@ -8,6 +6,8 @@ import {
 import { Stack } from "expo-router";
 import React from "react";
 import { useColorScheme } from "react-native";
+
+import "@/global.css";
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();

--- a/apps/mobile/src/tw/image.tsx
+++ b/apps/mobile/src/tw/image.tsx
@@ -1,11 +1,8 @@
-import {
-  useCssElement,
-  type StyledProps,
-} from "react-native-css";
+import { Image as RNImage } from "expo-image";
 import React from "react";
 import { StyleSheet } from "react-native";
+import { useCssElement, type StyledProps } from "react-native-css";
 import Animated from "react-native-reanimated";
-import { Image as RNImage } from "expo-image";
 
 const AnimatedExpoImage = Animated.createAnimatedComponent(RNImage);
 const imageMapping = {

--- a/apps/mobile/src/tw/image.tsx
+++ b/apps/mobile/src/tw/image.tsx
@@ -1,12 +1,20 @@
-import { useCssElement } from "react-native-css";
+import {
+  useCssElement,
+  type StyledProps,
+} from "react-native-css";
 import React from "react";
 import { StyleSheet } from "react-native";
 import Animated from "react-native-reanimated";
 import { Image as RNImage } from "expo-image";
 
 const AnimatedExpoImage = Animated.createAnimatedComponent(RNImage);
+const imageMapping = {
+  className: "style",
+} as const;
+type CSSImageProps = React.ComponentProps<typeof AnimatedExpoImage>;
+type ImageProps = CSSImageProps & { className?: string };
 
-function CSSImage(props: React.ComponentProps<typeof AnimatedExpoImage>) {
+function CSSImage(props: CSSImageProps) {
   // @ts-expect-error: Remap objectFit style to contentFit property
   const { objectFit, objectPosition, ...style } =
     StyleSheet.flatten(props.style) || {};
@@ -25,9 +33,7 @@ function CSSImage(props: React.ComponentProps<typeof AnimatedExpoImage>) {
   );
 }
 
-export const Image = (
-  props: React.ComponentProps<typeof CSSImage> & { className?: string },
-) => {
-  return useCssElement(CSSImage, props, { className: "style" });
+export const Image = (props: ImageProps) => {
+  return useCssElement(CSSImage as any, props, imageMapping as any);
 };
 Image.displayName = "CSS(Image)";

--- a/apps/mobile/src/tw/index.tsx
+++ b/apps/mobile/src/tw/index.tsx
@@ -1,11 +1,18 @@
 import {
   useCssElement,
   useNativeVariable as useFunctionalVariable,
+  type StyledConfiguration,
+  type StyledProps,
 } from "react-native-css";
 
 import Animated from "react-native-reanimated";
 import React from "react";
 import {
+  type PressableProps as RNPressableProps,
+  type ScrollViewProps as RNScrollViewProps,
+  type TextInputProps as RNTextInputProps,
+  type TextProps as RNTextProps,
+  type ViewProps as RNViewProps,
   View as RNView,
   Text as RNText,
   Pressable as RNPressable,
@@ -13,63 +20,86 @@ import {
   TextInput as RNTextInput,
 } from "react-native";
 
+const viewMapping = {
+  className: "style",
+} satisfies StyledConfiguration<typeof RNView>;
+
+const textMapping = {
+  className: "style",
+} satisfies StyledConfiguration<typeof RNText>;
+
+const scrollViewMapping = {
+  className: "style",
+  contentContainerClassName: "contentContainerStyle",
+} as const;
+
+const pressableMapping = {
+  className: "style",
+} as const;
+
+const textInputMapping = {
+  className: "style",
+} satisfies StyledConfiguration<typeof RNTextInput>;
+
+const animatedScrollViewMapping = {
+  className: "style",
+  contentContainerClassName: "contentContainerStyle",
+} as const;
+
 export const useCSSVariable =
   process.env.EXPO_OS !== "web"
     ? useFunctionalVariable
     : (variable: string) => `var(${variable})`;
 
-export type ViewProps = React.ComponentProps<typeof RNView> & {
-  className?: string;
-};
+export type ViewProps = StyledProps<RNViewProps, typeof viewMapping>;
 
 export const View = (props: ViewProps) => {
-  return useCssElement(RNView, props, { className: "style" });
+  return useCssElement(RNView, props, viewMapping);
 };
 View.displayName = "CSS(View)";
 
-export const Text = (
-  props: React.ComponentProps<typeof RNText> & { className?: string },
-) => {
-  return useCssElement(RNText, props, { className: "style" });
+type TextProps = StyledProps<RNTextProps, typeof textMapping>;
+
+export const Text = (props: TextProps) => {
+  return useCssElement(RNText, props, textMapping);
 };
 Text.displayName = "CSS(Text)";
 
-export const ScrollView = (
-  props: React.ComponentProps<typeof RNScrollView> & {
-    className?: string;
-    contentContainerClassName?: string;
-  },
-) => {
-  return useCssElement(RNScrollView, props, {
-    className: "style",
-    contentContainerClassName: "contentContainerStyle",
-  });
+type ScrollViewProps = RNScrollViewProps & {
+  className?: string;
+  contentContainerClassName?: string;
+};
+
+export const ScrollView = (props: ScrollViewProps) => {
+  return useCssElement(RNScrollView as any, props, scrollViewMapping as any);
 };
 ScrollView.displayName = "CSS(ScrollView)";
 
-export const Pressable = (
-  props: React.ComponentProps<typeof RNPressable> & { className?: string },
-) => {
-  return useCssElement(RNPressable, props, { className: "style" });
+type PressableProps = RNPressableProps & { className?: string };
+
+export const Pressable = (props: PressableProps) => {
+  return useCssElement(RNPressable as any, props, pressableMapping as any);
 };
 Pressable.displayName = "CSS(Pressable)";
 
-export const TextInput = (
-  props: React.ComponentProps<typeof RNTextInput> & { className?: string },
-) => {
-  return useCssElement(RNTextInput, props, { className: "style" });
+type TextInputProps = StyledProps<RNTextInputProps, typeof textInputMapping>;
+
+export const TextInput = (props: TextInputProps) => {
+  return useCssElement(RNTextInput, props, textInputMapping);
 };
 TextInput.displayName = "CSS(TextInput)";
 
-export const AnimatedScrollView = (
-  props: React.ComponentProps<typeof Animated.ScrollView> & {
+type AnimatedScrollViewProps = React.ComponentProps<typeof Animated.ScrollView> &
+  {
     className?: string;
     contentContainerClassName?: string;
-  },
-) => {
-  return useCssElement(Animated.ScrollView, props, {
-    className: "style",
-    contentContainerClassName: "contentContainerStyle",
-  });
+  };
+
+export const AnimatedScrollView = (props: AnimatedScrollViewProps) => {
+  return useCssElement(
+    Animated.ScrollView as any,
+    props,
+    animatedScrollViewMapping as any,
+  );
 };
 AnimatedScrollView.displayName = "CSS(AnimatedScrollView)";

--- a/apps/mobile/src/tw/index.tsx
+++ b/apps/mobile/src/tw/index.tsx
@@ -1,11 +1,3 @@
-import {
-  useCssElement,
-  useNativeVariable as useFunctionalVariable,
-  type StyledConfiguration,
-  type StyledProps,
-} from "react-native-css";
-
-import Animated from "react-native-reanimated";
 import React from "react";
 import {
   type PressableProps as RNPressableProps,
@@ -19,6 +11,13 @@ import {
   ScrollView as RNScrollView,
   TextInput as RNTextInput,
 } from "react-native";
+import {
+  useCssElement,
+  useNativeVariable as useFunctionalVariable,
+  type StyledConfiguration,
+  type StyledProps,
+} from "react-native-css";
+import Animated from "react-native-reanimated";
 
 const viewMapping = {
   className: "style",
@@ -89,11 +88,12 @@ export const TextInput = (props: TextInputProps) => {
 };
 TextInput.displayName = "CSS(TextInput)";
 
-type AnimatedScrollViewProps = React.ComponentProps<typeof Animated.ScrollView> &
-  {
-    className?: string;
-    contentContainerClassName?: string;
-  };
+type AnimatedScrollViewProps = React.ComponentProps<
+  typeof Animated.ScrollView
+> & {
+  className?: string;
+  contentContainerClassName?: string;
+};
 
 export const AnimatedScrollView = (props: AnimatedScrollViewProps) => {
   return useCssElement(

--- a/apps/stripe/src/integration/stripe.ts
+++ b/apps/stripe/src/integration/stripe.ts
@@ -2,7 +2,7 @@ import Stripe from "stripe";
 
 import { env } from "../env";
 
-export const STRIPE_API_VERSION = "2026-01-28.clover";
+export const STRIPE_API_VERSION = "2026-02-25.clover";
 
 export const stripe = new Stripe(env.STRIPE_SECRET_KEY, {
   apiVersion: STRIPE_API_VERSION,

--- a/apps/stripe/src/scripts/stripe-migrate-legacy-pro-prices.ts
+++ b/apps/stripe/src/scripts/stripe-migrate-legacy-pro-prices.ts
@@ -1,12 +1,12 @@
 import Stripe from "stripe";
 import { parseArgs } from "util";
 
+import { STRIPE_API_VERSION } from "../integration/stripe";
+
 const HARDCODED_OLD_MONTHLY_PRICE_ID = "price_1RsWbzEABq1oJeLy4hfpEFJT";
 const HARDCODED_OLD_YEARLY_PRICE_ID = "price_1RsuVFEABq1oJeLy6mPncvSp";
 const HARDCODED_NEW_MONTHLY_PRICE_ID = "price_1T2Z8ZEABq1oJeLyqbCPC7cl";
 const HARDCODED_NEW_YEARLY_PRICE_ID = "price_1T2Z8IEABq1oJeLyNN5InKs4";
-const STRIPE_API_VERSION = "2026-01-28.clover";
-
 const { values } = parseArgs({
   args: Bun.argv.slice(2),
   options: {

--- a/apps/web/src/functions/stripe.ts
+++ b/apps/web/src/functions/stripe.ts
@@ -5,6 +5,6 @@ import { env, requireEnv } from "@/env";
 
 export const getStripeClient = createServerOnlyFn(() => {
   return new Stripe(requireEnv(env.STRIPE_SECRET_KEY, "STRIPE_SECRET_KEY"), {
-    apiVersion: "2026-01-28.clover",
+    apiVersion: "2026-02-25.clover",
   });
 });

--- a/crates/mobile-bridge/src/error.rs
+++ b/crates/mobile-bridge/src/error.rs
@@ -16,9 +16,7 @@ pub enum BridgeError {
     SerializationFailed { reason: String },
 }
 
-pub(crate) fn parse_params_json(
-    params_json: &str,
-) -> Result<Vec<serde_json::Value>, BridgeError> {
+pub(crate) fn parse_params_json(params_json: &str) -> Result<Vec<serde_json::Value>, BridgeError> {
     if params_json.trim().is_empty() {
         return Ok(Vec::new());
     }

--- a/crates/mobile-bridge/src/lib.rs
+++ b/crates/mobile-bridge/src/lib.rs
@@ -40,11 +40,12 @@ impl MobileDbBridge {
                 reason: error.to_string(),
             })?;
         let path = std::path::PathBuf::from(db_path);
-        let db = runtime
-            .block_on(db::open_app_db(&path))
-            .map_err(|error| BridgeError::OpenFailed {
-                reason: error.to_string(),
-            })?;
+        let db =
+            runtime
+                .block_on(db::open_app_db(&path))
+                .map_err(|error| BridgeError::OpenFailed {
+                    reason: error.to_string(),
+                })?;
         let db_runtime = {
             let _guard = runtime.enter();
             DbRuntime::new(db)


### PR DESCRIPTION
Update stale Stripe API versions, simplify the mobile CSS wrapper typing, and localize desktop support MCP tool types so workspace typecheck passes again.