### PR TITLE
fix: keep live transcript scrolled to the latest segment

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -4,6 +4,7 @@ import { useMemo, useRef } from "react";
 import { cn } from "@hypr/utils";
 
 import { getSegmentColor } from "~/session/components/note-input/transcript/renderer/utils";
+import { useAutoScroll } from "~/session/components/note-input/transcript/renderer/viewport-hooks";
 import * as main from "~/store/tinybase/store/main";
 import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
 import { useListener } from "~/stt/contexts";
@@ -82,7 +83,6 @@ function LiveTranscriptFooter({
     return SpeakerLabelManager.fromSegments(segments, labelContext);
   }, [labelContext, segments, store]);
 
-  const scrollRef = useRef<HTMLDivElement>(null);
   const previewText = useMemo(() => getTranscriptPreview(segments), [segments]);
 
   return (
@@ -94,7 +94,6 @@ function LiveTranscriptFooter({
           <LiveTranscriptContent
             isExpanded={isExpanded}
             previewText={previewText}
-            scrollRef={scrollRef}
             segments={segments}
             labelContext={labelContext}
             speakerLabelManager={speakerLabelManager}
@@ -124,18 +123,19 @@ function RecordOnlyFooter({
 function LiveTranscriptContent({
   isExpanded,
   previewText,
-  scrollRef,
   segments,
   labelContext,
   speakerLabelManager,
 }: {
   isExpanded: boolean;
   previewText: string | null;
-  scrollRef: React.RefObject<HTMLDivElement | null>;
   segments: Segment[];
   labelContext: ReturnType<typeof defaultRenderLabelContext> | undefined;
   speakerLabelManager: SpeakerLabelManager;
 }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useAutoScroll(scrollRef, [segments, isExpanded], isExpanded);
+
   if (!isExpanded) {
     return <CollapsedFooterMessage message={previewText ?? "Listening..."} />;
   }

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.test.tsx
@@ -1,0 +1,138 @@
+import { act, render } from "@testing-library/react";
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAutoScroll } from "./viewport-hooks";
+
+let resizeCallback: ResizeObserverCallback | null = null;
+
+class MockResizeObserver implements ResizeObserver {
+  readonly root = null;
+  readonly rootMargin = "";
+  readonly thresholds = [];
+
+  constructor(callback: ResizeObserverCallback) {
+    resizeCallback = callback;
+  }
+
+  disconnect() {}
+  observe() {}
+  unobserve() {}
+}
+
+function TestHarness({
+  version,
+  enabled = true,
+}: {
+  version: number;
+  enabled?: boolean;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useAutoScroll(ref, [version], enabled);
+
+  return <div ref={ref} />;
+}
+
+function setScrollMetrics(
+  element: HTMLDivElement,
+  metrics: {
+    clientHeight: number;
+    scrollHeight: number;
+    scrollTop: number;
+  },
+) {
+  Object.defineProperty(element, "clientHeight", {
+    configurable: true,
+    value: metrics.clientHeight,
+  });
+  Object.defineProperty(element, "scrollHeight", {
+    configurable: true,
+    value: metrics.scrollHeight,
+  });
+  Object.defineProperty(element, "scrollTop", {
+    configurable: true,
+    value: metrics.scrollTop,
+    writable: true,
+  });
+}
+
+function triggerResize() {
+  if (!resizeCallback) {
+    throw new Error("ResizeObserver callback was not registered");
+  }
+
+  const callback = resizeCallback;
+  act(() => {
+    callback([], {} as ResizeObserver);
+  });
+}
+
+describe("useAutoScroll", () => {
+  beforeEach(() => {
+    let frameId = 0;
+
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      ((callback: FrameRequestCallback) => {
+        callback(0);
+        frameId += 1;
+        return frameId;
+      }) satisfies typeof requestAnimationFrame,
+    );
+    vi.stubGlobal(
+      "cancelAnimationFrame",
+      vi.fn() satisfies typeof cancelAnimationFrame,
+    );
+    vi.stubGlobal("ResizeObserver", MockResizeObserver);
+    resizeCallback = null;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps following when content grows after the viewport was pinned", () => {
+    const { container, rerender } = render(<TestHarness version={0} />);
+    const element = container.firstElementChild as HTMLDivElement;
+
+    setScrollMetrics(element, {
+      clientHeight: 100,
+      scrollHeight: 200,
+      scrollTop: 100,
+    });
+
+    rerender(<TestHarness version={1} />);
+
+    setScrollMetrics(element, {
+      clientHeight: 100,
+      scrollHeight: 340,
+      scrollTop: 100,
+    });
+    triggerResize();
+
+    expect(element.scrollTop).toBe(340);
+  });
+
+  it("does not force-scroll when the user moved away from the bottom", () => {
+    const { container, rerender } = render(<TestHarness version={0} />);
+    const element = container.firstElementChild as HTMLDivElement;
+
+    setScrollMetrics(element, {
+      clientHeight: 100,
+      scrollHeight: 200,
+      scrollTop: 100,
+    });
+
+    rerender(<TestHarness version={1} />);
+
+    setScrollMetrics(element, {
+      clientHeight: 100,
+      scrollHeight: 340,
+      scrollTop: 20,
+    });
+    triggerResize();
+
+    expect(element.scrollTop).toBe(20);
+  });
+});

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
@@ -7,6 +7,16 @@ import {
   useState,
 } from "react";
 
+const AUTO_SCROLL_THRESHOLD = 80;
+
+function isNearBottom(
+  element: HTMLElement,
+  scrollHeight = element.scrollHeight,
+) {
+  return scrollHeight - element.scrollTop - element.clientHeight <
+    AUTO_SCROLL_THRESHOLD;
+}
+
 export function useScrollDetection(
   containerRef: RefObject<HTMLDivElement | null>,
 ) {
@@ -78,20 +88,12 @@ export function useAutoScroll(
       return;
     }
 
-    lastHeightRef.current = element.scrollHeight;
-
-    const isPinned = () => {
-      const distanceToBottom =
-        element.scrollHeight - element.scrollTop - element.clientHeight;
-      return distanceToBottom < 80;
-    };
-
     const flush = () => {
       element.scrollTop = element.scrollHeight;
     };
 
-    const schedule = (force = false) => {
-      if (!force && (!enabled || !isPinned())) {
+    const schedule = () => {
+      if (!enabled) {
         return;
       }
 
@@ -106,18 +108,25 @@ export function useAutoScroll(
 
     if (initialFlushRef.current) {
       initialFlushRef.current = false;
-      schedule(true);
-    } else {
+      schedule();
+    } else if (isNearBottom(element, lastHeightRef.current)) {
       schedule();
     }
 
+    lastHeightRef.current = element.scrollHeight;
+
     const resizeObserver = new ResizeObserver(() => {
+      const previousHeight = lastHeightRef.current;
       const nextHeight = element.scrollHeight;
-      if (nextHeight === lastHeightRef.current) {
+      if (nextHeight === previousHeight) {
         return;
       }
+
       lastHeightRef.current = nextHeight;
-      schedule();
+
+      if (isNearBottom(element, previousHeight)) {
+        schedule();
+      }
     });
 
     const targets = new Set<Element>([element]);


### PR DESCRIPTION
Auto-follow the expanded live transcript drawer, and preserve transcript auto-scroll when large live updates extend the current viewport.