### PR TITLE
fix: use provided unsigned favicon

### DIFF
--- a/apps/unsigned-web/src/layouts/Base.astro
+++ b/apps/unsigned-web/src/layouts/Base.astro
@@ -19,29 +19,23 @@ const url = "https://unsigned.char.com";
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Instrument+Serif&display=swap"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Instrument+Serif&display=swap"
       rel="stylesheet"
     />
     <style>html { background: #fff }</style>
   </head>
   <body class="min-h-screen bg-white">
     <div class="flex min-h-screen flex-col">
-      <div
-        class="w-full border-b border-neutral-200 bg-neutral-50 px-4 py-3 text-center font-serif text-base text-neutral-700"
+      <a
+        href="https://char.com"
+        aria-label="Open char.com"
+        class="w-full border-b border-neutral-200 bg-neutral-50 px-4 py-3 text-center font-mono text-sm text-neutral-700"
       >
-        <span>Unsigned Char is an on-device version of </span>
-        <a
-          href="https://char.com"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="underline decoration-neutral-700 decoration-[1.5px] underline-offset-4"
-          >Char</a
-        >
-        <span> that is free for everyone to use.</span>
-      </div>
+        <span>Unsigned Char is an on-device version of Char that is free for everyone to use.</span>
+      </a>
 
       <main
-        class="flex w-full flex-1 items-center justify-center bg-white py-12 font-serif text-neutral-950"
+        class="flex flex-1 w-full items-center justify-center bg-white py-12 font-mono text-neutral-950"
       >
         <slot />
       </main>

--- a/apps/unsigned-web/src/pages/index.mdx
+++ b/apps/unsigned-web/src/pages/index.mdx
@@ -2,46 +2,39 @@
 layout: "../layouts/Base.astro"
 ---
 
-export const UNSIGNED_CHAR_REPO = "fastrepl/unsigned-char";
-export const UNSIGNED_CHAR_DOWNLOAD_URL =
-  `https://github.com/${UNSIGNED_CHAR_REPO}/releases/latest/download/unsigned-char-aarch64.dmg`;
-
 <section class="flex w-full flex-col items-center justify-center gap-8 text-center">
-  <div class="stagger-1 block w-full max-w-[720px]">
-    <img src="/logo.svg" alt="Unsigned Char" class="w-full" />
-  </div>
-
-  <div class="stagger-2 flex max-w-2xl flex-col items-center gap-4">
-    <p class="max-w-2xl font-serif text-[30px] leading-snug text-neutral-950 sm:text-[38px]">
-      Unsigned{" "}
-      <a
-        href="https://char.com"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="underline decoration-neutral-950 decoration-[1.5px] underline-offset-4"
-      >
-        Char
-      </a>{" "}
-      is a bot-free meeting note taker for macOS that runs fully on device. It&apos;s{" "}
-      <a
-        href="https://github.com/fastrepl/unsigned-char"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="underline decoration-neutral-950 decoration-[1.5px] underline-offset-4"
-      >
-        open source
-      </a>{" "}
-      and free to use forever.
-    </p>
-  </div>
-
   <a
-    href={UNSIGNED_CHAR_DOWNLOAD_URL}
-    class="stagger-3 inline-flex items-center justify-center gap-2.5 rounded-full border border-neutral-950 bg-neutral-950 px-7 py-3.5 text-lg text-white transition-colors hover:bg-neutral-800"
+    href="https://char.com"
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label="Open char.com"
+    class="stagger-1 block w-full max-w-[540px]"
   >
-    <svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5 fill-current">
-      <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47c-1.34.03-1.77-.79-3.29-.79c-1.53 0-2 .77-3.27.82c-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51c1.28-.02 2.5.87 3.29.87c.78 0 2.26-1.07 3.81-.91c.65.03 2.47.26 3.64 1.98c-.09.06-2.17 1.28-2.15 3.81c.03 3.02 2.65 4.03 2.68 4.04c-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5c.13 1.17-.34 2.35-1.04 3.19c-.69.85-1.83 1.51-2.95 1.42c-.15-1.15.41-2.35 1.05-3.11" />
-    </svg>
-    <span>Download app</span>
+    <img src="/logo.svg" alt="Unsigned Char" class="w-full" />
   </a>
+
+  <div class="stagger-2 flex items-center justify-center gap-3">
+    <a
+      href="https://github.com/fastrepl/unsigned-char/releases"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center justify-center gap-2.5 rounded-full border border-neutral-950 bg-neutral-950 px-7 py-3.5 font-mono text-base font-medium text-white transition-colors hover:bg-neutral-800"
+    >
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5 fill-current">
+        <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47c-1.34.03-1.77-.79-3.29-.79c-1.53 0-2 .77-3.27.82c-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51c1.28-.02 2.5.87 3.29.87c.78 0 2.26-1.07 3.81-.91c.65.03 2.47.26 3.64 1.98c-.09.06-2.17 1.28-2.15 3.81c.03 3.02 2.65 4.03 2.68 4.04c-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5c.13 1.17-.34 2.35-1.04 3.19c-.69.85-1.83 1.51-2.95 1.42c-.15-1.15.41-2.35 1.05-3.11" />
+      </svg>
+      <span>Download app</span>
+    </a>
+    <a
+      href="https://github.com/fastrepl/unsigned-char"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-flex items-center justify-center gap-2.5 rounded-full border border-neutral-950 bg-white px-7 py-3.5 font-mono text-base font-medium text-neutral-950 transition-colors hover:bg-neutral-100"
+    >
+      <svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5 fill-current">
+        <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2Z" />
+      </svg>
+      <span>GitHub</span>
+    </a>
+  </div>
 </section>

--- a/apps/unsigned-web/src/styles.css
+++ b/apps/unsigned-web/src/styles.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
 @theme {
+  --font-mono: "IBM Plex Mono", ui-monospace, "SFMono-Regular", monospace;
   --font-serif: "Instrument Serif", Georgia, serif;
 }
 


### PR DESCRIPTION
Prefer the supplied PNG as the unsigned.char.com favicon and keep the existing SVG as an alternate icon fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/content-only changes to the unsigned web landing page (fonts, links, and layout) with no backend or data-handling impact.
> 
> **Overview**
> Updates `unsigned-web` layout and landing page to use **IBM Plex Mono** (adds `--font-mono` theme + loads the font) and switches key sections from `font-serif` to `font-mono`.
> 
> Simplifies the header/hero CTAs: makes the announcement bar a single link to `char.com`, replaces the old dynamic DMG download URL and long description with a logo link to `char.com`, and adds explicit buttons for **Download app** (GitHub releases) and **GitHub** (repo).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 114340418e23709d2524b9070e5bad9bc2698a8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->