### PR TITLE
feat: update download link to direct dmg file

### DIFF
--- a/apps/unsigned-web/src/pages/index.mdx
+++ b/apps/unsigned-web/src/pages/index.mdx
@@ -15,9 +15,8 @@ layout: "../layouts/Base.astro"
 
   <div class="stagger-2 flex items-center justify-center gap-3">
     <a
-      href="https://github.com/fastrepl/unsigned-char/releases"
-      target="_blank"
-      rel="noopener noreferrer"
+      href="https://github.com/fastrepl/unsigned-char/releases/latest/download/unsigned-char-aarch64.dmg"
+      download
       class="inline-flex items-center justify-center gap-2.5 rounded-full border border-neutral-950 bg-neutral-950 px-7 py-3.5 font-mono text-base font-medium text-white transition-colors hover:bg-neutral-800"
     >
       <svg aria-hidden="true" viewBox="0 0 24 24" class="h-5 w-5 fill-current">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that updates a single external URL; main risk is broken/incorrect asset link or unexpected download behavior across browsers.
> 
> **Overview**
> Updates the landing page **Download app** button (`apps/unsigned-web/src/pages/index.mdx`) to link directly to the latest GitHub release DMG (`.../releases/latest/download/unsigned-char-aarch64.dmg`) instead of the releases list.
> 
> Adds the `download` attribute so clicking the button triggers a direct file download rather than opening GitHub in a new tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fba32840f8955f54fa0e5f86a3cb696b8d85381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->