### PR TITLE
fix: flatten profile facehash fallback

### DIFF
--- a/apps/desktop/src/main2/profile-menu.tsx
+++ b/apps/desktop/src/main2/profile-menu.tsx
@@ -7,7 +7,7 @@ import {
   UsersIcon,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { Kbd } from "@hypr/ui/components/ui/kbd";
 import { cn } from "@hypr/utils";
@@ -150,10 +150,7 @@ function ProfileName() {
   const name = main.UI.useCell("humans", userId ?? "", "name", main.STORE_ID);
   const displayName = name || auth?.session?.user.email || "Unknown";
 
-  const facehashName = useMemo(
-    () => displayName || auth?.session?.user.email || "user",
-    [displayName, auth?.session?.user.email],
-  );
+  const facehashName = displayName;
 
   const badgeLabel = plan === "trial" ? "PRO" : plan.toUpperCase();
 
@@ -202,10 +199,7 @@ function AvatarButton({
     },
   });
 
-  const facehashName = useMemo(
-    () => displayName || auth?.session?.user.email || "user",
-    [displayName, auth?.session?.user.email],
-  );
+  const facehashName = displayName;
 
   useEffect(() => {
     setImgError(false);

--- a/apps/desktop/src/main2/profile-menu.tsx
+++ b/apps/desktop/src/main2/profile-menu.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import { Facehash } from "facehash";
 import {
   CalendarIcon,
   CircleHelp,
@@ -17,7 +16,7 @@ import { useAuth } from "~/auth";
 import { useBillingAccess } from "~/auth/billing";
 import { useAutoCloser } from "~/shared/hooks/useAutoCloser";
 import { AuthSection } from "~/sidebar/profile/auth";
-import { MenuItem } from "~/sidebar/profile/shared";
+import { MenuItem, ProfileFacehash } from "~/sidebar/profile/shared";
 import * as main from "~/store/tinybase/store/main";
 import { useTabs } from "~/store/zustand/tabs";
 
@@ -152,8 +151,8 @@ function ProfileName() {
   const displayName = name || auth?.session?.user.email || "Unknown";
 
   const facehashName = useMemo(
-    () => auth?.session?.user.email || displayName || "user",
-    [auth?.session?.user.email, displayName],
+    () => displayName || auth?.session?.user.email || "user",
+    [displayName, auth?.session?.user.email],
   );
 
   const badgeLabel = plan === "trial" ? "PRO" : plan.toUpperCase();
@@ -161,14 +160,7 @@ function ProfileName() {
   return (
     <div className="flex items-center gap-2.5 px-3 py-2">
       <div className="flex size-6 shrink-0 items-center justify-center overflow-hidden rounded-full border border-neutral-300">
-        <div className="rounded-full bg-amber-50">
-          <Facehash
-            name={facehashName}
-            size={24}
-            interactive={false}
-            showInitial={false}
-          />
-        </div>
+        <ProfileFacehash name={facehashName} size={24} />
       </div>
       <div className="min-w-0 flex-1 truncate text-sm text-black">
         {displayName}
@@ -211,8 +203,8 @@ function AvatarButton({
   });
 
   const facehashName = useMemo(
-    () => auth?.session?.user.email || displayName || "user",
-    [auth?.session?.user.email, displayName],
+    () => displayName || auth?.session?.user.email || "user",
+    [displayName, auth?.session?.user.email],
   );
 
   useEffect(() => {
@@ -241,14 +233,11 @@ function AvatarButton({
         ])}
       >
         {showFacehash ? (
-          <div className="rounded-full bg-amber-50">
-            <Facehash
-              name={facehashName}
-              size={20}
-              interactive={false}
-              showInitial={false}
-            />
-          </div>
+          <ProfileFacehash
+            name={facehashName}
+            size={20}
+            showInitial={false}
+          />
         ) : (
           <img
             src={profile.data!}

--- a/apps/desktop/src/main2/profile-menu.tsx
+++ b/apps/desktop/src/main2/profile-menu.tsx
@@ -227,11 +227,7 @@ function AvatarButton({
         ])}
       >
         {showFacehash ? (
-          <ProfileFacehash
-            name={facehashName}
-            size={20}
-            showInitial={false}
-          />
+          <ProfileFacehash name={facehashName} size={20} showInitial={false} />
         ) : (
           <img
             src={profile.data!}

--- a/apps/desktop/src/sidebar/profile/index.tsx
+++ b/apps/desktop/src/sidebar/profile/index.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import { Facehash } from "facehash";
 import {
   CalendarIcon,
   ChevronUpIcon,
@@ -17,7 +16,7 @@ import { cn } from "@hypr/utils";
 
 import { AuthSection } from "./auth";
 import { NotificationsMenuContent } from "./notification";
-import { MenuItem } from "./shared";
+import { MenuItem, ProfileFacehash } from "./shared";
 
 import { useAuth } from "~/auth";
 import { useBillingAccess } from "~/auth/billing";
@@ -281,8 +280,8 @@ function ProfileButton({
   });
 
   const facehashName = useMemo(
-    () => auth?.session?.user.email || name || "user",
-    [auth?.session?.user.email, name],
+    () => name || auth?.session?.user.email || "user",
+    [name, auth?.session?.user.email],
   );
 
   useEffect(() => {
@@ -312,14 +311,7 @@ function ProfileButton({
         ])}
       >
         {showFacehash ? (
-          <div className="rounded-full bg-amber-50">
-            <Facehash
-              name={facehashName}
-              size={32}
-              interactive={false}
-              showInitial={false}
-            />
-          </div>
+          <ProfileFacehash name={facehashName} size={32} />
         ) : (
           <img
             src={profile.data!}

--- a/apps/desktop/src/sidebar/profile/index.tsx
+++ b/apps/desktop/src/sidebar/profile/index.tsx
@@ -8,7 +8,7 @@ import {
   UsersIcon,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useResizeObserver } from "usehooks-ts";
 
 import { Kbd } from "@hypr/ui/components/ui/kbd";
@@ -279,10 +279,7 @@ function ProfileButton({
     },
   });
 
-  const facehashName = useMemo(
-    () => name || auth?.session?.user.email || "user",
-    [name, auth?.session?.user.email],
-  );
+  const facehashName = name;
 
   useEffect(() => {
     setImgError(false);

--- a/apps/desktop/src/sidebar/profile/shared.tsx
+++ b/apps/desktop/src/sidebar/profile/shared.tsx
@@ -1,3 +1,5 @@
+import { Facehash } from "facehash";
+
 import { cn } from "@hypr/utils";
 
 export function MenuItem({
@@ -47,6 +49,31 @@ export function MenuItem({
           <SuffixIcon className={cn("h-4 w-4 shrink-0", "text-neutral-400")} />
         )}
       </button>
+    </div>
+  );
+}
+
+export function ProfileFacehash({
+  name,
+  size,
+  showInitial = true,
+  className,
+}: {
+  name: string;
+  size: number;
+  showInitial?: boolean;
+  className?: string;
+}) {
+  return (
+    <div className={cn(["rounded-full bg-amber-50", className])}>
+      <Facehash
+        name={name}
+        size={size}
+        interactive={false}
+        showInitial={showInitial}
+        variant="solid"
+        intensity3d="none"
+      />
     </div>
   );
 }


### PR DESCRIPTION
Use a shared profile facehash wrapper, prefer display-name initials for generated profile avatars, and remove the 3D gradient styling from the profile fallback surfaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that refactors the profile fallback avatar rendering and tweaks its styling; no auth or data flow changes.
> 
> **Overview**
> Refactors the profile avatar fallback to use a shared `ProfileFacehash` component in both the sidebar profile button and the `main2` profile menu, removing duplicated `Facehash` wrapper markup.
> 
> The fallback now derives the facehash seed from the display name (instead of preferring email), and standardizes the look by forcing a flat/solid variant with no 3D intensity (plus consistent `showInitial` behavior per usage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c69b307c8e89b30355c77f08df2ab11b1b836e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->