### PR TITLE
fix: shift unsigned hero logo left

### DIFF
--- a/apps/unsigned-web/src/pages/index.mdx
+++ b/apps/unsigned-web/src/pages/index.mdx
@@ -8,7 +8,7 @@ layout: "../layouts/Base.astro"
     target="_blank"
     rel="noopener noreferrer"
     aria-label="Open char.com"
-    class="stagger-1 block w-full max-w-[540px]"
+    class="stagger-1 block w-full max-w-[540px] md:-translate-x-12 lg:-translate-x-16"
   >
     <img src="/logo.svg" alt="Unsigned Char" class="w-full" />
   </a>


### PR DESCRIPTION
Move the unsigned landing page logo left on desktop breakpoints while keeping the mobile layout centered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adjusts Tailwind classes to translate the hero logo on md/lg screens, with no behavioral or data-handling impact.
> 
> **Overview**
> Shifts the landing page hero logo left on desktop by adding responsive `md`/`lg` negative `translate-x` classes to the logo link in `index.mdx`, while leaving the mobile centered layout unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32ebacfb96b35c7855c13e32d31e1ba82161b99d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->