### PR TITLE
fix: nudge unsigned logo right

### DIFF
--- a/apps/unsigned-web/src/pages/index.mdx
+++ b/apps/unsigned-web/src/pages/index.mdx
@@ -8,7 +8,7 @@ layout: "../layouts/Base.astro"
     target="_blank"
     rel="noopener noreferrer"
     aria-label="Open char.com"
-    class="stagger-1 block w-full max-w-[540px] md:-translate-x-12 lg:-translate-x-16"
+    class="stagger-1 block w-full max-w-[540px] md:-translate-x-[36px] lg:-translate-x-[52px]"
   >
     <img src="/logo.svg" alt="Unsigned Char" class="w-full" />
   </a>


### PR DESCRIPTION
Adjust the unsigned landing page desktop logo offsets by 12px while keeping the mobile layout centered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only tweak: updates Tailwind translate offsets for the landing-page logo on desktop breakpoints with no logic or data-flow changes.
> 
> **Overview**
> Tweaks the landing page logo positioning by reducing the negative `translate-x` values at the `md` and `lg` breakpoints (shifting the logo ~12px to the right) while leaving the mobile layout unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c66997e807091fbe1ea0b7b7f57c7206502d004d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->