### PR TITLE
fix: show event start time in session rows

### DIFF
--- a/apps/desktop/src/editor/node-views/session-view.test.tsx
+++ b/apps/desktop/src/editor/node-views/session-view.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { format } from "date-fns";
 import { describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => {
@@ -27,10 +28,16 @@ vi.mock("~/store/tinybase/store/main", () => ({
     useRow: () => ({
       created_at: "2026-04-06T00:00:00.000Z",
       event_json: JSON.stringify({
+        started_at: "2026-04-06T02:30:00.000Z",
         ended_at: "2026-04-06T01:00:00.000Z",
       }),
     }),
   },
+}));
+
+vi.mock("~/calendar/hooks", () => ({
+  useTimezone: () => undefined,
+  toTz: (date: Date) => date,
 }));
 
 vi.mock("~/stt/contexts", () => ({
@@ -160,5 +167,34 @@ describe("SessionNodeView", () => {
       id: "session-1",
       type: "sessions",
     });
+  });
+
+  it("renders the event start time instead of the session creation time", () => {
+    const expectedEventTime = format(
+      new Date("2026-04-06T02:30:00.000Z"),
+      "h:mm a",
+    );
+    const unexpectedCreatedTime = format(
+      new Date("2026-04-06T00:00:00.000Z"),
+      "h:mm a",
+    );
+
+    render(
+      <SessionNodeView
+        nodeProps={
+          {
+            node: {
+              attrs: { sessionId: "session-1", status: "todo", checked: false },
+            },
+            getPos: () => 7,
+          } as any
+        }
+      >
+        Meeting
+      </SessionNodeView>,
+    );
+
+    expect(screen.queryAllByText(expectedEventTime).length).toBeGreaterThan(0);
+    expect(screen.queryAllByText(unexpectedCreatedTime)).toHaveLength(0);
   });
 });

--- a/apps/desktop/src/editor/node-views/session-view.tsx
+++ b/apps/desktop/src/editor/node-views/session-view.tsx
@@ -16,6 +16,7 @@ import {
 } from "../tasks";
 import { TaskCheckbox } from "./task-checkbox";
 
+import { toTz, useTimezone } from "~/calendar/hooks";
 import { useLinkedItemOpenBehavior } from "~/editor/session/linked-item-open-behavior";
 import { getSessionEvent } from "~/session/utils";
 import * as main from "~/store/tinybase/store/main";
@@ -79,21 +80,29 @@ export const SessionNodeView = forwardRef<
   const sessionId = node.attrs.sessionId as string;
 
   const session = main.UI.useRow("sessions", sessionId, main.STORE_ID);
+  const tz = useTimezone();
   const liveSessionId = useListener((state) => state.live.sessionId);
   const liveStatus = useListener((state) => state.live.status);
   const isRecording =
     liveSessionId === sessionId &&
     (liveStatus === "active" || liveStatus === "finalizing");
-  const createdAt = session?.created_at
-    ? safeParseDate(session.created_at as string)
-    : null;
+  const event = useMemo(() => getSessionEvent(session), [session]);
+  const displayTime = useMemo(() => {
+    if (event?.is_all_day) {
+      return null;
+    }
+
+    const rawDate = event?.started_at ?? session?.created_at;
+    const parsed = rawDate ? safeParseDate(rawDate) : null;
+
+    return parsed ? format(toTz(parsed, tz), "h:mm a") : null;
+  }, [event?.is_all_day, event?.started_at, session?.created_at, tz]);
 
   const isMeetingOver = useMemo(() => {
-    const event = getSessionEvent(session);
     if (!event?.ended_at) return false;
     const endedAt = safeParseDate(event.ended_at);
     return endedAt ? endedAt.getTime() <= Date.now() : false;
-  }, [session]);
+  }, [event]);
 
   const linkedItemOpenBehavior = useLinkedItemOpenBehavior();
   const openCurrent = useTabs((state) => state.openCurrent);
@@ -182,12 +191,12 @@ export const SessionNodeView = forwardRef<
           >
             {children}
           </div>
-          {createdAt && (
+          {displayTime && (
             <span
               className="shrink-0 font-mono text-xs text-neutral-400"
               contentEditable={false}
             >
-              {format(createdAt, "h:mm a")}
+              {displayTime}
             </span>
           )}
         </div>


### PR DESCRIPTION
Prefer event-backed session start times over created_at in the daily note layout and add a regression test for SessionNodeView.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI display change limited to how `SessionNodeView` formats its timestamp, plus a targeted regression test; no persistence or auth logic is modified.
> 
> **Overview**
> Updates `SessionNodeView` to display the session’s *event start time* (`event.started_at`)—converted via `toTz`/`useTimezone`—instead of always using `created_at`, and hides the time for all-day events.
> 
> Adds a regression test ensuring the rendered time matches `started_at` and not `created_at`, with calendar/timezone hooks mocked for determinism.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1da19492486cfccb1740a18f8f7474dc027ae0fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->