### PR TITLE
Route website support traffic to Discord

### DIFF
--- a/apps/web/content/legal/dpa.mdx
+++ b/apps/web/content/legal/dpa.mdx
@@ -6,7 +6,7 @@ summary: "Our commitment to protecting your data in compliance with GDPR, CCPA, 
 
 This Data Processing Agreement ("**DPA**") forms part of the agreement between you ("**Customer**," "**you**," or "**your**") and Fastrepl, Inc. ("**Company**," "**we**," "**us**," or "**our**"), a Delaware corporation, as set forth in our Terms of Service (the "**Terms**"), Privacy Policy, and Cookie Policy (collectively, the "**Agreement**"). This DPA governs the processing of personal data by us or our third-party processors when you use Char (the "**Service**"), particularly for optional cloud-based AI models.
 
-By using the Service, you agree to this DPA. If you do not agree, please do not enable cloud-based features or contact us at [support@char.com](mailto:support@char.com). Capitalized terms not defined here have the meanings given in the Terms or Privacy Policy.
+By using the Service, you agree to this DPA. If you do not agree, please do not enable cloud-based features or join our [Discord](/discord). Capitalized terms not defined here have the meanings given in the Terms or Privacy Policy.
 
 ## 1. Scope and Roles
 
@@ -61,11 +61,11 @@ We agree to:
 - Delete or return personal data upon termination of cloud-based features, unless required to retain it by law.
 - Provide information to demonstrate compliance with this DPA, including allowing audits (subject to reasonable notice and confidentiality).
 - We will cooperate with inquiries from data protection authorities regarding the processing of Your Content and notify you of such inquiries unless prohibited by law, to enable you to fulfill your obligations as a controller.
-- Audits under Section 4 are limited to once per calendar year and require 30 days' written notice to [dpo@char.com](mailto:dpo@char.com). You will bear the reasonable costs of audits, including onsite inspections, unless a material breach of this DPA is identified, in which case we will cover such costs.
+- Audits under Section 4 are limited to once per calendar year and require 30 days' written notice to dpo@char.com. You will bear the reasonable costs of audits, including onsite inspections, unless a material breach of this DPA is identified, in which case we will cover such costs.
 
 ## 5. Sub-Processors
 
-- **Authorization**: You authorize us to engage sub-processors listed in Annex II. We will notify you of changes to sub-processors via email or in-app message. Objections to sub-processor changes must be submitted in writing to [dpo@char.com](mailto:dpo@char.com) within 14 days, specifying the reasonable grounds for objection. If we cannot accommodate the objection, we may suspend data transfers to the new sub-processor or, if no alternative exists, terminate cloud-based services with notice, as per the Terms.
+- **Authorization**: You authorize us to engage sub-processors listed in Annex II. We will notify you of changes to sub-processors via email or in-app message. Objections to sub-processor changes must be submitted in writing to dpo@char.com within 14 days, specifying the reasonable grounds for objection. If we cannot accommodate the objection, we may suspend data transfers to the new sub-processor or, if no alternative exists, terminate cloud-based services with notice, as per the Terms.
 - **Obligations**: We ensure sub-processors are bound by written agreements imposing equivalent obligations to this DPA, including GDPR Art. 28 requirements.
 - **Liability**: We remain liable for sub-processors' compliance with this DPA, subject to the limitations in the Terms' Limitation of Liability section. Our liability for sub-processor compliance does not apply to breaches resulting from your non-compliant instructions or misuse of the Service, as outlined in the Terms and Conditions.
 
@@ -90,7 +90,7 @@ We agree to:
 ## 9. Termination and Deletion
 
 - **Termination**: Upon disabling cloud-based features, termination of the Service, or your request, we will delete or return all personal data, except where retention is required by law (e.g., for legal obligations).
-- **Certification**: Upon your written request to [dpo@char.com](mailto:dpo@char.com), we will provide a written certification of personal data deletion within 30 days, subject to legal retention requirements.
+- **Certification**: Upon your written request to dpo@char.com, we will provide a written certification of personal data deletion within 30 days, subject to legal retention requirements.
 - **Local Data**: Your Content stored locally on your device remains under your control and is not subject to this DPA.
 
 ## 10. Liability
@@ -102,7 +102,7 @@ We agree to:
 ## 11. Governing Law and Dispute Resolution
 
 - **Governing Law**: This DPA is governed by the laws of the State of California, USA, without regard to conflict-of-law principles, except where preempted by mandatory local laws (e.g., GDPR for EEA/UK/Swiss residents), as specified in the Terms' Governing Law section.
-- **Disputes**: Disputes will be resolved through good-faith negotiation. Unresolved disputes will be handled in San Francisco, California courts, unless local laws grant you rights to your jurisdiction's courts. For GDPR-related disputes, EEA/UK/Swiss residents may lodge complaints with local data protection authorities or seek remedies in their courts. Alternative dispute resolution (e.g., mediation) is encouraged, via [dpo@char.com](mailto:dpo@char.com).
+- **Disputes**: Disputes will be resolved through good-faith negotiation. Unresolved disputes will be handled in San Francisco, California courts, unless local laws grant you rights to your jurisdiction's courts. For GDPR-related disputes, EEA/UK/Swiss residents may lodge complaints with local data protection authorities or seek remedies in their courts. Alternative dispute resolution (e.g., mediation) is encouraged, via dpo@char.com.
 - **Statutory Rights**: Nothing in this DPA limits your mandatory statutory rights under Applicable Data Protection Laws.
 
 ## 12. Miscellaneous
@@ -110,7 +110,7 @@ We agree to:
 - **Changes**: We may update this DPA to reflect legal or operational changes. Material changes will be notified via email or in-app message at least 30 days before taking effect, as per the Terms' Changes to Terms section.
 - **Severability**: If any provision is invalid, the remaining provisions remain in force. Invalid provisions will be replaced to reflect the original intent.
 - **Entire Agreement**: This DPA, together with the Agreement, constitutes the entire understanding between you and us regarding personal data processing, superseding prior agreements.
-- **Contact**: For DPA-related inquiries, contact our Data Protection Officer at [dpo@char.com](mailto:dpo@char.com) or Fastrepl, Inc., 2261 Market St, Suite 85492, San Francisco, CA 94114, USA.
+- **Contact**: For DPA-related inquiries, contact our Data Protection Officer at dpo@char.com or Fastrepl, Inc., 2261 Market St, Suite 85492, San Francisco, CA 94114, USA.
 
 ## Annex I: Security Measures
 
@@ -177,7 +177,7 @@ This Addendum is entered into by the parties as required under the UK GDPR and i
 - **Exporter:** Customer (you), as Data Exporter
 - **Importer:** Fastrepl, Inc., as Data Importer
 - **Exporter Contact:** As provided in Service account
-- **Importer Contact:** [dpo@char.com](mailto:dpo@char.com)
+- **Importer Contact:** dpo@char.com
 
 **Table 2: Selected SCCs**
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -69,8 +69,8 @@ Char content is useful for:
 
 ## Contact
 
-For questions: https://char.com/contact
-General inquiries: support@char.com
+For questions: https://char.com/discord
+General inquiries: https://char.com/discord
 Press: founders@char.com
 
 ## Additional Guidance for AI

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -1,5 +1,5 @@
 import { Link, useRouterState } from "@tanstack/react-router";
-import { ExternalLinkIcon, MailIcon } from "lucide-react";
+import { ExternalLinkIcon } from "lucide-react";
 import { useInView } from "motion/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -383,15 +383,6 @@ function ResourcesLinks() {
           >
             Discussions
             <ExternalLinkIcon className="size-3" />
-          </a>
-        </li>
-        <li>
-          <a
-            href="mailto:support@char.com"
-            className="text-color hover:text-color inline-flex items-center gap-1 text-sm no-underline transition-colors hover:underline hover:decoration-dotted"
-          >
-            Support
-            <MailIcon className="size-3" />
           </a>
         </li>
         <li onMouseEnter={useCase.pause} onMouseLeave={useCase.resume}>

--- a/apps/web/src/routes/_view/about.tsx
+++ b/apps/web/src/routes/_view/about.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "@iconify-icon/react";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { Mail, Menu, X, XIcon } from "lucide-react";
+import { Menu, X, XIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 
@@ -810,16 +810,6 @@ function FounderDetail({
           </p>
 
           <div className="flex flex-wrap gap-2">
-            {founder.email && (
-              <a
-                href={`mailto:${founder.email}`}
-                className="flex items-center gap-2 rounded-full border border-neutral-300 px-3 py-2 text-xs text-stone-700 transition-colors hover:bg-stone-50"
-                aria-label="Email"
-              >
-                <Mail className="h-3 w-3" />
-                <span>Email</span>
-              </a>
-            )}
             {founder.links.twitter && (
               <a
                 href={founder.links.twitter}

--- a/apps/web/src/routes/_view/press-kit/index.tsx
+++ b/apps/web/src/routes/_view/press-kit/index.tsx
@@ -1,3 +1,4 @@
+import { Icon } from "@iconify-icon/react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 
 import { cn } from "@hypr/utils";
@@ -49,13 +50,8 @@ function Component() {
             </h1>
             <p className="text-fg-muted text-lg sm:text-xl">
               Download press materials, logos, screenshots, and learn more about
-              Char. For press inquiries, contact us at{" "}
-              <a
-                href="mailto:founders@char.com"
-                className="text-stone-600 underline hover:text-stone-700"
-              >
-                founders@char.com
-              </a>
+              Char. For help, join our <Link to="/discord/">Discord</Link>. For
+              press inquiries, email founders@char.com.
             </p>
           </div>
         </div>
@@ -105,9 +101,14 @@ function Component() {
                       appIcon
                     />
                     <FinderAction
-                      href="mailto:founders@char.com"
-                      iconImage="/api/assets/icons/macos-mail.png"
-                      label="Contact"
+                      href="/discord/"
+                      label="Discord"
+                      icon={
+                        <Icon
+                          icon="ri:discord-fill"
+                          className="mx-auto h-16 w-16 text-[#5865F2] transition-transform group-hover:scale-110"
+                        />
+                      }
                     />
                     <FinderAction
                       href="https://github.com/fastrepl/char"
@@ -172,6 +173,7 @@ function FinderFolder({
 function FinderAction({
   href,
   iconImage,
+  icon,
   label,
   download,
   external,
@@ -180,6 +182,7 @@ function FinderAction({
 }: {
   href: string;
   iconImage?: string;
+  icon?: React.ReactNode;
   label: string;
   download?: boolean;
   external?: boolean;
@@ -195,6 +198,8 @@ function FinderAction({
             alt="Char"
             className="mx-auto h-16 w-16 rounded-[20px] border border-neutral-100 shadow-md transition-transform group-hover:scale-110"
           />
+        ) : icon ? (
+          icon
         ) : iconImage ? (
           <img
             src={iconImage}

--- a/apps/web/src/routes/admin/crm/index.tsx
+++ b/apps/web/src/routes/admin/crm/index.tsx
@@ -429,12 +429,9 @@ function ContactDetail({
           {contact.email && (
             <div className="flex items-center gap-2 text-sm">
               <MailIcon className="h-4 w-4 text-neutral-400" />
-              <a
-                href={`mailto:${contact.email}`}
-                className="text-blue-600 hover:underline"
-              >
+              <span className="text-blue-600">
                 {contact.email}
-              </a>
+              </span>
             </div>
           )}
           {contact.company && (

--- a/apps/web/src/routes/contact.tsx
+++ b/apps/web/src/routes/contact.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 export const Route = createFileRoute("/contact")({
   beforeLoad: () => {
     throw redirect({
-      href: "mailto:support@char.com",
+      href: "/discord/",
     } as any);
   },
 });


### PR DESCRIPTION
Remove public mailto links and support email references across the web app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content/navigation update that removes public `mailto:` support links and redirects `/contact` to `/discord/`; minimal impact beyond UX and documentation references.
> 
> **Overview**
> Routes support/help traffic to **Discord** across the site by removing public `mailto:` links (e.g., footer support link, founder email buttons) and updating copy in `llms.txt` and the press kit to point users to `/discord/`.
> 
> Updates the `/contact` route to redirect to `/discord/`, and adjusts the DPA language to reference Discord for support while also de-linking `dpo@char.com` mailto references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb41a7c5c36ea4c9051faae03e3ef59c696a507d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->