### PR TITLE
feat: file attachment support in editor

### DIFF
--- a/apps/desktop/src/editor/markdown.test.ts
+++ b/apps/desktop/src/editor/markdown.test.ts
@@ -374,3 +374,107 @@ describe("parseJsonContent", () => {
     expect(parseJsonContent(undefined)).toEqual(EMPTY_DOC);
   });
 });
+
+describe("fileAttachment round-trip", () => {
+  test("serializes fileAttachment node to markdown link", () => {
+    const md = json2md({
+      type: "doc",
+      content: [
+        {
+          type: "fileAttachment",
+          attrs: {
+            name: "report.pdf",
+            src: "asset://localhost/%2Fpath%2Freport.pdf",
+          },
+        },
+      ],
+    });
+    expect(md).toBe("[report.pdf](asset://localhost/%2Fpath%2Freport.pdf)");
+  });
+
+  test("parses markdown link with asset:// to fileAttachment", () => {
+    const json = md2json(
+      "[report.pdf](asset://localhost/%2Fpath%2Freport.pdf)",
+    );
+    const attachments = json.content!.filter(
+      (n) => n.type === "fileAttachment",
+    );
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].attrs?.name).toBe("report.pdf");
+    expect(attachments[0].attrs?.src).toBe(
+      "asset://localhost/%2Fpath%2Freport.pdf",
+    );
+  });
+
+  test("round-trips two file attachments without leaking URL tail", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "fileAttachment",
+          attrs: {
+            name: "CE2 The devil wears Prada script.pdf",
+            src: "asset://localhost/%2FUsers%2Fsungbin%2FLibrary%2FApplication%20Support%2Fcom.hyprnote.dev%2Fsessions%2Ff515cc6f%2Fattachments%2FCE2%20The%20devil%20wears%20Prada%20script%202.pdf",
+          },
+        },
+        {
+          type: "fileAttachment",
+          attrs: {
+            name: "2021-13630 조성빈 물리학 1 HW2.pdf",
+            src: "asset://localhost/%2FUsers%2Fsungbin%2FLibrary%2FApplication%20Support%2Fcom.hyprnote.dev%2Fsessions%2Ff515cc6f%2Fattachments%2F2021-13630%20%E1%84%8C%E1%85%A9%E1%84%89%E1%85%A5%E1%86%BC%E1%84%87%E1%85%B5%E1%86%AB%20%E1%84%86%E1%85%AE%E1%86%AF%E1%84%85%E1%85%B5%E1%84%92%E1%85%A1%E1%86%A8%201%20HW2.pdf",
+          },
+        },
+      ],
+    };
+
+    const md = json2md(doc);
+    const parsed = md2json(md);
+
+    const attachments = parsed.content!.filter(
+      (n) => n.type === "fileAttachment",
+    );
+    expect(attachments).toHaveLength(2);
+    expect(attachments[0].attrs?.name).toBe(
+      "CE2 The devil wears Prada script.pdf",
+    );
+    expect(attachments[1].attrs?.name).toBe(
+      "2021-13630 조성빈 물리학 1 HW2.pdf",
+    );
+    expect(attachments[0].attrs?.src).toBe(doc.content![0].attrs!.src);
+    expect(attachments[1].attrs?.src).toBe(doc.content![1].attrs!.src);
+
+    const leakedText = parsed
+      .content!.filter((n) => n.type === "paragraph")
+      .flatMap((p) => p.content ?? [])
+      .filter((n) => n.type === "text")
+      .map((n) => n.text)
+      .join("");
+    expect(leakedText).toBe("");
+  });
+
+  test("handles parentheses in filename via percent-encoding", () => {
+    const doc: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "fileAttachment",
+          attrs: {
+            name: "CE2 (Group 5) PPT.pdf",
+            src: "asset://localhost/%2Fpath%2FCE2%20(Group%205)%20PPT.pdf",
+          },
+        },
+      ],
+    };
+
+    const md = json2md(doc);
+    // Parens in URL must be encoded so the markdown link syntax is unambiguous.
+    expect(md).toContain("%28Group%205%29");
+
+    const parsed = md2json(md);
+    const attachments = parsed.content!.filter(
+      (n) => n.type === "fileAttachment",
+    );
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].attrs?.name).toBe("CE2 (Group 5) PPT.pdf");
+  });
+});

--- a/apps/desktop/src/editor/markdown.ts
+++ b/apps/desktop/src/editor/markdown.ts
@@ -263,6 +263,49 @@ const nodes: Record<string, NodeSpec> = {
     },
   },
 
+  fileAttachment: {
+    group: "block",
+    atom: true,
+    attrs: {
+      attachmentId: { default: null },
+      name: { default: "" },
+      mimeType: { default: "" },
+      src: { default: null },
+      path: { default: null },
+      size: { default: null },
+    },
+    parseDOM: [
+      {
+        tag: 'div[data-type="file-attachment"]',
+        getAttrs(dom) {
+          const el = dom as HTMLElement;
+          return {
+            attachmentId: el.getAttribute("data-attachment-id"),
+            name: el.getAttribute("data-name"),
+            mimeType: el.getAttribute("data-mime-type"),
+            src: el.getAttribute("data-src"),
+            size: el.getAttribute("data-size")
+              ? Number(el.getAttribute("data-size"))
+              : null,
+          };
+        },
+      },
+    ],
+    toDOM(node) {
+      const attrs: Record<string, string> = {
+        "data-type": "file-attachment",
+      };
+      if (node.attrs.attachmentId) {
+        attrs["data-attachment-id"] = node.attrs.attachmentId;
+      }
+      if (node.attrs.name) attrs["data-name"] = node.attrs.name;
+      if (node.attrs.mimeType) attrs["data-mime-type"] = node.attrs.mimeType;
+      if (node.attrs.src) attrs["data-src"] = node.attrs.src;
+      if (node.attrs.size != null) attrs["data-size"] = String(node.attrs.size);
+      return ["div", attrs];
+    },
+  },
+
   "mention-@": {
     group: "inline",
     inline: true,
@@ -659,6 +702,59 @@ function clipPlugin(md: MarkdownIt) {
   );
 }
 
+function fileAttachmentPlugin(md: MarkdownIt) {
+  md.block.ruler.before(
+    "paragraph",
+    "file_attachment",
+    (
+      state: StateBlock,
+      startLine: number,
+      _endLine: number,
+      silent: boolean,
+    ) => {
+      const pos = state.bMarks[startLine] + state.tShift[startLine];
+      const max = state.eMarks[startLine];
+      const line = state.src.slice(pos, max);
+
+      // [name](asset://localhost/...) with balanced parens in the URL
+      if (!line.startsWith("[")) return false;
+
+      const closeBracket = line.indexOf("](");
+      if (closeBracket === -1) return false;
+
+      const name = line.slice(1, closeBracket);
+      if (name.includes("]")) return false;
+
+      const urlStart = closeBracket + 2;
+      const PREFIX = "asset://localhost/";
+      if (!line.startsWith(PREFIX, urlStart)) return false;
+
+      let depth = 1;
+      let i = urlStart;
+      while (i < line.length && depth > 0) {
+        if (line[i] === "(") depth++;
+        else if (line[i] === ")") depth--;
+        if (depth > 0) i++;
+      }
+      if (depth !== 0) return false;
+
+      // Must be the entire line (trailing whitespace OK)
+      if (line.slice(i + 1).trim() !== "") return false;
+
+      if (silent) return true;
+
+      const url = line.slice(urlStart, i);
+      const token = state.push("file_attachment", "", 0);
+      token.attrSet("name", name);
+      token.attrSet("src", url);
+      token.map = [startLine, startLine + 1];
+      token.content = line;
+      state.line = startLine + 1;
+      return true;
+    },
+  );
+}
+
 function mentionPlugin(md: MarkdownIt) {
   md.inline.ruler.before(
     "html_inline",
@@ -714,9 +810,8 @@ function emptyParagraphsPlugin(md: MarkdownIt) {
         // Leading: the entire gap before the first block is empty paragraphs.
         // Between blocks: one blank line is normal separation; the rest are
         // empty paragraphs.
-        const extras = prevEndLine === -1
-          ? token.map![0]
-          : token.map![0] - prevEndLine - 1;
+        const extras =
+          prevEndLine === -1 ? token.map![0] : token.map![0] - prevEndLine - 1;
         for (let i = 0; i < extras; i++) pushEmpty();
       }
 
@@ -785,7 +880,6 @@ function wrapBlockImages(doc: JSONContent): JSONContent {
   return { ...doc, content: out };
 }
 
-
 // ---------------------------------------------------------------------------
 // Parser
 // ---------------------------------------------------------------------------
@@ -802,6 +896,7 @@ function getParser(): MarkdownParser {
   md.use(highlightPlugin);
   md.use(taskListPlugin);
   md.use(clipPlugin);
+  md.use(fileAttachmentPlugin);
   md.use(mentionPlugin);
   md.use(emptyParagraphsPlugin);
 
@@ -865,6 +960,17 @@ function getParser(): MarkdownParser {
     clip: {
       node: "clip",
       getAttrs: (tok) => ({ src: tok.attrGet("src") }),
+    },
+    file_attachment: {
+      node: "fileAttachment",
+      getAttrs: (tok) => ({
+        attachmentId: null,
+        name: tok.attrGet("name") ?? "",
+        mimeType: "",
+        src: tok.attrGet("src"),
+        path: null,
+        size: null,
+      }),
     },
     mention: {
       node: "mention-@",
@@ -998,6 +1104,15 @@ function getSerializer(): MarkdownSerializer {
       clip(state, node) {
         const src = (node.attrs.src || "").replace(/"/g, "&quot;");
         state.write(`<Clip src="${src}" />`);
+        state.closeBlock(node);
+      },
+
+      fileAttachment(state, node) {
+        const name = node.attrs.name || "file";
+        const src = (node.attrs.src || "")
+          .replace(/\(/g, "%28")
+          .replace(/\)/g, "%29");
+        state.write(`[${name}](${src})`);
         state.closeBlock(node);
       },
 

--- a/apps/desktop/src/editor/node-views/file-attachment-view.tsx
+++ b/apps/desktop/src/editor/node-views/file-attachment-view.tsx
@@ -1,0 +1,178 @@
+import {
+  type NodeViewComponentProps,
+  useEditorEventCallback,
+} from "@handlewithcare/react-prosemirror";
+import {
+  ExternalLinkIcon,
+  FileIcon,
+  FileSpreadsheetIcon,
+  FileTextIcon,
+  ImageIcon,
+  XIcon,
+} from "lucide-react";
+import type { NodeSpec } from "prosemirror-model";
+import { forwardRef } from "react";
+
+import { commands as openerCommands } from "@hypr/plugin-opener2";
+import { cn } from "@hypr/utils";
+
+const MIME_ICON_MAP: Record<string, typeof FileIcon> = {
+  "application/pdf": FileTextIcon,
+  "text/plain": FileTextIcon,
+  "text/csv": FileSpreadsheetIcon,
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+    FileSpreadsheetIcon,
+  "application/vnd.ms-excel": FileSpreadsheetIcon,
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+    FileTextIcon,
+  "application/msword": FileTextIcon,
+};
+
+function getFileIcon(mimeType: string) {
+  if (mimeType.startsWith("image/")) return ImageIcon;
+  return MIME_ICON_MAP[mimeType] ?? FileIcon;
+}
+
+function formatFileSize(bytes: number | null): string {
+  if (bytes == null) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export const fileAttachmentNodeSpec: NodeSpec = {
+  group: "block",
+  draggable: true,
+  atom: true,
+  selectable: true,
+  attrs: {
+    attachmentId: { default: null },
+    name: { default: "" },
+    mimeType: { default: "" },
+    src: { default: null },
+    path: { default: null },
+    size: { default: null },
+  },
+  parseDOM: [
+    {
+      tag: 'div[data-type="file-attachment"]',
+      getAttrs(dom) {
+        const el = dom as HTMLElement;
+        return {
+          attachmentId: el.getAttribute("data-attachment-id"),
+          name: el.getAttribute("data-name"),
+          mimeType: el.getAttribute("data-mime-type"),
+          src: el.getAttribute("data-src"),
+          size: el.getAttribute("data-size")
+            ? Number(el.getAttribute("data-size"))
+            : null,
+        };
+      },
+    },
+  ],
+  toDOM(node) {
+    const attrs: Record<string, string> = {
+      "data-type": "file-attachment",
+    };
+    if (node.attrs.attachmentId) {
+      attrs["data-attachment-id"] = node.attrs.attachmentId;
+    }
+    if (node.attrs.name) attrs["data-name"] = node.attrs.name;
+    if (node.attrs.mimeType) attrs["data-mime-type"] = node.attrs.mimeType;
+    if (node.attrs.src) attrs["data-src"] = node.attrs.src;
+    if (node.attrs.size != null) attrs["data-size"] = String(node.attrs.size);
+    return ["div", attrs, node.attrs.name || "attachment"];
+  },
+};
+
+export const FileAttachmentView = forwardRef<
+  HTMLDivElement,
+  NodeViewComponentProps
+>(function FileAttachmentView({ nodeProps, ...htmlAttrs }, ref) {
+  const { node, getPos } = nodeProps;
+  const { name, mimeType, src, path, size } = node.attrs;
+
+  const Icon = getFileIcon(mimeType ?? "");
+  const sizeLabel = formatFileSize(size);
+  const displayName =
+    name && name.length > 60 ? name.slice(0, 60) + "\u2026" : name || "file";
+
+  const handleRemove = useEditorEventCallback((view) => {
+    if (!view) return;
+    const pos = getPos();
+    view.dispatch(view.state.tr.delete(pos, pos + node.nodeSize));
+    view.focus();
+  });
+
+  const handleOpen = () => {
+    if (path) {
+      openerCommands.openPath(path, null);
+    }
+  };
+
+  const isImage = typeof mimeType === "string" && mimeType.startsWith("image/");
+
+  return (
+    <div ref={ref} {...htmlAttrs}>
+      <div
+        contentEditable={false}
+        suppressContentEditableWarning
+        className={cn([
+          "group my-1 flex items-center gap-3 rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2.5",
+          "hover:border-neutral-300 hover:bg-neutral-100",
+          "transition-colors",
+        ])}
+      >
+        {isImage && src ? (
+          <img
+            src={src}
+            alt={name}
+            className="h-10 w-10 shrink-0 rounded object-cover"
+          />
+        ) : (
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded bg-neutral-200/60">
+            <Icon size={20} className="text-neutral-500" />
+          </div>
+        )}
+
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-neutral-700">
+            {displayName}
+          </div>
+          {sizeLabel && (
+            <div className="text-xs text-neutral-400">{sizeLabel}</div>
+          )}
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+          {src && (
+            <button
+              type="button"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                handleOpen();
+              }}
+              className="rounded p-1 hover:bg-neutral-200"
+              title="Open file"
+            >
+              <ExternalLinkIcon size={14} className="text-neutral-500" />
+            </button>
+          )}
+          <button
+            type="button"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              handleRemove();
+            }}
+            className="rounded p-1 hover:bg-neutral-200"
+            title="Remove attachment"
+          >
+            <XIcon size={14} className="text-neutral-500" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/apps/desktop/src/editor/node-views/index.ts
+++ b/apps/desktop/src/editor/node-views/index.ts
@@ -1,5 +1,9 @@
 export { appLinkNodeSpec, AppLinkView } from "./app-link-view";
 export { attachmentNodeSpec, AttachmentChipView } from "./attachment-view";
+export {
+  fileAttachmentNodeSpec,
+  FileAttachmentView,
+} from "./file-attachment-view";
 export { imageNodeSpec, ResizableImageView } from "./image-view";
 export { mentionNodeSpec, MentionNodeView } from "./mention-view";
 export { sessionNodeSpec, SessionNodeView } from "./session-view";

--- a/apps/desktop/src/editor/plugins/file-handler.ts
+++ b/apps/desktop/src/editor/plugins/file-handler.ts
@@ -1,15 +1,23 @@
 import { Plugin, PluginKey } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
+export type FileUploadResult = {
+  url: string;
+  attachmentId: string;
+  path: string;
+};
+
 export type FileHandlerConfig = {
   onDrop?: (files: File[], pos?: number) => boolean | void;
   onPaste?: (files: File[]) => boolean | void;
-  onImageUpload?: (
-    file: File,
-  ) => Promise<{ url: string; attachmentId: string }>;
+  onFileUpload?: (file: File) => Promise<FileUploadResult>;
 };
 
 const IMAGE_MIME_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"];
+
+function isImageFile(file: File) {
+  return IMAGE_MIME_TYPES.includes(file.type);
+}
 
 export function fileHandlerPlugin(config: FileHandlerConfig) {
   function insertImage(
@@ -27,18 +35,53 @@ export function fileHandlerPlugin(config: FileHandlerConfig) {
     view.dispatch(tr);
   }
 
+  function insertFileAttachment(
+    view: EditorView,
+    attrs: {
+      attachmentId: string;
+      name: string;
+      mimeType: string;
+      src: string;
+      path: string;
+      size: number;
+    },
+    pos?: number,
+  ) {
+    const attachmentType = view.state.schema.nodes.fileAttachment;
+    if (!attachmentType) return;
+    const node = attachmentType.create(attrs);
+    const tr =
+      pos != null
+        ? view.state.tr.insert(pos, node)
+        : view.state.tr.replaceSelectionWith(node);
+    view.dispatch(tr);
+  }
+
   async function handleFiles(view: EditorView, files: File[], pos?: number) {
     for (const file of files) {
-      if (!IMAGE_MIME_TYPES.includes(file.type)) continue;
-
-      if (config.onImageUpload) {
+      if (config.onFileUpload) {
         try {
-          const { url, attachmentId } = await config.onImageUpload(file);
-          insertImage(view, url, attachmentId, pos);
+          const result = await config.onFileUpload(file);
+          if (isImageFile(file)) {
+            insertImage(view, result.url, result.attachmentId, pos);
+          } else {
+            insertFileAttachment(
+              view,
+              {
+                attachmentId: result.attachmentId,
+                name: file.name,
+                mimeType: file.type,
+                src: result.url,
+                path: result.path,
+                size: file.size,
+              },
+              pos,
+            );
+          }
         } catch (error) {
-          console.error("Failed to upload image:", error);
+          console.error("Failed to upload file:", error);
         }
-      } else {
+      } else if (isImageFile(file)) {
         const reader = new FileReader();
         reader.readAsDataURL(file);
         reader.onload = () => {
@@ -52,9 +95,7 @@ export function fileHandlerPlugin(config: FileHandlerConfig) {
     key: new PluginKey("fileHandler"),
     props: {
       handleDrop(view, event) {
-        const files = Array.from(event.dataTransfer?.files ?? []).filter((f) =>
-          IMAGE_MIME_TYPES.includes(f.type),
-        );
+        const files = Array.from(event.dataTransfer?.files ?? []);
         if (files.length === 0) return false;
 
         event.preventDefault();
@@ -73,9 +114,7 @@ export function fileHandlerPlugin(config: FileHandlerConfig) {
       },
 
       handlePaste(view, event) {
-        const files = Array.from(event.clipboardData?.files ?? []).filter((f) =>
-          IMAGE_MIME_TYPES.includes(f.type),
-        );
+        const files = Array.from(event.clipboardData?.files ?? []);
         if (files.length === 0) return false;
 
         if (config.onPaste) {

--- a/apps/desktop/src/editor/session/index.tsx
+++ b/apps/desktop/src/editor/session/index.tsx
@@ -33,6 +33,7 @@ import "@hypr/tiptap/styles.css";
 
 import {
   AppLinkView,
+  FileAttachmentView,
   MentionNodeView,
   ResizableImageView,
   SessionNodeView,
@@ -126,6 +127,7 @@ interface EditorProps {
 
 const nodeViews = {
   appLink: AppLinkView,
+  fileAttachment: FileAttachmentView,
   image: ResizableImageView,
   "mention-@": MentionNodeView,
   session: SessionNodeView,

--- a/apps/desktop/src/editor/session/schema.ts
+++ b/apps/desktop/src/editor/session/schema.ts
@@ -7,6 +7,7 @@ import {
   sessionNodeSpec,
   taskItemNodeSpec,
   taskListNodeSpec,
+  fileAttachmentNodeSpec,
 } from "../node-views";
 import { clipNodeSpec } from "../plugins";
 
@@ -122,6 +123,7 @@ const nodes: Record<string, NodeSpec> = {
   taskList: taskListNodeSpec,
   taskItem: taskItemNodeSpec,
   image: imageNodeSpec,
+  fileAttachment: fileAttachmentNodeSpec,
   appLink: appLinkNodeSpec,
   "mention-@": mentionNodeSpec,
   session: sessionNodeSpec,
@@ -199,8 +201,12 @@ const marks: Record<string, MarkSpec> = {
       {
         tag: "a[href]",
         getAttrs(dom) {
+          const href = (dom as HTMLElement).getAttribute("href");
+          if (href && href.startsWith("asset://")) {
+            return false;
+          }
           return {
-            href: (dom as HTMLElement).getAttribute("href"),
+            href,
             target: (dom as HTMLElement).getAttribute("target"),
           };
         },

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -7,7 +7,7 @@ import {
   type NoteEditorRef,
 } from "~/editor/session";
 import { useSearchEngine } from "~/search/contexts/engine";
-import { useImageUpload } from "~/shared/hooks/useImageUpload";
+import { useFileUpload } from "~/shared/hooks/useFileUpload";
 import * as main from "~/store/tinybase/store/main";
 
 export const EnhancedEditor = forwardRef<
@@ -18,7 +18,7 @@ export const EnhancedEditor = forwardRef<
     onNavigateToTitle?: (pixelWidth?: number) => void;
   }
 >(({ sessionId, enhancedNoteId, onNavigateToTitle }, ref) => {
-  const onImageUpload = useImageUpload(sessionId);
+  const onFileUpload = useFileUpload(sessionId);
   const content = main.UI.useCell(
     "enhanced_notes",
     enhancedNoteId,
@@ -91,7 +91,7 @@ export const EnhancedEditor = forwardRef<
     [search, sessions, humans, organizations],
   );
 
-  const fileHandlerConfig = useMemo(() => ({ onImageUpload }), [onImageUpload]);
+  const fileHandlerConfig = useMemo(() => ({ onFileUpload }), [onFileUpload]);
 
   return (
     <div className="h-full">

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -10,7 +10,7 @@ import {
   type PlaceholderFunction,
 } from "~/editor/session";
 import { useSearchEngine } from "~/search/contexts/engine";
-import { useImageUpload } from "~/shared/hooks/useImageUpload";
+import { useFileUpload } from "~/shared/hooks/useFileUpload";
 import * as main from "~/store/tinybase/store/main";
 
 export const RawEditor = forwardRef<
@@ -21,7 +21,7 @@ export const RawEditor = forwardRef<
   }
 >(({ sessionId, onNavigateToTitle }, ref) => {
   const rawMd = main.UI.useCell("sessions", sessionId, "raw_md", main.STORE_ID);
-  const onImageUpload = useImageUpload(sessionId);
+  const onFileUpload = useFileUpload(sessionId);
 
   const initialContent = useMemo<JSONContent>(
     () => parseJsonContent(rawMd as string),
@@ -119,7 +119,7 @@ export const RawEditor = forwardRef<
     [search, sessions, humans, organizations],
   );
 
-  const fileHandlerConfig = useMemo(() => ({ onImageUpload }), [onImageUpload]);
+  const fileHandlerConfig = useMemo(() => ({ onFileUpload }), [onFileUpload]);
 
   return (
     <NoteEditor

--- a/apps/desktop/src/session/components/outer-header/metadata/tags/chip.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/tags/chip.tsx
@@ -13,9 +13,12 @@ export function TagChip({ mappingId }: { mappingId: string }) {
     "tag_id",
     main.STORE_ID,
   ) as string | undefined;
-  const tagName = main.UI.useCell("tags", tagId ?? "", "name", main.STORE_ID) as
-    | string
-    | undefined;
+  const tagName = main.UI.useCell(
+    "tags",
+    tagId ?? "",
+    "name",
+    main.STORE_ID,
+  ) as string | undefined;
 
   if (!tagId || !tagName) {
     return null;

--- a/apps/desktop/src/shared/hooks/useFileUpload.ts
+++ b/apps/desktop/src/shared/hooks/useFileUpload.ts
@@ -6,13 +6,13 @@ import {
   commands as fsSyncCommands,
 } from "@hypr/plugin-fs-sync";
 
-export type ImageUploadResult = AttachmentSaveResult & {
+export type FileUploadResult = AttachmentSaveResult & {
   url: string;
 };
 
-export function useImageUpload(sessionId: string) {
+export function useFileUpload(sessionId: string) {
   return useCallback(
-    async (file: File): Promise<ImageUploadResult> => {
+    async (file: File): Promise<FileUploadResult> => {
       const filename = file.name;
       const arrayBuffer = await file.arrayBuffer();
       const data = Array.from(new Uint8Array(arrayBuffer));


### PR DESCRIPTION
## Summary
- Add TipTap file attachment extension with node view for rendering attached files
- Refactor `useImageUpload` → `useFileUpload` to support non-image file types
- Update file handler plugin to handle arbitrary file attachments
- Add editor schema and extension registration for file attachments

## Test plan
- [ ] Attach image files to a note and verify they render correctly
- [ ] Attach non-image files (PDF, text, etc.) and verify the attachment node appears
- [ ] Verify drag-and-drop file handling works
- [ ] Verify existing image upload functionality is not broken

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates editor schema/markdown round-tripping and drop/paste handling to introduce a new `fileAttachment` node, which could affect note serialization/parsing and attachment rendering across existing content.
> 
> **Overview**
> Adds a new block-level `fileAttachment` node to the editor (schema + node view) so dropped/pasted non-image files render as an attachment chip with open/remove actions and basic metadata (name, mime type, size).
> 
> Extends markdown conversion to round-trip attachments by serializing `fileAttachment` as `[name](asset://localhost/...)`, adding a markdown-it parser rule for these links (with balanced-paren handling and `%28/%29` encoding) and tests to prevent URL/text leakage.
> 
> Refactors upload handling from image-only to generic `onFileUpload` (renaming `useImageUpload`→`useFileUpload`) and updates the file handler plugin to insert images for image MIME types and `fileAttachment` nodes for everything else.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7712c4be835dc1606b1da57e28184d9460093a64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->