### PR TITLE
Welcome screen for daily notes

### DIFF
--- a/apps/desktop/src/editor/node-views/session-view.tsx
+++ b/apps/desktop/src/editor/node-views/session-view.tsx
@@ -156,26 +156,23 @@ export const SessionNodeView = forwardRef<
         onMouseDown={handleRowMouseDown}
         onClick={handleRowClick}
         className={cn([
-          "group flex items-start rounded-md px-2 py-1 transition-colors",
+          "group flex items-start rounded-md px-2 py-1.5 transition-colors",
           "-mx-2 focus-within:bg-neutral-50 hover:bg-neutral-50",
           "cursor-pointer",
         ])}
       >
         {isRecording ? (
-          <div
-            className="flex size-[18px] shrink-0 items-center justify-center"
-            contentEditable={false}
-          >
+          <div className="flex size-[18px] shrink-0" contentEditable={false}>
             <div className="size-2.5 animate-pulse rounded-full bg-red-500" />
           </div>
         ) : (
           <TaskCheckbox status={status} isInteractive onToggle={handleToggle} />
         )}
-        <div className="flex min-w-0 flex-1 items-baseline gap-2">
+        <div className="flex min-w-0 flex-1 gap-2">
           <div
             data-session-title
             className={cn([
-              "min-w-0 text-sm text-neutral-900",
+              "min-w-0 text-neutral-900",
               "[&>p]:m-0 [&>p]:min-w-0 [&>p]:truncate",
               status === "done" && "[&>p]:line-through [&>p]:opacity-60",
             ])}

--- a/apps/desktop/src/editor/node-views/task-item-view.tsx
+++ b/apps/desktop/src/editor/node-views/task-item-view.tsx
@@ -144,7 +144,7 @@ export const TaskItemView = forwardRef<
         onToggle={handleToggle}
       />
       <div className="flex min-w-0 flex-1 flex-wrap items-start gap-2">
-        <div className="min-w-0 flex-1">{children}</div>
+        <div className="text-box-trim min-w-0 flex-1">{children}</div>
         {taskSource && taskId ? (
           <div contentEditable={false} suppressContentEditableWarning>
             {showDueDateInput ? (

--- a/apps/desktop/src/main2/home/date-header.tsx
+++ b/apps/desktop/src/main2/home/date-header.tsx
@@ -19,7 +19,17 @@ function formatDateHeader(dateStr: string): string {
   return `${month} ${day}${ordinalSuffix(day)}`;
 }
 
-export function DateHeader({ date, muted }: { date: string; muted?: boolean }) {
+export function DateHeader({
+  date,
+  muted,
+  isToday,
+  onDismissWelcome,
+}: {
+  date: string;
+  muted?: boolean;
+  isToday?: boolean;
+  onDismissWelcome?: () => void;
+}) {
   return (
     <div className="flex items-center gap-3 px-6 pt-6 pb-3">
       <h2
@@ -31,6 +41,20 @@ export function DateHeader({ date, muted }: { date: string; muted?: boolean }) {
       >
         {formatDateHeader(date)}
       </h2>
+      {isToday && (
+        <span className="rounded-full bg-neutral-900 px-2.5 py-0.5 text-xs font-medium text-white">
+          today
+        </span>
+      )}
+      <div className="flex-1" />
+      {onDismissWelcome && (
+        <button
+          onClick={onDismissWelcome}
+          className="text-xs text-neutral-400 transition-colors hover:text-neutral-600"
+        >
+          Dismiss welcome
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/main2/home/date-header.tsx
+++ b/apps/desktop/src/main2/home/date-header.tsx
@@ -52,7 +52,7 @@ export function DateHeader({
           onClick={onDismissWelcome}
           className="text-xs text-neutral-400 transition-colors hover:text-neutral-600"
         >
-          Dismiss welcome
+          Clear welcome message
         </button>
       )}
     </div>

--- a/apps/desktop/src/main2/home/index.tsx
+++ b/apps/desktop/src/main2/home/index.tsx
@@ -7,24 +7,26 @@ import { LazyNote } from "./lazy-note";
 import { DailyNoteEditor } from "./note-editor";
 import { TodayButton } from "./today-button";
 import { useToday } from "./use-today";
-import { WelcomeNote } from "./welcome-note";
+import { WELCOME_DATE_KEY, WELCOME_DISMISSED_KEY } from "./welcome-content";
 
 import { useTimezone, toTz } from "~/calendar/hooks";
 import { StandardTabWrapper } from "~/shared/main";
-import * as main from "~/store/tinybase/store/main";
-
-const WELCOME_DISMISSED_KEY = "daily-notes-welcome-dismissed";
 
 export function Main2Home() {
   const today = useToday();
   const tz = useTimezone();
   const scrollRef = useRef<HTMLDivElement>(null);
   const todayRef = useRef<HTMLDivElement>(null);
-  const welcomeRef = useRef<HTMLDivElement>(null);
   const [showTodayButton, setShowTodayButton] = useState(false);
-  const [showWelcome, setShowWelcome] = useState(
-    () => localStorage.getItem(WELCOME_DISMISSED_KEY) !== "true",
-  );
+  const [showWelcome, setShowWelcome] = useState(() => {
+    if (localStorage.getItem(WELCOME_DISMISSED_KEY) === "true") return false;
+    const welcomeDate = localStorage.getItem(WELCOME_DATE_KEY);
+    if (!welcomeDate) {
+      localStorage.setItem(WELCOME_DATE_KEY, today);
+      return true;
+    }
+    return welcomeDate === today;
+  });
 
   const tomorrow = useMemo(() => {
     const d = new Date();
@@ -43,22 +45,15 @@ export function Main2Home() {
   const handleDismissWelcome = useCallback(() => {
     localStorage.setItem(WELCOME_DISMISSED_KEY, "true");
     setShowWelcome(false);
-    setTimeout(() => {
-      todayRef.current?.scrollIntoView({ behavior: "smooth" });
-    }, 0);
   }, []);
 
   const scrollToToday = useCallback(() => {
-    if (showWelcome) {
-      welcomeRef.current?.scrollIntoView({ behavior: "smooth" });
-    } else {
-      todayRef.current?.scrollIntoView({ behavior: "smooth" });
-    }
-  }, [showWelcome]);
+    todayRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, []);
 
   useEffect(() => {
     const scrollEl = scrollRef.current;
-    const targetEl = showWelcome ? welcomeRef.current : todayRef.current;
+    const targetEl = todayRef.current;
     if (!scrollEl || !targetEl) return;
 
     const observer = new IntersectionObserver(
@@ -70,7 +65,7 @@ export function Main2Home() {
 
     observer.observe(targetEl);
     return () => observer.disconnect();
-  }, [showWelcome]);
+  }, []);
 
   useEffect(() => {
     window.addEventListener("scroll-to-today", scrollToToday);
@@ -89,19 +84,15 @@ export function Main2Home() {
 
             <div className="mx-6 border-t border-neutral-200" />
 
-            {showWelcome && (
-              <div ref={welcomeRef} className="min-h-[400px]">
-                <WelcomeNote onDismiss={handleDismissWelcome} />
-              </div>
-            )}
-
-            {showWelcome && (
-              <div className="mx-6 border-t border-neutral-200" />
-            )}
-
             <div ref={todayRef} className="min-h-[400px]">
-              <DateHeader date={today} />
-              <DailyNoteEditor date={today} isToday />
+              <DateHeader
+                date={today}
+                isToday
+                onDismissWelcome={
+                  showWelcome ? handleDismissWelcome : undefined
+                }
+              />
+              <DailyNoteEditor date={today} isToday showWelcome={showWelcome} />
             </div>
 
             {pastDates.map((date) => (
@@ -113,7 +104,14 @@ export function Main2Home() {
 
             {import.meta.env.DEV && !showWelcome && (
               <div className="px-6 py-4">
-                <DebugResetWelcome onReset={() => setShowWelcome(true)} />
+                <DebugResetWelcome
+                  onReset={() => {
+                    localStorage.removeItem(WELCOME_DISMISSED_KEY);
+                    localStorage.removeItem(WELCOME_DATE_KEY);
+                    localStorage.setItem(WELCOME_DATE_KEY, today);
+                    setShowWelcome(true);
+                  }}
+                />
               </div>
             )}
           </div>
@@ -124,14 +122,9 @@ export function Main2Home() {
 }
 
 function DebugResetWelcome({ onReset }: { onReset: () => void }) {
-  const store = main.UI.useStore(main.STORE_ID);
   return (
     <button
-      onClick={() => {
-        localStorage.removeItem(WELCOME_DISMISSED_KEY);
-        store?.delRow("daily_notes", "welcome");
-        onReset();
-      }}
+      onClick={onReset}
       className="rounded bg-neutral-100 px-3 py-1.5 text-xs text-neutral-500 hover:bg-neutral-200"
     >
       [debug] Reset welcome note

--- a/apps/desktop/src/main2/home/index.tsx
+++ b/apps/desktop/src/main2/home/index.tsx
@@ -7,16 +7,24 @@ import { LazyNote } from "./lazy-note";
 import { DailyNoteEditor } from "./note-editor";
 import { TodayButton } from "./today-button";
 import { useToday } from "./use-today";
+import { WelcomeNote } from "./welcome-note";
 
 import { useTimezone, toTz } from "~/calendar/hooks";
 import { StandardTabWrapper } from "~/shared/main";
+import * as main from "~/store/tinybase/store/main";
+
+const WELCOME_DISMISSED_KEY = "daily-notes-welcome-dismissed";
 
 export function Main2Home() {
   const today = useToday();
   const tz = useTimezone();
   const scrollRef = useRef<HTMLDivElement>(null);
   const todayRef = useRef<HTMLDivElement>(null);
+  const welcomeRef = useRef<HTMLDivElement>(null);
   const [showTodayButton, setShowTodayButton] = useState(false);
+  const [showWelcome, setShowWelcome] = useState(
+    () => localStorage.getItem(WELCOME_DISMISSED_KEY) !== "true",
+  );
 
   const tomorrow = useMemo(() => {
     const d = new Date();
@@ -32,14 +40,26 @@ export function Main2Home() {
     });
   }, [today, tz]);
 
-  const scrollToToday = useCallback(() => {
-    todayRef.current?.scrollIntoView({ behavior: "smooth" });
+  const handleDismissWelcome = useCallback(() => {
+    localStorage.setItem(WELCOME_DISMISSED_KEY, "true");
+    setShowWelcome(false);
+    setTimeout(() => {
+      todayRef.current?.scrollIntoView({ behavior: "smooth" });
+    }, 0);
   }, []);
+
+  const scrollToToday = useCallback(() => {
+    if (showWelcome) {
+      welcomeRef.current?.scrollIntoView({ behavior: "smooth" });
+    } else {
+      todayRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [showWelcome]);
 
   useEffect(() => {
     const scrollEl = scrollRef.current;
-    const todayEl = todayRef.current;
-    if (!scrollEl || !todayEl) return;
+    const targetEl = showWelcome ? welcomeRef.current : todayRef.current;
+    if (!scrollEl || !targetEl) return;
 
     const observer = new IntersectionObserver(
       ([entry]) => {
@@ -48,9 +68,9 @@ export function Main2Home() {
       { root: scrollEl, threshold: 0 },
     );
 
-    observer.observe(todayEl);
+    observer.observe(targetEl);
     return () => observer.disconnect();
-  }, []);
+  }, [showWelcome]);
 
   useEffect(() => {
     window.addEventListener("scroll-to-today", scrollToToday);
@@ -69,6 +89,16 @@ export function Main2Home() {
 
             <div className="mx-6 border-t border-neutral-200" />
 
+            {showWelcome && (
+              <div ref={welcomeRef} className="min-h-[400px]">
+                <WelcomeNote onDismiss={handleDismissWelcome} />
+              </div>
+            )}
+
+            {showWelcome && (
+              <div className="mx-6 border-t border-neutral-200" />
+            )}
+
             <div ref={todayRef} className="min-h-[400px]">
               <DateHeader date={today} />
               <DailyNoteEditor date={today} isToday />
@@ -80,9 +110,31 @@ export function Main2Home() {
                 <LazyNote date={date} muted />
               </div>
             ))}
+
+            {import.meta.env.DEV && !showWelcome && (
+              <div className="px-6 py-4">
+                <DebugResetWelcome onReset={() => setShowWelcome(true)} />
+              </div>
+            )}
           </div>
         </div>
       </div>
     </StandardTabWrapper>
+  );
+}
+
+function DebugResetWelcome({ onReset }: { onReset: () => void }) {
+  const store = main.UI.useStore(main.STORE_ID);
+  return (
+    <button
+      onClick={() => {
+        localStorage.removeItem(WELCOME_DISMISSED_KEY);
+        store?.delRow("daily_notes", "welcome");
+        onReset();
+      }}
+      className="rounded bg-neutral-100 px-3 py-1.5 text-xs text-neutral-500 hover:bg-neutral-200"
+    >
+      [debug] Reset welcome note
+    </button>
   );
 }

--- a/apps/desktop/src/main2/home/note-editor.css
+++ b/apps/desktop/src/main2/home/note-editor.css
@@ -1,16 +1,80 @@
+/* --- Daily notes editor style overrides --- */
+
+.main2-daily-note-editor .tiptap p {
+  margin-bottom: 0rem;
+  line-height: 26px;
+}
+
+.main2-daily-note-editor .tiptap h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-top: 1.5rem;
+  margin-bottom: 1.25rem;
+}
+.main2-daily-note-editor .tiptap h2 {
+  font-weight: 600;
+  font-size: 1.25rem;
+  margin-top: 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.main2-daily-note-editor .tiptap h3,
+.main2-daily-note-editor .tiptap h4,
+.main2-daily-note-editor .tiptap h5,
+.main2-daily-note-editor .tiptap h6 {
+  font-weight: 600;
+  font-size: 1rem;
+  margin-top: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.main2-daily-note-editor .tiptap :not(:first-child):is(h1, h2, h3, h4, h5, h6) {
+  margin-top: 1rem;
+}
+
+.main2-daily-note-editor .tiptap ul[data-type="taskList"] {
+  padding: 0;
+  margin-left: 0;
+  margin-top: 0rem;
+}
+
+.main2-daily-note-editor .tiptap ul[data-type="taskList"] li {
+  margin-bottom: 0.5rem;
+}
+
+.main2-daily-note-editor .tiptap li[data-type="taskItem"] {
+  margin-bottom: 0.5rem;
+}
+
+.text-box-trim {
+  text-box-trim: trim-start;
+}
+
+.main2-daily-note-editor .tiptap hr {
+  border: none;
+  border-top: 1px solid #e5e5e5;
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+/* --- Session title icon --- */
+
 .main2-daily-note-editor [data-session-title] {
   position: relative;
-  padding-left: 28px;
+  padding-left: 24px;
   line-height: 1.25rem;
+}
+
+.main2-daily-note-editor [data-session-title] > p {
+  text-box-trim: trim-both;
 }
 
 .main2-daily-note-editor [data-session-title]::before {
   content: "";
   position: absolute;
-  top: calc((1.25rem - 13px) / 2);
-  left: 8px;
-  width: 13px;
-  height: 13px;
+  top: calc((1.25rem - 12px) / 2);
+  left: 4px;
+  width: 12px;
+  height: 12px;
   pointer-events: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23a3a3a3' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 2v4'/%3E%3Cpath d='M16 2v4'/%3E%3Crect width='18' height='18' x='3' y='4' rx='2'/%3E%3Cpath d='M3 10h18'/%3E%3C/svg%3E");
   background-position: center;

--- a/apps/desktop/src/main2/home/note-editor.tsx
+++ b/apps/desktop/src/main2/home/note-editor.tsx
@@ -7,6 +7,8 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { parseJsonContent } from "@hypr/tiptap/shared";
 import { format, parseISO, subDays } from "@hypr/utils";
 
+import { welcomeContent } from "./welcome-content";
+
 import { useCalendarData } from "~/calendar/hooks";
 import {
   type JSONContent,
@@ -32,6 +34,7 @@ import {
 } from "~/session/utils";
 import * as main from "~/store/tinybase/store/main";
 import { getOrCreateSessionForEventId } from "~/store/tinybase/store/sessions";
+import { useTabs } from "~/store/zustand/tabs";
 
 type Store = NonNullable<ReturnType<typeof main.UI.useStore>>;
 const emptyDoc: JSONContent = { type: "doc", content: [{ type: "paragraph" }] };
@@ -160,12 +163,45 @@ function readRawContent(store: Store, date: string): JSONContent {
   return normalizeTaskContent(parseJsonContent(cell as string)) ?? emptyDoc;
 }
 
+function hasWelcomeContent(content: JSONContent): boolean {
+  const firstWelcomeNode = welcomeContent.content?.[0];
+  const firstContentNode = content.content?.[0];
+  if (!firstWelcomeNode || !firstContentNode) return false;
+  return JSON.stringify(firstContentNode) === JSON.stringify(firstWelcomeNode);
+}
+
+const WELCOME_NODE_COUNT = (welcomeContent.content?.length ?? 0) + 1; // +1 for separator paragraph
+
+function prependWelcome(content: JSONContent): JSONContent {
+  const welcomeNodes = welcomeContent.content ?? [];
+  const existingNodes = content.content ?? [];
+  return {
+    type: "doc",
+    content: [...welcomeNodes, { type: "paragraph" }, ...existingNodes],
+  };
+}
+
+function stripWelcome(content: JSONContent): JSONContent {
+  let result = content;
+  while (hasWelcomeContent(result)) {
+    const nodes = result.content ?? [];
+    const remaining = nodes.slice(WELCOME_NODE_COUNT);
+    result = {
+      type: "doc",
+      content: remaining.length > 0 ? remaining : [{ type: "paragraph" }],
+    };
+  }
+  return result;
+}
+
 export function DailyNoteEditor({
   date,
   isToday,
+  showWelcome,
 }: {
   date: string;
   isToday?: boolean;
+  showWelcome?: boolean;
 }) {
   const store = main.UI.useStore(main.STORE_ID);
   const editorRef = useRef<NoteEditorRef>(null);
@@ -259,11 +295,18 @@ export function DailyNoteEditor({
       }
     }
 
-    if (JSON.stringify(content) !== JSON.stringify(rawContent)) {
+    // Strip any previously persisted welcome content
+    const cleanedContent = stripWelcome(content);
+    if (JSON.stringify(cleanedContent) !== JSON.stringify(rawContent)) {
+      content = cleanedContent;
       store.setPartialRow("daily_notes", date, {
         date,
-        content: JSON.stringify(content),
+        content: JSON.stringify(cleanedContent),
       });
+    }
+
+    if (showWelcome) {
+      content = prependWelcome(stripWelcome(content));
     }
 
     initialContentRef.current = content;
@@ -276,6 +319,24 @@ export function DailyNoteEditor({
     [date],
     main.STORE_ID,
   );
+
+  useEffect(() => {
+    if (!showWelcome) {
+      const view = editorRef.current?.view;
+      if (view && hasWelcomeContent(view.state.doc.toJSON() as JSONContent)) {
+        const currentContent = view.state.doc.toJSON() as JSONContent;
+        const cleaned = stripWelcome(currentContent);
+        const nextDoc = PMNode.fromJSON(schema, cleaned);
+        view.dispatch(
+          view.state.tr.replaceWith(
+            0,
+            view.state.doc.content.size,
+            nextDoc.content,
+          ),
+        );
+      }
+    }
+  }, [showWelcome]);
 
   useEffect(() => {
     const view = editorRef.current?.view;
@@ -292,8 +353,10 @@ export function DailyNoteEditor({
 
   const handleChange = useCallback(
     (input: JSONContent) => {
+      const contentToSave = showWelcome ? stripWelcome(input) : input;
+
       if (store) {
-        for (const node of input.content ?? []) {
+        for (const node of contentToSave.content ?? []) {
           if (node.type !== "session") {
             continue;
           }
@@ -311,9 +374,26 @@ export function DailyNoteEditor({
         }
       }
 
-      persistDailyNote(input);
+      persistDailyNote(contentToSave);
     },
-    [persistDailyNote, store],
+    [persistDailyNote, store, showWelcome],
+  );
+
+  const openNew = useTabs((s) => s.openNew);
+  const handleLinkClick = useCallback(
+    (e: React.MouseEvent) => {
+      const anchor = (e.target as HTMLElement).closest("a[href]");
+      if (!anchor) return;
+      const href = anchor.getAttribute("href");
+      if (!href) return;
+
+      if (href.startsWith("char://settings/")) {
+        e.preventDefault();
+        const tab = href.replace("char://settings/", "");
+        openNew({ type: "settings", state: { tab } });
+      }
+    },
+    [openNew],
   );
 
   if (!initialContentRef.current) {
@@ -321,7 +401,7 @@ export function DailyNoteEditor({
   }
 
   return (
-    <div className="main2-daily-note-editor px-6">
+    <div className="main2-daily-note-editor px-6" onClick={handleLinkClick}>
       <NoteEditor
         ref={editorRef}
         key={`daily-${date}`}

--- a/apps/desktop/src/main2/home/welcome-content.ts
+++ b/apps/desktop/src/main2/home/welcome-content.ts
@@ -1,0 +1,275 @@
+import type { JSONContent } from "~/editor/session";
+
+export const WELCOME_DISMISSED_KEY = "daily-notes-welcome-dismissed";
+export const WELCOME_DATE_KEY = "daily-notes-welcome-date";
+
+export const welcomeContent: JSONContent = {
+  type: "doc",
+  content: [
+    {
+      type: "heading",
+      attrs: { level: 2 },
+      content: [{ type: "text", text: "Welcome to Char!" }],
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "Every day you get a fresh note for your task, ideas and meetings \u2014 write it any way you want and build your own workflow.",
+        },
+      ],
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "Char record your daily work on screen, learn of your day and projects to help you with your routine. All data stays and processed locally and never leave your computer.",
+        },
+      ],
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          marks: [
+            {
+              type: "link",
+              attrs: { href: "char://settings/app" },
+            },
+          ],
+          text: "Setup permissions",
+        },
+        {
+          type: "text",
+          text: " and read more in ",
+        },
+        {
+          type: "text",
+          marks: [
+            {
+              type: "link",
+              attrs: { href: "https://char.com/docs" },
+            },
+          ],
+          text: "Docs",
+        },
+        {
+          type: "text",
+          text: " about how Char record your day",
+        },
+      ],
+    },
+    {
+      type: "heading",
+      attrs: { level: 3 },
+      content: [
+        { type: "text", text: "This is what you can do with Daily Notes" },
+      ],
+    },
+    {
+      type: "taskList",
+      content: [
+        {
+          type: "taskItem",
+          attrs: { checked: false },
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "text",
+                  text: "You can write and create any lists there. Just type ",
+                },
+                { type: "text", marks: [{ type: "code" }], text: "/" },
+                { type: "text", text: " or in markdown" },
+              ],
+            },
+          ],
+        },
+        {
+          type: "taskItem",
+          attrs: { checked: false },
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "text",
+                  marks: [
+                    {
+                      type: "link",
+                      attrs: { href: "char://settings/intelligence" },
+                    },
+                  ],
+                  text: "Configure",
+                },
+                {
+                  type: "text",
+                  text: " your AI to work with there. Char works with Cloud, API providers and local models to transcribe meetings, answer questions and complete your tasks",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "taskItem",
+          attrs: { checked: false },
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "text",
+                  text: "All your meetings appears there. Click on it to open",
+                },
+              ],
+            },
+            {
+              type: "session",
+              attrs: {
+                sessionId: "welcome-demo",
+                status: null,
+                checked: null,
+              },
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "This is dummy meeting" }],
+                },
+              ],
+            },
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "text",
+                  text: " Char will transcribe them by using all context around: audio, presentations, your notes",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "taskItem",
+          attrs: { checked: false },
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "text",
+                  text: "Create a new recording with ",
+                },
+                { type: "text", marks: [{ type: "code" }], text: "/" },
+                { type: "text", text: " command or by pressing " },
+                {
+                  type: "text",
+                  marks: [{ type: "code" }],
+                  text: "new recording",
+                },
+                {
+                  type: "text",
+                  text: ". It will appear in your daily note",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "taskItem",
+          attrs: { checked: false },
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                { type: "text", text: "Explore how to add " },
+                {
+                  type: "text",
+                  marks: [
+                    {
+                      type: "link",
+                      attrs: { href: "char://settings/agent" },
+                    },
+                  ],
+                  text: "integrations",
+                },
+                { type: "text", text: " in Char to accelerate your work" },
+              ],
+            },
+          ],
+        },
+        {
+          type: "taskItem",
+          attrs: { checked: false },
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                { type: "text", text: "Read " },
+                {
+                  type: "text",
+                  marks: [
+                    {
+                      type: "link",
+                      attrs: { href: "https://char.com/docs" },
+                    },
+                  ],
+                  text: "docs",
+                },
+                {
+                  type: "text",
+                  text: " to integrate Char in your workflow.",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "taskItem",
+          attrs: { checked: false },
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                { type: "text", text: "Join us on " },
+                {
+                  type: "text",
+                  marks: [
+                    {
+                      type: "link",
+                      attrs: { href: "https://x.com/char" },
+                    },
+                  ],
+                  text: "X",
+                },
+                { type: "text", text: " or " },
+                {
+                  type: "text",
+                  marks: [
+                    {
+                      type: "link",
+                      attrs: { href: "https://discord.gg/char" },
+                    },
+                  ],
+                  text: "Discord",
+                },
+                { type: "text", text: " to get latest updates" },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: "horizontalRule",
+    },
+    {
+      type: "heading",
+      attrs: { level: 3 },
+      content: [{ type: "text", text: "Enjoy Char! There is your day:" }],
+    },
+  ],
+};

--- a/apps/desktop/src/main2/home/welcome-content.ts
+++ b/apps/desktop/src/main2/home/welcome-content.ts
@@ -16,7 +16,7 @@ export const welcomeContent: JSONContent = {
       content: [
         {
           type: "text",
-          text: "Every day you get a fresh note for your task, ideas and meetings \u2014 write it any way you want and build your own workflow.",
+          text: "Every day you get a fresh note for your tasks, ideas and meetings \u2014 write it any way you want and build your own workflow.",
         },
       ],
     },
@@ -25,7 +25,7 @@ export const welcomeContent: JSONContent = {
       content: [
         {
           type: "text",
-          text: "Char record your daily work on screen, learn of your day and projects to help you with your routine. All data stays and processed locally and never leave your computer.",
+          text: "Char records your daily work on screen, learns about your day and projects to help you with your routine. All data is stored and processed locally and never leaves your computer.",
         },
       ],
     },
@@ -58,7 +58,7 @@ export const welcomeContent: JSONContent = {
         },
         {
           type: "text",
-          text: " about how Char record your day",
+          text: " about how Char records your day",
         },
       ],
     },
@@ -84,7 +84,7 @@ export const welcomeContent: JSONContent = {
                   text: "You can write and create any lists there. Just type ",
                 },
                 { type: "text", marks: [{ type: "code" }], text: "/" },
-                { type: "text", text: " or in markdown" },
+                { type: "text", text: " or use Markdown" },
               ],
             },
           ],
@@ -108,7 +108,7 @@ export const welcomeContent: JSONContent = {
                 },
                 {
                   type: "text",
-                  text: " your AI to work with there. Char works with Cloud, API providers and local models to transcribe meetings, answer questions and complete your tasks",
+                  text: " your AI to work with. Char works with Cloud, API providers and local models to transcribe meetings, answer questions and complete your tasks",
                 },
               ],
             },
@@ -123,7 +123,7 @@ export const welcomeContent: JSONContent = {
               content: [
                 {
                   type: "text",
-                  text: "All your meetings appears there. Click on it to open",
+                  text: "All your meetings appear here. Click on one to open notes and summarized files",
                 },
               ],
             },
@@ -137,16 +137,7 @@ export const welcomeContent: JSONContent = {
               content: [
                 {
                   type: "paragraph",
-                  content: [{ type: "text", text: "This is dummy meeting" }],
-                },
-              ],
-            },
-            {
-              type: "paragraph",
-              content: [
-                {
-                  type: "text",
-                  text: " Char will transcribe them by using all context around: audio, presentations, your notes",
+                  content: [{ type: "text", text: "This is a demo meeting" }],
                 },
               ],
             },
@@ -256,7 +247,7 @@ export const welcomeContent: JSONContent = {
                   ],
                   text: "Discord",
                 },
-                { type: "text", text: " to get latest updates" },
+                { type: "text", text: " to get the latest updates" },
               ],
             },
           ],
@@ -269,7 +260,7 @@ export const welcomeContent: JSONContent = {
     {
       type: "heading",
       attrs: { level: 3 },
-      content: [{ type: "text", text: "Enjoy Char! There is your day:" }],
+      content: [{ type: "text", text: "Enjoy Char! Here is your day:" }],
     },
   ],
 };

--- a/apps/desktop/src/main2/home/welcome-content.ts
+++ b/apps/desktop/src/main2/home/welcome-content.ts
@@ -8,7 +8,7 @@ export const welcomeContent: JSONContent = {
   content: [
     {
       type: "heading",
-      attrs: { level: 2 },
+      attrs: { level: 1 },
       content: [{ type: "text", text: "Welcome to Char!" }],
     },
     {
@@ -64,7 +64,7 @@ export const welcomeContent: JSONContent = {
     },
     {
       type: "heading",
-      attrs: { level: 3 },
+      attrs: { level: 2 },
       content: [
         { type: "text", text: "This is what you can do with Daily Notes" },
       ],
@@ -259,8 +259,8 @@ export const welcomeContent: JSONContent = {
     },
     {
       type: "heading",
-      attrs: { level: 3 },
-      content: [{ type: "text", text: "Enjoy Char! Here is your day:" }],
+      attrs: { level: 1 },
+      content: [{ type: "text", text: "Enjoy! Here is your day:" }],
     },
   ],
 };

--- a/apps/desktop/src/main2/home/welcome-note.tsx
+++ b/apps/desktop/src/main2/home/welcome-note.tsx
@@ -1,0 +1,265 @@
+import "./note-editor.css";
+
+import { useCallback, useRef } from "react";
+
+import { parseJsonContent } from "@hypr/tiptap/shared";
+
+import {
+  type JSONContent,
+  NoteEditor,
+  type NoteEditorRef,
+} from "~/editor/session";
+import * as main from "~/store/tinybase/store/main";
+
+const WELCOME_ROW_ID = "welcome";
+
+const welcomeContent: JSONContent = {
+  type: "doc",
+  content: [
+    {
+      type: "heading",
+      attrs: { level: 2 },
+      content: [{ type: "text", text: "This is your daily notes" }],
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "Every day you get a fresh note for your task, ideas and meetings \u2014 write it any way you want and build your own workflow. Char took all context around your work and help you to fill your day.",
+        },
+      ],
+    },
+    {
+      type: "heading",
+      attrs: { level: 2 },
+      content: [{ type: "text", text: "Create lists, tasks and mentions" }],
+    },
+    {
+      type: "taskList",
+      content: [
+        {
+          type: "taskItem",
+          attrs: { checked: false },
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "text",
+                  text: "You can create todo lists there. Try to type ",
+                },
+                { type: "text", marks: [{ type: "code" }], text: "-[]" },
+                { type: "text", text: " or just use " },
+                { type: "text", marks: [{ type: "code" }], text: "/" },
+                { type: "text", text: " for command" },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: "bulletList",
+      content: [
+        {
+          type: "listItem",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                { type: "text", text: "Write bullet lists and numbered one." },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: "heading",
+      attrs: { level: 2 },
+      content: [{ type: "text", text: "Check your meetings there" }],
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "All meetings from calendar appears in your daily notes. You can write notes inside the meetings or create new note",
+        },
+      ],
+    },
+    {
+      type: "session",
+      attrs: { sessionId: "welcome-demo", status: null, checked: null },
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "This is dummy meeting" }],
+        },
+      ],
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          marks: [{ type: "italic" }],
+          text: "Create a new note by pressing ",
+        },
+        {
+          type: "text",
+          marks: [{ type: "code" }],
+          text: "new recording",
+        },
+        {
+          type: "text",
+          marks: [{ type: "italic" }],
+          text: " button",
+        },
+      ],
+    },
+    {
+      type: "heading",
+      attrs: { level: 2 },
+      content: [{ type: "text", text: "Make this fully yourself with AI" }],
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "Get the tasks done right from Daily Notes with multiple ",
+        },
+        {
+          type: "text",
+          marks: [
+            {
+              type: "link",
+              attrs: { href: "https://char.com/docs/integrations" },
+            },
+          ],
+          text: "integrations",
+        },
+        { type: "text", text: " Char has" },
+      ],
+    },
+    {
+      type: "heading",
+      attrs: { level: 2 },
+      content: [{ type: "text", text: "And much more" }],
+    },
+    {
+      type: "paragraph",
+      content: [
+        { type: "text", text: "Read " },
+        {
+          type: "text",
+          marks: [{ type: "link", attrs: { href: "https://char.com/docs" } }],
+          text: "docs",
+        },
+        {
+          type: "text",
+          text: " to integrate all features in your workflow. Join us on ",
+        },
+        {
+          type: "text",
+          marks: [{ type: "link", attrs: { href: "https://x.com/char" } }],
+          text: "X",
+        },
+        { type: "text", text: " or " },
+        {
+          type: "text",
+          marks: [{ type: "link", attrs: { href: "https://discord.gg/char" } }],
+          text: "Discord",
+        },
+        { type: "text", text: " to get the last updates" },
+      ],
+    },
+    {
+      type: "heading",
+      attrs: { level: 2 },
+      content: [
+        { type: "text", text: "All your previous notes perfectly fine" },
+      ],
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "They are available through previous Daily Notes, search and folder where you keep them, nothing changes",
+        },
+      ],
+    },
+  ],
+};
+
+function readSavedContent(
+  store: NonNullable<ReturnType<typeof main.UI.useStore>>,
+): JSONContent | null {
+  const cell = store.getCell("daily_notes", WELCOME_ROW_ID, "content");
+  if (typeof cell !== "string" || cell === "") return null;
+  return parseJsonContent(cell) ?? null;
+}
+
+export function WelcomeNote({ onDismiss }: { onDismiss: () => void }) {
+  const store = main.UI.useStore(main.STORE_ID);
+  const editorRef = useRef<NoteEditorRef>(null);
+
+  const initialContentRef = useRef<JSONContent | null>(null);
+  if (!initialContentRef.current && store) {
+    initialContentRef.current = readSavedContent(store) ?? welcomeContent;
+  }
+
+  const persistWelcomeNote = main.UI.useSetPartialRowCallback(
+    "daily_notes",
+    WELCOME_ROW_ID,
+    (input: JSONContent) => ({
+      content: JSON.stringify(input),
+      date: WELCOME_ROW_ID,
+    }),
+    [],
+    main.STORE_ID,
+  );
+
+  const handleChange = useCallback(
+    (input: JSONContent) => {
+      persistWelcomeNote(input);
+    },
+    [persistWelcomeNote],
+  );
+
+  if (!initialContentRef.current) {
+    return null;
+  }
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 px-6 pt-6 pb-3">
+        <h2 className="text-xl font-semibold text-neutral-900">
+          Welcome to Char
+        </h2>
+      </div>
+
+      <div className="main2-daily-note-editor px-6">
+        <NoteEditor
+          ref={editorRef}
+          key="daily-welcome"
+          initialContent={initialContentRef.current}
+          handleChange={handleChange}
+          linkedItemOpenBehavior="new"
+        />
+      </div>
+
+      <div className="px-6 pt-4 pb-6">
+        <button
+          onClick={onDismiss}
+          className="rounded-full bg-neutral-900 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-neutral-800"
+        >
+          Start to use your Char
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/main2/home/welcome-note.tsx
+++ b/apps/desktop/src/main2/home/welcome-note.tsx
@@ -26,7 +26,7 @@ const welcomeContent: JSONContent = {
       content: [
         {
           type: "text",
-          text: "Every day you get a fresh note for your task, ideas and meetings \u2014 write it any way you want and build your own workflow. Char took all context around your work and help you to fill your day.",
+          text: "Every day you get a fresh note for your task, ideas and meetings \u2014 write it any way you want and build your own workflow. Char takes all context around your work and help you to fill your day.",
         },
       ],
     },
@@ -85,7 +85,7 @@ const welcomeContent: JSONContent = {
       content: [
         {
           type: "text",
-          text: "All meetings from calendar appears in your daily notes. You can write notes inside the meetings or create new note",
+          text: "All meetings from calendar appear in your daily notes. You can write notes inside the meetings or create new note",
         },
       ],
     },

--- a/apps/desktop/src/sidebar/devtool.tsx
+++ b/apps/desktop/src/sidebar/devtool.tsx
@@ -16,6 +16,7 @@ export function DevtoolView() {
     <div className="flex h-full flex-col overflow-hidden">
       <div className="flex flex-1 flex-col gap-2 overflow-y-auto px-1 py-2">
         <NavigationCard />
+        <DailyNotesCard />
         <ToastsCard />
         <CountdownTestCard />
         <ErrorTestCard />
@@ -278,6 +279,34 @@ function CountdownTestCard() {
           className={btnClass}
         >
           +Zoom in 60s
+        </button>
+      </div>
+    </DevtoolCard>
+  );
+}
+
+function DailyNotesCard() {
+  const handleResetWelcome = useCallback(() => {
+    localStorage.removeItem("daily-notes-welcome-dismissed");
+    localStorage.removeItem("daily-notes-welcome-date");
+    window.location.reload();
+  }, []);
+
+  return (
+    <DevtoolCard title="Daily Notes">
+      <div className="flex flex-col gap-1.5">
+        <button
+          type="button"
+          onClick={handleResetWelcome}
+          className={cn([
+            "w-full rounded-md px-2.5 py-1.5",
+            "text-left text-xs font-medium",
+            "border border-neutral-200 text-neutral-700",
+            "cursor-pointer transition-colors",
+            "hover:border-neutral-300 hover:bg-neutral-50",
+          ])}
+        >
+          Reset Welcome Screen
         </button>
       </div>
     </DevtoolCard>


### PR DESCRIPTION
welcome screen in the app that tells user about what they can do and how it works

<img width="2428" height="2484" alt="CleanShot 2026-04-14 at 22 33 10@2x" src="https://github.com/user-attachments/assets/f991add5-9755-4aca-bb27-ccaded15e70f" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces dynamic insertion/removal of a welcome block into the daily note editor and persists dismissal state in `localStorage`, which could affect note content serialization and user data if the strip/prepend logic misbehaves.
> 
> **Overview**
> Adds a *first-day Daily Notes welcome experience* that conditionally shows a predefined `welcomeContent` at the top of today’s note, with a “Clear welcome message” control and persisted state via `WELCOME_DATE_KEY`/`WELCOME_DISMISSED_KEY` in `localStorage`.
> 
> Updates `DailyNoteEditor` to **prepend the welcome nodes for display but strip them before saving**, including cleanup for any previously persisted welcome content, and adds in-editor handling for `char://settings/*` links to open the corresponding settings tab.
> 
> Includes styling tweaks for the daily note editor (headings, task list spacing, session icon alignment, `text-box-trim`) plus minor spacing adjustments in session/task node views, and adds devtools/debug actions to reset the welcome state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a8ff2649e3a54d2c33a2e986858aac9030dafc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->