### PR TITLE
fix: adapt web consent banner by region

### DIFF
--- a/apps/web/src/components/consent-aware-providers.tsx
+++ b/apps/web/src/components/consent-aware-providers.tsx
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { useMountEffect } from "@/hooks/useMountEffect";
+import { PostHogProvider } from "@/providers/posthog";
+
+import { usePrivacyConsent } from "./privacy-consent";
+
+const CHATWOOT_SNIPPET_ID = "chatwoot-snippet";
+const CHATWOOT_BASE_URL = "https://app.chatwoot.com";
+const CHATWOOT_WEBSITE_TOKEN = "FH1mNsxrXPZLcgi3Rfgrb13R";
+const GOOGLE_TAG_ID = "google-tag";
+const GOOGLE_ANALYTICS_ID = "G-4CDGPKJ8JB";
+
+type AnalyticsWindow = Window &
+  typeof globalThis & {
+    dataLayer?: unknown[];
+    gtag?: (...args: unknown[]) => void;
+  };
+
+function GoogleAnalyticsScript() {
+  useMountEffect(() => {
+    if (
+      typeof document === "undefined" ||
+      import.meta.env.DEV ||
+      window.location.pathname.startsWith("/admin")
+    ) {
+      return;
+    }
+
+    if (document.getElementById(GOOGLE_TAG_ID)) {
+      return;
+    }
+
+    const analyticsWindow = window as AnalyticsWindow;
+    analyticsWindow.dataLayer = analyticsWindow.dataLayer ?? [];
+    analyticsWindow.gtag =
+      analyticsWindow.gtag ??
+      function gtag() {
+        analyticsWindow.dataLayer?.push(arguments);
+      };
+    analyticsWindow.gtag("js", new Date());
+    analyticsWindow.gtag("config", GOOGLE_ANALYTICS_ID);
+
+    const script = document.createElement("script");
+    script.id = GOOGLE_TAG_ID;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_ID}`;
+    script.async = true;
+    document.head.appendChild(script);
+  });
+
+  return null;
+}
+
+type ChatwootWindow = Window &
+  typeof globalThis & {
+    chatwootSDK?: {
+      run: (config: { websiteToken: string; baseUrl: string }) => void;
+    };
+  };
+
+function ChatwootWidget() {
+  useMountEffect(() => {
+    if (
+      typeof document === "undefined" ||
+      import.meta.env.DEV ||
+      window.location.pathname.startsWith("/admin")
+    ) {
+      return;
+    }
+
+    if (document.getElementById(CHATWOOT_SNIPPET_ID)) {
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.id = CHATWOOT_SNIPPET_ID;
+    script.src = `${CHATWOOT_BASE_URL}/packs/js/sdk.js`;
+    script.async = true;
+    script.onload = () => {
+      (window as ChatwootWindow).chatwootSDK?.run({
+        websiteToken: CHATWOOT_WEBSITE_TOKEN,
+        baseUrl: CHATWOOT_BASE_URL,
+      });
+    };
+    document.body.appendChild(script);
+  });
+
+  return null;
+}
+
+export function ConsentAwareProviders({
+  children,
+  queryClient,
+}: {
+  children: React.ReactNode;
+  queryClient: QueryClient;
+}) {
+  const { analyticsEnabled } = usePrivacyConsent();
+
+  return (
+    <PostHogProvider enabled={analyticsEnabled}>
+      <QueryClientProvider client={queryClient}>
+        {children}
+        {analyticsEnabled ? <GoogleAnalyticsScript /> : null}
+        {analyticsEnabled ? <ChatwootWidget /> : null}
+      </QueryClientProvider>
+    </PostHogProvider>
+  );
+}

--- a/apps/web/src/components/privacy-consent.tsx
+++ b/apps/web/src/components/privacy-consent.tsx
@@ -1,5 +1,5 @@
 import { useRouterState } from "@tanstack/react-router";
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useState } from "react";
 
 import { Button } from "@hypr/ui/components/ui/button";
 import { Checkbox } from "@hypr/ui/components/ui/checkbox";
@@ -12,10 +12,13 @@ import {
 } from "@hypr/ui/components/ui/dialog";
 import { cn } from "@hypr/utils";
 
+import { useMountEffect } from "@/hooks/useMountEffect";
+import type { PrivacyConsentRegion } from "@/lib/privacy-consent";
+
 const STORAGE_KEY = "char_web_tracking_consent_v1";
 const COOKIE_POLICY_PATH = "/legal/cookies/";
 const PRIVACY_POLICY_PATH = "/legal/privacy/";
-const ACCEPT_CTA_BUTTON_CLASS =
+const PRIMARY_ACTION_BUTTON_CLASS =
   "rounded-full border-0 surface-dark text-white shadow-md transition-all hover:scale-[102%] hover:shadow-lg active:scale-[98%]";
 const MUTED_ACTION_BUTTON_CLASS =
   "border-0 bg-transparent text-fg-muted shadow-none hover:bg-transparent hover:text-fg";
@@ -142,8 +145,10 @@ export function CookiePreferencesButton() {
 
 export function PrivacyConsentProvider({
   children,
+  region,
 }: {
   children: React.ReactNode;
+  region: PrivacyConsentRegion;
 }) {
   const shouldHideConsentUi = useShouldHidePrivacyConsent();
   const [consent, setConsent] = useState<ConsentState | null>(null);
@@ -152,7 +157,7 @@ export function PrivacyConsentProvider({
   const [isReady, setIsReady] = useState(false);
   const [isGpcEnabled, setIsGpcEnabled] = useState(false);
 
-  useEffect(() => {
+  useMountEffect(() => {
     if (typeof window === "undefined") {
       return;
     }
@@ -186,15 +191,7 @@ export function PrivacyConsentProvider({
 
     window.addEventListener("storage", handleStorage);
     return () => window.removeEventListener("storage", handleStorage);
-  }, []);
-
-  useEffect(() => {
-    if (!isDialogOpen) {
-      return;
-    }
-
-    setDraftAnalytics(Boolean(consent?.analytics));
-  }, [consent, isDialogOpen]);
+  });
 
   const analyticsEnabled =
     isReady && consent?.analytics === true && !isGpcEnabled;
@@ -234,12 +231,20 @@ export function PrivacyConsentProvider({
     setDialogOpen(false);
   };
 
+  const handleDialogOpenChange = (value: boolean) => {
+    if (value) {
+      setDraftAnalytics(Boolean(consent?.analytics));
+    }
+
+    setDialogOpen(value);
+  };
+
   const contextValue = {
     analyticsChoice: consent?.analytics ?? null,
     analyticsEnabled,
     isGpcEnabled,
     isReady,
-    openPreferences: () => setDialogOpen(true),
+    openPreferences: () => handleDialogOpenChange(true),
     rejectNonEssential,
     saveAnalyticsChoice,
   };
@@ -248,7 +253,7 @@ export function PrivacyConsentProvider({
     <PrivacyConsentContext.Provider value={contextValue}>
       {children}
       {!shouldHideConsentUi ? (
-        <CookieConsentBanner isDialogOpen={isDialogOpen} />
+        <CookieConsentBanner isDialogOpen={isDialogOpen} region={region} />
       ) : null}
       {!shouldHideConsentUi ? (
         <CookiePreferencesDialog
@@ -256,14 +261,43 @@ export function PrivacyConsentProvider({
           isOpen={isDialogOpen}
           isGpcEnabled={isGpcEnabled}
           onAnalyticsChoiceChange={setDraftAnalytics}
-          onOpenChange={setDialogOpen}
+          onOpenChange={handleDialogOpenChange}
         />
       ) : null}
     </PrivacyConsentContext.Provider>
   );
 }
 
-function CookieConsentBanner({ isDialogOpen }: { isDialogOpen: boolean }) {
+function getCookieBannerCopy(region: PrivacyConsentRegion) {
+  switch (region) {
+    case "california":
+      return {
+        description:
+          "We use cookies and similar technologies for site analytics and support tools. Non-essential tracking stays off unless you accept all, and you can change this later from the footer.",
+        acceptLabel: "Accept all",
+      };
+    case "europe":
+      return {
+        description:
+          "We use cookies and similar technologies for site analytics and support tools. You can accept all, reject all, or customize your choice at any time from the footer.",
+        acceptLabel: "Accept all",
+      };
+    default:
+      return {
+        description:
+          "We use cookies and similar technologies for site analytics and support tools. You can accept all, reject non-essential tracking, or change your choice later from the footer.",
+        acceptLabel: "Accept all",
+      };
+  }
+}
+
+function CookieConsentBanner({
+  isDialogOpen,
+  region,
+}: {
+  isDialogOpen: boolean;
+  region: PrivacyConsentRegion;
+}) {
   const {
     analyticsChoice,
     isReady,
@@ -271,6 +305,7 @@ function CookieConsentBanner({ isDialogOpen }: { isDialogOpen: boolean }) {
     rejectNonEssential,
     saveAnalyticsChoice,
   } = usePrivacyConsentContext();
+  const bannerCopy = getCookieBannerCopy(region);
 
   if (!isReady || analyticsChoice !== null || isDialogOpen) {
     return null;
@@ -289,9 +324,7 @@ function CookieConsentBanner({ isDialogOpen }: { isDialogOpen: boolean }) {
           <div className="space-y-2">
             <p className="text-fg font-mono text-xl font-semibold">Cookies.</p>
             <p className="text-fg text-sm leading-6">
-              We use cookies and similar technologies for site analytics and
-              support tools. You can accept analytics, reject non-essential
-              tracking, or change your choice later from the footer.
+              {bannerCopy.description}
             </p>
             <p className="text-fg-muted text-xs leading-5">
               See our{" "}
@@ -313,26 +346,62 @@ function CookieConsentBanner({ isDialogOpen }: { isDialogOpen: boolean }) {
           </div>
 
           <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
-            <Button
-              className={MUTED_ACTION_BUTTON_CLASS}
-              variant="ghost"
-              onClick={rejectNonEssential}
-            >
-              Reject non-essential
-            </Button>
-            <Button
-              className={MUTED_ACTION_BUTTON_CLASS}
-              variant="ghost"
-              onClick={openPreferences}
-            >
-              Manage choices
-            </Button>
-            <Button
-              className={ACCEPT_CTA_BUTTON_CLASS}
-              onClick={() => saveAnalyticsChoice(true)}
-            >
-              Accept analytics
-            </Button>
+            {region === "europe" ? (
+              <>
+                <Button
+                  className={MUTED_ACTION_BUTTON_CLASS}
+                  variant="ghost"
+                  onClick={() => saveAnalyticsChoice(true)}
+                >
+                  Accept all
+                </Button>
+                <Button
+                  className={MUTED_ACTION_BUTTON_CLASS}
+                  variant="ghost"
+                  onClick={rejectNonEssential}
+                >
+                  Reject all
+                </Button>
+                <Button
+                  className={PRIMARY_ACTION_BUTTON_CLASS}
+                  onClick={openPreferences}
+                >
+                  Customize
+                </Button>
+              </>
+            ) : null}
+            {region === "default" ? (
+              <>
+                <Button
+                  className={MUTED_ACTION_BUTTON_CLASS}
+                  variant="ghost"
+                  onClick={rejectNonEssential}
+                >
+                  Reject non-essential
+                </Button>
+                <Button
+                  className={MUTED_ACTION_BUTTON_CLASS}
+                  variant="ghost"
+                  onClick={openPreferences}
+                >
+                  Manage choices
+                </Button>
+                <Button
+                  className={PRIMARY_ACTION_BUTTON_CLASS}
+                  onClick={() => saveAnalyticsChoice(true)}
+                >
+                  {bannerCopy.acceptLabel}
+                </Button>
+              </>
+            ) : null}
+            {region === "california" ? (
+              <Button
+                className={PRIMARY_ACTION_BUTTON_CLASS}
+                onClick={() => saveAnalyticsChoice(true)}
+              >
+                {bannerCopy.acceptLabel}
+              </Button>
+            ) : null}
           </div>
         </div>
       </div>
@@ -411,10 +480,10 @@ function CookiePreferencesDialog({
               variant="ghost"
               onClick={rejectNonEssential}
             >
-              Reject non-essential
+              Reject all
             </Button>
             <Button
-              className={ACCEPT_CTA_BUTTON_CLASS}
+              className={PRIMARY_ACTION_BUTTON_CLASS}
               onClick={() => saveAnalyticsChoice(analyticsChoice)}
             >
               Save preferences

--- a/apps/web/src/functions/privacy-consent.ts
+++ b/apps/web/src/functions/privacy-consent.ts
@@ -1,0 +1,39 @@
+import { createServerFn } from "@tanstack/react-start";
+import { getCookies, getRequestHeaders } from "@tanstack/react-start/server";
+
+import { resolvePrivacyConsentRegion } from "@/lib/privacy-consent";
+
+function getNetlifyGeo() {
+  return (
+    globalThis as typeof globalThis & {
+      Netlify?: {
+        context?: {
+          geo?: {
+            country?: { code?: string };
+            subdivision?: { code?: string };
+          };
+        } | null;
+      };
+    }
+  ).Netlify?.context?.geo;
+}
+
+export const getPrivacyConsentRegion = createServerFn({
+  method: "GET",
+}).handler(() => {
+  const headers = getRequestHeaders();
+  const cookies = getCookies();
+  const netlifyGeo = getNetlifyGeo();
+
+  return resolvePrivacyConsentRegion({
+    countryCode:
+      netlifyGeo?.country?.code ??
+      headers.get("x-vercel-ip-country") ??
+      headers.get("cf-ipcountry") ??
+      headers.get("cloudfront-viewer-country") ??
+      cookies.nf_country,
+    subdivisionCode:
+      netlifyGeo?.subdivision?.code ??
+      headers.get("x-vercel-ip-country-region"),
+  });
+});

--- a/apps/web/src/lib/privacy-consent.ts
+++ b/apps/web/src/lib/privacy-consent.ts
@@ -1,0 +1,76 @@
+export type PrivacyConsentRegion = "california" | "europe" | "default";
+
+const EUROPEAN_COUNTRY_CODES = new Set([
+  "AT",
+  "BE",
+  "BG",
+  "CH",
+  "CY",
+  "CZ",
+  "DE",
+  "DK",
+  "EE",
+  "ES",
+  "FI",
+  "FR",
+  "GB",
+  "GR",
+  "HR",
+  "HU",
+  "IE",
+  "IS",
+  "IT",
+  "LI",
+  "LT",
+  "LU",
+  "LV",
+  "MT",
+  "NL",
+  "NO",
+  "PL",
+  "PT",
+  "RO",
+  "SE",
+  "SI",
+  "SK",
+  "UK",
+]);
+
+function normalizeCode(value?: string | null) {
+  const normalized = value?.trim().toUpperCase();
+  return normalized ? normalized : undefined;
+}
+
+function normalizeSubdivisionCode(value?: string | null) {
+  const normalized = normalizeCode(value);
+  if (!normalized) {
+    return undefined;
+  }
+
+  const [, subdivisionCode = normalized] = normalized.split("-");
+  return subdivisionCode;
+}
+
+export function resolvePrivacyConsentRegion({
+  countryCode,
+  subdivisionCode,
+}: {
+  countryCode?: string | null;
+  subdivisionCode?: string | null;
+}): PrivacyConsentRegion {
+  const normalizedCountryCode = normalizeCode(countryCode);
+  const normalizedSubdivisionCode = normalizeSubdivisionCode(subdivisionCode);
+
+  if (normalizedCountryCode === "US" && normalizedSubdivisionCode === "CA") {
+    return "california";
+  }
+
+  if (
+    normalizedCountryCode &&
+    EUROPEAN_COUNTRY_CODES.has(normalizedCountryCode)
+  ) {
+    return "europe";
+  }
+
+  return "default";
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,121 +1,10 @@
 import * as Sentry from "@sentry/tanstackstart-react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient } from "@tanstack/react-query";
 import { createRouter } from "@tanstack/react-router";
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
-import { useEffect } from "react";
 
-import {
-  PrivacyConsentProvider,
-  usePrivacyConsent,
-} from "./components/privacy-consent";
 import { env } from "./env";
-import { PostHogProvider } from "./providers/posthog";
 import { routeTree } from "./routeTree.gen";
-
-const CHATWOOT_SNIPPET_ID = "chatwoot-snippet";
-const CHATWOOT_BASE_URL = "https://app.chatwoot.com";
-const CHATWOOT_WEBSITE_TOKEN = "FH1mNsxrXPZLcgi3Rfgrb13R";
-const GOOGLE_TAG_ID = "google-tag";
-const GOOGLE_ANALYTICS_ID = "G-4CDGPKJ8JB";
-
-type AnalyticsWindow = Window &
-  typeof globalThis & {
-    dataLayer?: unknown[];
-    gtag?: (...args: unknown[]) => void;
-  };
-
-function MaybeGoogleAnalytics({ enabled }: { enabled: boolean }) {
-  useEffect(() => {
-    if (
-      typeof document === "undefined" ||
-      import.meta.env.DEV ||
-      !enabled ||
-      window.location.pathname.startsWith("/admin")
-    ) {
-      return;
-    }
-
-    if (document.getElementById(GOOGLE_TAG_ID)) {
-      return;
-    }
-
-    const analyticsWindow = window as AnalyticsWindow;
-    analyticsWindow.dataLayer = analyticsWindow.dataLayer ?? [];
-    analyticsWindow.gtag =
-      analyticsWindow.gtag ??
-      function gtag() {
-        analyticsWindow.dataLayer?.push(arguments);
-      };
-    analyticsWindow.gtag("js", new Date());
-    analyticsWindow.gtag("config", GOOGLE_ANALYTICS_ID);
-
-    const script = document.createElement("script");
-    script.id = GOOGLE_TAG_ID;
-    script.src = `https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_ID}`;
-    script.async = true;
-    document.head.appendChild(script);
-  }, [enabled]);
-
-  return null;
-}
-
-type ChatwootWindow = Window &
-  typeof globalThis & {
-    chatwootSDK?: {
-      run: (config: { websiteToken: string; baseUrl: string }) => void;
-    };
-  };
-
-function MaybeChatwootWidget({ enabled }: { enabled: boolean }) {
-  useEffect(() => {
-    if (
-      typeof document === "undefined" ||
-      import.meta.env.DEV ||
-      !enabled ||
-      window.location.pathname.startsWith("/admin")
-    ) {
-      return;
-    }
-
-    if (document.getElementById(CHATWOOT_SNIPPET_ID)) {
-      return;
-    }
-
-    const script = document.createElement("script");
-    script.id = CHATWOOT_SNIPPET_ID;
-    script.src = `${CHATWOOT_BASE_URL}/packs/js/sdk.js`;
-    script.async = true;
-    script.onload = () => {
-      (window as ChatwootWindow).chatwootSDK?.run({
-        websiteToken: CHATWOOT_WEBSITE_TOKEN,
-        baseUrl: CHATWOOT_BASE_URL,
-      });
-    };
-    document.body.appendChild(script);
-  }, [enabled]);
-
-  return null;
-}
-
-function ConsentAwareProviders({
-  children,
-  queryClient,
-}: {
-  children: React.ReactNode;
-  queryClient: QueryClient;
-}) {
-  const { analyticsEnabled } = usePrivacyConsent();
-
-  return (
-    <PostHogProvider enabled={analyticsEnabled}>
-      <QueryClientProvider client={queryClient}>
-        {children}
-        <MaybeGoogleAnalytics enabled={analyticsEnabled} />
-        <MaybeChatwootWidget enabled={analyticsEnabled} />
-      </QueryClientProvider>
-    </PostHogProvider>
-  );
-}
 
 export function getRouter() {
   const queryClient = new QueryClient();
@@ -126,15 +15,6 @@ export function getRouter() {
     defaultPreload: "intent",
     scrollRestoration: true,
     trailingSlash: "always",
-    InnerWrap: (props: { children: React.ReactNode }) => {
-      return (
-        <PrivacyConsentProvider>
-          <ConsentAwareProviders queryClient={queryClient}>
-            {props.children}
-          </ConsentAwareProviders>
-        </PrivacyConsentProvider>
-      );
-    },
   });
 
   if (!router.isServer && env.VITE_SENTRY_DSN) {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -2,12 +2,16 @@ import type { QueryClient } from "@tanstack/react-query";
 import {
   createRootRouteWithContext,
   HeadContent,
+  Outlet,
   Scripts,
 } from "@tanstack/react-router";
 
 import { Toaster } from "@hypr/ui/components/ui/toast";
 
+import { ConsentAwareProviders } from "@/components/consent-aware-providers";
 import { NotFoundDocument } from "@/components/not-found";
+import { PrivacyConsentProvider } from "@/components/privacy-consent";
+import { getPrivacyConsentRegion } from "@/functions/privacy-consent";
 import {
   DEFAULT_OG_IMAGE_URL,
   ROOT_DESCRIPTION,
@@ -26,6 +30,10 @@ const FONT_STYLESHEETS = [
 ] as const;
 
 export const Route = createRootRouteWithContext<RouterContext>()({
+  loader: async () => ({
+    privacyConsentRegion: await getPrivacyConsentRegion(),
+  }),
+  staleTime: 60 * 60 * 1000,
   head: () => ({
     meta: [
       { charSet: "utf-8" },
@@ -68,9 +76,23 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       { rel: "icon", href: "/favicon.ico", sizes: "32x32" },
     ],
   }),
+  component: RootApp,
   shellComponent: RootDocument,
   notFoundComponent: NotFoundDocument,
 });
+
+function RootApp() {
+  const { queryClient } = Route.useRouteContext();
+  const { privacyConsentRegion } = Route.useLoaderData();
+
+  return (
+    <PrivacyConsentProvider region={privacyConsentRegion}>
+      <ConsentAwareProviders queryClient={queryClient}>
+        <Outlet />
+      </ConsentAwareProviders>
+    </PrivacyConsentProvider>
+  );
+}
 
 function RootDocument({ children }: { children: React.ReactNode }) {
   return (


### PR DESCRIPTION
Resolve consent region from request geo and switch the website consent flow for California and Europe.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches privacy-consent gating and conditional loading of third-party scripts (GA/Chatwoot/PostHog), so regressions could unintentionally enable/disable tracking or break consent UX for certain geos.
> 
> **Overview**
> Adds a request-geo based *consent region* concept (California/Europe/default) and wires it into the root route loader so the client can render region-specific consent UX.
> 
> Refactors consent/analytics setup by extracting `ConsentAwareProviders` (PostHog + React Query + conditional Google Analytics + Chatwoot injection) and updating `PrivacyConsentProvider` to accept `region`, adjust banner copy/button flows per region, and simplify mount/dialog state handling via `useMountEffect` and a centralized `handleDialogOpenChange`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8d50915e015e4b103677f871e0808e227acf5fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5066 
- <kbd>&nbsp;1&nbsp;</kbd> #5062 👈 
<!-- GitButler Footer Boundary Bottom -->

