### PR TITLE
fix: make collapsed Live handle neutral-50

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -105,6 +105,7 @@ export function useSessionBottomAccessory({
             isExpanded={effectiveExpanded}
             onToggle={() => setIsExpanded((v) => !v)}
             label="Live"
+            collapsedClassName="bg-neutral-50"
           />
         ) : null,
       bottomAccessoryState,


### PR DESCRIPTION
Set the collapsed Live footer toggle background to neutral-50 to match the accessory surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line, UI-only styling change limited to the Live footer toggle; no behavioral, data, or security impact.
> 
> **Overview**
> Updates the Live-session `ExpandToggle` in `bottom-accessory/index.tsx` to pass `collapsedClassName="bg-neutral-50"`, matching the collapsed background styling already used by the Transcript toggle and aligning the Live handle with the accessory surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533adf2f1a71f5f3d19fcadb61f7e1ad78a97953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->