### PR TITLE
fix: align live transcript panel with transcript view

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -1,13 +1,19 @@
-import { useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useRef } from "react";
 
 import { cn } from "@hypr/utils";
 
 import { TranscriptViewer } from "~/session/components/note-input/transcript/renderer";
 import { TranscriptListeningState } from "~/session/components/note-input/transcript/screens/listening";
 import { useTranscriptScreen } from "~/session/components/note-input/transcript/state";
+import * as main from "~/store/tinybase/store/main";
 import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
 import { useListener } from "~/stt/contexts";
 import type { Segment } from "~/stt/live-segment";
+import {
+  buildRenderTranscriptRequestFromStore,
+  renderTranscriptSegments,
+} from "~/stt/render-transcript";
 
 export function DuringSessionAccessory({
   sessionId,
@@ -43,6 +49,7 @@ function LiveTranscriptFooter({
   isExpanded?: boolean;
 }) {
   const screen = useTranscriptScreen({ sessionId });
+  const previewSegments = useLivePreviewSegments(sessionId, screen);
   const requestedLiveTranscription = useListener(
     (state) => state.live.requestedLiveTranscription,
   );
@@ -73,7 +80,11 @@ function LiveTranscriptFooter({
           <RecordOnlyFooter isFallbackFromLive={mode.isFallbackFromLive} />
         </div>
       ) : (
-        <LiveTranscriptContent isExpanded={isExpanded} screen={screen} />
+        <LiveTranscriptContent
+          isExpanded={isExpanded}
+          previewSegments={previewSegments}
+          screen={screen}
+        />
       )}
     </div>
   );
@@ -97,9 +108,11 @@ function RecordOnlyFooter({
 
 function LiveTranscriptContent({
   isExpanded,
+  previewSegments,
   screen,
 }: {
   isExpanded: boolean;
+  previewSegments: Segment[];
   screen: ReturnType<typeof useTranscriptScreen>;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -107,11 +120,7 @@ function LiveTranscriptContent({
   if (!isExpanded) {
     return (
       <CollapsedFooterMessage
-        message={
-          screen.kind === "ready"
-            ? (getTranscriptPreview(screen.liveSegments) ?? "Listening...")
-            : "Listening..."
-        }
+        message={getTranscriptPreview(previewSegments) ?? "Listening..."}
       />
     );
   }
@@ -136,6 +145,52 @@ function LiveTranscriptContent({
       </div>
     </div>
   );
+}
+
+function useLivePreviewSegments(
+  sessionId: string,
+  screen: ReturnType<typeof useTranscriptScreen>,
+): Segment[] {
+  const store = main.UI.useStore(main.STORE_ID);
+  const transcriptsTable = main.UI.useTable("transcripts", main.STORE_ID);
+  const participantMappingsTable = main.UI.useTable(
+    "mapping_session_participant",
+    main.STORE_ID,
+  );
+  const humansTable = main.UI.useTable("humans", main.STORE_ID);
+  const selfHumanId = main.UI.useValue("user_id", main.STORE_ID);
+  const transcriptIds = screen.kind === "ready" ? screen.transcriptIds : [];
+  const liveSegments = screen.kind === "ready" ? screen.liveSegments : [];
+
+  const request = useMemo(() => {
+    if (!store || transcriptIds.length === 0 || liveSegments.length > 0) {
+      return null;
+    }
+
+    return buildRenderTranscriptRequestFromStore(store, transcriptIds);
+  }, [
+    store,
+    transcriptIds,
+    liveSegments.length,
+    transcriptsTable,
+    participantMappingsTable,
+    humansTable,
+    selfHumanId,
+  ]);
+
+  const { data: renderedSegments = [] } = useQuery({
+    queryKey: ["live-transcript-footer-preview", sessionId, request],
+    queryFn: async () => {
+      if (!request) {
+        return [];
+      }
+
+      return renderTranscriptSegments(request);
+    },
+    enabled: !!request,
+  });
+
+  return liveSegments.length > 0 ? liveSegments : renderedSegments;
 }
 
 function CollapsedFooterMessage({ message }: { message: string }) {

--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -1,21 +1,13 @@
-import { useQuery } from "@tanstack/react-query";
-import { useMemo, useRef } from "react";
+import { useRef } from "react";
 
 import { cn } from "@hypr/utils";
 
-import { getSegmentColor } from "~/session/components/note-input/transcript/renderer/utils";
-import * as main from "~/store/tinybase/store/main";
+import { TranscriptViewer } from "~/session/components/note-input/transcript/renderer";
+import { TranscriptListeningState } from "~/session/components/note-input/transcript/screens/listening";
+import { useTranscriptScreen } from "~/session/components/note-input/transcript/state";
 import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
 import { useListener } from "~/stt/contexts";
-import { SegmentKeyUtils, type Segment } from "~/stt/live-segment";
-import {
-  buildRenderTranscriptRequestFromStore,
-  renderTranscriptSegments,
-} from "~/stt/render-transcript";
-import {
-  SpeakerLabelManager,
-  defaultRenderLabelContext,
-} from "~/stt/segment/shared";
+import type { Segment } from "~/stt/live-segment";
 
 export function DuringSessionAccessory({
   sessionId,
@@ -50,17 +42,12 @@ function LiveTranscriptFooter({
   sessionId: string;
   isExpanded?: boolean;
 }) {
-  const store = main.UI.useStore(main.STORE_ID);
-  const segments = useLiveTranscriptSegments(sessionId);
+  const screen = useTranscriptScreen({ sessionId });
   const requestedLiveTranscription = useListener(
     (state) => state.live.requestedLiveTranscription,
   );
   const liveTranscriptionActive = useListener(
     (state) => state.live.liveTranscriptionActive,
-  );
-  const labelContext = useMemo(
-    () => (store ? defaultRenderLabelContext(store) : undefined),
-    [store],
   );
   const captureMode = getLiveCaptureUiMode({
     requestedLiveTranscription,
@@ -74,33 +61,20 @@ function LiveTranscriptFooter({
           isFallbackFromLive: captureMode === "fallback_record_only",
         };
 
-  const speakerLabelManager = useMemo(() => {
-    if (!store) {
-      return new SpeakerLabelManager();
-    }
-
-    return SpeakerLabelManager.fromSegments(segments, labelContext);
-  }, [labelContext, segments, store]);
-
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const previewText = useMemo(() => getTranscriptPreview(segments), [segments]);
-
   return (
-    <div className="w-full select-none">
-      <div className="rounded-xl bg-neutral-50">
-        {mode.kind === "record_only" ? (
+    <div
+      className={cn([
+        "w-full select-none",
+        mode.kind === "live" && !isExpanded && "relative -mt-[6px] pb-1",
+      ])}
+    >
+      {mode.kind === "record_only" ? (
+        <div className="rounded-xl bg-neutral-50">
           <RecordOnlyFooter isFallbackFromLive={mode.isFallbackFromLive} />
-        ) : (
-          <LiveTranscriptContent
-            isExpanded={isExpanded}
-            previewText={previewText}
-            scrollRef={scrollRef}
-            segments={segments}
-            labelContext={labelContext}
-            speakerLabelManager={speakerLabelManager}
-          />
-        )}
-      </div>
+        </div>
+      ) : (
+        <LiveTranscriptContent isExpanded={isExpanded} screen={screen} />
+      )}
     </div>
   );
 }
@@ -123,45 +97,43 @@ function RecordOnlyFooter({
 
 function LiveTranscriptContent({
   isExpanded,
-  previewText,
-  scrollRef,
-  segments,
-  labelContext,
-  speakerLabelManager,
+  screen,
 }: {
   isExpanded: boolean;
-  previewText: string | null;
-  scrollRef: React.RefObject<HTMLDivElement | null>;
-  segments: Segment[];
-  labelContext: ReturnType<typeof defaultRenderLabelContext> | undefined;
-  speakerLabelManager: SpeakerLabelManager;
+  screen: ReturnType<typeof useTranscriptScreen>;
 }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
   if (!isExpanded) {
-    return <CollapsedFooterMessage message={previewText ?? "Listening..."} />;
+    return (
+      <CollapsedFooterMessage
+        message={
+          screen.kind === "ready"
+            ? (getTranscriptPreview(screen.liveSegments) ?? "Listening...")
+            : "Listening..."
+        }
+      />
+    );
   }
 
+  const transcriptIds = screen.kind === "ready" ? screen.transcriptIds : [];
+  const liveSegments = screen.kind === "ready" ? screen.liveSegments : [];
+
   return (
-    <div
-      ref={scrollRef}
-      className="flex max-h-[180px] flex-col gap-1 overflow-y-auto px-3 pt-2 pb-2.5"
-    >
-      {segments.length === 0 ? (
-        <span className="py-4 text-center text-xs text-neutral-400">
-          Transcript will appear here as you speak.
-        </span>
-      ) : (
-        segments.map((segment, index) => (
-          <TranscriptSegmentRow
-            key={getSegmentIdentity(segment, index)}
-            segment={segment}
-            label={SegmentKeyUtils.renderLabel(
-              segment.key,
-              labelContext,
-              speakerLabelManager,
-            )}
+    <div className="overflow-hidden rounded-b-xl border-x border-b border-neutral-200 bg-white">
+      <div className="h-[300px] overflow-hidden px-3 pt-2">
+        {screen.kind === "listening" ? (
+          <TranscriptListeningState status={screen.status} />
+        ) : (
+          <TranscriptViewer
+            transcriptIds={transcriptIds}
+            liveSegments={liveSegments}
+            currentActive
+            scrollRef={scrollRef}
+            enablePlaybackControls={false}
           />
-        ))
-      )}
+        )}
+      </div>
     </div>
   );
 }
@@ -170,7 +142,7 @@ function CollapsedFooterMessage({ message }: { message: string }) {
   return (
     <div
       className={cn([
-        "flex min-h-12 items-center gap-2 p-2",
+        "flex min-h-8 items-center gap-2 px-2 py-1",
         "w-full max-w-full",
       ])}
     >
@@ -181,74 +153,6 @@ function CollapsedFooterMessage({ message }: { message: string }) {
       </div>
     </div>
   );
-}
-
-function useLiveTranscriptSegments(sessionId: string): Segment[] {
-  const store = main.UI.useStore(main.STORE_ID);
-  const transcriptIds =
-    main.UI.useSliceRowIds(
-      main.INDEXES.transcriptBySession,
-      sessionId,
-      main.STORE_ID,
-    ) ?? [];
-  const transcriptsTable = main.UI.useTable("transcripts", main.STORE_ID);
-  const participantMappingsTable = main.UI.useTable(
-    "mapping_session_participant",
-    main.STORE_ID,
-  );
-  const humansTable = main.UI.useTable("humans", main.STORE_ID);
-  const selfHumanId = main.UI.useValue("user_id", main.STORE_ID);
-  const liveSegments = useListener((state) => state.liveSegments);
-
-  const request = useMemo(() => {
-    if (!store || transcriptIds.length === 0) {
-      return null;
-    }
-
-    return buildRenderTranscriptRequestFromStore(store, transcriptIds);
-  }, [
-    store,
-    transcriptIds,
-    transcriptsTable,
-    participantMappingsTable,
-    humansTable,
-    selfHumanId,
-  ]);
-
-  const { data: renderedSegments = [] } = useQuery({
-    queryKey: ["live-transcript-footer-segments", sessionId, request],
-    queryFn: async () => {
-      if (!request) {
-        return [];
-      }
-
-      return renderTranscriptSegments(request);
-    },
-    enabled: !!request,
-  });
-
-  return useMemo(() => {
-    return liveSegments.length > 0 ? liveSegments : renderedSegments;
-  }, [liveSegments, renderedSegments]);
-}
-
-function getSegmentIdentity(segment: Segment, fallbackIndex: number): string {
-  const firstWord = segment.words[0];
-  const lastWord = segment.words[segment.words.length - 1];
-
-  if (firstWord?.id && lastWord?.id) {
-    return `${firstWord.id}:${lastWord.id}`;
-  }
-
-  return `${segment.key.channel}:${segment.key.speaker_index ?? "unknown"}:${firstWord?.start_ms ?? fallbackIndex}:${lastWord?.end_ms ?? fallbackIndex}`;
-}
-
-function getSegmentText(segment: Segment): string {
-  const text = segment.words
-    .map((word) => word.text)
-    .join("")
-    .trim();
-  return text || "…";
 }
 
 function getTranscriptPreview(segments: Segment[]): string | null {
@@ -268,31 +172,4 @@ function getTranscriptPreview(segments: Segment[]): string | null {
   }
 
   return transcript.length > 500 ? transcript.slice(-500) : transcript;
-}
-
-function TranscriptSegmentRow({
-  segment,
-  label,
-}: {
-  segment: Segment;
-  label: string;
-}) {
-  const color = getSegmentColor(segment.key);
-
-  return (
-    <div className="grid min-w-0 grid-cols-[92px_1fr] items-start gap-x-3">
-      <span
-        className="mt-0.5 inline-flex min-h-5 items-center justify-start rounded-full px-2 text-[11px] font-medium whitespace-nowrap"
-        style={{
-          backgroundColor: `${color}1A`,
-          color,
-        }}
-      >
-        {label}
-      </span>
-      <span className="min-w-0 text-xs leading-5 text-neutral-700">
-        {getSegmentText(segment)}
-      </span>
-    </div>
-  );
 }

--- a/apps/desktop/src/session/components/bottom-accessory/expand-toggle.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/expand-toggle.tsx
@@ -1,4 +1,5 @@
 import { X } from "lucide-react";
+import type { ReactNode } from "react";
 
 import { cn } from "@hypr/utils";
 
@@ -8,12 +9,16 @@ export function ExpandToggle({
   label,
   showExpandedCloseIcon = false,
   collapsedClassName,
+  className,
+  children,
 }: {
   isExpanded: boolean;
   onToggle: () => void;
   label?: string;
   showExpandedCloseIcon?: boolean;
   collapsedClassName?: string;
+  className?: string;
+  children?: ReactNode;
 }) {
   const hasLabel = Boolean(label);
 
@@ -30,12 +35,14 @@ export function ExpandToggle({
         isExpanded ? "bg-white" : (collapsedClassName ?? "bg-white"),
         "transition-colors hover:bg-neutral-100 hover:text-neutral-600",
         "hover:cursor-pointer",
+        className,
       ])}
       aria-label={
         isExpanded ? `Collapse ${label ?? ""}`.trim() : `Expand ${label ?? ""}`
       }
     >
       {label ? <span className="text-[10px] font-medium">{label}</span> : null}
+      {children}
       {isExpanded && showExpandedCloseIcon ? (
         <X size={10} className="shrink-0" />
       ) : null}

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -105,7 +105,13 @@ export function useSessionBottomAccessory({
             onToggle={() => setIsExpanded((v) => !v)}
             label="Live"
             collapsedClassName="bg-neutral-50"
-          />
+            className="text-red-500 hover:bg-red-50 hover:text-red-600"
+          >
+            <span
+              aria-hidden
+              className="size-1.5 shrink-0 rounded-full bg-red-500"
+            />
+          </ExpandToggle>
         ) : null,
       bottomAccessoryState,
     };

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/data-hooks.ts
@@ -8,7 +8,9 @@ import {
   renderTranscriptSegments,
 } from "~/stt/render-transcript";
 
-export function useRenderedTranscriptSegments(transcriptId: string): Segment[] {
+export function useRenderedTranscriptSegments(
+  transcriptId?: string,
+): Segment[] {
   const store = main.UI.useStore(main.STORE_ID);
   const transcriptsTable = main.UI.useTable("transcripts", main.STORE_ID);
   const participantMappingsTable = main.UI.useTable(
@@ -19,7 +21,7 @@ export function useRenderedTranscriptSegments(transcriptId: string): Segment[] {
   const selfHumanId = main.UI.useValue("user_id", main.STORE_ID);
 
   const request = useMemo(() => {
-    if (!store) {
+    if (!store || !transcriptId) {
       return null;
     }
 
@@ -48,12 +50,12 @@ export function useRenderedTranscriptSegments(transcriptId: string): Segment[] {
   return data;
 }
 
-export function useTranscriptOffset(transcriptId: string): number {
+export function useTranscriptOffset(transcriptId?: string): number {
   const store = main.UI.useStore(main.STORE_ID);
   const transcriptsTable = main.UI.useTable("transcripts", main.STORE_ID);
   const sessionId = main.UI.useCell(
     "transcripts",
-    transcriptId,
+    transcriptId ?? "",
     "session_id",
     main.STORE_ID,
   );
@@ -65,7 +67,7 @@ export function useTranscriptOffset(transcriptId: string): number {
   );
 
   return useMemo(() => {
-    if (!store) {
+    if (!store || !transcriptId) {
       return 0;
     }
 

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -1,0 +1,124 @@
+import { render } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TranscriptViewer } from "./index";
+
+const {
+  renderTranscriptMock,
+  useHotkeysMock,
+  useAudioPlayerMock,
+  useAudioTimeMock,
+  useScrollDetectionMock,
+  useAutoScrollMock,
+  usePlaybackAutoScrollMock,
+} = vi.hoisted(() => ({
+  renderTranscriptMock: vi.fn(),
+  useHotkeysMock: vi.fn(),
+  useAudioPlayerMock: vi.fn(),
+  useAudioTimeMock: vi.fn(),
+  useScrollDetectionMock: vi.fn(),
+  useAutoScrollMock: vi.fn(),
+  usePlaybackAutoScrollMock: vi.fn(),
+}));
+
+vi.mock("react-hotkeys-hook", () => ({
+  useHotkeys: useHotkeysMock,
+}));
+
+vi.mock("./transcript", () => ({
+  RenderTranscript: (props: unknown) => {
+    renderTranscriptMock(props);
+    return <div data-testid="render-transcript" />;
+  },
+}));
+
+vi.mock("./selection-menu", () => ({
+  SelectionMenu: () => null,
+}));
+
+vi.mock("./separator", () => ({
+  TranscriptSeparator: () => <div data-testid="separator" />,
+}));
+
+vi.mock("./viewport-hooks", () => ({
+  useScrollDetection: useScrollDetectionMock,
+  useAutoScroll: useAutoScrollMock,
+  usePlaybackAutoScroll: usePlaybackAutoScrollMock,
+}));
+
+vi.mock("~/audio-player", () => ({
+  useAudioPlayer: useAudioPlayerMock,
+}));
+
+vi.mock("~/audio-player/provider", () => ({
+  useAudioTime: useAudioTimeMock,
+}));
+
+describe("TranscriptViewer", () => {
+  it("renders live segments without a persisted transcript id", () => {
+    useScrollDetectionMock.mockReturnValue({
+      isAtBottom: true,
+      autoScrollEnabled: true,
+      scrollToBottom: vi.fn(),
+    });
+    useAudioPlayerMock.mockReturnValue({
+      state: "stopped",
+      pause: vi.fn(),
+      resume: vi.fn(),
+      start: vi.fn(),
+      seek: vi.fn(),
+      audioExists: false,
+    });
+    useAudioTimeMock.mockReturnValue({ current: 0 });
+
+    const liveSegments = [
+      {
+        id: "segment-1",
+        key: {
+          channel: "DirectMic",
+          speaker_index: null,
+          speaker_human_id: null,
+        },
+        words: [
+          {
+            id: "word-1",
+            text: "Hello",
+            start_ms: 0,
+            end_ms: 500,
+            channel: 0,
+            is_final: true,
+          },
+        ],
+      },
+    ];
+
+    render(
+      <TranscriptViewer
+        transcriptIds={[]}
+        liveSegments={liveSegments as never[]}
+        currentActive
+        scrollRef={createRef()}
+        enablePlaybackControls={false}
+      />,
+    );
+
+    expect(renderTranscriptMock).toHaveBeenCalled();
+    expect(
+      renderTranscriptMock.mock.calls.some(
+        ([props]) =>
+          props &&
+          typeof props === "object" &&
+          "transcriptId" in props &&
+          "liveSegments" in props &&
+          (props as { transcriptId?: string }).transcriptId === undefined &&
+          (props as { liveSegments: unknown[] }).liveSegments === liveSegments,
+      ),
+    ).toBe(true);
+    expect(useHotkeysMock).toHaveBeenCalledWith(
+      "space",
+      expect.any(Function),
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+});

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -27,11 +27,13 @@ export function TranscriptViewer({
   liveSegments,
   currentActive,
   scrollRef,
+  enablePlaybackControls = true,
 }: {
   transcriptIds: string[];
   liveSegments: Segment[];
   currentActive: boolean;
   scrollRef: RefObject<HTMLDivElement | null>;
+  enablePlaybackControls?: boolean;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
@@ -60,6 +62,12 @@ export function TranscriptViewer({
   const time = useAudioTime();
   const deferredCurrentMs = useDeferredValue(time.current * 1000);
   const isPlaying = playerState === "playing";
+  const transcriptEntries =
+    transcriptIds.length > 0
+      ? transcriptIds.map((transcriptId) => ({ transcriptId }))
+      : liveSegments.length > 0
+        ? [{ transcriptId: undefined }]
+        : [];
 
   useHotkeys(
     "space",
@@ -73,10 +81,17 @@ export function TranscriptViewer({
         start();
       }
     },
-    { enableOnFormTags: false },
+    {
+      enabled: enablePlaybackControls,
+      enableOnFormTags: false,
+    },
   );
 
-  usePlaybackAutoScroll(containerRef, deferredCurrentMs, isPlaying);
+  usePlaybackAutoScroll(
+    containerRef,
+    deferredCurrentMs,
+    enablePlaybackControls && isPlaying,
+  );
   const shouldAutoScroll = currentActive && autoScrollEnabled;
   useAutoScroll(
     containerRef,
@@ -102,15 +117,18 @@ export function TranscriptViewer({
           "scrollbar-hide scroll-pb-32 pb-16",
         ])}
       >
-        {transcriptIds.map((transcriptId, index) => (
-          <div key={transcriptId} className="flex flex-col gap-8">
+        {transcriptEntries.map(({ transcriptId }, index) => (
+          <div
+            key={transcriptId ?? "live-transcript"}
+            className="flex flex-col gap-8"
+          >
             <RenderTranscript
               scrollElement={scrollElement}
-              isLastTranscript={index === transcriptIds.length - 1}
+              isLastTranscript={index === transcriptEntries.length - 1}
               isAtBottom={isAtBottom}
               transcriptId={transcriptId}
               liveSegments={
-                index === transcriptIds.length - 1 && currentActive
+                index === transcriptEntries.length - 1 && currentActive
                   ? liveSegments
                   : []
               }
@@ -119,7 +137,7 @@ export function TranscriptViewer({
               startPlayback={start}
               audioExists={audioExists}
             />
-            {index < transcriptIds.length - 1 && <TranscriptSeparator />}
+            {index < transcriptEntries.length - 1 && <TranscriptSeparator />}
           </div>
         ))}
 

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
@@ -16,28 +16,34 @@ export function SegmentHeader({
   speakerLabelManager,
 }: {
   segment: Segment;
-  transcriptId: string;
+  transcriptId?: string;
   speakerLabelManager?: SpeakerLabelManager;
 }) {
   const color = useSegmentColor(segment.key);
   const label = useSpeakerLabel(segment.key, speakerLabelManager);
   const timestamp = getTimestampRange(segment);
   const headerClassName = cn([
-    "sticky top-0 z-20 bg-neutral-50",
+    "sticky top-0 z-20 bg-white",
     "-mx-3 px-3 py-1",
-    "text-xs font-light",
+    "text-xs",
     "flex items-center justify-between",
   ]);
 
   return (
     <p className={headerClassName}>
-      <SpeakerAssignPopover
-        segment={segment}
-        transcriptId={transcriptId}
-        color={color}
-        label={label}
-      />
-      <span className="font-mono text-neutral-500">{timestamp}</span>
+      {transcriptId ? (
+        <SpeakerAssignPopover
+          segment={segment}
+          transcriptId={transcriptId}
+          color={color}
+          label={label}
+        />
+      ) : (
+        <span className="font-medium" style={{ color }}>
+          {label}
+        </span>
+      )}
+      <span className="font-mono font-light text-neutral-500">{timestamp}</span>
     </p>
   );
 }

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-hooks.ts
@@ -25,10 +25,10 @@ export function useStableSegments(segments: Segment[]): Segment[] {
 
 export function createSegmentKey(
   segment: Segment,
-  transcriptId: string,
+  transcriptId: string | undefined,
   fallbackIndex: number,
 ) {
-  return segment.id || `${transcriptId}-segment-${fallbackIndex}`;
+  return segment.id || `${transcriptId ?? "live"}-segment-${fallbackIndex}`;
 }
 
 function segmentsEqual(a: Segment, b: Segment) {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment.tsx
@@ -33,7 +33,7 @@ export const SegmentRenderer = memo(
   }: {
     segment: Segment;
     offsetMs: number;
-    transcriptId: string;
+    transcriptId?: string;
     speakerLabelManager?: SpeakerLabelManager;
     currentMs: number;
     seekAndPlay: (word: SegmentWord) => void;

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-assign.tsx
@@ -52,7 +52,11 @@ export function SpeakerAssignPopover({
   );
 
   if (isSelf) {
-    return <span style={{ color }}>{label}</span>;
+    return (
+      <span className="font-medium" style={{ color }}>
+        {label}
+      </span>
+    );
   }
 
   return (
@@ -62,6 +66,7 @@ export function SpeakerAssignPopover({
           type="button"
           className={cn([
             "-ml-1 cursor-pointer rounded-xs px-1",
+            "font-medium",
             "transition-colors hover:bg-neutral-100",
           ])}
           style={{ color }}

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
@@ -34,7 +34,7 @@ export function RenderTranscript({
   scrollElement: HTMLDivElement | null;
   isLastTranscript: boolean;
   isAtBottom: boolean;
-  transcriptId: string;
+  transcriptId?: string;
   liveSegments: Segment[];
   currentMs: number;
   seek: (sec: number) => void;
@@ -52,7 +52,7 @@ export function RenderTranscript({
   }
 
   return (
-    <SegmentsList
+    <TranscriptSegmentsList
       segments={segments}
       scrollElement={scrollElement}
       transcriptId={transcriptId}
@@ -66,7 +66,7 @@ export function RenderTranscript({
   );
 }
 
-const SegmentsList = memo(
+export const TranscriptSegmentsList = memo(
   ({
     segments,
     scrollElement,
@@ -80,7 +80,7 @@ const SegmentsList = memo(
   }: {
     segments: Segment[];
     scrollElement: HTMLDivElement | null;
-    transcriptId: string;
+    transcriptId?: string;
     offsetMs: number;
     shouldScrollToEnd: boolean;
     currentMs: number;

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -229,7 +229,8 @@ function TabContentNoteInner({
 
   const mergeTranscriptSurface =
     bottomAccessoryState?.expanded === true &&
-    (bottomAccessoryState.mode === "playback" ||
+    (bottomAccessoryState.mode === "live" ||
+      bottomAccessoryState.mode === "playback" ||
       bottomAccessoryState.mode === "transcript_only");
 
   return (


### PR DESCRIPTION
Merge the expanded live transcript surface into the session card, reuse transcript rendering for live-only segments, and add coverage for the live viewer path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the live session footer to reuse the main transcript rendering pipeline and introduces optional `transcriptId` flows, which could affect live transcript display/scrolling and playback hotkeys across session states.
> 
> **Overview**
> Aligns the **expanded live transcript** footer with the main transcript UI by replacing the bespoke segment-row renderer with `TranscriptViewer` and `useTranscriptScreen`, including a dedicated listening state and a bordered/merged surface.
> 
> Updates transcript rendering to support **live-only segments without a persisted transcript id** (making `transcriptId` optional through hooks/components, adding a live fallback key, and disabling playback hotkeys/auto-scroll when embedded in the live footer). Adds a unit test covering the live-only `TranscriptViewer` path, and enhances the live expand toggle styling to show a red live indicator dot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2637b40bb5fdd7ded417449ac5194017bc5e5e25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->