### PR TITLE
chore: add Microsoft Clarity script

### DIFF
--- a/apps/web/content/legal/cookies.mdx
+++ b/apps/web/content/legal/cookies.mdx
@@ -1,5 +1,5 @@
 ---
-date: "2026-03-31"
+date: "2026-04-16"
 title: "Cookie Policy"
 summary: "How we use cookies and similar tracking technologies"
 ---
@@ -24,9 +24,10 @@ These cookies are necessary for the Service to function properly. They enable co
 
 ### 3.2 Analytics Cookies
 
-These cookies help us understand how visitors interact with the Service by collecting and reporting information anonymously.
+These cookies help us understand how visitors interact with the Service by collecting and reporting interaction and performance information.
 
 - **Usage Data:** Pages visited, time spent, and navigation patterns
+- **Behavioral Analytics:** Clicks, scroll activity, heatmaps, and session replay on Char-owned web pages
 - **Performance Monitoring:** Load times and technical performance
 - **Error Tracking:** Identify and fix technical issues
 
@@ -47,7 +48,7 @@ We do not currently use third-party advertising or retargeting cookies on Char-o
 
 We may allow trusted third parties to place cookies on your device. These third parties include:
 
-- **Analytics Providers:** PostHog, Google Analytics
+- **Analytics Providers:** PostHog, Google Analytics, Microsoft Clarity
 - **Authentication & Account Services:** Supabase
 - **Security & Infrastructure Providers:** Cloudflare, Netlify
 - **Payment Processors:** Stripe (when using checkout/billing flows)
@@ -79,7 +80,7 @@ You can opt out of certain cookie-based tracking:
 
 - **Cookie preferences:** Use the `Cookie preferences` control in the website footer to accept or reject non-essential web tracking.
 - **Browser controls:** Block or clear cookies/local storage from your browser settings.
-- **Analytics providers:** Block analytics domains in your browser or content blocker settings (for example, PostHog, `google-analytics.com`, or `googletagmanager.com`).
+- **Analytics providers:** Block analytics domains in your browser or content blocker settings (for example, PostHog, `google-analytics.com`, `googletagmanager.com`, or `clarity.ms`).
 - **Desktop app telemetry:** Use the `Share usage data` toggle in desktop settings (desktop telemetry is not cookie-based).
 
 ### 6.3 Impact of Disabling Cookies

--- a/apps/web/content/legal/dpa.mdx
+++ b/apps/web/content/legal/dpa.mdx
@@ -1,5 +1,5 @@
 ---
-date: "2026-03-31"
+date: "2026-04-16"
 title: "Data Processing Agreement"
 summary: "Our commitment to protecting your data in compliance with GDPR, CCPA, and other data protection laws"
 ---
@@ -134,6 +134,7 @@ We implement the following technical and organizational measures:
 | [Sentry](https://sentry.io/)           | For logging errors                                       | USA          | GDPR/CCPA aligned DPA, prohibits sensitive data, deletion on request, customer audit rights                                                                    |
 | [PostHog](https://posthog.com/)        | For product analytics, feature usage telemetry, and cloud request metadata analytics | USA          | SOC 2 Type II, GDPR/CCPA-aligned DPA, strict use‑only data purpose clauses, hardware MFA, public audit transparency                                            |
 | [Google Analytics](https://marketingplatform.google.com/about/analytics/) | For consented website analytics on Char-owned web properties | USA          | Google Analytics data processing terms, configurable retention controls, encrypted transport, and account access controls                                       |
+| [Microsoft Clarity](https://clarity.microsoft.com/) | For consented website analytics, behavioral metrics, heatmaps, and session replay on Char-owned web properties | USA          | Microsoft privacy and data protection terms, consent controls, encrypted transport, and account access controls                                                |
 | [AWS](https://aws.amazon.com)          | For integrating with 3rd party apps like GCal or Outlook | USA          | Encryption in transit & at rest, strict access controls, incident response plans, privacy‑focused vendor management, confidentiality contracts, staff training |
 | [Nango](https://www.nango.dev/)        | For OAuth connection management, credential storage, and sync infrastructure for connected services such as Google Calendar | USA          | SOC 2 Type II, GDPR compliant, HIPAA compliant, AES-256-GCM encryption at rest for credentials, TLS 1.2+ in transit, 31-day default retention after deletion |
 | [Keygen](https://keygen.sh)            | For issuing licenses for Char Pro                    | USA          | Strong MFA, cryptographically signed APIs/licenses, automated vulnerability scanning, penetration testing, GDPR DSR support                                    |

--- a/apps/web/content/legal/privacy.mdx
+++ b/apps/web/content/legal/privacy.mdx
@@ -1,5 +1,5 @@
 ---
-date: "2026-03-31"
+date: "2026-04-16"
 title: "Privacy Policy"
 summary: "How we collect, use, and protect your personal information"
 ---
@@ -30,10 +30,11 @@ When you use our Service, we automatically collect:
 - **Usage Data:** Information about how you interact with the Service, including product interaction events (for example, onboarding, downloads, note creation, transcription, summary generation, exports, and settings interactions)
 - **Device Information:** Device type, operating system, browser type, and IP address
 - **Log Data:** Access times, pages viewed, system activity, and technical diagnostics (for example, latency, status codes, and error events)
+- **Website Analytics Data:** On Char-owned websites, behavioral metrics, heatmaps, session replay, click and scroll activity, referrers, approximate location derived from IP address, browser/device information, and similar interaction metadata when non-essential website analytics are enabled
 - **Service Telemetry Metadata:** Pseudonymous identifiers (such as device fingerprint or user ID), app/browser version metadata, and cloud feature usage metadata (for example, speech-to-text duration, AI token counts, AI latency, provider/model metadata, and subscription trial events) used for operations, billing, product improvement, and abuse prevention
 - **Cookies:** See our Cookie Policy for more information
 
-Analytics and telemetry events are designed to avoid including raw meeting audio, transcript text, note content, and summary text.
+Analytics and telemetry events are designed to avoid including raw meeting audio, transcript text, note content, and summary text. Website session replay and heatmap analytics are used to understand how visitors interact with Char-owned web pages, not to inspect your meeting content.
 
 ### 3.3 Google Calendar and Other Connected Calendar Accounts
 
@@ -82,7 +83,7 @@ We may share your information with third-party service providers who perform ser
 - **Cloud hosting and infrastructure providers** (e.g., Fly.io, Netlify, Cloudflare, Supabase) for hosting our application and storing your data securely
 - **Integration providers** (e.g., Nango) for OAuth connection management, credential handling, and calendar sync infrastructure when you connect Google Calendar or other supported accounts
 - **Payment processors** (e.g., Stripe) for processing payments securely
-- **Analytics services** (e.g., PostHog, Google Analytics) for understanding how users interact with our Service
+- **Analytics services** (e.g., PostHog, Google Analytics, Microsoft Clarity) for understanding how users interact with our Service and Char-owned web properties
 - **Speech-to-text providers** (e.g., Deepgram, AssemblyAI, Soniox) for cloud-based transcription when you enable this feature
 - **AI model providers** (e.g., via OpenRouter) for cloud-based AI features when you enable them
 - **Error monitoring services** (e.g., Sentry) for identifying and fixing issues
@@ -123,7 +124,7 @@ We retain your information for as long as your account is active or as needed to
 ### 7.4 Analytics and Telemetry Controls
 
 - **Desktop app setting:** You can disable desktop usage analytics in Settings (`Share usage data`).
-- **Web tracking controls:** You can accept or reject non-essential website tracking from the `Cookie preferences` control in the website footer, as described in our [Cookie Policy](/legal/cookies).
+- **Web tracking controls:** You can accept or reject non-essential website tracking, including PostHog, Google Analytics, Microsoft Clarity, and website support tools, from the `Cookie preferences` control in the website footer, as described in our [Cookie Policy](/legal/cookies).
 - **Global Privacy Control:** We honor Global Privacy Control (GPC) for non-essential website tracking.
 - **Cloud feature metadata:** Disabling desktop usage analytics does not disable limited server-side operational and billing telemetry required to provide cloud requests (for example, speech-to-text and AI request metadata, and subscription trial status events).
 

--- a/apps/web/src/components/consent-aware-providers.tsx
+++ b/apps/web/src/components/consent-aware-providers.tsx
@@ -10,6 +10,16 @@ const CHATWOOT_BASE_URL = "https://app.chatwoot.com";
 const CHATWOOT_WEBSITE_TOKEN = "FH1mNsxrXPZLcgi3Rfgrb13R";
 const GOOGLE_TAG_ID = "google-tag";
 const GOOGLE_ANALYTICS_ID = "G-4CDGPKJ8JB";
+const MICROSOFT_CLARITY_SCRIPT_ID = "microsoft-clarity-script";
+const MICROSOFT_CLARITY_TAG_ID = "wcjttoibok";
+
+type ClarityFunction = ((...args: unknown[]) => void) & {
+  q?: IArguments[];
+};
+type ClarityWindow = Window &
+  typeof globalThis & {
+    clarity?: ClarityFunction;
+  };
 
 type AnalyticsWindow = Window &
   typeof globalThis & {
@@ -88,6 +98,70 @@ function ChatwootWidget() {
   return null;
 }
 
+function ensureMicrosoftClarityScript() {
+  if (document.getElementById(MICROSOFT_CLARITY_SCRIPT_ID)) {
+    return;
+  }
+
+  const clarityWindow = window as ClarityWindow;
+  clarityWindow.clarity =
+    clarityWindow.clarity ??
+    function clarity() {
+      const queuedClarity = clarityWindow.clarity;
+      if (!queuedClarity) {
+        return;
+      }
+
+      queuedClarity.q = queuedClarity.q ?? [];
+      queuedClarity.q.push(arguments);
+    };
+
+  const script = document.createElement("script");
+  script.id = MICROSOFT_CLARITY_SCRIPT_ID;
+  script.async = true;
+  script.src = `https://www.clarity.ms/tag/${MICROSOFT_CLARITY_TAG_ID}`;
+  document.head.appendChild(script);
+}
+
+function MicrosoftClarityConsent({
+  enabled,
+  isReady,
+}: {
+  enabled: boolean;
+  isReady: boolean;
+}) {
+  useMountEffect(() => {
+    if (
+      !isReady ||
+      typeof window === "undefined" ||
+      import.meta.env.DEV ||
+      window.location.pathname.startsWith("/admin")
+    ) {
+      return;
+    }
+
+    if (enabled) {
+      ensureMicrosoftClarityScript();
+    }
+
+    const clarity = (window as ClarityWindow).clarity;
+    if (!clarity) {
+      return;
+    }
+
+    clarity("consentv2", {
+      ad_Storage: "denied",
+      analytics_Storage: enabled ? "granted" : "denied",
+    });
+
+    if (!enabled) {
+      clarity("consent", false);
+    }
+  });
+
+  return null;
+}
+
 export function ConsentAwareProviders({
   children,
   queryClient,
@@ -95,12 +169,17 @@ export function ConsentAwareProviders({
   children: React.ReactNode;
   queryClient: QueryClient;
 }) {
-  const { analyticsEnabled } = usePrivacyConsent();
+  const { analyticsEnabled, isReady } = usePrivacyConsent();
 
   return (
     <PostHogProvider enabled={analyticsEnabled}>
       <QueryClientProvider client={queryClient}>
         {children}
+        <MicrosoftClarityConsent
+          key={`${isReady}:${analyticsEnabled}`}
+          enabled={analyticsEnabled}
+          isReady={isReady}
+        />
         {analyticsEnabled ? <GoogleAnalyticsScript /> : null}
         {analyticsEnabled ? <ChatwootWidget /> : null}
       </QueryClientProvider>

--- a/apps/web/src/components/privacy-consent.tsx
+++ b/apps/web/src/components/privacy-consent.tsx
@@ -450,7 +450,8 @@ function CookiePreferencesDialog({
             <span className="space-y-1">
               <span className="block">Analytics and support tools</span>
               <span className="block text-sm leading-6 text-neutral-500">
-                Includes PostHog and the website support widget.
+                Includes PostHog, Google Analytics, Microsoft Clarity, and the
+                website support widget.
               </span>
             </span>
           </label>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -29,6 +29,8 @@ const FONT_STYLESHEETS = [
   "https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&display=swap",
 ] as const;
 
+const MICROSOFT_CLARITY_SCRIPT = `(function(c,l,a,r,i,t,y){try{if(l.location&&l.location.pathname.indexOf("/admin")===0){return;}var raw=c.localStorage&&c.localStorage.getItem("char_web_tracking_consent_v1");var consent=raw?JSON.parse(raw):null;var analytics=!!(consent&&consent.analytics===true);if(c.navigator&&c.navigator.globalPrivacyControl){analytics=false;}if(!analytics){return;}}catch(e){return;}c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};c[a]("consentv2",{ad_Storage:"denied",analytics_Storage:"granted"});t=l.createElement(r);t.id="microsoft-clarity-script";t.async=1;t.src="https://www.clarity.ms/tag/"+i;y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);})(window, document, "clarity", "script", "wcjttoibok");`;
+
 export const Route = createRootRouteWithContext<RouterContext>()({
   loader: async () => ({
     privacyConsentRegion: await getPrivacyConsentRegion(),
@@ -74,6 +76,12 @@ export const Route = createRootRouteWithContext<RouterContext>()({
     links: [
       { rel: "icon", href: "/favicon.svg", type: "image/svg+xml" },
       { rel: "icon", href: "/favicon.ico", sizes: "32x32" },
+    ],
+    scripts: [
+      {
+        type: "text/javascript",
+        children: MICROSOFT_CLARITY_SCRIPT,
+      },
     ],
   }),
   component: RootApp,


### PR DESCRIPTION
Add Microsoft Clarity to the web head, keep it behind website tracking consent, and document it in the legal policies.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5066 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5062 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new third-party tracking script with session replay/heatmap capabilities; risk is mainly around consent enforcement, privacy compliance, and performance/behavior changes from injecting scripts into the document head.
> 
> **Overview**
> Adds Microsoft Clarity tracking to the web app, including an inline head script and a runtime consent bridge that only loads/enables Clarity when non-essential analytics consent is granted (and disables it for `/admin`, dev, or when GPC is enabled).
> 
> Updates the cookie preferences copy to explicitly include Clarity, and updates `Cookie Policy`, `Privacy Policy`, and `DPA` to disclose Clarity as an analytics sub-processor and describe the additional behavioral/session-replay data collected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f4088752d7438c1bf32e8df29fae696b4ddf3f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->