### PR TITLE
Autoplayed video on hero section + multiple small fixes

### DIFF
--- a/apps/web/src/components/logo-cloud.tsx
+++ b/apps/web/src/components/logo-cloud.tsx
@@ -6,6 +6,7 @@ import { cn } from "@hypr/utils";
 type Logo = {
   src: string;
   alt: string;
+  small?: boolean;
 };
 
 const LOGOS: Logo[][] = [
@@ -27,12 +28,12 @@ const LOGOS: Logo[][] = [
   ],
   [
     { src: "/icons/wayfair.svg", alt: "Wayfair Logo" },
-    { src: "/icons/bain.svg", alt: "Bain Logo" },
+    { src: "/icons/bain.svg", alt: "Bain Logo", small: true },
   ],
 ];
 
 const CYCLE_INTERVAL = 3000;
-const STAGGER_DELAY = 300;
+const STAGGER_DELAY = 150;
 
 function LogoSlot({ logos, delay }: { logos: Logo[]; delay: number }) {
   const [index, setIndex] = useState(0);
@@ -70,7 +71,10 @@ function LogoSlot({ logos, delay }: { logos: Logo[]; delay: number }) {
           key={logo.src}
           src={logo.src}
           alt={logo.alt}
-          className="pointer-events-none h-5 select-none md:h-6"
+          className={cn([
+            "pointer-events-none select-none",
+            logo.small ? "h-5 md:h-6" : "h-7 md:h-8",
+          ])}
           initial={{ y: -30, opacity: 0, filter: "blur(8px)" }}
           animate={{ y: 0, opacity: 1, filter: "blur(0px)" }}
           exit={{ y: 30, opacity: 0, filter: "blur(8px)" }}

--- a/apps/web/src/routes/_view/blog/$slug.tsx
+++ b/apps/web/src/routes/_view/blog/$slug.tsx
@@ -155,7 +155,7 @@ function Component() {
 
 function HeroSection({ article }: { article: any }) {
   return (
-    <header className="px-4 pt-12 pb-8 text-left md:px-8 md:pt-12">
+    <header className="px-4 pt-4 pb-8 text-left md:px-8 md:pt-12">
       <Link
         to="/blog/"
         className="text-fg mb-8 inline-flex items-center gap-2 text-sm opacity-50 transition-opacity hover:opacity-100"
@@ -207,7 +207,7 @@ function HeroSection({ article }: { article: any }) {
 
 function ArticleContent({ article }: { article: any }) {
   return (
-    <article className="prose surface border-color-brand prose-neutral prose-p:text-base prose-headings:font-mono prose-headings:font-semibold prose-h1:text-3xl prose-h1:mt-16 prose-h1:mb-12 prose-h2:text-2xl prose-h2:mt-10 prose-h2:mb-8 prose-h3:text-xl prose-h3:mt-8 prose-h3:mb-6 prose-h4:text-lg prose-h4:mt-6 prose-h4:mb-3 prose-a:text-fg prose-a:underline prose-a:decoration-dotted hover:prose-a:text-stone-800 prose-headings:no-underline prose-headings:decoration-transparent prose-code:bg-stone-50 prose-code:border prose-code:border-color-brand prose-code:rounded prose-code:px-1.5 prose-code:py-0.5 prose-code:text-sm prose-code:font-mono prose-code:text-stone-700 prose-pre:bg-stone-50 prose-pre:border prose-pre:border-neutral-200 prose-pre:rounded-xs prose-pre:prose-code:bg-transparent prose-pre:prose-code:border-0 prose-pre:prose-code:p-0 prose-img:rounded-xs prose-img:border prose-img:border-neutral-200 prose-img:my-8 w-full max-w-none rounded-xl border py-16">
+    <article className="prose surface border-color-brand prose-neutral prose-p:text-base prose-headings:font-mono prose-headings:font-semibold prose-h1:text-3xl prose-h1:mt-16 prose-h1:mb-12 prose-h2:text-2xl prose-h2:mt-10 prose-h2:mb-8 prose-h3:text-xl prose-h3:mt-8 prose-h3:mb-6 prose-h4:text-lg prose-h4:mt-6 prose-h4:mb-3 prose-a:text-fg prose-a:underline prose-a:decoration-dotted hover:prose-a:text-stone-800 prose-headings:no-underline prose-headings:decoration-transparent prose-code:bg-stone-50 prose-code:border prose-code:border-color-brand prose-code:rounded prose-code:px-1.5 prose-code:py-0.5 prose-code:text-sm prose-code:font-mono prose-code:text-stone-700 prose-pre:bg-stone-50 prose-pre:border prose-pre:border-neutral-200 prose-pre:rounded-xs prose-pre:prose-code:bg-transparent prose-pre:prose-code:border-0 prose-pre:prose-code:p-0 prose-img:rounded-xs prose-img:border prose-img:border-neutral-200 prose-img:my-8 w-full max-w-none rounded-xl border px-4 py-8 sm:px-8 sm:py-16 md:px-16">
       <div className="mx-auto max-w-200">
         <MDXContent code={article.mdx} components={defaultMDXComponents} />
       </div>

--- a/apps/web/src/routes/_view/index.tsx
+++ b/apps/web/src/routes/_view/index.tsx
@@ -38,6 +38,8 @@ import {
   getStructuredDataGraph,
 } from "@/lib/seo";
 
+import { AnnouncementBanner } from "./route";
+
 const MUX_PLAYBACK_ID = "1s01BC9LBwzygOUWk9Pdn011KuxvIQRMbTEfCpOypfdrw";
 
 const mainFeatures = [
@@ -242,8 +244,9 @@ function HeroSection({
           className="isolate flex w-full overflow-visible pt-10 text-left"
         >
           <div className="border-brand-bright items-left relative z-10 flex min-h-[80vh] w-full flex-col content-between rounded-lg border md:flex-row">
-            <div className="flex flex-col justify-between px-4 pt-8 pb-8 md:px-6 md:pt-12 md:pr-8 md:pb-12 md:pl-12">
+            <div className="flex flex-col justify-between px-4 pt-8 pb-8 md:w-3/5 md:px-6 md:pt-12 md:pr-8 md:pb-12 md:pl-12">
               <div className="flex flex-col gap-2">
+                <AnnouncementBanner />
                 <h1
                   className="text-color break-words"
                   style={{
@@ -360,70 +363,62 @@ function HeroSection({
                       <DownloadButton />
                       <GithubStars />
                     </div>
-                    <a
-                      href="https://www.ycombinator.com/companies/char"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="mt-3 inline-flex items-center gap-2 text-sm text-stone-400 transition-colors hover:text-stone-600"
-                    >
-                      <span>Backed by</span>
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 90.222 18"
-                        fill="currentColor"
-                        className="h-5"
-                      >
-                        <g>
-                          <path
-                            d="M 0 18 L 18 18 L 18 0 L 0 0 Z"
-                            fill="rgb(251,101,30)"
-                          />
-                          <path
-                            d="M 9.731 9.894 L 9.731 13.894 L 8.212 13.894 L 8.212 9.894 L 4.337 4.106 L 6.187 4.106 L 8.977 8.381 L 11.756 4.106 L 13.607 4.106 Z"
-                            fill="rgb(255,255,255)"
-                          />
-                          <g transform="translate(23.954 4.118)">
-                            <path d="M 4.601 1.918 C 2.936 1.918 1.688 3.206 1.688 4.871 C 1.688 6.536 2.936 7.836 4.601 7.836 C 5.67 7.836 6.598 7.284 7.099 6.356 L 8.528 7.206 C 7.729 8.572 6.233 9.461 4.601 9.461 C 2.036 9.456 0 7.419 0 4.871 C 0 2.317 2.036 0.281 4.601 0.281 C 6.249 0.281 7.729 1.159 8.528 2.537 L 7.099 3.386 C 6.593 2.458 5.67 1.918 4.601 1.918" />
-                            <path d="M 14.018 6.03 C 14.018 7.071 13.241 7.858 12.279 7.858 C 11.273 7.858 10.513 7.071 10.513 6.03 C 10.513 4.989 11.273 4.202 12.279 4.202 C 13.258 4.202 14.018 4.989 14.018 6.03 Z M 8.876 6.03 C 8.876 7.909 10.384 9.416 12.279 9.416 C 14.147 9.416 15.654 7.909 15.654 6.03 C 15.654 4.151 14.147 2.644 12.279 2.644 C 10.384 2.644 8.876 4.151 8.876 6.03 Z" />
-                            <path d="M 26.274 5.49 L 26.274 9.27 L 24.643 9.27 L 24.643 5.777 C 24.643 4.798 24.165 4.179 23.445 4.179 C 22.708 4.179 22.168 4.798 22.168 5.777 L 22.168 9.27 L 20.593 9.27 L 20.593 5.777 C 20.593 4.798 20.098 4.179 19.372 4.179 C 18.647 4.179 18.118 4.798 18.118 5.777 L 18.118 9.27 L 16.487 9.27 L 16.487 2.801 L 18.118 2.801 L 18.118 3.628 C 18.517 3.009 19.136 2.621 19.896 2.621 C 20.722 2.621 21.375 3.088 21.774 3.814 C 22.185 3.167 22.944 2.621 23.901 2.621 C 25.335 2.621 26.274 3.887 26.274 5.49" />
-                            <path d="M 32.074 6.097 C 32.074 7.155 31.404 7.914 30.493 7.92 C 29.565 7.92 28.856 7.177 28.856 6.081 C 28.856 4.978 29.548 4.241 30.465 4.241 C 31.404 4.241 32.074 5.017 32.074 6.097 Z M 30.808 9.439 C 32.479 9.439 33.784 8.021 33.756 6.058 C 33.728 4.117 32.451 2.677 30.78 2.677 C 29.919 2.677 29.256 3.06 28.862 3.589 L 28.862 0.27 L 27.231 0.27 L 27.231 9.27 L 28.862 9.27 L 28.862 8.46 C 29.244 9.028 29.908 9.439 30.808 9.439 Z" />
-                            <path d="M 34.431 2.801 L 36.062 2.801 L 36.062 9.27 L 34.431 9.27 Z M 34.222 0.967 C 34.222 0.416 34.684 0 35.241 0 C 35.781 0 36.231 0.411 36.231 0.967 C 36.231 1.519 35.781 1.935 35.241 1.935 C 34.689 1.929 34.222 1.519 34.222 0.967 Z" />
-                            <path d="M 43.093 5.518 L 43.093 9.27 L 41.518 9.27 L 41.518 5.867 C 41.518 4.826 40.973 4.179 40.185 4.179 C 39.319 4.179 38.706 4.967 38.706 5.895 L 38.706 9.27 L 37.131 9.27 L 37.131 2.801 L 38.706 2.801 L 38.706 3.617 C 39.144 3.009 39.848 2.621 40.669 2.621 C 42.12 2.621 43.093 3.859 43.093 5.518" />
-                            <path d="M 48.043 6.401 C 48.043 7.267 47.34 8.021 46.474 8.049 C 45.872 8.066 45.506 7.768 45.506 7.369 C 45.506 6.992 45.844 6.711 46.395 6.581 L 48.043 6.261 Z M 49.618 5.366 C 49.618 3.757 48.431 2.661 46.845 2.672 C 45.782 2.672 44.713 3.24 44.106 4.089 L 45.293 4.95 C 45.641 4.461 46.221 4.072 46.839 4.072 C 47.464 4.072 47.874 4.483 48.004 5.023 L 46.108 5.383 C 44.803 5.642 43.926 6.311 43.926 7.481 C 43.926 8.719 44.893 9.439 45.99 9.439 C 46.817 9.422 47.565 9.039 48.043 8.522 L 48.043 9.27 L 49.618 9.27 Z" />
-                            <path d="M 52.937 4.264 L 52.937 6.975 C 52.937 7.504 53.167 7.746 53.646 7.746 L 54.456 7.746 L 54.456 9.264 L 53.421 9.264 C 52.042 9.264 51.362 8.589 51.362 7.172 L 51.362 4.264 L 50.181 4.264 L 50.181 2.801 L 51.306 2.801 L 51.306 1.204 L 52.937 0.703 L 52.937 2.801 L 54.456 2.801 L 54.456 4.264 Z" />
-                            <path d="M 60.131 6.03 C 60.131 7.071 59.355 7.858 58.393 7.858 C 57.386 7.858 56.627 7.071 56.627 6.03 C 56.627 4.989 57.386 4.202 58.393 4.202 C 59.372 4.202 60.131 4.989 60.131 6.03 Z M 54.99 6.03 C 54.99 7.909 56.497 9.416 58.393 9.416 C 60.261 9.416 61.768 7.909 61.768 6.03 C 61.768 4.151 60.261 2.644 58.393 2.644 C 56.497 2.644 54.99 4.151 54.99 6.03 Z" />
-                            <path d="M 66.268 2.661 L 66.268 4.23 C 64.811 4.23 64.187 4.939 64.187 5.867 L 64.187 9.27 L 62.612 9.27 L 62.612 2.801 L 64.187 2.801 L 64.187 3.611 C 64.631 3.032 65.346 2.661 66.268 2.661" />
-                          </g>
-                        </g>
-                      </svg>
-                    </a>
                   </>
                 )}
               </div>
             </div>
 
-            <div className="relative hidden w-full shrink-0 self-stretch overflow-hidden p-8 md:block md:w-1/2">
+            <div className="relative hidden w-full shrink-0 self-stretch overflow-hidden p-8 md:block md:w-2/5">
               <NotebookGrid />
+
+              <a
+                href="https://www.ycombinator.com/companies/char"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="surface shadow-ring absolute top-10 right-10 z-10 flex rotate-[-5deg] items-center gap-3 rounded-xl py-2 pr-4 pl-2 transition-transform hover:scale-105 hover:rotate-[0deg]"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 18 18"
+                  className="size-10 shrink-0"
+                >
+                  <path
+                    d="M 0 18 L 18 18 L 18 0 L 0 0 Z"
+                    fill="rgb(251,101,30)"
+                  />
+                  <path
+                    d="M 9.731 9.894 L 9.731 13.894 L 8.212 13.894 L 8.212 9.894 L 4.337 4.106 L 6.187 4.106 L 8.977 8.381 L 11.756 4.106 L 13.607 4.106 Z"
+                    fill="rgb(255,255,255)"
+                  />
+                </svg>
+                <div className="flex flex-col">
+                  <span className="text-xs text-stone-400">Backed by</span>
+                  <span className="text-sm font-semibold text-stone-700">
+                    Y Combinator
+                  </span>
+                </div>
+              </a>
 
               <div className="absolute right-0 bottom-0 flex justify-end p-10">
                 <button
                   onClick={() => onVideoExpand(MUX_PLAYBACK_ID)}
-                  className="group surface border-color-brand relative flex w-4/5 flex-col overflow-hidden rounded-xl border shadow-xl"
+                  className="group surface border-color-brand relative flex w-4/5 flex-col overflow-hidden rounded-xl border shadow-xl transition-transform duration-200 hover:scale-105"
                   style={{ aspectRatio: "16/9" }}
                 >
-                  <div className="h-full w-full">
-                    <img
-                      src="/demo_thumbnail.webp"
-                      alt="Product demo"
-                      className="h-full w-full object-cover"
-                    />
-                    <div className="absolute inset-0 flex items-center justify-center transition-colors group-hover:bg-black/30">
-                      <div className="flex size-10 items-center justify-center rounded-full bg-white/90 shadow-lg transition-transform group-hover:scale-110">
-                        <Icon
-                          icon="mdi:play"
-                          className="text-color ml-0.5 text-lg"
-                        />
-                      </div>
+                  <MuxPlayer
+                    playbackId={MUX_PLAYBACK_ID}
+                    autoPlay="muted"
+                    muted
+                    loop
+                    className="h-full w-full object-cover"
+                    style={{ "--controls": "none" } as React.CSSProperties}
+                  />
+                  <div className="absolute inset-0 flex items-end justify-end p-3 transition-colors">
+                    <div className="flex size-10 items-center justify-center rounded-full bg-white/90 shadow-lg transition-transform group-hover:scale-120">
+                      <Icon
+                        icon="mdi:play"
+                        className="text-color ml-0.5 text-lg"
+                      />
                     </div>
                   </div>
                 </button>

--- a/apps/web/src/routes/_view/route.tsx
+++ b/apps/web/src/routes/_view/route.tsx
@@ -94,7 +94,6 @@ function Component() {
               }}
             >
               <div className="relative flex min-h-screen flex-col">
-                {isHomePage && <AnnouncementBanner />}
                 {!isResourcePage && !isAppPage && (
                   <>
                     <div
@@ -302,7 +301,7 @@ const ANNOUNCEMENT_STORAGE_KEY = "char_announcement_dismissed";
 
 const ANNOUNCEMENT_BAR_HEIGHT = "36px";
 
-function AnnouncementBanner() {
+export function AnnouncementBanner() {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -313,44 +312,34 @@ function AnnouncementBanner() {
     }
   }, []);
 
-  useEffect(() => {
-    document.documentElement.style.setProperty(
-      "--announcement-bar-h",
-      visible ? ANNOUNCEMENT_BAR_HEIGHT : "0px",
-    );
-  }, [visible]);
-
   if (!visible) return null;
 
   return (
-    <>
-      <Link
-        to="/blog/$slug/"
-        params={{ slug: "hyprnote-is-now-char" }}
-        className={cn([
-          "fixed inset-x-0 top-0 z-[60] flex items-center justify-center",
-          "bg-stone-800 px-10 py-2",
-          "font-serif text-sm text-stone-200",
-          "transition-colors hover:bg-stone-700",
-        ])}
+    <Link
+      to="/blog/$slug/"
+      params={{ slug: "hyprnote-is-now-char" }}
+      className={cn([
+        "relative inline-flex w-fit items-center gap-2 rounded-full",
+        "bg-stone-800 px-4 py-1.5",
+        "font-serif text-sm text-stone-200",
+        "transition-colors hover:bg-stone-700",
+      ])}
+    >
+      <span>
+        Hyprnote is now <strong>Char</strong>.
+      </span>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          window.localStorage.setItem(ANNOUNCEMENT_STORAGE_KEY, "true");
+          setVisible(false);
+        }}
+        className="cursor-pointer text-stone-400 transition-colors hover:text-white"
       >
-        <span>
-          Hyprnote is now <strong>Char</strong>.
-        </span>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            window.localStorage.setItem(ANNOUNCEMENT_STORAGE_KEY, "true");
-            setVisible(false);
-          }}
-          className="absolute right-4 cursor-pointer text-stone-400 transition-colors hover:text-white"
-        >
-          <XIcon size={14} />
-        </button>
-      </Link>
-      <div style={{ height: ANNOUNCEMENT_BAR_HEIGHT }} />
-    </>
+        <XIcon size={14} />
+      </button>
+    </Link>
   );
 }


### PR DESCRIPTION
changed announce banner 
make demo video autoplayed
change size of grid on the right
change size of logos from companies
change paddings for mobile version of blog

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely front-end layout/UX changes; main risk is visual regressions and increased bandwidth/CPU from autoplaying the hero video.
> 
> **Overview**
> Updates the home page hero layout by resizing the left/right columns, moving the YC “Backed by” callout into the right visual panel, and replacing the static demo thumbnail with an autoplaying, looping `MuxPlayer` preview (still expandable on click).
> 
> Refactors the announcement banner from a fixed top bar into an inline pill used inside the hero (exported `AnnouncementBanner`, removed global spacer/CSS var side effects).
> 
> Tweaks presentation details: logo cloud now supports per-logo sizing (and faster stagger), and blog article pages get improved mobile padding/spacing for the header and content container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f8b968d2362f57d4f516d6f2e0c13cb0639fc86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->