### PR TITLE
fix: remove stale announcement height constant

### DIFF
--- a/apps/web/src/routes/_view/route.tsx
+++ b/apps/web/src/routes/_view/route.tsx
@@ -299,8 +299,6 @@ function MobileHandbookDrawer({
 
 const ANNOUNCEMENT_STORAGE_KEY = "char_announcement_dismissed";
 
-const ANNOUNCEMENT_BAR_HEIGHT = "36px";
-
 export function AnnouncementBanner() {
   const [visible, setVisible] = useState(false);
 


### PR DESCRIPTION
Remove the unused announcement banner height constant left after the inline banner refactor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure cleanup removing an unused constant; no runtime behavior changes expected.
> 
> **Overview**
> Removes the stale, unused `ANNOUNCEMENT_BAR_HEIGHT` constant from `apps/web/src/routes/_view/route.tsx` (announcement banner code cleanup after the inline banner refactor).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8922e4c8b74268d86aefa75d721007bc0c2d56c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->