### PR TITLE
fix: reduce sentry trace sampling to mitigate memory leak on sleep (#5068)

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -53,11 +53,15 @@ pub async fn main() {
             let release =
                 option_env!("APP_VERSION").map(|v| format!("hyprnote-desktop@{}", v).into());
 
+            // traces_sample_rate=1.0 captured every trace and accumulated them in
+            // the sentry transport's in-memory queue. When the machine slept with the
+            // lid closed, traces couldn't flush (no network) and the queue grew
+            // unboundedly -- one of the drivers behind #5068.
             let client = sentry::init((
                 dsn,
                 sentry::ClientOptions {
                     release,
-                    traces_sample_rate: 1.0,
+                    traces_sample_rate: 0.1,
                     auto_session_tracking: false,
                     ..Default::default()
                 },
@@ -195,6 +199,7 @@ pub async fn main() {
     let specta_builder = make_specta_builder::<tauri::Wry>();
 
     let root_supervisor_ctx_for_run = root_supervisor_ctx.clone();
+    let sentry_enabled = sentry_client.is_some();
 
     let app = builder
         .invoke_handler(specta_builder.invoke_handler())
@@ -319,6 +324,15 @@ pub async fn main() {
             }
 
             let _ = app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+
+            // Drain sentry's in-memory trace/event queue before we go idle in the
+            // tray. If the user puts the machine to sleep from here the queue
+            // would otherwise grow unboundedly (see #5068).
+            if sentry_enabled {
+                if let Some(client) = sentry::Hub::current().client() {
+                    client.flush(Some(std::time::Duration::from_secs(2)));
+                }
+            }
         }
         tauri::RunEvent::Exit => {
             {


### PR DESCRIPTION
## Summary

Issue #5068 reports 150GB+ RAM consumption after the MacBook lid stays closed for 3-4 hours. Root cause analysis points to **sentry's in-memory trace queue accumulating unboundedly** while the network transport is idle.

Contributing factors:
- `traces_sample_rate: 1.0` captured every single trace
- Background work never stops: root supervisor, STT supervisor, sleep detector (500ms poll), network actor, notify file watcher, tantivy writer
- Every tracing span (`tracing::info!`, `warn!`, `error!`) routes through sentry via the `sentry::integrations::tracing::layer`
- When the laptop sleeps, network → no flush → queue grows forever

## Changes

1. **Drop trace sampling from 100% to 10%** (`traces_sample_rate: 1.0` → `0.1`). Still plenty of signal for observability, ~10x less memory pressure from traces.
2. **Flush sentry when the app retreats to the tray** on macOS. Before the user potentially sleeps the machine from a tray-only state, drain the queue with a 2-second timeout.

```rust
if sentry_enabled {
    if let Some(client) = sentry::Hub::current().client() {
        client.flush(Some(std::time::Duration::from_secs(2)));
    }
}
```

## Test Plan

- [x] `cargo check -p desktop` passes locally
- [ ] Manual: close lid for 3-4 hours with dev build, verify RSS stays reasonable
- [ ] Before/after RSS comparison using Instruments or `ps -o rss`

## Follow-ups (not in this PR)

The lid-closed scenario has several other contributing factors that deserve their own PRs:

- **Pause actors + file watcher on `ExitRequested`** — currently `ctx.mark_exiting()` is called but `ctx.stop()` is not. Background actors keep running forever in tray mode.
- **Wire `NSWorkspaceWillSleep` / `DidWake`** to pause/resume heavy subsystems. The `SleepDetector` already fires these events — nothing listens for idle pause today.
- **Review tantivy `IndexWriter`** — the 50MB writer buffer plus segments accumulate in memory when indexing continues in background without explicit `commit()`/`merge()`.
- **Verify `notify-debouncer-full::RecommendedCache`** doesn't retain file metadata unboundedly — it's designed to grow as files are discovered.

Closes #5068 (partial — primary driver)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized telemetry configuration change plus a best-effort flush during tray transition; primary risk is reduced observability and minor shutdown/tray latency.
> 
> **Overview**
> Reduces Sentry performance tracing volume by changing `traces_sample_rate` from `1.0` to `0.1`, with added inline rationale tied to #5068.
> 
> On macOS `ExitRequested` (when the app is prevented from exiting and moved to tray/accessory mode), it now flushes the active Sentry client with a 2s timeout (guarded by `sentry_enabled`) to drain any queued events/traces before the app goes idle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aed019ef8a2a3fca628ccfe0ca4a7cab5aeb93fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->