### PR TITLE
fix: repair Safari hero video card

### DIFF
--- a/apps/web/src/routes/_view/index.tsx
+++ b/apps/web/src/routes/_view/index.tsx
@@ -399,10 +399,9 @@ function HeroSection({
                 </div>
               </a>
 
-              <div className="absolute right-0 bottom-0 flex justify-end p-10">
-                <button
-                  onClick={() => onVideoExpand(MUX_PLAYBACK_ID)}
-                  className="group surface border-color-brand relative flex w-4/5 flex-col overflow-hidden rounded-xl border shadow-xl transition-transform duration-200 hover:scale-105"
+              <div className="absolute inset-x-0 bottom-0 flex justify-end p-10">
+                <div
+                  className="group surface border-color-brand relative w-4/5 overflow-hidden rounded-xl border shadow-xl"
                   style={{ aspectRatio: "16/9" }}
                 >
                   <MuxPlayer
@@ -410,18 +409,24 @@ function HeroSection({
                     autoPlay="muted"
                     muted
                     loop
-                    className="h-full w-full object-cover"
+                    playsInline
+                    className="pointer-events-none h-full w-full object-cover"
                     style={{ "--controls": "none" } as React.CSSProperties}
                   />
-                  <div className="absolute inset-0 flex items-end justify-end p-3 transition-colors">
+                  <button
+                    type="button"
+                    onClick={() => onVideoExpand(MUX_PLAYBACK_ID)}
+                    className="absolute inset-0 flex items-end justify-end p-3 transition-transform duration-200 hover:scale-105"
+                    aria-label="Open product demo video"
+                  >
                     <div className="flex size-10 items-center justify-center rounded-full bg-white/90 shadow-lg transition-transform group-hover:scale-120">
                       <Icon
                         icon="mdi:play"
                         className="text-color ml-0.5 text-lg"
                       />
                     </div>
-                  </div>
-                </button>
+                  </button>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add playsInline to the landing page hero Mux player
- avoid nesting the player inside a button by moving the click target to an overlay button
- keep the full card clickable while preventing the player from owning pointer events

## Testing
- unable to run pnpm -F @hypr/web typecheck in this worktree because dependencies are not installed
- dprint currently fails on this file in this environment with a stable-format error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI/interaction change on the landing page hero with no data or auth impact; main risk is minor layout/click-target regressions across browsers.
> 
> **Overview**
> Updates the landing-page hero video card to improve Safari behavior by enabling inline playback (`playsInline`) and preventing the `MuxPlayer` from capturing pointer events.
> 
> Refactors the click target from a wrapped `<button>` to an overlay button (with an `aria-label`) so the full card remains clickable while keeping the video element non-interactive, and tweaks the container positioning (`right-0`  `inset-x-0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87b70f4f2f54c732a1de3a2880b164553626d963. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->