### PR TITLE
fix(web): restore flexible-ai product page content

### DIFF
--- a/apps/web/src/routes/_view/product/flexible-ai.tsx
+++ b/apps/web/src/routes/_view/product/flexible-ai.tsx
@@ -88,6 +88,212 @@ const localCapabilities = [
       "Run Llama, Mistral, Qwen, or other open models locally for summaries, action items, and question answering.",
   },
 ];
+
 function Component() {
-  return <div />;
+  return (
+    <main className="min-h-screen flex-1">
+      <div className="mx-auto">
+        <HeroSection />
+        <AISetupSection />
+        <LocalFeaturesSection />
+        <SwitchSection />
+        <BenchmarkSection />
+        <FAQSection />
+        <CTASection
+          title="Pick the AI setup that fits every meeting"
+          description="Start with managed defaults, bring your own providers, or run fully local without switching apps."
+        />
+      </div>
+    </main>
+  );
+}
+
+function SectionTitle({ children }: { children: ReactNode }) {
+  return (
+    <div className="border-b border-neutral-100 text-left">
+      <p className="py-6 font-mono font-medium tracking-wide text-neutral-600 uppercase">
+        {children}
+      </p>
+    </div>
+  );
+}
+
+function HeroSection() {
+  return (
+    <section className="bg-linear-to-b from-stone-50/30 to-stone-100/30">
+      <div className="flex flex-col items-center gap-6 px-4 py-24 text-left">
+        <div className="flex max-w-4xl flex-col gap-6">
+          <h1 className="font-mono text-4xl tracking-tight text-stone-700 sm:text-5xl">
+            Take Meeting Notes With
+            <br />
+            AI of Your Choice
+          </h1>
+          <p className="mx-auto max-w-3xl text-lg text-neutral-600 sm:text-xl">
+            Char lets you choose between managed cloud AI, your own provider
+            keys, or fully local models on your machine.
+          </p>
+        </div>
+        <div className="flex flex-col items-center gap-4 pt-6 sm:flex-row">
+          <DownloadButton />
+          <GithubStars />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function AISetupSection() {
+  return (
+    <section>
+      <SectionTitle>Pick your AI setup</SectionTitle>
+      <div className="grid md:grid-cols-3">
+        {setupOptions.map((option, index) => (
+          <div
+            key={option.title}
+            className={cn([
+              "border-b border-neutral-100 p-8",
+              index < setupOptions.length - 1 && "md:border-r",
+            ])}
+          >
+            <Icon icon={option.icon} className="mb-4 text-3xl text-stone-700" />
+            <p className="mb-1 font-mono text-sm text-neutral-500">
+              {option.eyebrow}
+            </p>
+            <h3 className="mb-2 font-mono text-xl text-stone-700">
+              {option.title}
+            </h3>
+            <p className="mb-4 text-sm font-medium text-stone-700">
+              {option.detail}
+            </p>
+            <p className="text-neutral-600">{option.description}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function LocalFeaturesSection() {
+  return (
+    <section>
+      <SectionTitle>Local features</SectionTitle>
+      <div className="divide-y divide-neutral-100">
+        {localCapabilities.map((capability) => (
+          <div key={capability.title} className="flex items-start gap-4 p-8">
+            <Icon
+              icon={capability.icon}
+              className="shrink-0 text-3xl text-stone-700"
+            />
+            <div>
+              <h3 className="mb-2 font-mono text-xl text-stone-700">
+                {capability.title}
+              </h3>
+              <p className="text-neutral-600">{capability.description}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SwitchSection() {
+  return (
+    <section>
+      <SectionTitle>Switch providers anytime</SectionTitle>
+      <p className="border-b border-neutral-100 px-4 py-6 text-left text-neutral-600">
+        Your notes are never locked to a single AI provider.
+      </p>
+      <div className="grid md:grid-cols-2">
+        {switchBenefits.map((benefit, index) => (
+          <div
+            key={benefit.title}
+            className={cn([
+              "border-neutral-100 p-8",
+              index < 2 && "border-b",
+              index % 2 === 0 && "md:border-r",
+            ])}
+          >
+            <h3 className="mb-2 font-mono text-lg text-stone-700">
+              {benefit.title}
+            </h3>
+            <p className="text-neutral-600">{benefit.description}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function BenchmarkSection() {
+  return (
+    <section className="bg-linear-to-b from-stone-50/30 to-stone-100/30">
+      <div className="flex flex-col items-center gap-6 px-4 py-16 text-left">
+        <h2 className="font-mono text-2xl text-stone-700 sm:text-3xl">
+          Compare model performance before you decide
+        </h2>
+        <p className="mx-auto max-w-2xl text-neutral-600">
+          We benchmark leading models on meeting tasks like summaries, action
+          items, speaker tracking, and Q&A so you can choose with confidence.
+        </p>
+        <div className="flex flex-col gap-4 sm:flex-row">
+          <Link
+            to="/eval/"
+            className={cn([
+              "rounded-full px-8 py-3 text-base font-medium",
+              "border border-neutral-300 text-stone-700",
+              "transition-colors hover:bg-stone-50",
+            ])}
+          >
+            View AI model evaluations
+          </Link>
+          <Link
+            to="/product/local-ai/"
+            className={cn([
+              "rounded-full px-8 py-3 text-base font-medium",
+              "border border-neutral-300 text-stone-700",
+              "transition-colors hover:bg-stone-50",
+            ])}
+          >
+            Explore local AI setup
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FAQSection() {
+  return (
+    <section className="px-4 py-16">
+      <div className="mx-auto max-w-4xl">
+        <div className="mb-12 text-left">
+          <h2 className="font-mono text-3xl text-stone-700">
+            Frequently asked questions
+          </h2>
+        </div>
+        <FAQ>
+          <FAQItem question="Which AI models does Char use?">
+            Char Cloud routes requests to the best models for each task.
+          </FAQItem>
+          <FAQItem question="Can I use different models for different meetings?">
+            Yes. You can switch providers before any meeting or re-process
+            existing transcripts with different models anytime.
+          </FAQItem>
+          <FAQItem question="What happens to my notes if I switch providers?">
+            Nothing changes in your notes. They stay as Markdown files on your
+            device.
+          </FAQItem>
+          <FAQItem question="Is local AI good enough?">
+            Local models keep improving and work well for many meetings. Cloud
+            models can still help for tougher reasoning-heavy conversations.
+          </FAQItem>
+          <FAQItem question="Does Char train AI models on my data?">
+            No. Char does not use your recordings, transcripts, or notes to
+            train AI models.
+          </FAQItem>
+        </FAQ>
+      </div>
+    </section>
+  );
 }

--- a/apps/web/src/routes/_view/product/flexible-ai.tsx
+++ b/apps/web/src/routes/_view/product/flexible-ai.tsx
@@ -91,8 +91,8 @@ const localCapabilities = [
 
 function Component() {
   return (
-    <main className="min-h-screen flex-1">
-      <div className="mx-auto">
+    <main className="min-h-screen flex-1 overflow-x-hidden px-2 md:px-8">
+      <div className="">
         <HeroSection />
         <AISetupSection />
         <LocalFeaturesSection />
@@ -110,8 +110,8 @@ function Component() {
 
 function SectionTitle({ children }: { children: ReactNode }) {
   return (
-    <div className="border-b border-neutral-100 text-left">
-      <p className="text-color-muted py-6 font-mono font-medium tracking-wide uppercase">
+    <div className="text-left">
+      <p className="text-color-secondary py-6 font-mono text-xs font-medium tracking-widest uppercase">
         {children}
       </p>
     </div>
@@ -120,43 +120,48 @@ function SectionTitle({ children }: { children: ReactNode }) {
 
 function HeroSection() {
   return (
-    <section className="bg-linear-to-b from-stone-50/30 to-stone-100/30">
-      <div className="flex flex-col items-center gap-6 px-4 py-24 text-left">
-        <div className="flex max-w-4xl flex-col gap-6">
-          <h1 className="text-color font-mono text-4xl tracking-tight sm:text-5xl">
+    <div className="">
+      <div className="px-6 py-12 lg:py-20">
+        <header className="mx-auto mb-12 text-left">
+          <h1 className="text-color mb-6 font-mono text-2xl tracking-wide sm:text-5xl">
             Take Meeting Notes With
             <br />
             AI of Your Choice
           </h1>
-          <p className="text-color-muted mx-auto max-w-3xl text-lg sm:text-xl">
+          <p className="text-color text-lg sm:text-xl">
             Char lets you choose between managed cloud AI, your own provider
-            keys, or fully local models on your machine.
+            keys,
+            <br className="hidden sm:inline" /> or fully local models on your
+            machine.
           </p>
-        </div>
-        <div className="flex flex-col items-center gap-4 pt-6 sm:flex-row">
-          <DownloadButton />
-          <GithubStars />
-        </div>
+          <div className="mt-8 flex items-center gap-4">
+            <DownloadButton />
+            <GithubStars />
+          </div>
+        </header>
       </div>
-    </section>
+    </div>
   );
 }
 
 function AISetupSection() {
   return (
-    <section>
-      <SectionTitle>Pick your AI setup</SectionTitle>
+    <section className="border-color-brand surface rounded-xl border">
+      <div className="border-color-brand border-b px-4 py-6">
+        {" "}
+        <SectionTitle>Pick your AI setup</SectionTitle>
+      </div>
       <div className="grid md:grid-cols-3">
         {setupOptions.map((option, index) => (
           <div
             key={option.title}
             className={cn([
-              "border-b border-neutral-100 p-8",
+              "border-color-brand p-8",
               index < setupOptions.length - 1 && "md:border-r",
             ])}
           >
             <Icon icon={option.icon} className="text-color mb-4 text-3xl" />
-            <p className="text-color-secondary mb-1 font-mono text-sm">
+            <p className="text-color-secondary mb-1 font-mono text-xs tracking-widest uppercase">
               {option.eyebrow}
             </p>
             <h3 className="text-color mb-2 font-mono text-xl">
@@ -165,7 +170,9 @@ function AISetupSection() {
             <p className="text-color mb-4 text-sm font-medium">
               {option.detail}
             </p>
-            <p className="text-color-muted">{option.description}</p>
+            <p className="text-fg text-base leading-relaxed">
+              {option.description}
+            </p>
           </div>
         ))}
       </div>
@@ -175,9 +182,9 @@ function AISetupSection() {
 
 function LocalFeaturesSection() {
   return (
-    <section>
+    <section className="pt-8">
       <SectionTitle>Local features</SectionTitle>
-      <div className="divide-y divide-neutral-100">
+      <div className="divide-brand flex flex-row divide-x pb-8">
         {localCapabilities.map((capability) => (
           <div key={capability.title} className="flex items-start gap-4 p-8">
             <Icon
@@ -188,7 +195,9 @@ function LocalFeaturesSection() {
               <h3 className="text-color mb-2 font-mono text-xl">
                 {capability.title}
               </h3>
-              <p className="text-color-muted">{capability.description}</p>
+              <p className="text-fg text-base leading-relaxed">
+                {capability.description}
+              </p>
             </div>
           </div>
         ))}
@@ -199,9 +208,12 @@ function LocalFeaturesSection() {
 
 function SwitchSection() {
   return (
-    <section>
-      <SectionTitle>Switch providers anytime</SectionTitle>
-      <p className="text-color-muted border-b border-neutral-100 px-4 py-6 text-left">
+    <section className="border-color-brand surface rounded-xl border">
+      <div className="px-8 pt-6">
+        {" "}
+        <SectionTitle>Switch providers anytime</SectionTitle>
+      </div>
+      <p className="text-fg border-color-brand border-b px-8 pb-8 text-left text-base leading-relaxed">
         Your notes are never locked to a single AI provider.
       </p>
       <div className="grid md:grid-cols-2">
@@ -209,15 +221,17 @@ function SwitchSection() {
           <div
             key={benefit.title}
             className={cn([
-              "border-neutral-100 p-8",
+              "border-color-brand p-8",
               index < 2 && "border-b",
               index % 2 === 0 && "md:border-r",
             ])}
           >
-            <h3 className="text-color mb-2 font-mono text-lg">
+            <h3 className="text-color mb-2 font-mono text-lg font-medium">
               {benefit.title}
             </h3>
-            <p className="text-color-muted">{benefit.description}</p>
+            <p className="text-fg text-base leading-relaxed">
+              {benefit.description}
+            </p>
           </div>
         ))}
       </div>
@@ -227,37 +241,35 @@ function SwitchSection() {
 
 function BenchmarkSection() {
   return (
-    <section className="bg-linear-to-b from-stone-50/30 to-stone-100/30">
-      <div className="flex flex-col items-center gap-6 px-4 py-16 text-left">
-        <h2 className="text-color font-mono text-2xl sm:text-3xl">
+    <section className="px-4 pt-16 pb-16">
+      <div className="">
+        <h2 className="text-color mb-8 font-mono text-2xl tracking-wide sm:text-3xl">
           Compare model performance before you decide
         </h2>
-        <p className="text-color-muted mx-auto max-w-2xl">
+        <p className="text-fg max-w-2xl text-base leading-relaxed">
           We benchmark leading models on meeting tasks like summaries, action
           items, speaker tracking, and Q&A so you can choose with confidence.
         </p>
-        <div className="flex flex-col gap-4 sm:flex-row">
-          <Link
-            to="/eval/"
-            className={cn([
-              "rounded-full px-8 py-3 text-base font-medium",
-              "border border-neutral-300 text-color",
-              "transition-colors hover:bg-stone-50",
-            ])}
-          >
-            View AI model evaluations
-          </Link>
-          <Link
-            to="/product/local-ai/"
-            className={cn([
-              "rounded-full px-8 py-3 text-base font-medium",
-              "border border-neutral-300 text-color",
-              "transition-colors hover:bg-stone-50",
-            ])}
-          >
-            Explore local AI setup
-          </Link>
-        </div>
+      </div>
+      <div className="flex flex-col gap-4 pt-10 sm:flex-row">
+        <Link
+          to="/eval/"
+          className={cn([
+            "flex h-9 items-center rounded-lg px-4 text-sm transition-colors",
+            "border border-neutral-200 bg-white text-neutral-700 hover:bg-neutral-50",
+          ])}
+        >
+          View AI model evaluations
+        </Link>
+        <Link
+          to="/product/local-ai/"
+          className={cn([
+            "flex h-9 items-center rounded-lg px-4 text-sm transition-colors",
+            "border border-neutral-200 bg-white text-neutral-700 hover:bg-neutral-50",
+          ])}
+        >
+          Explore local AI setup
+        </Link>
       </div>
     </section>
   );
@@ -265,13 +277,14 @@ function BenchmarkSection() {
 
 function FAQSection() {
   return (
-    <section className="px-4 py-16">
-      <div className="mx-auto max-w-4xl">
-        <div className="mb-12 text-left">
-          <h2 className="text-color font-mono text-3xl">
-            Frequently asked questions
+    <section id="faq" className="px-4 pt-16 pb-16">
+      <div className="mx-auto flex flex-col gap-4 md:flex-row md:gap-8">
+        <div className="mb-4 text-left md:mb-12">
+          <h2 className="text-color mb-4 font-mono text-2xl tracking-wide md:text-4xl">
+            Frequently Asked Questions
           </h2>
         </div>
+
         <FAQ>
           <FAQItem question="Which AI models does Char use?">
             Char Cloud routes requests to the best models for each task.

--- a/apps/web/src/routes/_view/product/flexible-ai.tsx
+++ b/apps/web/src/routes/_view/product/flexible-ai.tsx
@@ -111,7 +111,7 @@ function Component() {
 function SectionTitle({ children }: { children: ReactNode }) {
   return (
     <div className="border-b border-neutral-100 text-left">
-      <p className="py-6 font-mono font-medium tracking-wide text-neutral-600 uppercase">
+      <p className="text-color-muted py-6 font-mono font-medium tracking-wide uppercase">
         {children}
       </p>
     </div>
@@ -123,12 +123,12 @@ function HeroSection() {
     <section className="bg-linear-to-b from-stone-50/30 to-stone-100/30">
       <div className="flex flex-col items-center gap-6 px-4 py-24 text-left">
         <div className="flex max-w-4xl flex-col gap-6">
-          <h1 className="font-mono text-4xl tracking-tight text-stone-700 sm:text-5xl">
+          <h1 className="text-color font-mono text-4xl tracking-tight sm:text-5xl">
             Take Meeting Notes With
             <br />
             AI of Your Choice
           </h1>
-          <p className="mx-auto max-w-3xl text-lg text-neutral-600 sm:text-xl">
+          <p className="text-color-muted mx-auto max-w-3xl text-lg sm:text-xl">
             Char lets you choose between managed cloud AI, your own provider
             keys, or fully local models on your machine.
           </p>
@@ -155,17 +155,17 @@ function AISetupSection() {
               index < setupOptions.length - 1 && "md:border-r",
             ])}
           >
-            <Icon icon={option.icon} className="mb-4 text-3xl text-stone-700" />
-            <p className="mb-1 font-mono text-sm text-neutral-500">
+            <Icon icon={option.icon} className="text-color mb-4 text-3xl" />
+            <p className="text-color-secondary mb-1 font-mono text-sm">
               {option.eyebrow}
             </p>
-            <h3 className="mb-2 font-mono text-xl text-stone-700">
+            <h3 className="text-color mb-2 font-mono text-xl">
               {option.title}
             </h3>
-            <p className="mb-4 text-sm font-medium text-stone-700">
+            <p className="text-color mb-4 text-sm font-medium">
               {option.detail}
             </p>
-            <p className="text-neutral-600">{option.description}</p>
+            <p className="text-color-muted">{option.description}</p>
           </div>
         ))}
       </div>
@@ -182,13 +182,13 @@ function LocalFeaturesSection() {
           <div key={capability.title} className="flex items-start gap-4 p-8">
             <Icon
               icon={capability.icon}
-              className="shrink-0 text-3xl text-stone-700"
+              className="text-color shrink-0 text-3xl"
             />
             <div>
-              <h3 className="mb-2 font-mono text-xl text-stone-700">
+              <h3 className="text-color mb-2 font-mono text-xl">
                 {capability.title}
               </h3>
-              <p className="text-neutral-600">{capability.description}</p>
+              <p className="text-color-muted">{capability.description}</p>
             </div>
           </div>
         ))}
@@ -201,7 +201,7 @@ function SwitchSection() {
   return (
     <section>
       <SectionTitle>Switch providers anytime</SectionTitle>
-      <p className="border-b border-neutral-100 px-4 py-6 text-left text-neutral-600">
+      <p className="text-color-muted border-b border-neutral-100 px-4 py-6 text-left">
         Your notes are never locked to a single AI provider.
       </p>
       <div className="grid md:grid-cols-2">
@@ -214,10 +214,10 @@ function SwitchSection() {
               index % 2 === 0 && "md:border-r",
             ])}
           >
-            <h3 className="mb-2 font-mono text-lg text-stone-700">
+            <h3 className="text-color mb-2 font-mono text-lg">
               {benefit.title}
             </h3>
-            <p className="text-neutral-600">{benefit.description}</p>
+            <p className="text-color-muted">{benefit.description}</p>
           </div>
         ))}
       </div>
@@ -229,10 +229,10 @@ function BenchmarkSection() {
   return (
     <section className="bg-linear-to-b from-stone-50/30 to-stone-100/30">
       <div className="flex flex-col items-center gap-6 px-4 py-16 text-left">
-        <h2 className="font-mono text-2xl text-stone-700 sm:text-3xl">
+        <h2 className="text-color font-mono text-2xl sm:text-3xl">
           Compare model performance before you decide
         </h2>
-        <p className="mx-auto max-w-2xl text-neutral-600">
+        <p className="text-color-muted mx-auto max-w-2xl">
           We benchmark leading models on meeting tasks like summaries, action
           items, speaker tracking, and Q&A so you can choose with confidence.
         </p>
@@ -241,7 +241,7 @@ function BenchmarkSection() {
             to="/eval/"
             className={cn([
               "rounded-full px-8 py-3 text-base font-medium",
-              "border border-neutral-300 text-stone-700",
+              "border border-neutral-300 text-color",
               "transition-colors hover:bg-stone-50",
             ])}
           >
@@ -251,7 +251,7 @@ function BenchmarkSection() {
             to="/product/local-ai/"
             className={cn([
               "rounded-full px-8 py-3 text-base font-medium",
-              "border border-neutral-300 text-stone-700",
+              "border border-neutral-300 text-color",
               "transition-colors hover:bg-stone-50",
             ])}
           >
@@ -268,7 +268,7 @@ function FAQSection() {
     <section className="px-4 py-16">
       <div className="mx-auto max-w-4xl">
         <div className="mb-12 text-left">
-          <h2 className="font-mono text-3xl text-stone-700">
+          <h2 className="text-color font-mono text-3xl">
             Frequently asked questions
           </h2>
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- restore `/product/flexible-ai` so the route no longer renders a blank page
- bring back the full sectioned layout (hero, AI setup options, local features, provider switching, benchmark CTA, FAQ)
- wire the existing `setupOptions`, `switchBenefits`, and `localCapabilities` constants into rendered UI to remove dead/unused data
- ensure previously unused imports are now actively used by the page
- align text colors in `flexible-ai.tsx` with semantic `styles.css` utilities (`text-color`, `text-color-muted`, `text-color-secondary`) instead of hardcoded tone classes

## Verification
- `pnpm -F @hypr/web typecheck` *(fails due to pre-existing unrelated errors in `apps/web/src/functions/stripe.ts`, `apps/web/src/routes/_view/index.tsx`, and `apps/web/src/routes/_view/route.tsx`; flexible-ai route builds successfully during this run)*
- `pnpm exec dprint fmt` *(repository-level formatting fails in this environment due to existing formatter/plugin instability unrelated to this file; no additional files were modified)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f8d961e-3d42-4adf-a4e9-acb76fc32ecc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f8d961e-3d42-4adf-a4e9-acb76fc32ecc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

