### PR TITLE
fix: layer editor toolbar below modals

### DIFF
--- a/apps/desktop/src/editor/widgets/format-toolbar.tsx
+++ b/apps/desktop/src/editor/widgets/format-toolbar.tsx
@@ -51,6 +51,10 @@ const TOOLBAR_BUTTONS: {
 export function FormatToolbar() {
   const toolbarRef = useRef<HTMLDivElement>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
+  const portalRoot =
+    typeof document === "undefined"
+      ? null
+      : (document.getElementById("root") ?? document.body);
 
   const editorState = useEditorState();
   const hasSelection = editorState ? !editorState.selection.empty : false;
@@ -87,6 +91,7 @@ export function FormatToolbar() {
 
     const update = () => {
       void computePosition(referenceEl, toolbar, {
+        strategy: "fixed",
         placement: "top",
         middleware: [offset(8), flip(), shift({ padding: 8 })],
       }).then(({ x, y }) => {
@@ -102,16 +107,16 @@ export function FormatToolbar() {
     update();
   });
 
-  if (!hasSelection || !editorState) return null;
+  if (!hasSelection || !editorState || !portalRoot) return null;
 
   return createPortal(
     <div
       ref={toolbarRef}
       className={cn([
-        "absolute z-[9999] flex items-center gap-0.5 rounded-lg bg-white p-1",
+        "fixed z-30 flex items-center gap-0.5 rounded-lg bg-white p-1",
         "shadow-[0_0_0_1px_rgba(0,0,0,0.05),0_6px_12px_-3px_rgba(0,0,0,0.08)]",
       ])}
-      style={{ top: 0, left: 0 }}
+      style={{ position: "fixed", top: 0, left: 0 }}
       onMouseDown={(e) => e.preventDefault()}
     >
       {TOOLBAR_BUTTONS.map((button) => {
@@ -133,6 +138,6 @@ export function FormatToolbar() {
         );
       })}
     </div>,
-    document.body,
+    portalRoot,
   );
 }


### PR DESCRIPTION
Lower the editor format toolbar z-index so floating chat and modal surfaces stay above it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to the editor floating toolbar’s positioning/portal target; main risk is minor regressions in toolbar placement or visibility in edge cases (selection, scrolling, SSR).
> 
> **Overview**
> Adjusts the editor `FormatToolbar` overlay so it no longer sits above modal/chat surfaces by lowering its stacking context (`z-30`) and switching from `absolute` to `fixed` positioning.
> 
> Updates Floating UI positioning to use `strategy: "fixed"`, and renders the portal into `#root` (falling back to `document.body`) with an SSR-safe `document` guard to avoid crashes when `document` is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 701a2c3f71df454c7d5cbcfda691e9a1aef1dbff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->