### PR TITLE
fix: contain floating chat modal input

### DIFF
--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -139,7 +139,10 @@ function Container({
 }) {
   return (
     <div
-      className={cn(["relative min-h-0 shrink", !isRightPanel && "px-2 pb-2"])}
+      className={cn([
+        "relative min-w-0 shrink-0",
+        !isRightPanel && "px-2 pb-2",
+      ])}
     >
       <div
         className={cn([

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -152,7 +152,7 @@ export function PersistentChatPanel({
           transition={{ duration: 0.2 }}
         >
           <div
-            className="pointer-events-auto flex h-full items-end justify-center px-4 pb-4"
+            className="pointer-events-auto flex h-full min-h-0 items-end justify-center px-4 pb-4"
             onClick={(event) => {
               if (event.target === event.currentTarget) {
                 chat.sendEvent({ type: "CLOSE" });
@@ -161,8 +161,8 @@ export function PersistentChatPanel({
           >
             <motion.div
               className={cn([
-                "relative flex flex-col overflow-hidden",
-                "max-h-[70vh] w-full max-w-[640px]",
+                "relative flex min-h-0 flex-col overflow-hidden",
+                "max-h-[min(70vh,calc(100%_-_1rem))] w-full max-w-[640px]",
                 "rounded-2xl bg-white shadow-2xl",
                 "border border-neutral-200",
               ])}


### PR DESCRIPTION
Constrain the floating chat panel to its anchor and keep the composer from shrinking outside the modal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts flex/min-size and max-height constraints to prevent the floating chat modal and input composer from shrinking/overflowing unexpectedly.
> 
> **Overview**
> Tightens layout constraints for the floating chat modal and its composer so it stays contained within its anchored container.
> 
> Updates the input container to use `min-w-0`/`shrink-0` (instead of `min-h-0`/`shrink`) and adjusts the floating modal wrapper to include `min-h-0` and a safer `max-h` calc (`min(70vh, 100% - 1rem)`) to avoid clipping/overflow in constrained heights.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fd0f1cfb23cdc3bf206b011cd91d1d5ce2de9ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->