### PR TITLE
fix: remove gaps between main toolbar buttons

### DIFF
--- a/apps/desktop/src/main2/shell.tsx
+++ b/apps/desktop/src/main2/shell.tsx
@@ -272,7 +272,7 @@ export function Main2Shell() {
             </div>
           </div>
 
-          <div className="ml-auto flex shrink-0 items-center gap-2">
+          <div className="ml-auto flex shrink-0 items-center">
             {showAdHocButton && (
               <Button
                 type="button"


### PR DESCRIPTION
Drop gap-2 so the ad-hoc, search, chat, and profile buttons sit flush together in the main shell header.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts Tailwind classes to remove spacing between toolbar buttons; no logic or data flow changes.
> 
> **Overview**
> Removes the `gap-2` spacing from the right-side header toolbar container in `Main2Shell` so the ad-hoc, search, chat, and profile controls sit flush together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f7590005a330ebc3d01e466ccacda3d90a15e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->