### PR TITLE
fix: focus daily note from header click and reflect active state

### DIFF
--- a/apps/desktop/src/main2/home/date-header.tsx
+++ b/apps/desktop/src/main2/home/date-header.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@hypr/utils";
+
 import { openDailySummaryTab } from "~/daily-summary";
 
 function ordinalSuffix(day: number): string {
@@ -41,11 +43,15 @@ export function DateHeader({
       <button
         type="button"
         onClick={() => openDailySummaryTab(date)}
-        className={
+        className={cn([
+          "hover:text-neutral-600",
           muted
-            ? "text-lg font-medium text-neutral-400 hover:text-neutral-600"
-            : "text-xl font-semibold text-neutral-900 hover:text-neutral-600"
-        }
+            ? [
+                "text-lg font-medium text-neutral-400",
+                "group-focus-within/daily-note:text-xl group-focus-within/daily-note:font-semibold group-focus-within/daily-note:text-neutral-900",
+              ]
+            : "text-xl font-semibold text-neutral-900",
+        ])}
       >
         {formatDateHeader(date)}
       </button>

--- a/apps/desktop/src/main2/home/index.tsx
+++ b/apps/desktop/src/main2/home/index.tsx
@@ -71,7 +71,6 @@ export function Main2Home() {
             <div className="mx-6 border-t border-neutral-200" />
 
             <div ref={todayRef} className={dailyNoteSectionClassName}>
-              <DateHeader date={today} />
               <DailyNoteEditor date={today} isToday />
             </div>
 

--- a/apps/desktop/src/main2/home/lazy-note.tsx
+++ b/apps/desktop/src/main2/home/lazy-note.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
 import { dailyNoteSectionClassName } from "./constants";
-import { DateHeader } from "./date-header";
 import { DailyNoteEditor } from "./note-editor";
 
 export function LazyNote({ date, muted }: { date: string; muted?: boolean }) {
@@ -28,12 +27,7 @@ export function LazyNote({ date, muted }: { date: string; muted?: boolean }) {
 
   return (
     <div ref={ref} className={dailyNoteSectionClassName}>
-      {visible && (
-        <>
-          <DateHeader date={date} muted={muted} />
-          <DailyNoteEditor date={date} />
-        </>
-      )}
+      {visible && <DailyNoteEditor date={date} muted={muted} />}
     </div>
   );
 }

--- a/apps/desktop/src/main2/home/note-editor.tsx
+++ b/apps/desktop/src/main2/home/note-editor.tsx
@@ -6,6 +6,8 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { format, parseISO, subDays } from "@hypr/utils";
 
+import { DateHeader } from "./date-header";
+
 import { useCalendarData } from "~/calendar/hooks";
 import { parseJsonContent } from "~/editor/markdown";
 import {
@@ -166,12 +168,21 @@ function isEditorTarget(target: EventTarget | null): boolean {
   );
 }
 
+function isInteractiveTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLElement &&
+    target.closest("button, a, [role='button']") !== null
+  );
+}
+
 export function DailyNoteEditor({
   date,
   isToday,
+  muted,
 }: {
   date: string;
   isToday?: boolean;
+  muted?: boolean;
 }) {
   const store = main.UI.useStore(main.STORE_ID);
   const editorRef = useRef<NoteEditorRef>(null);
@@ -328,7 +339,7 @@ export function DailyNoteEditor({
 
   const handleContainerMouseDownCapture = useCallback(
     (event: React.MouseEvent) => {
-      if (isEditorTarget(event.target)) {
+      if (isEditorTarget(event.target) || isInteractiveTarget(event.target)) {
         return;
       }
 
@@ -340,7 +351,7 @@ export function DailyNoteEditor({
 
   const handleContainerClick = useCallback(
     (event: React.MouseEvent) => {
-      if (isEditorTarget(event.target)) {
+      if (isEditorTarget(event.target) || isInteractiveTarget(event.target)) {
         return;
       }
 
@@ -355,18 +366,21 @@ export function DailyNoteEditor({
 
   return (
     <div
-      className="main2-daily-note-editor flex-1 px-6"
+      className="group/daily-note flex flex-1 flex-col"
       onMouseDownCapture={handleContainerMouseDownCapture}
       onClick={handleContainerClick}
     >
-      <NoteEditor
-        ref={editorRef}
-        key={`daily-${date}`}
-        initialContent={initialContentRef.current}
-        handleChange={handleChange}
-        linkedItemOpenBehavior="new"
-        taskSource={taskSource}
-      />
+      <DateHeader date={date} muted={muted} />
+      <div className="main2-daily-note-editor flex-1 cursor-text px-6">
+        <NoteEditor
+          ref={editorRef}
+          key={`daily-${date}`}
+          initialContent={initialContentRef.current}
+          handleChange={handleChange}
+          linkedItemOpenBehavior="new"
+          taskSource={taskSource}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
- Move click-to-focus handler to a wrapper around the header and editor so clicks anywhere in a daily note section focus the ProseMirror view
- Skip focus when the click targets an interactive element (e.g. the header button that opens the daily summary)
- Un-mute the muted DateHeader on group focus-within so the currently edited past note stands out instead of staying faded

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change limited to the daily note section; main behavior change is click-to-focus handling and conditional styling, with minimal impact outside the editor container.
> 
> **Overview**
> Daily note sections now wrap the `DateHeader` and `NoteEditor` in a single clickable container so clicking non-editor whitespace focuses the ProseMirror editor, while clicks on interactive elements (e.g. the header button/link) no longer steal focus.
> 
> `DateHeader` styling was adjusted so muted headers automatically “un-mute” via `group-focus-within` when their note is active, and header rendering was consolidated into `DailyNoteEditor` (removing separate `DateHeader` usage from `LazyNote` and the today section in `index.tsx`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f18df4fb981bac8c62969d60c6933f77b4763a1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->