### PR TITLE
refactor: collapse chat to right-panel-only and gate audio player on transcript expansion

### DIFF
--- a/apps/desktop/src/changelog/index.tsx
+++ b/apps/desktop/src/changelog/index.tsx
@@ -57,7 +57,7 @@ export function TabContentChangelog({
 
   useEffect(() => {
     leftsidebar.setExpanded(false);
-    if (chat.mode === "RightPanelOpen" || chat.mode === "FloatingOpen") {
+    if (chat.mode === "RightPanelOpen") {
       chat.sendEvent({ type: "CLOSE" });
     }
   }, []);

--- a/apps/desktop/src/chat/components/body/index.tsx
+++ b/apps/desktop/src/chat/components/body/index.tsx
@@ -2,7 +2,6 @@ import type { ChatStatus } from "ai";
 import { ChevronDownIcon } from "lucide-react";
 
 import { Button } from "@hypr/ui/components/ui/button";
-import { cn } from "@hypr/utils";
 
 import { ChatBodyEmpty } from "./empty";
 import { ChatBodyNonEmpty } from "./non-empty";
@@ -10,7 +9,6 @@ import { useChatAutoScroll } from "./use-chat-auto-scroll";
 
 import type { ContextRef } from "~/chat/context/entities";
 import type { HyprUIMessage } from "~/chat/types";
-import { useShell } from "~/contexts/shell";
 
 export function ChatBody({
   messages,
@@ -33,7 +31,6 @@ export function ChatBody({
     contextRefs?: ContextRef[],
   ) => void;
 }) {
-  const { chat } = useShell();
   const {
     contentRef,
     isAtBottom,
@@ -54,10 +51,7 @@ export function ChatBody({
       >
         <div
           ref={contentRef}
-          className={cn([
-            "flex min-h-full flex-1 flex-col py-3",
-            chat.mode === "FloatingOpen" ? "px-4" : "px-2",
-          ])}
+          className="flex min-h-full flex-1 flex-col px-2 py-3"
         >
           <div className="flex-1" />
           {messages.length === 0 ? (

--- a/apps/desktop/src/chat/components/header.tsx
+++ b/apps/desktop/src/chat/components/header.tsx
@@ -2,10 +2,7 @@ import {
   ChevronDown,
   MessageCircle,
   PanelRightCloseIcon,
-  PanelRightIcon,
-  PictureInPicture2Icon,
   Plus,
-  X,
 } from "lucide-react";
 import { useState } from "react";
 
@@ -16,7 +13,6 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@hypr/ui/components/ui/dropdown-menu";
-import { Kbd } from "@hypr/ui/components/ui/kbd";
 import {
   Tooltip,
   TooltipContent,
@@ -66,30 +62,7 @@ export function ChatHeader({
 
       <div className="flex shrink-0 items-center">
         <ChatActionButton
-          icon={
-            chat.mode === "RightPanelOpen" ? (
-              <PictureInPicture2Icon className="h-4 w-4" />
-            ) : (
-              <PanelRightIcon className="h-4 w-4" />
-            )
-          }
-          onClick={() => chat.sendEvent({ type: "SHIFT" })}
-          title={
-            chat.mode === "RightPanelOpen"
-              ? "Move to floating chat"
-              : "Dock to right panel"
-          }
-          shortcut="⌘ R"
-          isRightPanel={chat.mode === "RightPanelOpen"}
-        />
-        <ChatActionButton
-          icon={
-            chat.mode === "RightPanelOpen" ? (
-              <PanelRightCloseIcon className="h-4 w-4" />
-            ) : (
-              <X size={16} />
-            )
-          }
+          icon={<PanelRightCloseIcon className="h-4 w-4" />}
           onClick={handleClose}
           title="Close"
           isRightPanel={chat.mode === "RightPanelOpen"}
@@ -103,13 +76,11 @@ function ChatActionButton({
   icon,
   title,
   onClick,
-  shortcut,
   isRightPanel = false,
 }: {
   icon: React.ReactNode;
   title: string;
   onClick: () => void;
-  shortcut?: string;
   isRightPanel?: boolean;
 }) {
   return (
@@ -125,10 +96,7 @@ function ChatActionButton({
           {icon}
         </Button>
       </TooltipTrigger>
-      <TooltipContent side="bottom" className="flex items-center gap-2">
-        <span>{title}</span>
-        {shortcut && <Kbd>{shortcut}</Kbd>}
-      </TooltipContent>
+      <TooltipContent side="bottom">{title}</TooltipContent>
     </Tooltip>
   );
 }

--- a/apps/desktop/src/chat/components/input/index.tsx
+++ b/apps/desktop/src/chat/components/input/index.tsx
@@ -41,8 +41,7 @@ export function ChatMessageInput({
   const editorRef = useRef<ChatEditorHandle>(null);
   const disabled =
     typeof disabledProp === "object" ? disabledProp.disabled : disabledProp;
-  const shouldFocus =
-    chat.mode === "FloatingOpen" || chat.mode === "RightPanelOpen";
+  const shouldFocus = chat.mode === "RightPanelOpen";
 
   const { hasContent, initialContent, handleEditorUpdate } = useDraftState({
     draftKey,
@@ -64,13 +63,7 @@ export function ChatMessageInput({
       hasContextBar={hasContextBar}
       isRightPanel={chat.mode === "RightPanelOpen"}
     >
-      <div
-        data-chat-message-input
-        className={cn([
-          "flex flex-col pt-3 pb-2",
-          chat.mode === "RightPanelOpen" ? "px-2" : "px-2",
-        ])}
-      >
+      <div data-chat-message-input className="flex flex-col px-2 pt-3 pb-2">
         <div className="mb-1 min-h-0 flex-1">
           <ChatEditor
             ref={editorRef}

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -1,8 +1,5 @@
-import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
-
-import { cn } from "@hypr/utils";
 
 import { ChatView } from "./chat-panel";
 
@@ -10,32 +7,15 @@ import { useShell } from "~/contexts/shell";
 
 export function PersistentChatPanel({
   panelContainerRef,
-  floatingContainerRef,
 }: {
   panelContainerRef: React.RefObject<HTMLDivElement | null>;
-  floatingContainerRef: React.RefObject<HTMLDivElement | null>;
 }) {
   const { chat } = useShell();
-  const mode = chat.mode;
-  const isFloating = mode === "FloatingOpen";
-  const isPanel = mode === "RightPanelOpen";
-  const isVisible = isFloating || isPanel;
+  const isVisible = chat.mode === "RightPanelOpen";
 
   const [hasBeenOpened, setHasBeenOpened] = useState(false);
   const [containerRect, setContainerRect] = useState<DOMRect | null>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
-
-  const getActiveContainer = () => {
-    if (isPanel) {
-      return panelContainerRef.current;
-    }
-
-    return (
-      floatingContainerRef.current?.querySelector<HTMLDivElement>(
-        "[data-chat-floating-anchor]",
-      ) ?? floatingContainerRef.current
-    );
-  };
 
   useEffect(() => {
     if (isVisible && !hasBeenOpened) {
@@ -55,30 +35,18 @@ export function PersistentChatPanel({
     [chat, isVisible],
   );
 
-  useHotkeys(
-    "mod+r",
-    () => chat.sendEvent({ type: "SHIFT" }),
-    {
-      enabled: isVisible,
-      preventDefault: true,
-      enableOnFormTags: true,
-      enableOnContentEditable: true,
-    },
-    [chat, isVisible],
-  );
-
   useLayoutEffect(() => {
-    const container = getActiveContainer();
+    const container = panelContainerRef.current;
 
     if (!isVisible || !container) {
       setContainerRect(null);
       return;
     }
     setContainerRect(container.getBoundingClientRect());
-  }, [isVisible, isPanel, panelContainerRef, floatingContainerRef]);
+  }, [isVisible, panelContainerRef]);
 
   useEffect(() => {
-    const container = getActiveContainer();
+    const container = panelContainerRef.current;
 
     if (!isVisible || !container) {
       if (observerRef.current) {
@@ -103,79 +71,29 @@ export function PersistentChatPanel({
       window.removeEventListener("resize", updateRect);
       window.removeEventListener("scroll", updateRect, true);
     };
-  }, [isVisible, isPanel, panelContainerRef, floatingContainerRef]);
+  }, [isVisible, panelContainerRef]);
 
-  if (!hasBeenOpened) {
+  if (!hasBeenOpened || !isVisible) {
     return null;
   }
 
-  if (isPanel) {
-    return (
-      <div
-        className="pointer-events-none fixed z-100"
-        style={
-          containerRect
-            ? {
-                top: containerRect.top,
-                left: containerRect.left,
-                width: containerRect.width,
-                height: containerRect.height,
-              }
-            : { display: "none" }
-        }
-      >
-        <div className="pointer-events-auto flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden">
-          <ChatView />
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <AnimatePresence>
-      {isFloating && (
-        <motion.div
-          className="pointer-events-none fixed z-100"
-          style={
-            containerRect
-              ? {
-                  top: containerRect.top,
-                  left: containerRect.left,
-                  width: containerRect.width,
-                  height: containerRect.height,
-                }
-              : { display: "none" }
-          }
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.2 }}
-        >
-          <div
-            className="pointer-events-auto flex h-full min-h-0 items-end justify-center px-4 pb-4"
-            onClick={(event) => {
-              if (event.target === event.currentTarget) {
-                chat.sendEvent({ type: "CLOSE" });
-              }
-            }}
-          >
-            <motion.div
-              className={cn([
-                "relative flex min-h-0 flex-col overflow-hidden",
-                "max-h-[min(70vh,calc(100%_-_1rem))] w-full max-w-[640px]",
-                "rounded-2xl bg-white shadow-2xl",
-                "border border-neutral-200",
-              ])}
-              initial={{ y: 40, opacity: 0 }}
-              animate={{ y: 0, opacity: 1 }}
-              exit={{ y: 40, opacity: 0 }}
-              transition={{ duration: 0.25, ease: [0.32, 0.72, 0, 1] }}
-            >
-              <ChatView />
-            </motion.div>
-          </div>
-        </motion.div>
-      )}
-    </AnimatePresence>
+    <div
+      className="pointer-events-none fixed z-100"
+      style={
+        containerRect
+          ? {
+              top: containerRect.top,
+              left: containerRect.left,
+              width: containerRect.width,
+              height: containerRect.height,
+            }
+          : { display: "none" }
+      }
+    >
+      <div className="pointer-events-auto flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden">
+        <ChatView />
+      </div>
+    </div>
   );
 }

--- a/apps/desktop/src/main/tab-chrome.tsx
+++ b/apps/desktop/src/main/tab-chrome.tsx
@@ -281,8 +281,7 @@ export function ClassicMainTabChrome({ tabs }: { tabs: Tab[] }) {
 
 function TabChatButton({ shortcutLabel }: { shortcutLabel?: string }) {
   const { chat } = useShell();
-  const isChatOpen =
-    chat.mode === "FloatingOpen" || chat.mode === "RightPanelOpen";
+  const isChatOpen = chat.mode === "RightPanelOpen";
   const isTabbarSelected = isChatOpen;
 
   const { data: isChatEnabled } = useQuery({

--- a/apps/desktop/src/main2/shell.tsx
+++ b/apps/desktop/src/main2/shell.tsx
@@ -92,8 +92,7 @@ export function Main2Shell() {
   });
 
   const isHomeActive = currentTab === null;
-  const isChatOpen =
-    chat.mode === "FloatingOpen" || chat.mode === "RightPanelOpen";
+  const isChatOpen = chat.mode === "RightPanelOpen";
   const liveSessionId = useListener((state) => state.live.sessionId);
   const liveStatus = useListener((state) => state.live.status);
   const showAdHocButton = !(

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -41,8 +41,7 @@ export function useSessionBottomAccessory({
   const canExpandLiveTranscript = isLive && liveCaptureMode === "live";
   const effectiveExpanded =
     isLive && !canExpandLiveTranscript ? false : isExpanded;
-  const isChatVisible =
-    chat.mode === "FloatingOpen" || chat.mode === "RightPanelOpen";
+  const isChatVisible = chat.mode === "RightPanelOpen";
 
   const prevLive = useRef(isLive);
   useEffect(() => {
@@ -113,15 +112,16 @@ export function useSessionBottomAccessory({
   }
 
   if (showPostSession) {
+    const hasAccessoryContent = isExpanded || isBatching;
     return {
-      bottomAccessory: (
+      bottomAccessory: hasAccessoryContent ? (
         <PostSessionAccessory
           sessionId={sessionId}
           hasAudio={hasAudio}
           hasTranscript={hasTranscript}
           isTranscriptExpanded={isExpanded}
         />
-      ),
+      ) : null,
       bottomBorderHandle: (
         <ExpandToggle
           isExpanded={isExpanded}

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -36,20 +36,19 @@ export function PostSessionAccessory({
   isTranscriptExpanded: boolean;
 }) {
   const screen = useTranscriptScreen({ sessionId });
-  const hasTranscriptPanel = isTranscriptExpanded;
-  const timeline =
-    screen.kind === "running_batch" ? (
-      <BatchProgressTimeline sessionId={sessionId} screen={screen} />
-    ) : hasAudio ? (
-      <AudioPlayer.Timeline />
-    ) : null;
+  const isBatching = screen.kind === "running_batch";
+  const timeline = isBatching ? (
+    <BatchProgressTimeline sessionId={sessionId} screen={screen} />
+  ) : hasAudio && isTranscriptExpanded ? (
+    <AudioPlayer.Timeline />
+  ) : null;
 
-  if (!hasTranscriptPanel && !timeline) {
+  if (!isTranscriptExpanded && !timeline) {
     return null;
   }
 
   const shouldBalanceCollapsedTimeline =
-    !hasTranscriptPanel && Boolean(timeline);
+    !isTranscriptExpanded && Boolean(timeline);
 
   return (
     <div
@@ -65,7 +64,7 @@ export function PostSessionAccessory({
           className="pointer-events-none absolute top-[-4px] right-0 left-0 h-px bg-neutral-50"
         />
       ) : null}
-      {hasTranscriptPanel ? (
+      {isTranscriptExpanded ? (
         <TranscriptPanel
           sessionId={sessionId}
           screen={screen}

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -10,10 +10,8 @@ import { useListener } from "~/stt/contexts";
 
 export function FloatingActionButton({
   tab,
-  chatOpenMode = "floating",
 }: {
   tab: Extract<Tab, { type: "sessions" }>;
-  chatOpenMode?: "floating" | "right-panel";
 }) {
   const shouldShowListen = useShouldShowListeningFab(tab);
   const shouldShowChat = useShouldShowChatFab(tab);
@@ -24,11 +22,7 @@ export function FloatingActionButton({
 
   return (
     <div className="absolute bottom-4 left-1/2 z-20 -translate-x-1/2">
-      {shouldShowListen ? (
-        <ListenButton tab={tab} />
-      ) : (
-        <ChatCTA openMode={chatOpenMode} />
-      )}
+      {shouldShowListen ? <ListenButton tab={tab} /> : <ChatCTA />}
     </div>
   );
 }

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -21,7 +21,6 @@ import { getSessionTabStatus } from "./tab-visual-state";
 
 import { useTitleGeneration } from "~/ai/hooks";
 import * as AudioPlayer from "~/audio-player";
-import { useShell } from "~/contexts/shell";
 import { useSessionStatusBanner } from "~/shared/main";
 import { type TabItem, TabItemBase } from "~/shared/tabs";
 import * as main from "~/store/tinybase/store/main";
@@ -180,7 +179,6 @@ function TabContentNoteInner({
 }) {
   const titleInputRef = React.useRef<TitleInputHandle>(null);
   const noteInputRef = React.useRef<NoteInputHandle>(null);
-  const { chat } = useShell();
 
   const currentView = useCurrentNoteTab(tab);
   const { generateTitle } = useTitleGeneration(tab);
@@ -229,24 +227,10 @@ function TabContentNoteInner({
     bottomAccessoryState,
   });
 
-  const chatOpenMode =
-    bottomAccessoryState?.expanded === true ? "right-panel" : "floating";
   const mergeTranscriptSurface =
     bottomAccessoryState?.expanded === true &&
     (bottomAccessoryState.mode === "playback" ||
       bottomAccessoryState.mode === "transcript_only");
-
-  useEffect(() => {
-    if (bottomAccessoryState?.expanded !== true) {
-      return;
-    }
-
-    if (chat.mode !== "FloatingOpen") {
-      return;
-    }
-
-    chat.sendEvent({ type: "OPEN_RIGHT_PANEL" });
-  }, [bottomAccessoryState?.expanded, chat]);
 
   return (
     <SessionSurface
@@ -264,9 +248,7 @@ function TabContentNoteInner({
       afterBorder={bottomAccessory}
       bottomBorderHandle={bottomBorderHandle}
       mergeAfterBorder={mergeTranscriptSurface}
-      floatingButton={
-        <FloatingActionButton tab={tab} chatOpenMode={chatOpenMode} />
-      }
+      floatingButton={<FloatingActionButton tab={tab} />}
     >
       <NoteInput
         ref={noteInputRef}

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -1,32 +1,21 @@
-import { useCallback } from "react";
-
 import { useShell } from "~/contexts/shell";
 
 export function ChatCTA({
   label = "Ask about this session",
-  openMode = "remember",
 }: {
   label?: string;
-  openMode?: "remember" | "floating" | "right-panel";
 }) {
   const { chat } = useShell();
-  const isChatOpen =
-    chat.mode === "FloatingOpen" || chat.mode === "RightPanelOpen";
+  const isChatOpen = chat.mode === "RightPanelOpen";
 
-  const handleClick = useCallback(() => {
+  const handleClick = () => {
     if (isChatOpen) {
       chat.sendEvent({ type: "TOGGLE" });
       return;
     }
 
-    chat.sendEvent(
-      openMode === "floating"
-        ? { type: "OPEN_FLOATING" }
-        : openMode === "right-panel"
-          ? { type: "OPEN_RIGHT_PANEL" }
-          : { type: "OPEN" },
-    );
-  }, [chat, isChatOpen, openMode]);
+    chat.sendEvent({ type: "OPEN_RIGHT_PANEL" });
+  };
 
   if (isChatOpen) {
     return null;

--- a/apps/desktop/src/shared/main/body-frame.tsx
+++ b/apps/desktop/src/shared/main/body-frame.tsx
@@ -20,7 +20,6 @@ export function MainShellBodyFrame({
       <MainChatPanels
         autoSaveId={autoSaveId}
         isRightPanelOpen={chat.mode === "RightPanelOpen"}
-        rightPanelMode={chat.mode}
       >
         {children}
       </MainChatPanels>

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -15,28 +15,18 @@ const CHAT_MIN_WIDTH_PX = 280;
 export function MainChatPanels({
   autoSaveId,
   isRightPanelOpen,
-  rightPanelMode,
   children,
 }: {
   autoSaveId: string;
   isRightPanelOpen: boolean;
-  rightPanelMode: string;
   children: React.ReactNode;
 }) {
-  const previousModeRef = useRef(rightPanelMode);
+  const previousOpenRef = useRef(isRightPanelOpen);
   const bodyPanelRef = useRef<ImperativePanelHandle>(null);
   const chatPanelContainerRef = useRef<HTMLDivElement>(null);
-  const bodyPanelContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const isOpeningRightPanel =
-      rightPanelMode === "RightPanelOpen" &&
-      previousModeRef.current !== "RightPanelOpen";
-    const isClosingRightPanel =
-      rightPanelMode !== "RightPanelOpen" &&
-      previousModeRef.current === "RightPanelOpen";
-
-    if (isOpeningRightPanel) {
+    if (isRightPanelOpen && !previousOpenRef.current) {
       if (bodyPanelRef.current) {
         const currentSize = bodyPanelRef.current.getSize();
         bodyPanelRef.current.resize(currentSize);
@@ -44,12 +34,12 @@ export function MainChatPanels({
       windowsCommands
         .windowExpandWidth(400, null, true, false)
         .catch(console.error);
-    } else if (isClosingRightPanel) {
+    } else if (!isRightPanelOpen && previousOpenRef.current) {
       windowsCommands.windowRestoreWidth().catch(console.error);
     }
 
-    previousModeRef.current = rightPanelMode;
-  }, [rightPanelMode]);
+    previousOpenRef.current = isRightPanelOpen;
+  }, [isRightPanelOpen]);
 
   return (
     <>
@@ -62,9 +52,7 @@ export function MainChatPanels({
           ref={bodyPanelRef}
           className="min-h-0 flex-1 overflow-hidden"
         >
-          <div ref={bodyPanelContainerRef} className="h-full min-h-0">
-            {children}
-          </div>
+          <div className="h-full min-h-0">{children}</div>
         </ResizablePanel>
         {isRightPanelOpen && (
           <>
@@ -85,10 +73,7 @@ export function MainChatPanels({
         )}
       </ResizablePanelGroup>
 
-      <PersistentChatPanel
-        panelContainerRef={chatPanelContainerRef}
-        floatingContainerRef={bodyPanelContainerRef}
-      />
+      <PersistentChatPanel panelContainerRef={chatPanelContainerRef} />
     </>
   );
 }

--- a/apps/desktop/src/shared/useTabsShortcuts.tsx
+++ b/apps/desktop/src/shared/useTabsShortcuts.tsx
@@ -232,7 +232,7 @@ export function useMainTabsShortcuts({ onModT }: { onModT: () => void }) {
 function isPersistentChatInputFocused(
   mode: ReturnType<typeof useShell>["chat"]["mode"],
 ) {
-  if (mode !== "FloatingOpen" && mode !== "RightPanelOpen") {
+  if (mode !== "RightPanelOpen") {
     return false;
   }
 

--- a/apps/desktop/src/store/zustand/tabs/chat-mode.test.ts
+++ b/apps/desktop/src/store/zustand/tabs/chat-mode.test.ts
@@ -12,26 +12,20 @@ describe("Chat Mode", () => {
     expect(useTabs.getState().chatMode).toBe("FloatingClosed");
   });
 
-  test("TOGGLE from FloatingClosed → FloatingOpen", () => {
+  test("TOGGLE from FloatingClosed → RightPanelOpen", () => {
     useTabs.getState().transitionChatMode({ type: "TOGGLE" });
-    expect(useTabs.getState().chatMode).toBe("FloatingOpen");
+    expect(useTabs.getState().chatMode).toBe("RightPanelOpen");
   });
 
-  test("TOGGLE from FloatingOpen → FloatingClosed", () => {
+  test("TOGGLE from RightPanelOpen → FloatingClosed", () => {
     useTabs.getState().transitionChatMode({ type: "TOGGLE" });
     useTabs.getState().transitionChatMode({ type: "TOGGLE" });
     expect(useTabs.getState().chatMode).toBe("FloatingClosed");
   });
 
-  test("SHIFT from FloatingOpen → RightPanelOpen", () => {
+  test("OPEN from FloatingClosed → RightPanelOpen", () => {
     useTabs.getState().transitionChatMode({ type: "OPEN" });
-    useTabs.getState().transitionChatMode({ type: "SHIFT" });
     expect(useTabs.getState().chatMode).toBe("RightPanelOpen");
-  });
-
-  test("OPEN_FLOATING from FloatingClosed → FloatingOpen", () => {
-    useTabs.getState().transitionChatMode({ type: "OPEN_FLOATING" });
-    expect(useTabs.getState().chatMode).toBe("FloatingOpen");
   });
 
   test("OPEN_RIGHT_PANEL from FloatingClosed → RightPanelOpen", () => {
@@ -48,21 +42,21 @@ describe("Chat Mode", () => {
     const session = createSessionTab();
     useTabs.getState().openNew(session);
     useTabs.getState().transitionChatMode({ type: "OPEN" });
-    expect(useTabs.getState().chatMode).toBe("FloatingOpen");
+    expect(useTabs.getState().chatMode).toBe("RightPanelOpen");
 
     const sessionTab = useTabs
       .getState()
       .tabs.find((t) => t.type === "sessions")!;
     useTabs.getState().close(sessionTab);
-    expect(useTabs.getState().chatMode).toBe("FloatingOpen");
+    expect(useTabs.getState().chatMode).toBe("RightPanelOpen");
   });
 
-  test("closeAll leaves the floating chat mode unchanged", () => {
+  test("closeAll leaves the right panel chat mode unchanged", () => {
     const session = createSessionTab();
     useTabs.getState().openNew(session);
     useTabs.getState().transitionChatMode({ type: "OPEN" });
 
     useTabs.getState().closeAll();
-    expect(useTabs.getState().chatMode).toBe("FloatingOpen");
+    expect(useTabs.getState().chatMode).toBe("RightPanelOpen");
   });
 });

--- a/apps/desktop/src/store/zustand/tabs/chat-mode.ts
+++ b/apps/desktop/src/store/zustand/tabs/chat-mode.ts
@@ -1,60 +1,34 @@
 import type { StoreApi } from "zustand";
 
-export type ChatMode = "RightPanelOpen" | "FloatingClosed" | "FloatingOpen";
+export type ChatMode = "RightPanelOpen" | "FloatingClosed";
 
 export type ChatEvent =
   | { type: "OPEN" }
-  | { type: "OPEN_FLOATING" }
   | { type: "OPEN_RIGHT_PANEL" }
   | { type: "CLOSE" }
-  | { type: "SHIFT" }
   | { type: "TOGGLE" };
 
 export type ChatModeState = {
   chatMode: ChatMode;
-  lastOpenChatMode: "FloatingOpen" | "RightPanelOpen";
 };
 
 export type ChatModeActions = {
   transitionChatMode: (event: ChatEvent) => void;
 };
 
-const computeNextChatMode = (
-  state: ChatMode,
-  event: ChatEvent,
-  lastOpenMode: "FloatingOpen" | "RightPanelOpen",
-): ChatMode => {
+const computeNextChatMode = (state: ChatMode, event: ChatEvent): ChatMode => {
   switch (state) {
     case "RightPanelOpen":
-      if (event.type === "OPEN_FLOATING") {
-        return "FloatingOpen";
-      }
       if (event.type === "CLOSE" || event.type === "TOGGLE") {
         return "FloatingClosed";
-      }
-      if (event.type === "SHIFT") {
-        return "FloatingOpen";
       }
       return state;
     case "FloatingClosed":
-      if (event.type === "OPEN" || event.type === "TOGGLE") {
-        return lastOpenMode;
-      }
-      if (event.type === "OPEN_FLOATING") {
-        return "FloatingOpen";
-      }
-      if (event.type === "OPEN_RIGHT_PANEL") {
-        return "RightPanelOpen";
-      }
-      return state;
-    case "FloatingOpen":
-      if (event.type === "OPEN_RIGHT_PANEL") {
-        return "RightPanelOpen";
-      }
-      if (event.type === "CLOSE" || event.type === "TOGGLE") {
-        return "FloatingClosed";
-      }
-      if (event.type === "SHIFT") {
+      if (
+        event.type === "OPEN" ||
+        event.type === "OPEN_RIGHT_PANEL" ||
+        event.type === "TOGGLE"
+      ) {
         return "RightPanelOpen";
       }
       return state;
@@ -68,18 +42,13 @@ export const createChatModeSlice = <T extends ChatModeState>(
   get: StoreApi<T>["getState"],
 ): ChatModeState & ChatModeActions => ({
   chatMode: "FloatingClosed",
-  lastOpenChatMode: "FloatingOpen",
   transitionChatMode: (event) => {
     const currentMode = get().chatMode;
-    const lastOpenMode = get().lastOpenChatMode;
-    const nextMode = computeNextChatMode(currentMode, event, lastOpenMode);
+    const nextMode = computeNextChatMode(currentMode, event);
     if (nextMode === currentMode) return;
 
     set({
       chatMode: nextMode,
-      ...(currentMode === "FloatingOpen" || currentMode === "RightPanelOpen"
-        ? { lastOpenChatMode: currentMode }
-        : {}),
     } as Partial<T>);
   },
 });


### PR DESCRIPTION
**Chat mode → right panel only**
- Collapse `ChatMode` to `{ RightPanelOpen, FloatingClosed }`; remove `OPEN_FLOATING` / `SHIFT` events and `lastOpenChatMode` bookkeeping
- Strip the floating chat overlay and container-ref plumbing from `PersistentChatPanel`, `MainChatPanels`, and `MainShellBodyFrame`
- Remove the dock / picture-in-picture toggle button and `⌘R` shortcut from the chat header
- Simplify `ChatCTA`, `ChatMessageInput` / `Body` styles, tab shortcuts, and chat-mode tests to the single right-panel experience
**Audio player stays hidden while transcript is collapsed**
- Gate the post-session audio timeline on `isTranscriptExpanded` so the wave bar only shows when the transcript panel is open
- Batch-progress timeline still renders during transcription so users see status
- Return `null` from `useSessionBottomAccessory` when there's no accessory content, so `StandardTabWrapper` doesn't add its `pt-[10px]` wrapper — restores the intended 4px bottom gap under the collapsed handle

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it removes an entire chat presentation mode and rewires related UI/shortcuts/state transitions, which could affect chat open/close behavior and layout. Transcript/audio accessory visibility rules also change and may impact session playback UX.
> 
> **Overview**
> Collapses chat to a **right-panel-only** experience: removes the floating chat mode/events, the shift/dock UI (and shortcut), and simplifies layout/styling and open/close checks across chat components, tab chrome, and shell panels.
> 
> Adjusts session post-run UI so the post-session accessory (including the audio timeline) only renders when the transcript is expanded (batch progress still shows during transcription), avoiding extra bottom padding when collapsed. Updates chat-mode tests to match the new state machine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c88ddf67e48d88170ca0317ee4d487996cf59221. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->