### PR TITLE
fix: regenerate summary after resumed listening

### DIFF
--- a/apps/desktop/src/services/enhancer/index.test.ts
+++ b/apps/desktop/src/services/enhancer/index.test.ts
@@ -225,6 +225,70 @@ describe("EnhancerService", () => {
       expect(result).toEqual({ type: "already_active", noteId: "note-1" });
       expect(aiTaskStore.getState().generate).not.toHaveBeenCalled();
     });
+
+    it("regenerates auto-enhance when the previous task has succeeded", () => {
+      const tables = createTables({
+        enhanced_notes: {
+          "note-1": {
+            session_id: "session-1",
+            template_id: undefined as any,
+          },
+        },
+      });
+      const aiTaskStore = createMockAITaskStore();
+      aiTaskStore.getState.mockReturnValue({
+        generate: vi.fn(),
+        getState: vi.fn().mockReturnValue({ status: "success" }),
+      });
+      const deps = createDeps({
+        mainStore: createMockStore(tables),
+        indexes: createMockIndexes(tables),
+        aiTaskStore,
+      });
+      const service = new EnhancerService(deps);
+
+      const result = service.enhance("session-1", { isAuto: true });
+      expect(result).toEqual({ type: "started", noteId: "note-1" });
+      expect(aiTaskStore.getState().generate).toHaveBeenCalled();
+    });
+
+    it("regenerates auto-enhance with a selected default template after previous success", () => {
+      const tables = createTables({
+        enhanced_notes: {
+          "note-1": {
+            session_id: "session-1",
+            template_id: "default-template",
+          },
+        },
+      });
+      const generate = vi.fn();
+      const aiTaskStore = createMockAITaskStore();
+      aiTaskStore.getState.mockReturnValue({
+        generate,
+        getState: vi.fn().mockReturnValue({ status: "success" }),
+      });
+      const deps = createDeps({
+        mainStore: createMockStore(tables),
+        indexes: createMockIndexes(tables),
+        aiTaskStore,
+        getSelectedTemplateId: () => "default-template",
+      });
+      const service = new EnhancerService(deps);
+
+      const result = service.enhance("session-1", { isAuto: true });
+      expect(result).toEqual({ type: "started", noteId: "note-1" });
+      expect(generate).toHaveBeenCalledWith(
+        "note-1-enhance",
+        expect.objectContaining({
+          taskType: "enhance",
+          args: {
+            sessionId: "session-1",
+            enhancedNoteId: "note-1",
+            templateId: "default-template",
+          },
+        }),
+      );
+    });
   });
 
   describe("checkEligibility()", () => {

--- a/apps/desktop/src/services/enhancer/index.ts
+++ b/apps/desktop/src/services/enhancer/index.ts
@@ -192,7 +192,7 @@ export class EnhancerService {
     const existingTask = aiTaskStore.getState().getState(enhanceTaskId);
     if (
       existingTask?.status === "generating" ||
-      existingTask?.status === "success"
+      (existingTask?.status === "success" && !opts?.isAuto)
     ) {
       return { type: "already_active", noteId: enhancedNoteId };
     }


### PR DESCRIPTION
Allow automatic enhancement to rerun after a previous summary succeeded and cover the resumed-listening path with a regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task deduplication behavior so auto-enhance can re-trigger even when a previous enhance task is marked `success`, which could cause unexpected re-generation or extra task load if misclassified. Scoped to `EnhancerService.enhance()` with added tests covering the new behavior and template selection.
> 
> **Overview**
> Auto-enhance can now **re-run after a previous enhancement succeeded**: `EnhancerService.enhance()` only treats `success` as `already_active` for *manual* runs, while still blocking when the task is `generating`.
> 
> Adds regression tests verifying that auto-enhance restarts after `success`, including the case where a default/selected template is applied and passed through to task generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57caed1b0ee3761fb3e168c1367d311d1152d60b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->