### PR TITLE
fix: move chat controls into toolbar

### DIFF
--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -4,7 +4,6 @@ import { cn } from "@hypr/utils";
 
 import { ChatBody } from "./body";
 import { ChatContent } from "./content";
-import { ChatHeader } from "./header";
 import { ChatSession } from "./session-provider";
 import { useSessionTab } from "./use-session-tab";
 
@@ -15,7 +14,7 @@ import * as main from "~/store/tinybase/store/main";
 
 export function ChatView() {
   const { chat } = useShell();
-  const { groupId, sessionId, setGroupId, startNewChat, selectChat } = chat;
+  const { groupId, sessionId, setGroupId } = chat;
 
   const { currentSessionId } = useSessionTab();
 
@@ -41,12 +40,6 @@ export function ChatView() {
         chat.mode !== "RightPanelOpen" && "bg-stone-50",
       ])}
     >
-      <ChatHeader
-        currentChatGroupId={groupId}
-        onNewChat={startNewChat}
-        onSelectChat={selectChat}
-        handleClose={() => chat.sendEvent({ type: "CLOSE" })}
-      />
       {user_id && (
         <ChatSession
           key={sessionId}

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -1,9 +1,4 @@
-import {
-  ChevronDown,
-  MessageCircle,
-  PanelRightCloseIcon,
-  Plus,
-} from "lucide-react";
+import { ChevronDown, MessageCircle, Plus } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@hypr/ui/components/ui/button";
@@ -20,54 +15,31 @@ import {
 } from "@hypr/ui/components/ui/tooltip";
 import { cn, formatDistanceToNow } from "@hypr/utils";
 
-import { useShell } from "~/contexts/shell";
 import * as main from "~/store/tinybase/store/main";
 
-export function ChatHeader({
+export function ChatToolbarControls({
   currentChatGroupId,
   onNewChat,
   onSelectChat,
-  handleClose,
 }: {
   currentChatGroupId: string | undefined;
   onNewChat: () => void;
   onSelectChat: (chatGroupId: string) => void;
-  handleClose: () => void;
 }) {
-  const { chat } = useShell();
-
   return (
     <div
-      data-tauri-drag-region={chat.mode === "RightPanelOpen"}
-      className={cn([
-        "flex h-9 items-center justify-between",
-        chat.mode !== "RightPanelOpen" && "px-1",
-      ])}
+      data-tauri-drag-region
+      className="flex h-full min-w-0 items-center gap-1"
     >
-      <div className="flex min-w-0 flex-1 items-center">
-        <div className="min-w-0 flex-1">
-          <ChatGroups
-            currentChatGroupId={currentChatGroupId}
-            onSelectChat={onSelectChat}
-            isRightPanel={chat.mode === "RightPanelOpen"}
-          />
-        </div>
-        <ChatActionButton
-          icon={<Plus size={16} />}
-          onClick={onNewChat}
-          title="New chat"
-          isRightPanel={chat.mode === "RightPanelOpen"}
-        />
-      </div>
-
-      <div className="flex shrink-0 items-center">
-        <ChatActionButton
-          icon={<PanelRightCloseIcon className="h-4 w-4" />}
-          onClick={handleClose}
-          title="Close"
-          isRightPanel={chat.mode === "RightPanelOpen"}
-        />
-      </div>
+      <ChatGroups
+        currentChatGroupId={currentChatGroupId}
+        onSelectChat={onSelectChat}
+      />
+      <ChatActionButton
+        icon={<Plus size={16} />}
+        onClick={onNewChat}
+        title="New chat"
+      />
     </div>
   );
 }
@@ -76,12 +48,10 @@ function ChatActionButton({
   icon,
   title,
   onClick,
-  isRightPanel = false,
 }: {
   icon: React.ReactNode;
   title: string;
   onClick: () => void;
-  isRightPanel?: boolean;
 }) {
   return (
     <Tooltip>
@@ -91,7 +61,7 @@ function ChatActionButton({
           title={title}
           size="icon"
           variant="ghost"
-          className={cn([isRightPanel && "rounded-none"])}
+          className="text-neutral-600"
         >
           {icon}
         </Button>
@@ -104,11 +74,9 @@ function ChatActionButton({
 function ChatGroups({
   currentChatGroupId,
   onSelectChat,
-  isRightPanel = false,
 }: {
   currentChatGroupId: string | undefined;
   onSelectChat: (chatGroupId: string) => void;
-  isRightPanel?: boolean;
 }) {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -133,17 +101,10 @@ function ChatGroups({
         <Button
           variant="ghost"
           className={cn([
-            "group flex h-auto max-w-full min-w-0 justify-start gap-2 py-1.5",
-            isRightPanel ? "rounded-none px-0" : "px-2",
+            "group flex h-8 max-w-64 min-w-0 justify-start gap-2 px-2",
+            "text-neutral-700",
           ])}
         >
-          {!isRightPanel && (
-            <img
-              src="/assets/char-chat-bubble.svg"
-              alt="Char"
-              className="size-[13px] shrink-0 object-contain opacity-55 transition-opacity group-hover:opacity-75"
-            />
-          )}
           <h3 className="min-w-0 flex-1 truncate text-xs font-medium text-neutral-700">
             {currentChatTitle || "Ask Charlie anything"}
           </h3>

--- a/apps/desktop/src/main/tab-chrome.tsx
+++ b/apps/desktop/src/main/tab-chrome.tsx
@@ -20,12 +20,16 @@ import {
 } from "@hypr/ui/components/ui/tooltip";
 import { cn } from "@hypr/utils";
 
+import { ChatToolbarControls } from "~/chat/components/toolbar-controls";
 import { useNotifications } from "~/contexts/notifications";
 import { useShell } from "~/contexts/shell";
 import { ClassicMainTabItem } from "~/main/tab-item";
 import { useClassicMainTabsShortcuts } from "~/main/useTabsShortcuts";
 import { useNativeContextMenu } from "~/shared/hooks/useNativeContextMenu";
-import { useScrollActiveTabIntoView } from "~/shared/main";
+import {
+  useChatPanelToolbarWidth,
+  useScrollActiveTabIntoView,
+} from "~/shared/main";
 import { NotificationBadge } from "~/shared/ui/notification-badge";
 import { TrafficLights } from "~/shared/ui/traffic-lights";
 import { useNewNote, useNewNoteAndListen } from "~/shared/useNewNote";
@@ -34,7 +38,9 @@ import { type Tab, uniqueIdfromTab, useTabs } from "~/store/zustand/tabs";
 import { useListener } from "~/stt/contexts";
 
 export function ClassicMainTabChrome({ tabs }: { tabs: Tab[] }) {
-  const { leftsidebar } = useShell();
+  const { chat, leftsidebar } = useShell();
+  const isChatOpen = chat.mode === "RightPanelOpen";
+  const chatToolbarWidth = useChatPanelToolbarWidth(isChatOpen);
   const currentPlatform = platform();
   const isLinux = currentPlatform === "linux";
   const chatPanelShortcutLabel = currentPlatform === "macos" ? "⌘ J" : "Ctrl J";
@@ -270,9 +276,29 @@ export function ClassicMainTabChrome({ tabs }: { tabs: Tab[] }) {
           <PlusIcon size={16} />
         </Button>
 
-        <div className="ml-auto flex h-full items-center gap-1">
-          <Update />
-          <TabChatButton shortcutLabel={chatPanelShortcutLabel} />
+        <div
+          className={cn([
+            "ml-auto flex h-full min-w-0 items-center",
+            isChatOpen ? "justify-between gap-2" : "gap-1",
+          ])}
+          style={
+            chatToolbarWidth !== null ? { width: chatToolbarWidth } : undefined
+          }
+        >
+          <div className="min-w-0">
+            {isChatOpen ? (
+              <ChatToolbarControls
+                currentChatGroupId={chat.groupId}
+                onNewChat={chat.startNewChat}
+                onSelectChat={chat.selectChat}
+              />
+            ) : null}
+          </div>
+
+          <div className="flex shrink-0 items-center gap-1">
+            <Update />
+            <TabChatButton shortcutLabel={chatPanelShortcutLabel} />
+          </div>
         </div>
       </div>
     </div>

--- a/apps/desktop/src/main2/shell.tsx
+++ b/apps/desktop/src/main2/shell.tsx
@@ -14,6 +14,7 @@ import { useShallow } from "zustand/shallow";
 import { Button } from "@hypr/ui/components/ui/button";
 import { cn } from "@hypr/utils";
 
+import { ChatToolbarControls } from "~/chat/components/toolbar-controls";
 import { useShell } from "~/contexts/shell";
 import { Main2Home } from "~/main2/home";
 import { ProfileMenu } from "~/main2/profile-menu";
@@ -24,6 +25,7 @@ import {
   MainShellScaffold,
   MainTabContent,
   MainTabItem,
+  useChatPanelToolbarWidth,
   useScrollActiveTabIntoView,
 } from "~/shared/main";
 import { OpenNoteDialog } from "~/shared/open-note-dialog";
@@ -93,6 +95,7 @@ export function Main2Shell() {
 
   const isHomeActive = currentTab === null;
   const isChatOpen = chat.mode === "RightPanelOpen";
+  const chatToolbarWidth = useChatPanelToolbarWidth(isChatOpen);
   const liveSessionId = useListener((state) => state.live.sessionId);
   const liveStatus = useListener((state) => state.live.status);
   const showAdHocButton = !(
@@ -271,54 +274,76 @@ export function Main2Shell() {
             </div>
           </div>
 
-          <div className="ml-auto flex shrink-0 items-center">
-            {showAdHocButton && (
+          <div
+            className={cn([
+              "ml-auto flex h-full min-w-0 items-center",
+              isChatOpen ? "justify-between gap-2" : "shrink-0",
+            ])}
+            style={
+              chatToolbarWidth !== null
+                ? { width: chatToolbarWidth }
+                : undefined
+            }
+          >
+            <div className="min-w-0">
+              {isChatOpen ? (
+                <ChatToolbarControls
+                  currentChatGroupId={chat.groupId}
+                  onNewChat={chat.startNewChat}
+                  onSelectChat={chat.selectChat}
+                />
+              ) : null}
+            </div>
+
+            <div className="flex shrink-0 items-center">
+              {showAdHocButton && (
+                <Button
+                  type="button"
+                  onClick={handleAdHoc}
+                  title="New ad-hoc session"
+                  aria-label="New ad-hoc session"
+                  variant="ghost"
+                  size="icon"
+                  className="group shrink-0"
+                >
+                  <span className="relative h-3.5 w-3.5 overflow-hidden rounded-full border border-red-500/60 bg-linear-to-b from-red-400 to-red-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.22),0_1px_2px_rgba(127,29,29,0.14)] transition-[filter] group-hover:brightness-110">
+                    <span className="pointer-events-none absolute top-[1px] left-1/2 h-[22%] w-[68%] -translate-x-1/2 rounded-full bg-white/18" />
+                  </span>
+                </Button>
+              )}
               <Button
-                type="button"
-                onClick={handleAdHoc}
-                title="New ad-hoc session"
-                aria-label="New ad-hoc session"
+                onClick={() => setOpenNoteDialogOpen(true)}
                 variant="ghost"
                 size="icon"
-                className="group shrink-0"
+                className="text-neutral-600"
+                title="Search (⌘K)"
               >
-                <span className="relative h-3.5 w-3.5 overflow-hidden rounded-full border border-red-500/60 bg-linear-to-b from-red-400 to-red-500 shadow-[inset_0_1px_0_rgba(255,255,255,0.22),0_1px_2px_rgba(127,29,29,0.14)] transition-[filter] group-hover:brightness-110">
-                  <span className="pointer-events-none absolute top-[1px] left-1/2 h-[22%] w-[68%] -translate-x-1/2 rounded-full bg-white/18" />
-                </span>
+                <SearchIcon size={16} />
               </Button>
-            )}
-            <Button
-              onClick={() => setOpenNoteDialogOpen(true)}
-              variant="ghost"
-              size="icon"
-              className="text-neutral-600"
-              title="Search (⌘K)"
-            >
-              <SearchIcon size={16} />
-            </Button>
-            <Button
-              onClick={handleChat}
-              variant="ghost"
-              size="icon"
-              className={cn([
-                "text-neutral-600",
-                isChatOpen &&
-                  "bg-neutral-200 text-neutral-900 hover:bg-neutral-200",
-              ])}
-              aria-label={isChatOpen ? "Close chat" : "Chat with notes"}
-              aria-pressed={isChatOpen}
-              title={isChatOpen ? "Close chat" : "Chat with notes"}
-            >
-              <img
-                src="/assets/char-chat-bubble.svg"
-                alt="Char"
+              <Button
+                onClick={handleChat}
+                variant="ghost"
+                size="icon"
                 className={cn([
-                  "size-[16px] shrink-0 object-contain opacity-65",
-                  isChatOpen && "opacity-100",
+                  "text-neutral-600",
+                  isChatOpen &&
+                    "bg-neutral-200 text-neutral-900 hover:bg-neutral-200",
                 ])}
-              />
-            </Button>
-            <ProfileMenu />
+                aria-label={isChatOpen ? "Close chat" : "Chat with notes"}
+                aria-pressed={isChatOpen}
+                title={isChatOpen ? "Close chat" : "Chat with notes"}
+              >
+                <img
+                  src="/assets/char-chat-bubble.svg"
+                  alt="Char"
+                  className={cn([
+                    "size-[16px] shrink-0 object-contain opacity-65",
+                    isChatOpen && "opacity-100",
+                  ])}
+                />
+              </Button>
+              <ProfileMenu />
+            </div>
           </div>
         </div>
 

--- a/apps/desktop/src/shared/main/chat-panel-toolbar-width.ts
+++ b/apps/desktop/src/shared/main/chat-panel-toolbar-width.ts
@@ -1,0 +1,44 @@
+import { useLayoutEffect, useState } from "react";
+
+const CHAT_PANEL_CONTAINER_SELECTOR = "[data-chat-panel-container]";
+const FALLBACK_CHAT_PANEL_WIDTH = 400;
+const CHAT_TOOLBAR_LEFT_BLEED_PX = 12;
+
+export function useChatPanelToolbarWidth(isEnabled: boolean) {
+  const [width, setWidth] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    if (!isEnabled) {
+      setWidth(null);
+      return;
+    }
+
+    const getContainer = () =>
+      document.querySelector<HTMLElement>(CHAT_PANEL_CONTAINER_SELECTOR);
+
+    const updateWidth = () => {
+      const container = getContainer();
+      setWidth(container?.getBoundingClientRect().width ?? null);
+    };
+
+    updateWidth();
+
+    const resizeObserver = new ResizeObserver(updateWidth);
+    const container = getContainer();
+    if (container) {
+      resizeObserver.observe(container);
+    }
+
+    window.addEventListener("resize", updateWidth);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener("resize", updateWidth);
+    };
+  }, [isEnabled]);
+
+  const measuredWidth = width ?? (isEnabled ? FALLBACK_CHAT_PANEL_WIDTH : null);
+  return measuredWidth === null
+    ? null
+    : measuredWidth + CHAT_TOOLBAR_LEFT_BLEED_PX;
+}

--- a/apps/desktop/src/shared/main/chat-panels.tsx
+++ b/apps/desktop/src/shared/main/chat-panels.tsx
@@ -66,6 +66,7 @@ export function MainChatPanels({
             >
               <div
                 ref={chatPanelContainerRef}
+                data-chat-panel-container
                 className="mx-2 -mb-1 h-[calc(100%+0.25rem)] min-h-0 overflow-hidden"
               />
             </ResizablePanel>

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -11,6 +11,7 @@ export {
 export { MainShellScaffold } from "./shell-scaffold";
 export { MainTabItem } from "./tab-item";
 export { MainTabContent } from "./tab-content";
+export { useChatPanelToolbarWidth } from "./chat-panel-toolbar-width";
 export { useScrollActiveTabIntoView } from "./tab-scroll";
 
 export function StandardTabWrapper({


### PR DESCRIPTION
Reimplement the right-panel chat controls as top chrome controls and remove the redundant in-panel collapse button.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly a UI/UX refactor that relocates chat controls; main risk is layout/measurement regressions when resizing or toggling the chat panel.
> 
> **Overview**
> Moves the in-panel chat header/controls out of the right chat panel and into the main top chrome for both classic (`tab-chrome.tsx`) and `main2` (`shell.tsx`), removing the redundant in-panel close button.
> 
> Introduces `ChatToolbarControls` (chat group dropdown + new chat) and a new `useChatPanelToolbarWidth` hook that measures the chat panel width via a `ResizeObserver` (`data-chat-panel-container`) so the top toolbar can align to the panel width when chat is open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1451303ec44c7288c1a328d810e36fa5d2b98f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->