### PR TITLE
fix: remove tab toolbar gaps

### DIFF
--- a/apps/desktop/src/main2/profile-menu.tsx
+++ b/apps/desktop/src/main2/profile-menu.tsx
@@ -10,6 +10,7 @@ import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useState } from "react";
 
 import { commands as openerCommands } from "@hypr/plugin-opener2";
+import { Button } from "@hypr/ui/components/ui/button";
 import { Kbd } from "@hypr/ui/components/ui/kbd";
 import { cn } from "@hypr/utils";
 
@@ -198,14 +199,14 @@ function AvatarButton({
   const showFacehash = !profile.data || imgError;
 
   return (
-    <button
+    <Button
       type="button"
       onClick={onClick}
+      variant="ghost"
+      size="icon"
       className={cn([
-        "flex size-8 cursor-pointer items-center justify-center rounded-md",
-        "transition-colors duration-150",
-        "hover:bg-neutral-100",
-        isOpen && "bg-neutral-200 hover:bg-neutral-200",
+        "text-neutral-600",
+        isOpen && "bg-neutral-200 text-neutral-900 hover:bg-neutral-200",
       ])}
       title={displayName}
     >
@@ -227,6 +228,6 @@ function AvatarButton({
           />
         )}
       </div>
-    </button>
+    </Button>
   );
 }

--- a/apps/desktop/src/main2/shell.tsx
+++ b/apps/desktop/src/main2/shell.tsx
@@ -179,11 +179,11 @@ export function Main2Shell() {
       <div className="flex h-full min-w-0 flex-1 flex-col">
         <div
           data-tauri-drag-region
-          className="flex h-10 w-full min-w-0 shrink-0 items-center gap-1 pr-1 pl-3"
+          className="flex h-10 w-full min-w-0 shrink-0 items-center gap-0 pr-1 pl-3"
         >
           <div
             className={cn([
-              "flex shrink-0 items-center gap-1",
+              "flex shrink-0 items-center gap-0",
               isLinux ? "mr-1" : !showSidebar && "pl-16",
             ])}
           >
@@ -239,7 +239,7 @@ export function Main2Shell() {
                 axis="x"
                 values={tabs}
                 onReorder={reorder}
-                className="flex h-full w-max items-center gap-1"
+                className="flex h-full w-max items-center gap-0"
               >
                 {tabs.map((tab) => (
                   <Reorder.Item


### PR DESCRIPTION
Set the main toolbar, nav controls, and tab strip spacing to zero.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes that adjust layout spacing and standardize the profile avatar trigger on the shared `Button` component; no business logic or data flow changes.
> 
> **Overview**
> Removes extra horizontal spacing in the main window toolbar by setting `gap-0` for the nav controls container and the draggable tab strip (`Reorder.Group`).
> 
> Updates the profile avatar trigger in `profile-menu.tsx` to use the shared `Button` (`ghost`, `icon`) instead of a raw `button`, aligning styling/hover behavior with the rest of the toolbar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f30304ea46dc16a54478cd469224a08d98fd07a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->