### PR TITLE
feat: add drag region attributes to toolbar divs

### DIFF
--- a/apps/desktop/src/main2/shell.tsx
+++ b/apps/desktop/src/main2/shell.tsx
@@ -275,6 +275,7 @@ export function Main2Shell() {
           </div>
 
           <div
+            data-tauri-drag-region
             className={cn([
               "ml-auto flex h-full min-w-0 items-center",
               isChatOpen ? "justify-between gap-2" : "shrink-0",
@@ -285,7 +286,7 @@ export function Main2Shell() {
                 : undefined
             }
           >
-            <div className="min-w-0">
+            <div data-tauri-drag-region className="min-w-0">
               {isChatOpen ? (
                 <ChatToolbarControls
                   currentChatGroupId={chat.groupId}
@@ -295,7 +296,7 @@ export function Main2Shell() {
               ) : null}
             </div>
 
-            <div className="flex shrink-0 items-center">
+            <div data-tauri-drag-region className="flex shrink-0 items-center">
               {showAdHocButton && (
                 <Button
                   type="button"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds `data-tauri-drag-region` attributes; main impact is potential unintended draggable areas affecting click/drag interactions.
> 
> **Overview**
> Expands the window drag region in `Main2Shell` by adding `data-tauri-drag-region` to the right-side toolbar container and its inner control groups, improving where users can drag the Tauri desktop window without changing any underlying behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52946ccafa41f402124d8ccc77493f1acfbb3fb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->