### PR TITLE
Publish: Best Self-Hosted AI Notetakers in 2026

### DIFF
--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -140,6 +140,8 @@ Free and open-source (MIT).
 
 ### 5. Whishper
 
+![](/api/assets/blog/blog/Screenshot-2026-04-20-at-1.55.51-PM.png "char-editor-width=80")
+
 [Whishper](https://github.com/pluja/whishper) is another Docker-deployed web UI for Whisper with drag-and-drop upload and subtitle generation (SRT, VTT). 
 
 It's built for teams that need a transcription service without any setup complexity. Automatic language detection across 90+ languages. 
@@ -194,7 +196,7 @@ Free and open-source (BSD-4-Clause).
 It depends on what you're optimizing for.
 
 - If you want a full meeting workspace, Char is the most complete option on this list. 
-- If you're on Windows and need real-time capture with local transcription and summarization, Meetily is the closest alternative.
+- If you're on Windows and need real-time capture with local transcription and summarization, go for Meetily.
 - If you need a shared transcription service for a team, deploy Scriberr or Whishper via Docker and give everyone a browser-based upload interface.
 - If you just need fast, reliable file transcription on your desktop, Vibe is the simplest path.
 - If you're building a custom pipeline and need word-level timestamps with speaker diarization, WhisperX gives you the research-grade engine to wire into your own stack.

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -30,7 +30,7 @@ If you don't want your meeting audio on someone else's servers, these are your o
 
 ![Char review](/api/assets/blog/blog/char-summary.png "char-editor-width=80")
 
-[Char](char.com) is the only tool on this list that handles the full meeting workflow in one app — capture, transcription, note-taking, summarization, and structured export. 
+[Char](https://char.com/) is the only tool on this list that handles the full meeting workflow in one app — capture, transcription, note-taking, summarization, and structured export. 
 
 It ships with a built-in notepad where you write during the meeting, and the AI merges your manual notes with the transcript into structured output using your template. Notes are plain Markdown files on disk. Open them in Obsidian, VS Code, whatever.
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -27,7 +27,7 @@ Self-hosted AI meeting tools run on your infrastructure. Your servers, your devi
 
 #### 1. Char
 
-Char is the only tool on this list that handles the full meeting workflow in one app — capture, transcription, note-taking, summarization, and structured export. It ships with a built-in notepad where you write during the meeting, and the AI merges your manual notes with the transcript into structured output using your template. Notes are plain Markdown files on disk. Open them in Obsidian, VS Code, whatever. 8.3k GitHub stars.
+[Char](char.com) is the only tool on this list that handles the full meeting workflow in one app — capture, transcription, note-taking, summarization, and structured export. It ships with a built-in notepad where you write during the meeting, and the AI merges your manual notes with the transcript into structured output using your template. Notes are plain Markdown files on disk. Open them in Obsidian, VS Code, whatever. 8.3k GitHub stars.
 
 #### Setup
 
@@ -55,7 +55,7 @@ Free for fully local use (on-device STT + local LLM). Cloud features available a
 
 ### 2. Meetily
 
-Meetily is the Windows-friendly option. It captures system audio and mic input in real time, transcribes locally, and summarizes through Ollama. So you get the record → transcribe → summarize pipeline without leaving the app. 
+[Meetily](meetily.ai) is the Windows-friendly option. It captures system audio and mic input in real time, transcribes locally, and summarizes through Ollama. So you get the record → transcribe → summarize pipeline without leaving the app. 
 
 It sits in your system tray and works with any conferencing platform producing audio.
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -23,106 +23,97 @@ Self-hosted AI meeting tools run on your infrastructure. Your servers, your devi
 | **WhisperX** | BSD-4       | CLI / Docker    | Whisper-based                                 | No                 | Free                           |
 
 
+**6 Best Self-Hosted AI Notetakers**
 
+**1. Char**
 
-## 6 Best Self-Hosted AI Notetakers: Detailed Reviews
+Char is the only tool on this list that handles the full meeting workflow in one app — capture, transcription, note-taking, summarization, and structured export. It ships with a built-in notepad where you write during the meeting, and the AI merges your manual notes with the transcript into structured output using your template. Notes are plain Markdown files on disk. Open them in Obsidian, VS Code, whatever. 8.3k GitHub stars.
 
-### 1. Char
+***Setup***
 
-[Char](https://char.com) is an open-source AI meeting notetaker built around a single idea: everything runs on your machine unless you choose otherwise. 
+**Install:** brew install char, or clone the GPL repo and build from source.
 
-It ships with two fully on-device speech-to-text engines—Parakeet V3 (accelerated on Apple's Neural Engine via Cactus) and Whisper Small (also via Cactus), plus seven cloud BYOK providers (Deepgram, AssemblyAI, ElevenLabs, OpenAI, Rev AI, Speechmatics, and Azure) for teams that want cloud accuracy with their own API keys. 
+**Transcription:** Pick from 9 STT providers in Preferences. Two are fully on-device — Parakeet V3 (Apple Neural Engine via Cactus) and Whisper Small (also Cactus). The other seven are cloud BYOK: paste your API key, audio goes to that provider, Char never touches it.
 
-Summarization is handled separately: connect Ollama or LM Studio for fully local LLM processing, or bring your own key for OpenAI, Anthropic, or Google Gemini. 
+**Summarization:** Configured separately. Point it at Ollama or LM Studio for offline, or add a key for OpenAI, Anthropic, or Gemini.
 
-What sets Char apart from every other tool on this list is that it's not just a transcription app. It has a built-in notepad where you take notes during the meeting, and the AI merges your manual notes with the full transcript into structured output using your chosen template. 
+**Storage:** Plain .md and audio files on your local filesystem. No proprietary database.
 
-With 45+ languages, calendar integration (Apple, Google, Outlook), AI chat over your transcripts, and a meeting countdown that auto-starts recording for calendar events, Char functions as a complete meeting workspace, not just a recorder. 
+***What else***
 
-#### How to self-host
+Calendar integration (Apple, Google, Outlook) with auto-record on event start. AI chat over your transcripts. Code blocks, @mentions with backlinks. Export to Markdown, PDF, JSON, VTT, Org mode. 45+ languages. Record-only mode — capture now, transcribe later.
 
-- Install via Homebrew: brew install char. Or clone the GPL-licensed repo from GitHub and build from source. GPL means you can audit every line and modify it for your org.
-- Transcription: select from 9 STT providers in Preferences. Two are fully on-device—Parakeet V3 (runs on Apple's Neural Processing Unit via the Cactus runtime) and Whisper Small (also Cactus). The remaining seven are cloud BYOK: paste your own API key, audio goes to that provider, Char never touches it.
-- Summarization: configure separately from transcription. Point Char at a local Ollama or LM Studio instance for fully offline summarization, or add an API key for OpenAI, Anthropic, or Google Gemini.
-- Storage: all transcripts, notes, and audio saved as plain Markdown and audio files on your local filesystem. No proprietary database. Syncs naturally with any file-based tool (Obsidian, iCloud, Git).
-- CLI available: brew install gives you a command-line interface alongside the GUI app.
-- Templates: create reusable templates for different meeting types. The AI uses your template to structure the merged output (your notes + transcript).
-- Record-only mode: capture audio now, transcribe later when you're ready or when you've switched to a different STT provider.
-- Meeting countdown: connects to Apple Calendar, Google Calendar, or Outlook and auto-starts recording when a calendar event begins.
-
-***Where it falls short***
+***Limitations***
 
 - macOS only. No Windows or Linux client.
-- On-device transcription quality depends on your hardware. Older Macs without a Neural Engine won't get Parakeet V3 acceleration.
-- No web UI for team sharing. It's a single-user desktop app—collaboration means sharing exported files.
+- On-device transcription quality scales with hardware — older Macs without a Neural Engine won't get Parakeet V3 acceleration.
+- Single-user desktop app. No web UI for team sharing — collaboration means sharing exported files.
 
 ***Pricing***
 
-Free for fully local use (on-device STT + local LLM). Cloud features (BYOK cloud STT, cloud LLM summarization, calendar sync) are available on paid plans at $8–$25/month.
+Free for fully local use (on-device STT + local LLM). Cloud features available at $8–$25/month.
 
 **2. Meetily**
 
-[Meetily](https://github.com/Zackriya-Solutions/meetily) is an open-source meeting assistant that captures system audio and microphone input in real time, transcribes with Whisper or Parakeet, and generates summaries using a local LLM through Ollama. It runs on Windows and macOS, with a desktop app that sits in your system tray and records meetings from any conferencing platform—Zoom, Google Meet, Teams, or anything else producing audio.
+Meetily is the Windows-friendly option. It captures system audio and mic input in real time, transcribes locally, and summarizes through Ollama — so you get the record → transcribe → summarize pipeline without leaving the app. It sits in your system tray and works with any conferencing platform producing audio.
 
-***How to self-host***
+***Setup***
 
-- Download the desktop app for Windows or macOS from GitHub releases, or build from source.
-- Transcription: Whisper or Parakeet running locally. Models download automatically on first run.
-- Summarization: Ollama integration for local LLM summaries. Configure your preferred model in settings.
-- Real-time capture: records system audio and mic input simultaneously. Works with any meeting platform.
-- Storage: transcripts and summaries saved locally.
+**Install:** Download the desktop app for Windows or macOS from GitHub releases, or build from source.
 
-***Where it falls short***
+**Transcription:** Whisper or Parakeet, running locally. Models download on first run.
 
-- No Linux support yet.
-- Speaker diarization is limited compared to dedicated pipelines like WhisperX.
-- No rich editor, no contacts, no templates on the free tier. The UI is recording-focused, not note-taking. For a detailed [full comparison](https://char.com/blog/char-vs-meetily/).
-- Early-stage project. Expect rough edges and incomplete documentation.
+**Summarization:** Ollama. Configure your preferred model in settings.
+
+***Limitations***
+
+- No Linux support.
+- Recording-focused UI. No rich editor, templates, or contact management on the free tier.
+- Early-stage project — expect rough edges and incomplete docs.
 
 ***Pricing***
 
-Free and open-source (MIT) for local use. Pro plan at $10/month adds cloud features and priority support.
+Free and open-source (MIT). Pro plan at $10/month adds cloud features and priority support.
 
 **3. Scriberr**
 
-[Scriberr](https://github.com/rishikanthc/Scriberr) is a self-hosted web app that gives your team a shared transcription interface in the browser. Upload audio or video, get a transcript powered by Whisper.cpp, then optionally summarize with a local LLM through Ollama. It's built for teams that want a central place to drop recordings and pull transcripts without installing anything on individual machines.
+Scriberr is a team transcription service you deploy with Docker. Upload recordings through the browser, get transcripts back from Whisper.cpp on your server. Optional Ollama sidecar for summarization. Useful when you want one shared interface and don't need anything installed on individual machines.
 
-***How to self-host***
+***Setup***
 
-- Deploy via Docker Compose. One container for the web UI, one for Whisper.cpp, optional Ollama sidecar for summarization.
-- Transcription: Whisper.cpp running on your server. Supports GPU acceleration with CUDA.
-- Summarization: Ollama integration for local LLM summaries. Configure which model to use in the web UI.
-- Storage: all files and transcripts stored on the host filesystem. No external database required beyond the included SQLite.
-- Access: browser-based. Share the URL with your team. Basic auth or reverse proxy for access control.
+**Deploy:** Docker Compose. One container for the web UI, one for Whisper.cpp, optional Ollama sidecar.
 
-***Where it falls short***
+**GPU:** CUDA acceleration supported for Whisper.cpp.
 
-- No real-time transcription. Upload-only workflow—you record elsewhere, then drop the file in.
-- No speaker diarization. Every word is attributed to a single stream.
-- Early-stage project. Updates can be infrequent, and documentation is thin.
-- No desktop or mobile app. Browser only.
+**Storage:** Host filesystem + SQLite. No external database.
+
+**Access control:** Basic auth or reverse proxy. Share the URL with your team.
+
+***Limitations***
+
+- Upload-only workflow — no real-time capture. You record elsewhere, then drop the file in.
+- Updates can be infrequent, documentation is thin.
 
 ***Pricing***
 
-Free and open-source (MIT). Self-host only—no managed cloud option.
+Free and open-source (MIT). Self-host only — no managed cloud option.
 
 **4. Vibe**
 
-[Vibe](https://github.com/thewh1teagle/vibe) is a cross-platform desktop app for transcribing audio and video files using Whisper.cpp. It runs on Windows, macOS, and Linux, with a clean UI that stays out of your way. No summarization built in—Vibe does one thing (transcription) and does it well. It also exposes an API, which makes it useful as a local transcription backend for other tools.
+Vibe does one thing: transcribe audio and video files using Whisper.cpp. Cross-platform desktop app with a clean UI. It also exposes a local API, which makes it useful as a transcription backend you can wire into other tools. If you don't need summarization, note-taking, or real-time capture, this is the simplest path.
 
-***How to self-host***
+***Setup***
 
-- Download the desktop app for Windows, macOS, or Linux. No Docker, no server setup.
-- Transcription: Whisper.cpp with automatic model downloading. Supports GPU acceleration on all platforms.
-- API mode: run Vibe as a local transcription server. Other apps can POST audio files and get transcripts back.
-- Storage: transcripts saved locally as text files. Choose your output format (TXT, SRT, VTT).
+**Install:** Download the desktop app for Windows, macOS, or Linux. No Docker, no server.
 
-***Where it falls short***
+**Models:** Whisper.cpp with automatic model download. GPU acceleration on all platforms.
 
-- No summarization. Transcription only—you need a separate tool or workflow for meeting notes.
-- No real-time capture. You transcribe pre-recorded files, not live audio.
-- No collaboration features. Single-user desktop app.
-- No speaker diarization out of the box.
+**API mode:** Run as a local transcription server. POST audio, get transcripts back (TXT, SRT, VTT).
+
+***Limitations***
+
+- Transcription only — no summarization, no note-taking features.
+- Single-user. No collaboration or sharing features.
 
 ***Pricing***
 
@@ -130,23 +121,18 @@ Free and open-source (MIT).
 
 **5. Whishper**
 
-[Whishper](https://github.com/pluja/whishper) is a self-hosted web UI for Whisper. Deploy it with Docker, upload audio files through the browser, get transcripts back. It focuses on making Whisper accessible to non-technical users on your team—no CLI required, no model management. If all you need is a simple internal transcription service, Whishper gets you there fast.
+Whishper is Scriberr's simpler cousin — a Docker-deployed web UI for Whisper with drag-and-drop upload and subtitle generation (SRT, VTT). It's built for teams that need a transcription service without any setup complexity. Automatic language detection across 90+ languages. No summarization, no post-processing — you get the transcript and take it elsewhere.
 
-***How to self-host***
+***Setup***
 
-- Docker Compose deployment. Pull the image, set your Whisper model size, start the stack.
-- Transcription: OpenAI Whisper running on your server. Configurable model size (tiny to large-v3).
-- Supports subtitle generation (SRT, VTT) alongside plain text transcripts.
-- Multi-language: automatic language detection or manual selection for 90+ languages.
-- Web UI with simple drag-and-drop upload.
+**Deploy:** Docker Compose. Pull the image, set your Whisper model size (tiny through large-v3), start.
 
-***Where it falls short***
+**Interface:** Browser-based drag-and-drop. Share the URL with your team.
 
-- No summarization at all. Transcription and subtitle generation only.
-- No real-time capture. Upload workflow only.
-- No speaker diarization.
-- No desktop or mobile app. Browser-based only.
-- Limited post-processing. You get the transcript, but editing and formatting happen elsewhere.
+***Limitations***
+
+- No editing or formatting tools — you get raw transcript output.
+- Less configurable than Scriberr if you need GPU tuning or Ollama integration.
 
 ***Pricing***
 
@@ -154,27 +140,37 @@ Free and open-source (MIT). Self-host only.
 
 **6. WhisperX**
 
-[WhisperX](https://github.com/m-bain/whisperX) is a research-grade transcription pipeline, not a product. It extends Whisper with forced alignment and speaker diarization, giving you word-level timestamps and per-speaker attribution. If you're building your own meeting intelligence stack—or need the highest accuracy transcription for a custom workflow—WhisperX is the engine you wire in.
+WhisperX isn't a product — it's a research-grade transcription pipeline. It extends Whisper with forced alignment (word-level timestamps via wav2vec2) and speaker diarization (pyannote.audio). It's the only tool on this list that tells you exactly who said what and when, down to the word. If you're building a custom meeting intelligence stack, this is the engine.
 
-***How to self-host***
+***Setup***
 
-- Install via pip or run in Docker. Requires Python and a CUDA-capable GPU for reasonable performance.
-- Transcription: Whisper-based with VAD (voice activity detection) pre-processing for better accuracy on long recordings.
-- Forced alignment: word-level timestamps using wav2vec2 models. Far more precise than base Whisper.
-- Speaker diarization: built-in via pyannote.audio. Requires a Hugging Face token for model access.
-- CLI-driven. Pipe audio in, get JSON/SRT/VTT out. No UI included.
+**Install:** pip install or Docker. Requires Python and a CUDA GPU for reasonable performance.
 
-***Where it falls short***
+**Diarization:** pyannote.audio models — requires accepting license terms on Hugging Face and providing a token.
 
-- No UI at all. Command-line only—you need to build any interface yourself.
-- No summarization. Transcription pipeline only.
-- GPU effectively required. CPU inference is impractically slow for long recordings.
-- Diarization setup is fiddly. Pyannote models require accepting license terms on Hugging Face.
-- BSD-4-Clause license has an advertising clause that some organizations flag during legal review.
+**I/O:** CLI-driven. Pipe audio in, get JSON/SRT/VTT out.
+
+***Limitations***
+
+- No UI. You build any interface yourself.
+- GPU effectively required — CPU inference is impractically slow for long recordings.
+- BSD-4-Clause license has an advertising clause some legal teams flag.
 
 ***Pricing***
 
 Free and open-source (BSD-4-Clause).
+
+**Which Self-Hosted AI Notetaker Should You Use?**
+
+If you want one app that records, transcribes, takes notes, and produces structured meeting output — Char. It's the only tool here where you don't need a second app to do something useful with the transcript.
+
+If you're on Windows and need real-time capture with local summarization, Meetily.
+
+If your team needs a shared transcription service in the browser, Scriberr gives you more control (GPU config, Ollama), Whishper gets you there faster.
+
+If you're building a custom pipeline and need word-level timestamps with speaker attribution, WhisperX is the engine — but you're writing the rest yourself.
+
+Vibe is the right call when all you need is fast local file transcription with no extras.
 
 **Which Self-Hosted AI Notetaker Should You Use?**
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -87,6 +87,8 @@ Free and open source (MIT) for the Community Edition. Pro is $120/year ($10/mont
 
 ### 3. Scriberr
 
+
+
 [Scriberr](https://github.com/rishikanthc/Scriberr) is a team transcription service you deploy with Docker. Upload recordings through the browser, get transcripts back from Whisper.cpp on your server. Optional Ollama sidecar for summarization. 
 
 Useful when you want one shared interface and don't need anything installed on individual machines.

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -45,7 +45,7 @@ Calendar integration (Apple, Google, Outlook) with auto-record on event start. A
 
 #### Limitations
 
-- macOS only. No Windows or Linux client.
+- macOS only. No Windows
 - On-device transcription quality scales with hardware — older Macs without a Neural Engine won't get Parakeet V3 acceleration.
 - Single-user desktop app. No web UI for team sharing — collaboration means sharing exported files.
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -43,7 +43,7 @@ It ships with a built-in notepad where you write during the meeting, and the AI 
 
 #### What else
 
-Calendar integration (Apple, Google, Outlook) with auto-record on event start. AI chat over your transcripts. Code blocks, @mentions with backlinks. Export to Markdown, PDF, JSON, VTT, Org mode. 45+ languages. Record-only mode — capture now, transcribe later.
+Calendar integration (Apple, Google, Outlook) with auto-record on event start. AI chat over your transcripts. Code blocks, @mentions with backlinks. Export to Markdown, PDF, JSON, VTT, Org mode. 45+ languages. 
 
 #### Limitations
 
@@ -98,12 +98,12 @@ Useful when you want one shared interface and don't need anything installed on i
 
 #### Limitations
 
-- Upload-only workflow — no real-time capture. You record elsewhere, then drop the file in.
+- Upload-only workflow. You record elsewhere, then drop the file in.
 - Updates can be infrequent, documentation is thin.
 
 #### Pricing
 
-Free and open-source (MIT). Self-host only — no managed cloud option.
+Free and open-source (MIT). Self-host only.
 
 ### 4. Vibe
 
@@ -121,7 +121,7 @@ If you don't need summarization, note-taking, or real-time capture, this is the 
 
 #### Limitations
 
-- Transcription only — no summarization, no note-taking features.
+- Transcription only.
 - Single-user. No collaboration or sharing features.
 
 #### Pricing
@@ -155,7 +155,7 @@ Free and open-source (MIT). Self-host only.
 
 ### 6. WhisperX
 
-WhisperX is a research-grade transcription pipeline. It extends Whisper with forced alignment (word-level timestamps via wav2vec2) and speaker diarization (pyannote.audio). 
+[WhisperX](https://github.com/m-bain/whisperX) is a research-grade transcription pipeline. It extends Whisper with forced alignment (word-level timestamps via wav2vec2) and speaker diarization (pyannote.audio). 
 
 It's the only tool on this list that tells you exactly who said what and when, down to the word. If you're building a custom meeting intelligence stack, this is the engine.
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -49,9 +49,8 @@ Calendar integration (Apple, Google, Outlook) with auto-record on event start. A
 
 #### Limitations
 
-- macOS only. No Windows.
-- On-device transcription quality scales with hardware — older Macs without a Neural Engine won't get Parakeet V3 acceleration.
-- Single-user desktop app. No web UI for team sharing — collaboration means sharing exported files.
+- On-device transcription quality scales with hardware. The older Macs without a Neural Engine won't get Parakeet V3 acceleration.
+- Single-user desktop app. No web UI for team sharing yet.
 
 #### Pricing
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -26,7 +26,7 @@ If you don't want your meeting audio on someone else's servers, these are your o
 
 ### 6 Best Self-Hosted AI Notetakers
 
-#### 1. Char
+### 1. Char
 
 ![Char review](/api/assets/blog/blog/char-summary.png "char-editor-width=80")
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -67,6 +67,8 @@ It sits in your system tray and works with any conferencing platform producing a
 
 **Summarization:** Ollama. Configure your preferred model in settings.
 
+**Storgae:** Locally on disk
+
 #### Limitations
 
 - No Linux support.
@@ -88,7 +90,7 @@ Useful when you want one shared interface and don't need anything installed on i
 
 **GPU:** CUDA acceleration supported for Whisper.cpp.
 
-**Storage:** Host filesystem + SQLite. No external database.
+**Storage:** Host filesystem + SQLite. 
 
 **Access control:** Basic auth or reverse proxy. Share the URL with your team.
 
@@ -137,6 +139,8 @@ No summarization, no post-processing — you get the transcript and take it else
 **Deploy:** Docker Compose. Pull the image, set your Whisper model size (tiny through large-v3), start.
 
 **Interface:** Browser-based drag-and-drop. Share the URL with your team.
+
+**Storage: Host filesystem,**
 
 #### Limitations
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -43,9 +43,7 @@ With 45+ languages, calendar integration (Apple, Google, Outlook), AI chat over 
 
 - Brew install char. Or clone the GPL-licensed repo from GitHub and build from source. 
 - Choose your preferred STT and LLM provider
-- Storage: all transcripts, notes, and audio saved as plain Markdown and audio files on your local filesystem. No proprietary database. Syncs naturally with any file-based tool (Obsidian, iCloud, Git).
-- CLI available: brew install gives you a command-line interface alongside the GUI app.
-- Templates: create reusable templates for different meeting types. The AI uses your template to structure the merged output (your notes + transcript).
+- Create reusable templates for different meeting types. The AI uses your template to structure the merged output (your notes + transcript).
 - Record-only mode: capture audio now, transcribe later when you're ready or when you've switched to a different STT provider.
 - Meeting countdown: connects to Apple Calendar, Google Calendar, or Outlook and auto-starts recording when a calendar event begins.
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -128,7 +128,7 @@ Free and open-source (MIT).
 
 ### 5. Whishper
 
-[Whishper](https://whishper.net) is another Docker-deployed web UI for Whisper with drag-and-drop upload and subtitle generation (SRT, VTT). 
+[Whishper](https://github.com/pluja/whishper) is another Docker-deployed web UI for Whisper with drag-and-drop upload and subtitle generation (SRT, VTT). 
 
 It's built for teams that need a transcription service without any setup complexity. Automatic language detection across 90+ languages. 
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -37,6 +37,8 @@ Char is the only tool on this list that handles the full meeting workflow in one
 
 **Summarization:** Configured separately. Point it at Ollama or LM Studio for offline, or add a key for OpenAI, Anthropic, or Gemini.
 
+**Storage:** Local filesystem
+
 #### What else
 
 Calendar integration (Apple, Google, Outlook) with auto-record on event start. AI chat over your transcripts. Code blocks, @mentions with backlinks. Export to Markdown, PDF, JSON, VTT, Org mode. 45+ languages. Record-only mode — capture now, transcribe later.
@@ -80,7 +82,7 @@ Scriberr is a team transcription service you deploy with Docker. Upload recordin
 
 Useful when you want one shared interface and don't need anything installed on individual machines.
 
-Setup
+#### Setup
 
 **Deploy:** Docker Compose. One container for the web UI, one for Whisper.cpp, optional Ollama sidecar.
 
@@ -90,20 +92,22 @@ Setup
 
 **Access control:** Basic auth or reverse proxy. Share the URL with your team.
 
-***Limitations***
+#### Limitations
 
 - Upload-only workflow — no real-time capture. You record elsewhere, then drop the file in.
 - Updates can be infrequent, documentation is thin.
 
-***Pricing***
+#### Pricing
 
 Free and open-source (MIT). Self-host only — no managed cloud option.
 
-**4. Vibe**
+### 4. Vibe
 
-Vibe does one thing: transcribe audio and video files using Whisper.cpp. Cross-platform desktop app with a clean UI. It also exposes a local API, which makes it useful as a transcription backend you can wire into other tools. If you don't need summarization, note-taking, or real-time capture, this is the simplest path.
+Vibe does one thing: transcribe audio and video files using Whisper.cpp. Cross-platform desktop app with a clean UI. It also exposes a local API, which makes it useful as a transcription backend you can wire into other tools. 
 
-***Setup***
+If you don't need summarization, note-taking, or real-time capture, this is the simplest path.
+
+### Setup
 
 **Install:** Download the desktop app for Windows, macOS, or Linux. No Docker, no server.
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -27,11 +27,13 @@ Self-hosted AI meeting tools run on your infrastructure. Your servers, your devi
 
 #### 1. Char
 
-[Char](char.com) is the only tool on this list that handles the full meeting workflow in one app — capture, transcription, note-taking, summarization, and structured export. It ships with a built-in notepad where you write during the meeting, and the AI merges your manual notes with the transcript into structured output using your template. Notes are plain Markdown files on disk. Open them in Obsidian, VS Code, whatever. 8.3k GitHub stars.
+[Char](char.com) is the only tool on this list that handles the full meeting workflow in one app — capture, transcription, note-taking, summarization, and structured export. 
+
+It ships with a built-in notepad where you write during the meeting, and the AI merges your manual notes with the transcript into structured output using your template. Notes are plain Markdown files on disk. Open them in Obsidian, VS Code, whatever. 8.3k GitHub stars.
 
 #### Setup
 
-**Install:** brew install char, or clone the GPL repo and build from source.
+**Install:** brew install char, or clone the [GPL repo](https://github.com/fastrepl/char) and build from source.
 
 **Transcription:** Pick from 9 STT providers in Preferences. Two are fully on-device — Parakeet V3 (Apple Neural Engine via Cactus) and Whisper Small (also Cactus). The other seven are cloud BYOK: paste your API key, audio goes to that provider, Char never touches it.
 
@@ -80,7 +82,7 @@ Free and open-source (MIT). Pro plan at $10/month adds cloud features and priori
 
 ### 3. Scriberr
 
-Scriberr is a team transcription service you deploy with Docker. Upload recordings through the browser, get transcripts back from Whisper.cpp on your server. Optional Ollama sidecar for summarization. 
+[Scriberr](https://github.com/ClinicianFOCUS/Scriberr) is a team transcription service you deploy with Docker. Upload recordings through the browser, get transcripts back from Whisper.cpp on your server. Optional Ollama sidecar for summarization. 
 
 Useful when you want one shared interface and don't need anything installed on individual machines.
 
@@ -105,7 +107,7 @@ Free and open-source (MIT). Self-host only — no managed cloud option.
 
 ### 4. Vibe
 
-Vibe does one thing: transcribe audio and video files using Whisper.cpp. Cross-platform desktop app with a clean UI. It also exposes a local API, which makes it useful as a transcription backend you can wire into other tools. 
+[Vibe](https://thewh1teagle.github.io/vibe/) does one thing: transcribe audio and video files using Whisper.cpp. Cross-platform desktop app with a clean UI. It also exposes a local API, which makes it useful as a transcription backend you can wire into other tools. 
 
 If you don't need summarization, note-taking, or real-time capture, this is the simplest path.
 
@@ -128,7 +130,7 @@ Free and open-source (MIT).
 
 ### 5. Whishper
 
-Whishper is another Docker-deployed web UI for Whisper with drag-and-drop upload and subtitle generation (SRT, VTT). 
+[Whishper](https://whishper.net) is another Docker-deployed web UI for Whisper with drag-and-drop upload and subtitle generation (SRT, VTT). 
 
 It's built for teams that need a transcription service without any setup complexity. Automatic language detection across 90+ languages. 
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -140,7 +140,7 @@ No summarization, no post-processing — you get the transcript and take it else
 
 **Interface:** Browser-based drag-and-drop. Share the URL with your team.
 
-**Storage: Host filesystem,**
+**Storage:** also**** 
 
 #### Limitations
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -165,6 +165,8 @@ Free and open-source (MIT). Self-host only.
 
 ### 6. WhisperX
 
+
+
 [WhisperX](https://github.com/m-bain/whisperX) is a research-grade transcription pipeline. It extends Whisper with forced alignment (word-level timestamps via wav2vec2) and speaker diarization (pyannote.audio). 
 
 It's the only tool on this list that tells you exactly who said what and when, down to the word. If you're building a custom meeting intelligence stack, this is the engine.

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -114,7 +114,7 @@ Free and open-source (MIT). Self-host only.
 
 ### 4. Vibe
 
-
+![vibe review](/api/assets/blog/blog/telegram-cloud-photo-size-5-6282995305728905642-y.jpg "char-editor-width=80")
 
 [Vibe](https://thewh1teagle.github.io/vibe/) does one thing: transcribe audio and video files using Whisper.cpp. Cross-platform desktop app with a clean UI. It also exposes a local API, which makes it useful as a transcription backend you can wire into other tools. 
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -126,26 +126,30 @@ Free and open-source (MIT).
 
 ### 5. Whishper
 
-Whishper is another Docker-deployed web UI for Whisper with drag-and-drop upload and subtitle generation (SRT, VTT). It's built for teams that need a transcription service without any setup complexity. Automatic language detection across 90+ languages. No summarization, no post-processing — you get the transcript and take it elsewhere.
+Whishper is another Docker-deployed web UI for Whisper with drag-and-drop upload and subtitle generation (SRT, VTT). 
 
-***Setup***
+It's built for teams that need a transcription service without any setup complexity. Automatic language detection across 90+ languages. 
+
+No summarization, no post-processing — you get the transcript and take it elsewhere.
+
+#### Setup
 
 **Deploy:** Docker Compose. Pull the image, set your Whisper model size (tiny through large-v3), start.
 
 **Interface:** Browser-based drag-and-drop. Share the URL with your team.
 
-***Limitations***
+#### Limitations
 
 - No editing or formatting tools — you get raw transcript output.
 - Less configurable than Scriberr if you need GPU tuning or Ollama integration.
 
-***Pricing***
+#### Pricing
 
 Free and open-source (MIT). Self-host only.
 
-**6. WhisperX**
+### 6. WhisperX
 
-WhisperX isn't a product — it's a research-grade transcription pipeline. It extends Whisper with forced alignment (word-level timestamps via wav2vec2) and speaker diarization (pyannote.audio). It's the only tool on this list that tells you exactly who said what and when, down to the word. If you're building a custom meeting intelligence stack, this is the engine.
+WhisperX is a research-grade transcription pipeline. It extends Whisper with forced alignment (word-level timestamps via wav2vec2) and speaker diarization (pyannote.audio). It's the only tool on this list that tells you exactly who said what and when, down to the word. If you're building a custom meeting intelligence stack, this is the engine.
 
 ***Setup***
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -37,7 +37,7 @@ Char is the only tool on this list that handles the full meeting workflow in one
 
 **Summarization:** Configured separately. Point it at Ollama or LM Studio for offline, or add a key for OpenAI, Anthropic, or Gemini.
 
-**Storage:** Plain .md and audio files on your local filesystem. No proprietary database.
+**Storage:** You data stays on 
 
 ***What else***
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -149,9 +149,11 @@ Free and open-source (MIT). Self-host only.
 
 ### 6. WhisperX
 
-WhisperX is a research-grade transcription pipeline. It extends Whisper with forced alignment (word-level timestamps via wav2vec2) and speaker diarization (pyannote.audio). It's the only tool on this list that tells you exactly who said what and when, down to the word. If you're building a custom meeting intelligence stack, this is the engine.
+WhisperX is a research-grade transcription pipeline. It extends Whisper with forced alignment (word-level timestamps via wav2vec2) and speaker diarization (pyannote.audio). 
 
-***Setup***
+It's the only tool on this list that tells you exactly who said what and when, down to the word. If you're building a custom meeting intelligence stack, this is the engine.
+
+#### Setup
 
 **Install:** pip install or Docker. Requires Python and a CUDA GPU for reasonable performance.
 
@@ -159,29 +161,17 @@ WhisperX is a research-grade transcription pipeline. It extends Whisper with for
 
 **I/O:** CLI-driven. Pipe audio in, get JSON/SRT/VTT out.
 
-***Limitations***
+#### Limitations
 
 - No UI. You build any interface yourself.
-- GPU effectively required — CPU inference is impractically slow for long recordings.
+- GPU effectively required because the CPU inference is impractically slow for long recordings.
 - BSD-4-Clause license has an advertising clause some legal teams flag.
 
-***Pricing***
+#### Pricing
 
 Free and open-source (BSD-4-Clause).
 
-**Which Self-Hosted AI Notetaker Should You Use?**
-
-If you want one app that records, transcribes, takes notes, and produces structured meeting output — Char. It's the only tool here where you don't need a second app to do something useful with the transcript.
-
-If you're on Windows and need real-time capture with local summarization, Meetily.
-
-If your team needs a shared transcription service in the browser, Scriberr gives you more control (GPU config, Ollama), Whishper gets you there faster.
-
-If you're building a custom pipeline and need word-level timestamps with speaker attribution, WhisperX is the engine — but you're writing the rest yourself.
-
-Vibe is the right call when all you need is fast local file transcription with no extras.
-
-**Which Self-Hosted AI Notetaker Should You Use?**
+## Which Self-Hosted AI Notetaker Should You Use?
 
 It depends on what you're optimizing for.
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -87,7 +87,7 @@ Free and open source (MIT) for the Community Edition. Pro is $120/year ($10/mont
 
 ### 3. Scriberr
 
-
+![scribber review](/api/assets/blog/blog/telegram-cloud-photo-size-5-6282995305728905641-w.jpg "char-editor-width=80")
 
 [Scriberr](https://github.com/rishikanthc/Scriberr) is a team transcription service you deploy with Docker. Upload recordings through the browser, get transcripts back from Whisper.cpp on your server. Optional Ollama sidecar for summarization. 
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -161,7 +161,7 @@ It's the only tool on this list that tells you exactly who said what and when, d
 
 **Install:** pip install or Docker. Requires Python and a CUDA GPU for reasonable performance.
 
-**Diarization:** pyannote.audio models — requires accepting license terms on Hugging Face and providing a token.
+**Diarization:** pyannote.audio models. It requires accepting license terms on Hugging Face and providing a token.
 
 **I/O:** CLI-driven. Pipe audio in, get JSON/SRT/VTT out.
 
@@ -179,7 +179,7 @@ Free and open-source (BSD-4-Clause).
 
 It depends on what you're optimizing for.
 
-- If you want a full meeting workspace with local transcription, local summarization, a built-in notepad, templates, and Markdown export—Char is the most complete option on this list. It's the only tool here that handles the entire workflow from recording to structured notes without leaving the app.
+- If you want a full meeting workspace, Char is the most complete option on this list. It's the only tool here that handles the entire workflow from recording to structured notes without leaving the app.
 - If you're on Windows and need real-time capture with local transcription and summarization, Meetily is the closest alternative.
 - If you need a shared transcription service for a team, deploy Scriberr or Whishper via Docker and give everyone a browser-based upload interface.
 - If you just need fast, reliable file transcription on your desktop, Vibe is the simplest path.

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -107,7 +107,7 @@ Vibe does one thing: transcribe audio and video files using Whisper.cpp. Cross-p
 
 If you don't need summarization, note-taking, or real-time capture, this is the simplest path.
 
-### Setup
+#### Setup
 
 **Install:** Download the desktop app for Windows, macOS, or Linux. No Docker, no server.
 
@@ -115,18 +115,18 @@ If you don't need summarization, note-taking, or real-time capture, this is the 
 
 **API mode:** Run as a local transcription server. POST audio, get transcripts back (TXT, SRT, VTT).
 
-***Limitations***
+#### Limitations
 
 - Transcription only — no summarization, no note-taking features.
 - Single-user. No collaboration or sharing features.
 
-***Pricing***
+#### Pricing
 
 Free and open-source (MIT).
 
-**5. Whishper**
+### 5. Whishper
 
-Whishper is Scriberr's simpler cousin — a Docker-deployed web UI for Whisper with drag-and-drop upload and subtitle generation (SRT, VTT). It's built for teams that need a transcription service without any setup complexity. Automatic language detection across 90+ languages. No summarization, no post-processing — you get the transcript and take it elsewhere.
+Whishper is another Docker-deployed web UI for Whisper with drag-and-drop upload and subtitle generation (SRT, VTT). It's built for teams that need a transcription service without any setup complexity. Automatic language detection across 90+ languages. No summarization, no post-processing — you get the transcript and take it elsewhere.
 
 ***Setup***
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -58,7 +58,7 @@ Free for fully local use (on-device STT + local LLM). Cloud features available a
 
 ### 2. Meetily
 
-[Meetily](meetily.ai) captures system audio and mic input in real time, transcribes locally using Whisper or Parakeet, and summarizes through your choice of AI provider. 
+[Meetily](https://meetily.ai/) captures system audio and mic input in real time, transcribes locally using Whisper or Parakeet, and summarizes through your choice of AI provider. 
 
 It covers the full record → transcribe → summarize pipeline without leaving the app, and works with any conferencing platform that produces audio on your machine.
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -37,25 +37,25 @@ Char is the only tool on this list that handles the full meeting workflow in one
 
 **Summarization:** Configured separately. Point it at Ollama or LM Studio for offline, or add a key for OpenAI, Anthropic, or Gemini.
 
-**Storage:** You data stays on 
-
-***What else***
+#### What else
 
 Calendar integration (Apple, Google, Outlook) with auto-record on event start. AI chat over your transcripts. Code blocks, @mentions with backlinks. Export to Markdown, PDF, JSON, VTT, Org mode. 45+ languages. Record-only mode — capture now, transcribe later.
 
-***Limitations***
+#### Limitations
 
 - macOS only. No Windows or Linux client.
 - On-device transcription quality scales with hardware — older Macs without a Neural Engine won't get Parakeet V3 acceleration.
 - Single-user desktop app. No web UI for team sharing — collaboration means sharing exported files.
 
-***Pricing***
+#### Pricing
 
 Free for fully local use (on-device STT + local LLM). Cloud features available at $8–$25/month.
 
-**2. Meetily**
+### 2. Meetily
 
-Meetily is the Windows-friendly option. It captures system audio and mic input in real time, transcribes locally, and summarizes through Ollama — so you get the record → transcribe → summarize pipeline without leaving the app. It sits in your system tray and works with any conferencing platform producing audio.
+Meetily is the Windows-friendly option. It captures system audio and mic input in real time, transcribes locally, and summarizes through Ollama. So you get the record → transcribe → summarize pipeline without leaving the app. 
+
+It sits in your system tray and works with any conferencing platform producing audio.
 
 ***Setup***
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -27,7 +27,7 @@ date: "2026-04-20"
 
 [Char](char.com) is the only tool on this list that handles the full meeting workflow in one app — capture, transcription, note-taking, summarization, and structured export. 
 
-It ships with a built-in notepad where you write during the meeting, and the AI merges your manual notes with the transcript into structured output using your template. Notes are plain Markdown files on disk. Open them in Obsidian, VS Code, whatever. 8.3k GitHub stars.
+It ships with a built-in notepad where you write during the meeting, and the AI merges your manual notes with the transcript into structured output using your template. Notes are plain Markdown files on disk. Open them in Obsidian, VS Code, whatever.
 
 #### Setup
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -179,7 +179,7 @@ Free and open-source (BSD-4-Clause).
 
 It depends on what you're optimizing for.
 
-- If you want a full meeting workspace, Char is the most complete option on this list. It's the only tool here that handles the entire workflow from recording to structured notes without leaving the app.
+- If you want a full meeting workspace, Char is the most complete option on this list. 
 - If you're on Windows and need real-time capture with local transcription and summarization, Meetily is the closest alternative.
 - If you need a shared transcription service for a team, deploy Scriberr or Whishper via Docker and give everyone a browser-based upload interface.
 - If you just need fast, reliable file transcription on your desktop, Vibe is the simplest path.

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -58,24 +58,26 @@ Free for fully local use (on-device STT + local LLM). Cloud features available a
 
 ### 2. Meetily
 
-[Meetily](meetily.ai) is the Windows-friendly option. It captures system audio and mic input in real time, transcribes locally, and summarizes through Ollama. So you get the record → transcribe → summarize pipeline without leaving the app. 
+[Meetily](meetily.ai) captures system audio and mic input in real time, transcribes locally using Whisper or Parakeet, and summarizes through your choice of AI provider. 
 
-It sits in your system tray and works with any conferencing platform producing audio.
+It covers the full record → transcribe → summarize pipeline without leaving the app, and works with any conferencing platform that produces audio on your machine.
 
 #### Setup
 
-**Install:** Download the desktop app for Windows or macOS from GitHub releases, or build from source.
+**Install:** Download the desktop app for Windows or macOS from GitHub releases. Linux is supported but requires building from source.
 
-**Transcription:** Whisper or Parakeet, running locally. Models download on first run.
+**Transcription:** Whisper or Parakeet, running locally. GPU acceleration is automatic — Metal/CoreML on Apple Silicon, CUDA for NVIDIA, Vulkan for AMD/Intel.
 
-**Summarization:** Ollama. Configure your preferred model in settings.
+**Summarization:** Pluggable. Use Ollama for fully local processing, or bring your own API key for Claude, Groq, OpenRouter, or OpenAI.
 
-**Storgae:** Locally on disk
+**Storage:** Local SQLite database on disk.
 
 #### Limitations
 
-- No Linux support.
-- Recording-focused UI. No rich editor, templates, or contact management on the free tier.
+- No rich editor or note-taking interface — it's a transcription and summarization tool, not a writing workspace.
+- Linux requires building from source; no prebuilt installer.
+- Speaker diarization not yet available in the Community Edition.
+- Auto-meeting detection and calendar integration are Pro-only features.
 
 #### Pricing
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -185,4 +185,4 @@ It depends on what you're optimizing for.
 - If you just need fast, reliable file transcription on your desktop, Vibe is the simplest path.
 - If you're building a custom pipeline and need word-level timestamps with speaker diarization, WhisperX gives you the research-grade engine to wire into your own stack.
 
-For most users who want privacy-first meeting notes that just work, start with [Char](https://char.com). Free for fully local use, no account required.
+For most users who want privacy-first meeting notes that just work, start with [Char](https://char.com/download/apple-silicon). Free for fully local use, no account required.

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -1,9 +1,10 @@
 ---
 meta_title: "Best Self-Hosted AI Notetakers in 2026"
+meta_description: "Six open-source AI meeting notetakers you can self-host — from full meeting workspaces to raw transcription pipelines. Covers Char, Meetily, Scriberr, Vibe, Whishper, and WhisperX."
 author:
   - "Harshika"
 featured: false
-category: "Product"
+category: "Comparisons"
 date: "2026-04-20"
 ---
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -1,11 +1,183 @@
 ---
-meta_title: ""
-display_title: ""
-meta_description: ""
+meta_title: "Best Self-Hosted AI Notetakers in 2026"
 author:
-- "John Jeong"
+  - "Harshika"
 featured: false
 category: "Product"
 date: "2026-04-20"
 ---
 
+Self-hosted AI meeting tools run on your infrastructure. Your servers, your device, your models. No audio going to someone else's cloud, no vendor lock-in, no trusting a privacy policy you didn't read. Here are six tools that let you do exactly that.
+
+**Self-Hosted AI Notetaker Comparison**
+
+
+|              |             |                 |                                               |                    |                                |
+| ------------ | ----------- | --------------- | --------------------------------------------- | ------------------ | ------------------------------ |
+| **Tool**     | **License** | **Platform**    | **Local STT**                                 | **Local LLM**      | **Pricing**                    |
+| **Char**     | GPL         | macOS           | Parakeet V3, Whisper Small (Cactus) + 7 cloud | Ollama / LM Studio | Free (local) · $8–$25/mo cloud |
+| **Meetily**  | MIT         | Windows, macOS  | Whisper, Parakeet                             | Ollama             | Free · $10/mo Pro              |
+| **Scriberr** | MIT         | Docker (web)    | Whisper.cpp                                   | Ollama             | Free                           |
+| **Vibe**     | MIT         | Win, Mac, Linux | Whisper.cpp                                   | No built-in        | Free                           |
+| **Whishper** | MIT         | Docker (web)    | Whisper                                       | No                 | Free                           |
+| **WhisperX** | BSD-4       | CLI / Docker    | Whisper-based                                 | No                 | Free                           |
+
+
+
+
+**6 Best Self-Hosted AI Notetakers: Detailed Reviews**
+
+**1. Char**
+
+[Char](https://char.com) is a macOS-native AI meeting notetaker built around a single idea: everything runs on your machine unless you choose otherwise. Transcription, summarization, note-taking, and storage all happen locally by default. It ships with two fully on-device speech-to-text engines—Parakeet V3 (accelerated on Apple's Neural Engine via Cactus) and Whisper Small (also via Cactus)—plus seven cloud BYOK providers (Deepgram, AssemblyAI, ElevenLabs, OpenAI, Rev AI, Speechmatics, and Azure) for teams that want cloud accuracy with their own API keys. Summarization is handled separately: connect Ollama or LM Studio for fully local LLM processing, or bring your own key for OpenAI, Anthropic, or Google Gemini. You pick your transcription provider and your summarization provider independently—mix and match local and cloud however you want.
+
+What sets Char apart from every other tool on this list is that it's not just a transcription app. It has a built-in notepad where you take notes during the meeting, and the AI merges your manual notes with the full transcript into structured output using your chosen template. All notes are saved as plain Markdown files on disk—open them in Obsidian, VS Code, or any text editor. It supports code blocks, @mentions with backlinks between notes, and exports to Markdown, PDF, JSON, VTT, and Org mode. With 45+ languages, calendar integration (Apple, Google, Outlook), AI chat over your transcripts, and a meeting countdown that auto-starts recording for calendar events, Char functions as a complete meeting workspace, not just a recorder. It has 8.3k GitHub stars.
+
+***How to self-host***
+
+- Install via Homebrew: brew install char. Or clone the GPL-licensed repo from GitHub and build from source. GPL means you can audit every line and modify it for your org.
+- Transcription: select from 9 STT providers in Preferences. Two are fully on-device—Parakeet V3 (runs on Apple's Neural Processing Unit via the Cactus runtime) and Whisper Small (also Cactus). The remaining seven are cloud BYOK: paste your own API key, audio goes to that provider, Char never touches it.
+- Summarization: configure separately from transcription. Point Char at a local Ollama or LM Studio instance for fully offline summarization, or add an API key for OpenAI, Anthropic, or Google Gemini.
+- Storage: all transcripts, notes, and audio saved as plain Markdown and audio files on your local filesystem. No proprietary database. Syncs naturally with any file-based tool (Obsidian, iCloud, Git).
+- CLI available: brew install gives you a command-line interface alongside the GUI app.
+- Templates: create reusable templates for different meeting types. The AI uses your template to structure the merged output (your notes + transcript).
+- Record-only mode: capture audio now, transcribe later when you're ready or when you've switched to a different STT provider.
+- Meeting countdown: connects to Apple Calendar, Google Calendar, or Outlook and auto-starts recording when a calendar event begins.
+
+***Where it falls short***
+
+- macOS only. No Windows or Linux client.
+- On-device transcription quality depends on your hardware. Older Macs without a Neural Engine won't get Parakeet V3 acceleration.
+- No web UI for team sharing. It's a single-user desktop app—collaboration means sharing exported files.
+
+***Pricing***
+
+Free for fully local use (on-device STT + local LLM). Cloud features (BYOK cloud STT, cloud LLM summarization, calendar sync) are available on paid plans at $8–$25/month.
+
+**2. Meetily**
+
+[Meetily](https://github.com/Zackriya-Solutions/meetily) is an open-source meeting assistant that captures system audio and microphone input in real time, transcribes with Whisper or Parakeet, and generates summaries using a local LLM through Ollama. It runs on Windows and macOS, with a desktop app that sits in your system tray and records meetings from any conferencing platform—Zoom, Google Meet, Teams, or anything else producing audio.
+
+***How to self-host***
+
+- Download the desktop app for Windows or macOS from GitHub releases, or build from source.
+- Transcription: Whisper or Parakeet running locally. Models download automatically on first run.
+- Summarization: Ollama integration for local LLM summaries. Configure your preferred model in settings.
+- Real-time capture: records system audio and mic input simultaneously. Works with any meeting platform.
+- Storage: transcripts and summaries saved locally.
+
+***Where it falls short***
+
+- No Linux support yet.
+- Speaker diarization is limited compared to dedicated pipelines like WhisperX.
+- No rich editor, no contacts, no templates on the free tier. The UI is recording-focused, not note-taking. For a detailed [full comparison](https://char.com/blog/char-vs-meetily/).
+- Early-stage project. Expect rough edges and incomplete documentation.
+
+***Pricing***
+
+Free and open-source (MIT) for local use. Pro plan at $10/month adds cloud features and priority support.
+
+**3. Scriberr**
+
+[Scriberr](https://github.com/rishikanthc/Scriberr) is a self-hosted web app that gives your team a shared transcription interface in the browser. Upload audio or video, get a transcript powered by Whisper.cpp, then optionally summarize with a local LLM through Ollama. It's built for teams that want a central place to drop recordings and pull transcripts without installing anything on individual machines.
+
+***How to self-host***
+
+- Deploy via Docker Compose. One container for the web UI, one for Whisper.cpp, optional Ollama sidecar for summarization.
+- Transcription: Whisper.cpp running on your server. Supports GPU acceleration with CUDA.
+- Summarization: Ollama integration for local LLM summaries. Configure which model to use in the web UI.
+- Storage: all files and transcripts stored on the host filesystem. No external database required beyond the included SQLite.
+- Access: browser-based. Share the URL with your team. Basic auth or reverse proxy for access control.
+
+***Where it falls short***
+
+- No real-time transcription. Upload-only workflow—you record elsewhere, then drop the file in.
+- No speaker diarization. Every word is attributed to a single stream.
+- Early-stage project. Updates can be infrequent, and documentation is thin.
+- No desktop or mobile app. Browser only.
+
+***Pricing***
+
+Free and open-source (MIT). Self-host only—no managed cloud option.
+
+**4. Vibe**
+
+[Vibe](https://github.com/thewh1teagle/vibe) is a cross-platform desktop app for transcribing audio and video files using Whisper.cpp. It runs on Windows, macOS, and Linux, with a clean UI that stays out of your way. No summarization built in—Vibe does one thing (transcription) and does it well. It also exposes an API, which makes it useful as a local transcription backend for other tools.
+
+***How to self-host***
+
+- Download the desktop app for Windows, macOS, or Linux. No Docker, no server setup.
+- Transcription: Whisper.cpp with automatic model downloading. Supports GPU acceleration on all platforms.
+- API mode: run Vibe as a local transcription server. Other apps can POST audio files and get transcripts back.
+- Storage: transcripts saved locally as text files. Choose your output format (TXT, SRT, VTT).
+
+***Where it falls short***
+
+- No summarization. Transcription only—you need a separate tool or workflow for meeting notes.
+- No real-time capture. You transcribe pre-recorded files, not live audio.
+- No collaboration features. Single-user desktop app.
+- No speaker diarization out of the box.
+
+***Pricing***
+
+Free and open-source (MIT).
+
+**5. Whishper**
+
+[Whishper](https://github.com/pluja/whishper) is a self-hosted web UI for Whisper. Deploy it with Docker, upload audio files through the browser, get transcripts back. It focuses on making Whisper accessible to non-technical users on your team—no CLI required, no model management. If all you need is a simple internal transcription service, Whishper gets you there fast.
+
+***How to self-host***
+
+- Docker Compose deployment. Pull the image, set your Whisper model size, start the stack.
+- Transcription: OpenAI Whisper running on your server. Configurable model size (tiny to large-v3).
+- Supports subtitle generation (SRT, VTT) alongside plain text transcripts.
+- Multi-language: automatic language detection or manual selection for 90+ languages.
+- Web UI with simple drag-and-drop upload.
+
+***Where it falls short***
+
+- No summarization at all. Transcription and subtitle generation only.
+- No real-time capture. Upload workflow only.
+- No speaker diarization.
+- No desktop or mobile app. Browser-based only.
+- Limited post-processing. You get the transcript, but editing and formatting happen elsewhere.
+
+***Pricing***
+
+Free and open-source (MIT). Self-host only.
+
+**6. WhisperX**
+
+[WhisperX](https://github.com/m-bain/whisperX) is a research-grade transcription pipeline, not a product. It extends Whisper with forced alignment and speaker diarization, giving you word-level timestamps and per-speaker attribution. If you're building your own meeting intelligence stack—or need the highest accuracy transcription for a custom workflow—WhisperX is the engine you wire in.
+
+***How to self-host***
+
+- Install via pip or run in Docker. Requires Python and a CUDA-capable GPU for reasonable performance.
+- Transcription: Whisper-based with VAD (voice activity detection) pre-processing for better accuracy on long recordings.
+- Forced alignment: word-level timestamps using wav2vec2 models. Far more precise than base Whisper.
+- Speaker diarization: built-in via pyannote.audio. Requires a Hugging Face token for model access.
+- CLI-driven. Pipe audio in, get JSON/SRT/VTT out. No UI included.
+
+***Where it falls short***
+
+- No UI at all. Command-line only—you need to build any interface yourself.
+- No summarization. Transcription pipeline only.
+- GPU effectively required. CPU inference is impractically slow for long recordings.
+- Diarization setup is fiddly. Pyannote models require accepting license terms on Hugging Face.
+- BSD-4-Clause license has an advertising clause that some organizations flag during legal review.
+
+***Pricing***
+
+Free and open-source (BSD-4-Clause).
+
+**Which Self-Hosted AI Notetaker Should You Use?**
+
+It depends on what you're optimizing for.
+
+- If you want a full meeting workspace with local transcription, local summarization, a built-in notepad, templates, and Markdown export—Char is the most complete option on this list. It's the only tool here that handles the entire workflow from recording to structured notes without leaving the app.
+- If you're on Windows and need real-time capture with local transcription and summarization, Meetily is the closest alternative.
+- If you need a shared transcription service for a team, deploy Scriberr or Whishper via Docker and give everyone a browser-based upload interface.
+- If you just need fast, reliable file transcription on your desktop, Vibe is the simplest path.
+- If you're building a custom pipeline and need word-level timestamps with speaker diarization, WhisperX gives you the research-grade engine to wire into your own stack.
+
+For most users who want privacy-first meeting notes that just work, start with [Char](https://char.com). Free for fully local use, no account required.

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -27,6 +27,8 @@ If you don't want your meeting audio on someone else's servers, these are your o
 
 #### 1. Char
 
+
+
 [Char](char.com) is the only tool on this list that handles the full meeting workflow in one app — capture, transcription, note-taking, summarization, and structured export. 
 
 It ships with a built-in notepad where you write during the meeting, and the AI merges your manual notes with the transcript into structured output using your template. Notes are plain Markdown files on disk. Open them in Obsidian, VS Code, whatever.

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -23,13 +23,13 @@ Self-hosted AI meeting tools run on your infrastructure. Your servers, your devi
 | **WhisperX** | BSD-4       | CLI / Docker    | Whisper-based                                 | No                 | Free                           |
 
 
-**6 Best Self-Hosted AI Notetakers**
+### 6 Best Self-Hosted AI Notetakers
 
-**1. Char**
+#### 1. Char
 
 Char is the only tool on this list that handles the full meeting workflow in one app — capture, transcription, note-taking, summarization, and structured export. It ships with a built-in notepad where you write during the meeting, and the AI merges your manual notes with the transcript into structured output using your template. Notes are plain Markdown files on disk. Open them in Obsidian, VS Code, whatever. 8.3k GitHub stars.
 
-***Setup***
+#### Setup
 
 **Install:** brew install char, or clone the GPL repo and build from source.
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -140,7 +140,7 @@ No summarization, no post-processing — you get the transcript and take it else
 
 **Interface:** Browser-based drag-and-drop. Share the URL with your team.
 
-**Storage:** also**** 
+**Storage:** Host filesystem via Docker volumes.
 
 #### Limitations
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -37,13 +37,12 @@ Summarization is handled separately: connect Ollama or LM Studio for fully local
 
 What sets Char apart from every other tool on this list is that it's not just a transcription app. It has a built-in notepad where you take notes during the meeting, and the AI merges your manual notes with the full transcript into structured output using your chosen template. 
 
-With 45+ languages, calendar integration (Apple, Google, Outlook), AI chat over your transcripts, and a meeting countdown that auto-starts recording for calendar events, Char functions as a complete meeting workspace, not just a recorder. It has 8.3k GitHub stars.
+With 45+ languages, calendar integration (Apple, Google, Outlook), AI chat over your transcripts, and a meeting countdown that auto-starts recording for calendar events, Char functions as a complete meeting workspace, not just a recorder. 
 
-***How to self-host***
+#### How to self-host
 
-- Install via Homebrew: brew install char. Or clone the GPL-licensed repo from GitHub and build from source. GPL means you can audit every line and modify it for your org.
-- Transcription: select from 9 STT providers in Preferences. Two are fully on-device—Parakeet V3 (runs on Apple's Neural Processing Unit via the Cactus runtime) and Whisper Small (also Cactus). The remaining seven are cloud BYOK: paste your own API key, audio goes to that provider, Char never touches it.
-- Summarization: configure separately from transcription. Point Char at a local Ollama or LM Studio instance for fully offline summarization, or add an API key for OpenAI, Anthropic, or Google Gemini.
+- Brew install char. Or clone the GPL-licensed repo from GitHub and build from source. 
+- Choose your preferred STT and LLM provider
 - Storage: all transcripts, notes, and audio saved as plain Markdown and audio files on your local filesystem. No proprietary database. Syncs naturally with any file-based tool (Obsidian, iCloud, Git).
 - CLI available: brew install gives you a command-line interface alongside the GUI app.
 - Templates: create reusable templates for different meeting types. The AI uses your template to structure the merged output (your notes + transcript).

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -7,8 +7,6 @@ category: "Product"
 date: "2026-04-20"
 ---
 
-
-
 ## Self-Hosted AI Notetaker Comparison
 
 
@@ -82,7 +80,7 @@ Free and open-source (MIT). Pro plan at $10/month adds cloud features and priori
 
 ### 3. Scriberr
 
-[Scriberr](https://github.com/ClinicianFOCUS/Scriberr) is a team transcription service you deploy with Docker. Upload recordings through the browser, get transcripts back from Whisper.cpp on your server. Optional Ollama sidecar for summarization. 
+[Scriberr](https://github.com/rishikanthc/Scriberr) is a team transcription service you deploy with Docker. Upload recordings through the browser, get transcripts back from Whisper.cpp on your server. Optional Ollama sidecar for summarization. 
 
 Useful when you want one shared interface and don't need anything installed on individual machines.
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -27,7 +27,7 @@ If you don't want your meeting audio on someone else's servers, these are your o
 
 #### 1. Char
 
-
+![Char review](/api/assets/blog/blog/char-summary.png "char-editor-width=80")
 
 [Char](char.com) is the only tool on this list that handles the full meeting workflow in one app — capture, transcription, note-taking, summarization, and structured export. 
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -114,6 +114,8 @@ Free and open-source (MIT). Self-host only.
 
 ### 4. Vibe
 
+
+
 [Vibe](https://thewh1teagle.github.io/vibe/) does one thing: transcribe audio and video files using Whisper.cpp. Cross-platform desktop app with a clean UI. It also exposes a local API, which makes it useful as a transcription backend you can wire into other tools. 
 
 If you don't need summarization, note-taking, or real-time capture, this is the simplest path.

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -79,7 +79,7 @@ It sits in your system tray and works with any conferencing platform producing a
 
 #### Pricing
 
-Free and open-source (MIT). Pro plan at $10/month adds cloud features and priority support.
+Free and open source (MIT) for the Community Edition. Pro is $120/year ($10/month billed annually) and runs on a separate codebase with enhanced accuracy and additional features. Enterprise pricing is custom.
 
 ### 3. Scriberr
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -9,7 +9,7 @@ date: "2026-04-20"
 
 Self-hosted AI meeting tools run on your infrastructure. Your servers, your device, your models. No audio going to someone else's cloud, no vendor lock-in, no trusting a privacy policy you didn't read. Here are six tools that let you do exactly that.
 
-**Self-Hosted AI Notetaker Comparison**
+## Self-Hosted AI Notetaker Comparison
 
 
 |              |             |                 |                                               |                    |                                |
@@ -25,11 +25,11 @@ Self-hosted AI meeting tools run on your infrastructure. Your servers, your devi
 
 
 
-**6 Best Self-Hosted AI Notetakers: Detailed Reviews**
+## 6 Best Self-Hosted AI Notetakers: Detailed Reviews
 
-**1. Char**
+### 1. Char
 
-[Char](https://char.com) is a macOS-native AI meeting notetaker built around a single idea: everything runs on your machine unless you choose otherwise. Transcription, summarization, note-taking, and storage all happen locally by default. It ships with two fully on-device speech-to-text engines—Parakeet V3 (accelerated on Apple's Neural Engine via Cactus) and Whisper Small (also via Cactus)—plus seven cloud BYOK providers (Deepgram, AssemblyAI, ElevenLabs, OpenAI, Rev AI, Speechmatics, and Azure) for teams that want cloud accuracy with their own API keys. Summarization is handled separately: connect Ollama or LM Studio for fully local LLM processing, or bring your own key for OpenAI, Anthropic, or Google Gemini. You pick your transcription provider and your summarization provider independently—mix and match local and cloud however you want.
+[Char](https://char.com) is an open-source AI meeting notetaker built around a single idea: everything runs on your machine unless you choose otherwise. Transcription, summarization, note-taking, and storage all happen locally by default. It ships with two fully on-device speech-to-text engines—Parakeet V3 (accelerated on Apple's Neural Engine via Cactus) and Whisper Small (also via Cactus)—plus seven cloud BYOK providers (Deepgram, AssemblyAI, ElevenLabs, OpenAI, Rev AI, Speechmatics, and Azure) for teams that want cloud accuracy with their own API keys. Summarization is handled separately: connect Ollama or LM Studio for fully local LLM processing, or bring your own key for OpenAI, Anthropic, or Google Gemini. You pick your transcription provider and your summarization provider independently—mix and match local and cloud however you want.
 
 What sets Char apart from every other tool on this list is that it's not just a transcription app. It has a built-in notepad where you take notes during the meeting, and the AI merges your manual notes with the full transcript into structured output using your chosen template. All notes are saved as plain Markdown files on disk—open them in Obsidian, VS Code, or any text editor. It supports code blocks, @mentions with backlinks between notes, and exports to Markdown, PDF, JSON, VTT, and Org mode. With 45+ languages, calendar integration (Apple, Google, Outlook), AI chat over your transcripts, and a meeting countdown that auto-starts recording for calendar events, Char functions as a complete meeting workspace, not just a recorder. It has 8.3k GitHub stars.
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -58,6 +58,8 @@ Free for fully local use (on-device STT + local LLM). Cloud features available a
 
 ### 2. Meetily
 
+![Meetily review](https://github.com/Zackriya-Solutions/meetily/raw/main/docs/home.png "char-editor-width=80")
+
 [Meetily](https://meetily.ai/) captures system audio and mic input in real time, transcribes locally using Whisper or Parakeet, and summarizes through your choice of AI provider. 
 
 It covers the full record → transcribe → summarize pipeline without leaving the app, and works with any conferencing platform that produces audio on your machine.

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -57,7 +57,7 @@ Meetily is the Windows-friendly option. It captures system audio and mic input i
 
 It sits in your system tray and works with any conferencing platform producing audio.
 
-***Setup***
+#### Setup
 
 **Install:** Download the desktop app for Windows or macOS from GitHub releases, or build from source.
 
@@ -65,21 +65,22 @@ It sits in your system tray and works with any conferencing platform producing a
 
 **Summarization:** Ollama. Configure your preferred model in settings.
 
-***Limitations***
+#### Limitations
 
 - No Linux support.
 - Recording-focused UI. No rich editor, templates, or contact management on the free tier.
-- Early-stage project — expect rough edges and incomplete docs.
 
-***Pricing***
+#### Pricing
 
 Free and open-source (MIT). Pro plan at $10/month adds cloud features and priority support.
 
-**3. Scriberr**
+### 3. Scriberr
 
-Scriberr is a team transcription service you deploy with Docker. Upload recordings through the browser, get transcripts back from Whisper.cpp on your server. Optional Ollama sidecar for summarization. Useful when you want one shared interface and don't need anything installed on individual machines.
+Scriberr is a team transcription service you deploy with Docker. Upload recordings through the browser, get transcripts back from Whisper.cpp on your server. Optional Ollama sidecar for summarization. 
 
-***Setup***
+Useful when you want one shared interface and don't need anything installed on individual machines.
+
+Setup
 
 **Deploy:** Docker Compose. One container for the web UI, one for Whisper.cpp, optional Ollama sidecar.
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -107,7 +107,7 @@ Useful when you want one shared interface and don't need anything installed on i
 #### Limitations
 
 - Upload-only workflow. You record elsewhere, then drop the file in.
-- Updates can be infrequent, documentation is thin.
+- Development is currently paused by the sole maintainer. The project works and is not abandoned, but expect slower updates and limited support in the near term.
 
 #### Pricing
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -45,7 +45,7 @@ Calendar integration (Apple, Google, Outlook) with auto-record on event start. A
 
 #### Limitations
 
-- macOS only. No Windows
+- macOS only. No Windows.
 - On-device transcription quality scales with hardware — older Macs without a Neural Engine won't get Parakeet V3 acceleration.
 - Single-user desktop app. No web UI for team sharing — collaboration means sharing exported files.
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -29,9 +29,15 @@ Self-hosted AI meeting tools run on your infrastructure. Your servers, your devi
 
 ### 1. Char
 
-[Char](https://char.com) is an open-source AI meeting notetaker built around a single idea: everything runs on your machine unless you choose otherwise. Transcription, summarization, note-taking, and storage all happen locally by default. It ships with two fully on-device speech-to-text engines—Parakeet V3 (accelerated on Apple's Neural Engine via Cactus) and Whisper Small (also via Cactus)—plus seven cloud BYOK providers (Deepgram, AssemblyAI, ElevenLabs, OpenAI, Rev AI, Speechmatics, and Azure) for teams that want cloud accuracy with their own API keys. Summarization is handled separately: connect Ollama or LM Studio for fully local LLM processing, or bring your own key for OpenAI, Anthropic, or Google Gemini. You pick your transcription provider and your summarization provider independently—mix and match local and cloud however you want.
+[Char](https://char.com) is an open-source AI meeting notetaker built around a single idea: everything runs on your machine unless you choose otherwise. 
 
-What sets Char apart from every other tool on this list is that it's not just a transcription app. It has a built-in notepad where you take notes during the meeting, and the AI merges your manual notes with the full transcript into structured output using your chosen template. All notes are saved as plain Markdown files on disk—open them in Obsidian, VS Code, or any text editor. It supports code blocks, @mentions with backlinks between notes, and exports to Markdown, PDF, JSON, VTT, and Org mode. With 45+ languages, calendar integration (Apple, Google, Outlook), AI chat over your transcripts, and a meeting countdown that auto-starts recording for calendar events, Char functions as a complete meeting workspace, not just a recorder. It has 8.3k GitHub stars.
+It ships with two fully on-device speech-to-text engines—Parakeet V3 (accelerated on Apple's Neural Engine via Cactus) and Whisper Small (also via Cactus), plus seven cloud BYOK providers (Deepgram, AssemblyAI, ElevenLabs, OpenAI, Rev AI, Speechmatics, and Azure) for teams that want cloud accuracy with their own API keys. 
+
+Summarization is handled separately: connect Ollama or LM Studio for fully local LLM processing, or bring your own key for OpenAI, Anthropic, or Google Gemini. 
+
+What sets Char apart from every other tool on this list is that it's not just a transcription app. It has a built-in notepad where you take notes during the meeting, and the AI merges your manual notes with the full transcript into structured output using your chosen template. 
+
+With 45+ languages, calendar integration (Apple, Google, Outlook), AI chat over your transcripts, and a meeting countdown that auto-starts recording for calendar events, Char functions as a complete meeting workspace, not just a recorder. It has 8.3k GitHub stars.
 
 ***How to self-host***
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -41,9 +41,12 @@ With 45+ languages, calendar integration (Apple, Google, Outlook), AI chat over 
 
 #### How to self-host
 
-- Brew install char. Or clone the GPL-licensed repo from GitHub and build from source. 
-- Choose your preferred STT and LLM provider
-- Create reusable templates for different meeting types. The AI uses your template to structure the merged output (your notes + transcript).
+- Install via Homebrew: brew install char. Or clone the GPL-licensed repo from GitHub and build from source. GPL means you can audit every line and modify it for your org.
+- Transcription: select from 9 STT providers in Preferences. Two are fully on-device—Parakeet V3 (runs on Apple's Neural Processing Unit via the Cactus runtime) and Whisper Small (also Cactus). The remaining seven are cloud BYOK: paste your own API key, audio goes to that provider, Char never touches it.
+- Summarization: configure separately from transcription. Point Char at a local Ollama or LM Studio instance for fully offline summarization, or add an API key for OpenAI, Anthropic, or Google Gemini.
+- Storage: all transcripts, notes, and audio saved as plain Markdown and audio files on your local filesystem. No proprietary database. Syncs naturally with any file-based tool (Obsidian, iCloud, Git).
+- CLI available: brew install gives you a command-line interface alongside the GUI app.
+- Templates: create reusable templates for different meeting types. The AI uses your template to structure the merged output (your notes + transcript).
 - Record-only mode: capture audio now, transcribe later when you're ready or when you've switched to a different STT provider.
 - Meeting countdown: connects to Apple Calendar, Google Calendar, or Outlook and auto-starts recording when a calendar event begins.
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -1,0 +1,11 @@
+---
+meta_title: ""
+display_title: ""
+meta_description: ""
+author:
+- "John Jeong"
+featured: false
+category: "Product"
+date: "2026-04-20"
+---
+

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -7,7 +7,7 @@ category: "Product"
 date: "2026-04-20"
 ---
 
-Self-hosted AI meeting tools run on your infrastructure. Your servers, your device, your models. No audio going to someone else's cloud, no vendor lock-in, no trusting a privacy policy you didn't read. Here are six tools that let you do exactly that.
+
 
 ## Self-Hosted AI Notetaker Comparison
 
@@ -35,7 +35,7 @@ It ships with a built-in notepad where you write during the meeting, and the AI 
 
 **Install:** brew install char, or clone the [GPL repo](https://github.com/fastrepl/char) and build from source.
 
-**Transcription:** Pick from 9 STT providers in Preferences. Two are fully on-device — Parakeet V3 (Apple Neural Engine via Cactus) and Whisper Small (also Cactus). The other seven are cloud BYOK: paste your API key, audio goes to that provider, Char never touches it.
+**Transcription:** Pick from 9 STT providers in Preferences. Two are fully on-device - Parakeet V3 (Apple Neural Engine via Cactus) and Whisper Small (also Cactus). The other seven are cloud BYOK: paste your API key, audio goes to that provider, Char never touches it.
 
 **Summarization:** Configured separately. Point it at Ollama or LM Studio for offline, or add a key for OpenAI, Anthropic, or Gemini.
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -7,6 +7,8 @@ category: "Product"
 date: "2026-04-20"
 ---
 
+If you don't want your meeting audio on someone else's servers, these are your options. Six tools, from full note-taking apps to raw transcription pipelines. All of them are self-hostable and open-source.
+
 ## Self-Hosted AI Notetaker Comparison
 
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -165,7 +165,7 @@ Free and open-source (MIT). Self-host only.
 
 ### 6. WhisperX
 
-
+![whisperx review](/api/assets/blog/blog/Screenshot-2026-04-20-at-12.53.00-PM-1.png "char-editor-width=80")
 
 [WhisperX](https://github.com/m-bain/whisperX) is a research-grade transcription pipeline. It extends Whisper with forced alignment (word-level timestamps via wav2vec2) and speaker diarization (pyannote.audio). 
 


### PR DESCRIPTION
## Article Ready for Publication

**Title:** Best Self-Hosted AI Notetakers in 2026
**Author:** Harshika
**Date:** 2026-04-20
**Category:** Comparisons

**Branch:** blog/selfhosted-ai-notetakers
**File:** apps/web/content/articles/selfhosted-ai-notetakers.mdx

---
Auto-generated PR from admin panel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only change (new MDX article) with no impact to runtime logic; main risk is broken links/assets or formatting issues in rendering.
> 
> **Overview**
> Publishes a new comparison article, `selfhosted-ai-notetakers.mdx`, covering six self-hosted/open-source AI meeting notetaker options (Char, Meetily, Scriberr, Vibe, Whishper, WhisperX) with a feature/pricing table, setup notes, limitations, and a recommendation section.
> 
> No application code changes; this PR only adds content/metadata for the blog post (title/description/author/date/category and embedded images/links).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7fc0906f2e7077e8fdb13a3d467312a9a8aefff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->