### PR TITLE
fix: harden legacy note JSON in search and editor

### DIFF
--- a/apps/desktop/src/search/contexts/engine/utils.test.ts
+++ b/apps/desktop/src/search/contexts/engine/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { getSessionSearchTimestamp } from "./utils";
+import { extractPlainText, getSessionSearchTimestamp } from "./utils";
 
 describe("getSessionSearchTimestamp", () => {
   test("prefers embedded event started_at over session created_at", () => {
@@ -23,5 +23,32 @@ describe("getSessionSearchTimestamp", () => {
         }),
       }),
     ).toBe(Date.parse("2024-01-01T00:00:00Z"));
+  });
+});
+
+describe("extractPlainText", () => {
+  test("drops malformed nested tiptap nodes while preserving text", () => {
+    expect(
+      extractPlainText(
+        JSON.stringify({
+          type: "doc",
+          content: [
+            null,
+            {
+              type: "paragraph",
+              content: [
+                { type: "text", text: "hello" },
+                undefined,
+                { text: "ignored" },
+                {
+                  type: "text",
+                  text: "world",
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+    ).toBe("hello world");
   });
 });

--- a/apps/desktop/src/search/contexts/engine/utils.ts
+++ b/apps/desktop/src/search/contexts/engine/utils.ts
@@ -6,6 +6,28 @@ interface TiptapNode {
   text?: string;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function sanitizeTiptapNode(value: unknown): TiptapNode | null {
+  if (!isRecord(value) || typeof value.type !== "string") {
+    return null;
+  }
+
+  const content = Array.isArray(value.content)
+    ? value.content
+        .map((child) => sanitizeTiptapNode(child))
+        .filter((child): child is TiptapNode => child !== null)
+    : undefined;
+
+  return {
+    type: value.type,
+    ...(content ? { content } : {}),
+    ...(typeof value.text === "string" ? { text: value.text } : {}),
+  };
+}
+
 function isValidTiptapContent(content: unknown): content is TiptapNode {
   if (!content || typeof content !== "object") {
     return false;
@@ -36,8 +58,9 @@ export function extractPlainText(value: unknown): string {
 
   try {
     const parsed = JSON.parse(trimmed);
-    if (isValidTiptapContent(parsed)) {
-      const text = extractTextFromTiptapNode(parsed).trim();
+    const sanitized = sanitizeTiptapNode(parsed);
+    if (sanitized && isValidTiptapContent(sanitized)) {
+      const text = extractTextFromTiptapNode(sanitized).trim();
       return text.replace(SPACE_REGEX, " ");
     }
     return trimmed;

--- a/packages/editor/src/markdown.test.ts
+++ b/packages/editor/src/markdown.test.ts
@@ -373,6 +373,67 @@ describe("parseJsonContent", () => {
     expect(parseJsonContent(null)).toEqual(EMPTY_DOC);
     expect(parseJsonContent(undefined)).toEqual(EMPTY_DOC);
   });
+
+  test("drops malformed nested nodes while preserving valid content", () => {
+    const raw = JSON.stringify({
+      type: "doc",
+      attrs: { ignored: true },
+      content: [
+        null,
+        {
+          type: "paragraph",
+          attrs: { align: "left" },
+          content: [
+            { type: "text", text: "hello" },
+            undefined,
+            { text: "missing type" },
+          ],
+        },
+        {
+          type: "taskList",
+          content: [
+            {
+              type: "taskItem",
+              attrs: { taskId: "task-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  content: [null, { type: "text", text: "todo" }],
+                },
+              ],
+            },
+            null,
+          ],
+        },
+      ],
+    });
+
+    expect(parseJsonContent(raw)).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          attrs: { align: "left" },
+          content: [{ type: "text", text: "hello" }],
+        },
+        {
+          type: "taskList",
+          content: [
+            {
+              type: "taskItem",
+              attrs: { taskId: "task-1" },
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "todo" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
 });
 
 describe("fileAttachment round-trip", () => {

--- a/packages/editor/src/markdown.ts
+++ b/packages/editor/src/markdown.ts
@@ -1187,6 +1187,61 @@ export interface JSONContent {
   text?: string;
 }
 
+function isJSONRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function sanitizeMarks(
+  marks: unknown,
+): { type: string; attrs?: Record<string, any> }[] | undefined {
+  if (!Array.isArray(marks)) {
+    return undefined;
+  }
+
+  const sanitized = marks
+    .map((mark) => {
+      if (!isJSONRecord(mark) || typeof mark.type !== "string") {
+        return null;
+      }
+
+      return {
+        type: mark.type,
+        ...(isJSONRecord(mark.attrs)
+          ? { attrs: mark.attrs as Record<string, any> }
+          : {}),
+      };
+    })
+    .filter(
+      (mark): mark is { type: string; attrs?: Record<string, any> } =>
+        mark !== null,
+    );
+
+  return sanitized.length > 0 ? sanitized : undefined;
+}
+
+function sanitizeJSONContentNode(value: unknown): JSONContent | null {
+  if (!isJSONRecord(value) || typeof value.type !== "string") {
+    return null;
+  }
+
+  const marks = sanitizeMarks(value.marks);
+  const content = Array.isArray(value.content)
+    ? value.content
+        .map((child) => sanitizeJSONContentNode(child))
+        .filter((child): child is JSONContent => child !== null)
+    : undefined;
+
+  return {
+    type: value.type,
+    ...(isJSONRecord(value.attrs)
+      ? { attrs: value.attrs as Record<string, any> }
+      : {}),
+    ...(content ? { content } : {}),
+    ...(marks ? { marks } : {}),
+    ...(typeof value.text === "string" ? { text: value.text } : {}),
+  };
+}
+
 export const EMPTY_DOC: JSONContent = {
   type: "doc",
   content: [{ type: "paragraph" }],
@@ -1206,7 +1261,18 @@ export function parseJsonContent(raw: string | undefined | null): JSONContent {
   }
   try {
     const parsed = JSON.parse(raw);
-    return isValidContent(parsed) ? parsed : EMPTY_DOC;
+    const sanitized = sanitizeJSONContentNode(parsed);
+    if (!sanitized || sanitized.type !== "doc") {
+      return EMPTY_DOC;
+    }
+
+    return {
+      type: "doc",
+      content:
+        sanitized.content && sanitized.content.length > 0
+          ? sanitized.content
+          : [{ type: "paragraph" }],
+    };
   } catch {
     return EMPTY_DOC;
   }

--- a/packages/editor/src/tasks.test.ts
+++ b/packages/editor/src/tasks.test.ts
@@ -10,6 +10,57 @@ import {
 } from "./tasks";
 
 describe("task content", () => {
+  it("drops invalid nested children while normalizing task content", () => {
+    const content = normalizeTaskContent({
+      type: "doc",
+      content: [
+        null as any,
+        {
+          type: "taskList",
+          content: [
+            undefined as any,
+            {
+              type: "taskItem",
+              attrs: { checked: false, taskId: "task-1" },
+              content: [
+                null as any,
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Recover me" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(content).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "taskList",
+          content: [
+            {
+              type: "taskItem",
+              attrs: {
+                checked: false,
+                taskId: "task-1",
+                taskItemId: expect.any(String),
+              },
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Recover me" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
   it("assigns unique task ids and task item ids to missing and duplicated task items", () => {
     const content = normalizeTaskContent({
       type: "doc",
@@ -131,6 +182,47 @@ describe("task content", () => {
       },
       content: tasks[0]?.body,
     });
+  });
+
+  it("extracts tasks from malformed legacy content without crashing", () => {
+    const source = { type: "daily_note", id: "2026-04-06" };
+    const tasks = extractTasksFromContent(
+      {
+        type: "doc",
+        content: [
+          undefined as any,
+          {
+            type: "taskList",
+            content: [
+              null as any,
+              {
+                type: "taskItem",
+                attrs: { checked: false, taskId: "task-1" },
+                content: [
+                  undefined as any,
+                  {
+                    type: "paragraph",
+                    content: [{ type: "text", text: "Legacy task" }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      } as any,
+      source,
+    );
+
+    expect(tasks).toMatchObject([
+      {
+        taskId: "task-1",
+        sourceId: source.id,
+        sourceType: source.type,
+        sourceOrder: 0,
+        status: "todo",
+        textPreview: "Legacy task",
+      },
+    ]);
   });
 
   it("preserves in-progress status when extracting and rebuilding tasks", () => {

--- a/packages/editor/src/tasks.ts
+++ b/packages/editor/src/tasks.ts
@@ -263,6 +263,16 @@ export function moveOpenTasksBetweenContents(args: {
   };
 }
 
+function isContentNode(value: unknown): value is JSONContent {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function getValidContentChildren(
+  content: JSONContent[] | undefined,
+): JSONContent[] {
+  return (content ?? []).filter(isContentNode);
+}
+
 function hydrateNodeContent(
   node: JSONContent,
   sourceTasksById: ReadonlyMap<string, TaskRecord>,
@@ -311,18 +321,19 @@ function hydrateNode(
     return node;
   }
 
-  const nextContent = node.content
+  const contentChildren = getValidContentChildren(node.content);
+  const nextContent = contentChildren
     .map((child) => hydrateNode(child, sourceTasksById, usedTaskIds, getTask))
     .filter((child): child is JSONContent => child !== null);
   const changed = nextContent.some(
-    (child, index) => child !== node.content?.[index],
+    (child, index) => child !== contentChildren[index],
   );
 
   if (node.type === "taskList" && nextContent.length === 0) {
     return null;
   }
 
-  if (!changed && nextContent.length === node.content.length) {
+  if (!changed && contentChildren.length === node.content.length) {
     return node;
   }
 
@@ -358,18 +369,19 @@ function removeTaskNodes(
     return node;
   }
 
-  const nextContent = node.content
+  const contentChildren = getValidContentChildren(node.content);
+  const nextContent = contentChildren
     .map((child) => removeTaskNodes(child, taskIds))
     .filter((child): child is JSONContent => child !== null);
   const changed = nextContent.some(
-    (child, index) => child !== node.content?.[index],
+    (child, index) => child !== contentChildren[index],
   );
 
   if (node.type === "taskList" && nextContent.length === 0) {
     return null;
   }
 
-  if (!changed && nextContent.length === node.content.length) {
+  if (!changed && contentChildren.length === node.content.length) {
     return node;
   }
 
@@ -426,10 +438,14 @@ function normalizeNode(
   }
 
   if (node.content?.length) {
-    const normalizedChildren = node.content.map((child) =>
+    const contentChildren = getValidContentChildren(node.content);
+    const normalizedChildren = contentChildren.map((child) =>
       normalizeNode(child, seenTaskIds, seenTaskItemIds),
     );
-    if (normalizedChildren.some((child) => child.changed)) {
+    if (
+      contentChildren.length !== node.content.length ||
+      normalizedChildren.some((child) => child.changed)
+    ) {
       nextContent = normalizedChildren.map((child) => child.node);
       changed = true;
     }
@@ -453,13 +469,13 @@ function walkContent(
   node: JSONContent | undefined,
   visit: (node: JSONContent) => void,
 ) {
-  if (!node) {
+  if (!isContentNode(node)) {
     return;
   }
 
   visit(node);
 
-  for (const child of node.content ?? []) {
+  for (const child of getValidContentChildren(node.content)) {
     walkContent(child, visit);
   }
 }
@@ -473,7 +489,7 @@ function getNodeTextContent(node: JSONContent | undefined): string {
     return node.text;
   }
 
-  return (node.content ?? [])
+  return getValidContentChildren(node.content)
     .map((child) => getNodeTextContent(child))
     .join(" ")
     .replace(/\s+/g, " ")
@@ -481,7 +497,9 @@ function getNodeTextContent(node: JSONContent | undefined): string {
 }
 
 function getTaskItemTextContent(node: JSONContent): string {
-  const paragraph = node.content?.find((child) => child.type === "paragraph");
+  const paragraph = getValidContentChildren(node.content).find(
+    (child) => child.type === "paragraph",
+  );
   return getNodeTextContent(paragraph);
 }
 
@@ -512,7 +530,8 @@ function appendTaskItems(
 }
 
 function cloneContentArray(content: JSONContent[] | undefined): JSONContent[] {
-  return (
-    content?.map((node) => structuredClone(node)) ?? [{ type: "paragraph" }]
+  const cloned = getValidContentChildren(content).map((node) =>
+    structuredClone(node),
   );
+  return cloned.length > 0 ? cloned : [{ type: "paragraph" }];
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- sanitize malformed nested TipTap JSON before desktop note editors consume stored session content
- harden task traversal/extraction so legacy notes with missing child nodes no longer crash on `node.type`
- harden session search text extraction and add regressions covering malformed historical note JSON

## Testing
- `pnpm -F @hypr/editor test`
- `pnpm -F @hypr/editor typecheck`
- `pnpm -F @hypr/desktop typecheck`
- `pnpm -F @hypr/desktop test -- src/search/contexts/engine/utils.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://fastrepl.slack.com/archives/D091V1CFPAT/p1776762388970889?thread_ts=1776762388.970889&cid=D091V1CFPAT)

<div><a href="https://cursor.com/agents/bc-80171608-badd-538e-9292-2453613ebeae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80171608-badd-538e-9292-2453613ebeae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

