### PR TITLE
fix: update Discord invite link to https://discord.gg/atz8UzSRBM

### DIFF
--- a/apps/web/content/docs/developers/14.bug-report.mdx
+++ b/apps/web/content/docs/developers/14.bug-report.mdx
@@ -135,7 +135,7 @@ Do **not** delete:
 Still stuck? We're here to help:
 
 - Use the **in-app support chat** (profile icon → Report Bug)
-- Join our [Discord community](https://discord.gg/hyprnote)
+- Join our [Discord community](https://discord.gg/atz8UzSRBM)
 - Create a [GitHub issue](https://github.com/fastrepl/char/issues)
 
 When reaching out, please include:

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -72,7 +72,7 @@ const resourcesList: {
   { to: "/changelog/", label: "Changelog", icon: History },
   { to: "/company-handbook/", label: "Company Handbook", icon: Building2 },
   {
-    to: "https://discord.gg/hyprnote",
+    to: "https://discord.gg/atz8UzSRBM",
     label: "Community",
     icon: MessageCircle,
     external: true,

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -63,7 +63,7 @@ const resourcesList: MenuItem[] = [
   { to: "/changelog/", label: "Changelog", icon: History },
   { to: "/company-handbook/", label: "Company Handbook", icon: Building2 },
   {
-    to: "https://discord.gg/hyprnote",
+    to: "https://discord.gg/atz8UzSRBM",
     label: "Community",
     icon: MessageCircle,
     external: true,

--- a/apps/web/src/routes/discord.tsx
+++ b/apps/web/src/routes/discord.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 export const Route = createFileRoute("/discord")({
   beforeLoad: () => {
     throw redirect({
-      href: "https://discord.gg/CX8gTH2tj9",
+      href: "https://discord.gg/atz8UzSRBM",
     } as any);
   },
 });


### PR DESCRIPTION
Updated discord link everywhere on a website to the one without expiration date.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only URL updates in navigation, docs, and a redirect route with no logic or data-flow changes.
> 
> **Overview**
> Updates the Discord invite URL across the web app to a new non-expiring link (`https://discord.gg/atz8UzSRBM`).
> 
> This changes the Community link in the header and sidebar menus, updates the developer bug-report docs, and repoints the `/discord` redirect route to the new invite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86122c1fd2e4d5a26173d63502284e955e6e16ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->