### PR TITLE
fix: do not auto-stop recording on MicStopped events (#5120)

### DIFF
--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -41,7 +41,7 @@ describe("ListenerProvider detect events", () => {
     listenMock.mockResolvedValue(() => {});
   });
 
-  test("stops listening when MicStopped arrives", async () => {
+  test("does not stop listening when MicStopped arrives with no apps", async () => {
     const store = createListenerStore();
     const stopSpy = vi.fn();
 
@@ -65,7 +65,37 @@ describe("ListenerProvider detect events", () => {
       },
     });
 
-    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  test("does not stop listening when MicStopped arrives with tracked apps (regression: #5120)", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+
+    store.setState({ stop: stopSpy });
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [
+          { id: "/opt/homebrew/bin/ffmpeg", name: "ffmpeg" },
+          { id: "us.zoom.xos", name: "Zoom" },
+        ],
+      },
+    });
+
+    expect(stopSpy).not.toHaveBeenCalled();
   });
 
   test("passes ignorable app ids and footer metadata through mic-detected notifications", async () => {

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -143,8 +143,6 @@ const useHandleDetectEvents = (store: ListenerStore) => {
             footer,
             icon: null,
           });
-        } else if (payload.type === "micStopped") {
-          stop();
         } else if (payload.type === "sleepStateChanged") {
           if (payload.value) {
             stop();


### PR DESCRIPTION
## Summary

Fixes #5120 — *"Not recording full! 1h meeting → 9min audio on char 1.0.24"*. Root cause: the frontend unconditionally called `stop()` on any `MicStopped` event, so any app that briefly released the microphone silently ended the active recording.

## Reproduction (takes ~2 min on any Mac with BlackHole installed)

```bash
# 1. Start a recording in Char (Cmd+Shift+N)
# 2. While recording, in another terminal, briefly probe the mic:
ffmpeg -f avfoundation -i ":BlackHole 2ch" -t 2 -af volumedetect -f null -

# 3. Char's recording ends silently ~10ms after ffmpeg exits.
#    The saved audio.mp3 duration = time-of-ffmpeg-start, not time-of-user-stop.
```

Log timeline from my machine (`~/Library/Logs/com.hyprnote.stable/app.log`):

```
01:52:18.412  detect::mic::macos::app: detected_via_polling event=MicStarted([InstalledApp { id: "/opt/homebrew/bin/ffmpeg", name: "ffmpeg" }])
01:52:20.448  detect::mic::macos::app: detected_via_polling event=MicStopped([InstalledApp { id: "/opt/homebrew/bin/ffmpeg", name: "ffmpeg" }])
01:52:20.457  tauri_plugin_detect::mic_usage_tracker: cancelled_mic_active_timer app_id=/opt/homebrew/bin/ffmpeg
01:52:20.458  stop_capture:session{hyprnote.session.id=…}: listener_core::actors::root: session_finalizing
```

Final output: `98.57s` MP3 for a recording the user never explicitly stopped.

## Root cause

`apps/desktop/src/stt/contexts.tsx` subscribed to detect events and unconditionally called `stop()` on `MicStopped`:

```tsx
} else if (payload.type === "micStopped") {
  stop();                              // ← any app stops mic = silent data loss
}
```

`MicStopped` fires for **every** app that passes `should_track_app` in `plugins/detect/src/policy.rs`. That filter returns true for any app without a known category (see [`policy.rs:121-128`](https://github.com/fastrepl/hyprnote/blob/main/plugins/detect/src/policy.rs#L121-L128) — `user_included_bundle_ids.contains(app_id) || AppCategory::find_category(app_id).is_none()`), so CLI tools like `ffmpeg`, system audio probes, and background daemons all count as "tracked apps". There is no session-ownership correlation linking the stopping app to the active Hyprnote recording.

## Related issues (same mechanism, different triggers)

- **#4846** OPEN — *"Recording randomly pauses during Discord calls, requires manual resume"*. Discord's WebRTC stack oscillates mic state during a call (screen share toggle, codec renegotiation) → repeated `MicStopped` → `stop()` loop.
- **#5006** OPEN — *"Transcription stops at ~23 minutes on long meetings (3+ hours)"*. Any app that grabs the mic ~23 min in → silent stop.
- **#5058** CLOSED — *"Beginning of long recording missing"* (adjacent variant).
- **#2831** CLOSED — sleep-path equivalent (`sleepStateChanged → stop()`), intentionally left in scope of a follow-up PR.

## Fix

Delete the `MicStopped → stop()` branch. `MicDetected` notifications are unchanged (users still get the *"Are you in a meeting?"* prompt when an app uses the mic long enough). `sleepStateChanged → stop()` is left as-is — different risk profile, valid use case (Mac cannot record while asleep anyway).

```diff
         } else if (payload.type === "micStopped") {
-          stop();
         } else if (payload.type === "sleepStateChanged") {
```

## Tests

Flipped the existing `contexts.test.tsx` assertion that was encoding the broken contract, added a regression test that uses the exact apps payload from the reproducer above:

```ts
test("does not stop listening when MicStopped arrives with tracked apps (regression: #5120)", …)
  handler({
    payload: {
      type: "micStopped",
      apps: [
        { id: "/opt/homebrew/bin/ffmpeg", name: "ffmpeg" },
        { id: "us.zoom.xos", name: "Zoom" },
      ],
    },
  });
  expect(stopSpy).not.toHaveBeenCalled();
```

Verified:
- On `main` (before this PR): 2 tests FAIL (`stopSpy` gets called unexpectedly)
- On this branch: 4/4 tests in `contexts.test.tsx` pass; full desktop suite 637/637 passes

## Out of scope

- **Backend policy** (`should_track_app` in `plugins/detect/src/policy.rs`). The current "track any app without a known category" logic is inverted from what most products do (whitelist known meeting apps). Fixing it helps `MicDetected` false prompts, but isn't required to fix truncation — left for a separate PR.
- **`sleepStateChanged → stop()`**. Different justification (system actually can't record during sleep) and related to #2831's separate data-loss bug in the finalize path. Left untouched here.

## Test plan

- [x] `pnpm -F @hypr/desktop typecheck` passes
- [x] `pnpm exec dprint fmt` applied
- [x] `pnpm vitest run src/stt/contexts.test.tsx` — 4/4 passing
- [x] Full desktop suite `pnpm -F @hypr/desktop test` — 637/637 passing
- [ ] Reproduced the bug end-to-end on macOS with Char 1.0.24 (98s MP3 artifact + log excerpt available on request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recording/listener stop behavior by removing the `micStopped` auto-stop path, which could affect session lifecycle and user expectations around when recording ends. Scope is small and covered by targeted regression tests.
> 
> **Overview**
> Prevents active listening/recording sessions from being auto-stopped when a `micStopped` detect event is received, avoiding silent early termination when other apps briefly release the microphone.
> 
> Updates `contexts.test.tsx` to reflect the new contract and adds a regression case covering `micStopped` events that include tracked apps (e.g., `ffmpeg`, Zoom), while keeping the existing `sleepStateChanged` stop behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2908f715caa8d805106bec77589465296fc4167f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->