### PR TITLE
fix: gate MicStopped auto-stop on the app that started the session (#5120)

### DIFF
--- a/apps/desktop/src/services/event-listeners.test.tsx
+++ b/apps/desktop/src/services/event-listeners.test.tsx
@@ -13,6 +13,7 @@ const {
   openNewMock,
   createSessionMock,
   getOrCreateSessionForEventIdMock,
+  setTriggerAppIdsMock,
 } = vi.hoisted(() => ({
   notificationListenMock: vi.fn(),
   updaterListenMock: vi.fn(),
@@ -23,6 +24,7 @@ const {
   openNewMock: vi.fn(),
   createSessionMock: vi.fn(() => "session-new"),
   getOrCreateSessionForEventIdMock: vi.fn(() => "session-event"),
+  setTriggerAppIdsMock: vi.fn(),
 }));
 
 vi.mock("@hypr/plugin-notification", () => ({
@@ -72,6 +74,12 @@ vi.mock("~/store/zustand/tabs", () => ({
     selector({ openNew: openNewMock }),
 }));
 
+vi.mock("~/store/zustand/listener/instance", () => ({
+  listenerStore: {
+    getState: () => ({ setTriggerAppIds: setTriggerAppIdsMock }),
+  },
+}));
+
 describe("EventListeners notification events", () => {
   beforeEach(() => {
     notificationListenMock.mockReset();
@@ -83,6 +91,7 @@ describe("EventListeners notification events", () => {
     openNewMock.mockReset();
     createSessionMock.mockReset();
     getOrCreateSessionForEventIdMock.mockReset();
+    setTriggerAppIdsMock.mockReset();
 
     getCurrentWebviewWindowLabelMock.mockReturnValue("main");
     notificationListenMock.mockResolvedValue(() => {});
@@ -127,5 +136,121 @@ describe("EventListeners notification events", () => {
       JSON.stringify(["com.existing.app", "us.zoom.xos"]),
     );
     expect(openNewMock).not.toHaveBeenCalled();
+  });
+
+  test("notification_confirm with mic_detected source sets triggerAppIds (regression: #5120 confirm path)", async () => {
+    useMainStoreMock.mockReturnValue({} as never);
+
+    render(<EventListeners />);
+
+    await vi.waitFor(() =>
+      expect(notificationListenMock).toHaveBeenCalledTimes(1),
+    );
+
+    const handler = notificationListenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "notification_confirm",
+        source: {
+          type: "mic_detected",
+          app_names: ["Zoom"],
+          app_ids: ["us.zoom.xos"],
+          event_ids: [],
+        },
+      },
+    });
+
+    expect(setTriggerAppIdsMock).toHaveBeenCalledWith(["us.zoom.xos"]);
+    expect(openNewMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("notification_option_selected with mic_detected source sets triggerAppIds", async () => {
+    useMainStoreMock.mockReturnValue({} as never);
+
+    render(<EventListeners />);
+
+    await vi.waitFor(() =>
+      expect(notificationListenMock).toHaveBeenCalledTimes(1),
+    );
+
+    const handler = notificationListenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "notification_option_selected",
+        selected_index: 0,
+        source: {
+          type: "mic_detected",
+          app_names: ["Zoom"],
+          app_ids: ["us.zoom.xos"],
+          event_ids: [],
+        },
+      },
+    });
+
+    expect(setTriggerAppIdsMock).toHaveBeenCalledWith(["us.zoom.xos"]);
+    expect(openNewMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("notification_confirm with mic_detected source preserves triggerAppIds across pending-auto-start (regression: bugbot follow-up)", async () => {
+    useMainStoreMock.mockReturnValue(null);
+
+    const { rerender } = render(<EventListeners />);
+
+    await vi.waitFor(() =>
+      expect(notificationListenMock).toHaveBeenCalledTimes(1),
+    );
+
+    const handler = notificationListenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "notification_confirm",
+        source: {
+          type: "mic_detected",
+          app_names: ["Zoom"],
+          app_ids: ["us.zoom.xos"],
+          event_ids: [],
+        },
+      },
+    });
+
+    expect(setTriggerAppIdsMock).not.toHaveBeenCalled();
+    expect(openNewMock).not.toHaveBeenCalled();
+
+    useMainStoreMock.mockReturnValue({} as never);
+    rerender(<EventListeners />);
+
+    await vi.waitFor(() =>
+      expect(setTriggerAppIdsMock).toHaveBeenCalledWith(["us.zoom.xos"]),
+    );
+    expect(openNewMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("notification_confirm with calendar_event source does not set triggerAppIds", async () => {
+    useMainStoreMock.mockReturnValue({} as never);
+
+    render(<EventListeners />);
+
+    await vi.waitFor(() =>
+      expect(notificationListenMock).toHaveBeenCalledTimes(1),
+    );
+
+    const handler = notificationListenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "notification_confirm",
+        source: { type: "calendar_event", event_id: "evt-1" },
+      },
+    });
+
+    expect(setTriggerAppIdsMock).not.toHaveBeenCalled();
+    expect(openNewMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/services/event-listeners.tsx
+++ b/apps/desktop/src/services/event-listeners.tsx
@@ -14,6 +14,7 @@ import {
   getOrCreateSessionForEventId,
 } from "~/store/tinybase/store/sessions";
 import * as settings from "~/store/tinybase/store/settings";
+import { listenerStore } from "~/store/zustand/listener/instance";
 import { useTabs } from "~/store/zustand/tabs";
 
 function parseIgnoredPlatforms(value: unknown) {
@@ -65,7 +66,10 @@ function useNotificationEvents() {
   const store = main.UI.useStore(main.STORE_ID);
   const settingsStore = settings.UI.useStore(settings.STORE_ID);
   const openNew = useTabs((state) => state.openNew);
-  const pendingAutoStart = useRef<{ eventId: string | null } | null>(null);
+  const pendingAutoStart = useRef<{
+    eventId: string | null;
+    triggerAppIds: string[] | null;
+  } | null>(null);
   const storeRef = useRef(store);
   const settingsStoreRef = useRef(settingsStore);
   const openNewRef = useRef(openNew);
@@ -78,11 +82,16 @@ function useNotificationEvents() {
 
   useEffect(() => {
     if (pendingAutoStart.current && store) {
-      const { eventId } = pendingAutoStart.current;
+      const { eventId, triggerAppIds } = pendingAutoStart.current;
       pendingAutoStart.current = null;
       const sessionId = eventId
         ? getOrCreateSessionForEventId(store, eventId)
         : createSession(store);
+
+      if (triggerAppIds && triggerAppIds.length > 0) {
+        listenerStore.getState().setTriggerAppIds(triggerAppIds);
+      }
+
       openNew({
         type: "sessions",
         id: sessionId,
@@ -109,14 +118,23 @@ function useNotificationEvents() {
             payload.source?.type === "calendar_event"
               ? payload.source.event_id
               : null;
+          const triggerAppIds =
+            payload.source?.type === "mic_detected"
+              ? (payload.source.app_ids ?? null)
+              : null;
           const currentStore = storeRef.current;
           if (!currentStore) {
-            pendingAutoStart.current = { eventId };
+            pendingAutoStart.current = { eventId, triggerAppIds };
             return;
           }
           const sessionId = eventId
             ? getOrCreateSessionForEventId(currentStore, eventId)
             : createSession(currentStore);
+
+          if (triggerAppIds && triggerAppIds.length > 0) {
+            listenerStore.getState().setTriggerAppIds(triggerAppIds);
+          }
+
           openNewRef.current({
             type: "sessions",
             id: sessionId,
@@ -139,6 +157,15 @@ function useNotificationEvents() {
                   eventIds[selectedIndex],
                 )
               : createSession(currentStore);
+
+          if (payload.source?.type === "mic_detected") {
+            const triggerAppIds = payload.source.app_ids ?? [];
+            listenerStore
+              .getState()
+              .setTriggerAppIds(
+                triggerAppIds.length > 0 ? triggerAppIds : null,
+              );
+          }
 
           openNewRef.current({
             type: "sessions",

--- a/apps/desktop/src/store/zustand/listener/general-shared.ts
+++ b/apps/desktop/src/store/zustand/listener/general-shared.ts
@@ -36,6 +36,7 @@ export type GeneralState = {
     requestedLiveTranscription: boolean | null;
     liveTranscriptionActive: boolean | null;
     finalizingBySession: Record<string, { startedAtMs: number }>;
+    triggerAppIds: string[] | null;
   };
 };
 
@@ -56,6 +57,7 @@ const initialLiveState: LiveState = {
   requestedLiveTranscription: null,
   liveTranscriptionActive: null,
   finalizingBySession: {},
+  triggerAppIds: null,
 };
 
 export const initialGeneralState: GeneralState = {
@@ -121,6 +123,7 @@ export const markLiveInactive = (live: LiveState, error: string | null) => {
   live.requestedLiveTranscription = null;
   live.liveTranscriptionActive = null;
   live.muted = initialLiveState.muted;
+  live.triggerAppIds = null;
 };
 
 export const markLiveStartFailed = (live: LiveState) => {
@@ -137,6 +140,7 @@ export const markLiveStartFailed = (live: LiveState) => {
   live.degraded = null;
   live.requestedLiveTranscription = null;
   live.liveTranscriptionActive = null;
+  live.triggerAppIds = null;
 };
 
 export const updateLiveProgress = (

--- a/apps/desktop/src/store/zustand/listener/general.ts
+++ b/apps/desktop/src/store/zustand/listener/general.ts
@@ -37,6 +37,7 @@ export type GeneralActions = {
   ) => Promise<boolean>;
   stop: () => void;
   setMuted: (value: boolean) => void;
+  setTriggerAppIds: (appIds: string[] | null) => void;
   startTranscription: (
     params: TranscriptionParams,
     options?: { handlePersist?: BatchPersistCallback },
@@ -114,6 +115,11 @@ export const createGeneralSlice = <
         void listenerCommands.setMicMuted(value);
       }),
     );
+  },
+  setTriggerAppIds: (appIds) => {
+    setLiveState(set, (live) => {
+      live.triggerAppIds = appIds;
+    });
   },
   startTranscription: async (params, options) => {
     const sessionId = params.session_id;

--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -41,7 +41,7 @@ describe("ListenerProvider detect events", () => {
     listenMock.mockResolvedValue(() => {});
   });
 
-  test("stops listening when MicStopped arrives", async () => {
+  test("does not stop listening on MicStopped when no trigger apps are set (manual session — regression: #5120)", async () => {
     const store = createListenerStore();
     const stopSpy = vi.fn();
 
@@ -61,11 +61,70 @@ describe("ListenerProvider detect events", () => {
     handler({
       payload: {
         type: "micStopped",
-        apps: [],
+        apps: [
+          { id: "/opt/homebrew/bin/ffmpeg", name: "ffmpeg" },
+          { id: "us.zoom.xos", name: "Zoom" },
+        ],
+      },
+    });
+
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  test("stops listening on MicStopped when a trigger app stops (auto-session — preserves Zoom end UX)", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["us.zoom.xos"]);
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "us.zoom.xos", name: "Zoom" }],
       },
     });
 
     expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not stop on MicStopped when only a non-trigger app stops (auto-session — regression: #4846)", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["us.zoom.xos"]);
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "/opt/homebrew/bin/ffmpeg", name: "ffmpeg" }],
+      },
+    });
+
+    expect(stopSpy).not.toHaveBeenCalled();
   });
 
   test("passes ignorable app ids and footer metadata through mic-detected notifications", async () => {

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -144,7 +144,14 @@ const useHandleDetectEvents = (store: ListenerStore) => {
             icon: null,
           });
         } else if (payload.type === "micStopped") {
-          stop();
+          const trigger = store.getState().live.triggerAppIds;
+          if (
+            trigger &&
+            trigger.length > 0 &&
+            payload.apps.some((app) => trigger.includes(app.id))
+          ) {
+            stop();
+          }
         } else if (payload.type === "sleepStateChanged") {
           if (payload.value) {
             stop();


### PR DESCRIPTION
## Summary

- Frontend unconditionally called `stop()` on `MicStopped`, so any app briefly releasing the mic silently ended recordings — including CLI tools like `ffmpeg`, background daemons, and Discord's WebRTC stack renegotiating during a call.
- Now only auto-stops when the stopping app is one that triggered the session via the "Are you in a meeting?" notification flow. Manual sessions (Cmd+Shift+N) never auto-stop on this event.
- Fixes #5120 (1h → 9min). Same mechanism underlies #4846 (Discord pause loop) and #5006 (23-min stop).

Known edge case: ~100ms race between notif-accept and the `autoStart` `useEffect` where a manual session could inherit `triggerAppIds`. Low probability; happy to extend to a `start()`-threaded variant if reviewers prefer airtight semantics.

## Reproduction

Reproduced with [`audiokit`](https://github.com/YouLearn-AI/audiokit), a CLI we built for testing voice-input bugs — it downloads fixture audio, streams it into a virtual microphone (BlackHole), and can fire scripted mic access from other processes.

With a Hyprnote recording active, a 2-second mic probe from another process triggers `session_finalizing` within ~10ms:

```
01:52:18.412  detect::mic: MicStarted([ffmpeg])
01:52:20.448  detect::mic: MicStopped([ffmpeg])
01:52:20.458  listener_core: session_finalizing   ← 10ms after MicStopped
```

Final file duration ends equal to the timing of the probe, not the user's manual stop.

## Test plan

- [x] `pnpm -F @hypr/desktop typecheck` clean
- [x] `pnpm exec dprint fmt` applied
- [x] `pnpm vitest run src/stt/contexts.test.tsx` — 5/5 (3 new regression tests: manual / matching trigger / non-matching trigger)
- [x] Full desktop suite — 638/638 passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes listener start/stop behavior for live capture by threading new `triggerAppIds` state through notification flows and gating `MicStopped` shutdown on it. Risk is moderate because it affects recording lifecycle and could cause sessions to not stop (or stop unexpectedly) if app-id propagation is wrong.
> 
> **Overview**
> Auto-started sessions created from *mic-detected* notifications now persist the triggering app bundle IDs into the listener store via a new `live.triggerAppIds` field and `setTriggerAppIds` action.
> 
> `ListenerProvider` no longer unconditionally calls `stop()` on `micStopped`; it stops only when the event includes an app whose ID matches `triggerAppIds`, leaving manual sessions unaffected and avoiding spurious stops from unrelated mic probes.
> 
> Adds targeted regression tests covering confirm/option-selected notification paths (including pending auto-start) and the new `micStopped` gating behavior for trigger vs non-trigger apps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7d72650ed937ae4ac04dda85fe8498f15a88a46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->