### PR TITLE
chore: remove stale apps/claw workspace member

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ debug = false
 resolver = "2"
 members = [
   "apps/api",
-  "apps/claw",
   "apps/cli",
   "apps/desktop/src-tauri",
   "crates/*",


### PR DESCRIPTION
## Summary

`apps/claw` was deleted in 44518e73d ("remove unused") but its workspace member entry in `Cargo.toml` was left behind, so any cargo command that touches the workspace fails:

\`\`\`
error: failed to load manifest for workspace member \`.../apps/claw\`
Caused by: failed to read \`.../apps/claw/Cargo.toml\`
Caused by: No such file or directory (os error 2)
\`\`\`

Surfaced this morning on \`desktop_ci\` running \`cargo check -p desktop\` (post-merge of #5129; pre-existing rot, unrelated to that PR's TypeScript-only diff).

The workspace dependency `hypr-api-claw = { path = "crates/api-claw" }` on line 45 is intentionally left as-is — `crates/api-claw` still exists and is consumed.

## Verification

\`\`\`
$ cargo check -p desktop
... (warnings only, exit 0)
\`\`\`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a single invalid workspace member entry to restore `cargo` workspace commands; no runtime or dependency behavior changes beyond build configuration.
> 
> **Overview**
> Removes the stale `apps/claw` entry from the root `Cargo.toml` workspace `members` list so workspace-wide `cargo` commands no longer fail due to a missing manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f45d5896e1d6550ccb2ac137891ae8ab52cf7e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->