### PR TITLE
chore: update README for anarlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,95 +1,51 @@
-![twitter-image](https://github.com/user-attachments/assets/b6161cfd-ddfa-4c09-9fbb-ab5a2d6961fc)
+> **Note:** We're now working primarily on **[char](https://char.com)** — a new productivity-focused product that's where most of our active development goes. **anarlog** stays open-source, MIT-licensed, and maintained. The cross-link to char lives here so you know where the team's attention is. Same team, different bets.
+
+![anarlog](https://repository-images.githubusercontent.com/900550981/a4267a9f-414b-4c36-965c-419313ce2417)
 
 <p align="center">
-  <p align="center">Char - The AI notepad for <strong>private</strong> meetings</p>
   <p align="center">
    <a href="https://deepwiki.com/fastrepl/char"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
    <a href="https://char.com/discord" target="_blank"><img src="https://img.shields.io/static/v1?label=Join%20our&message=Discord&color=blue&logo=Discord" alt="Discord"></a>
    <a href="https://x.com/getcharnotes" target="_blank"><img src="https://img.shields.io/static/v1?label=Follow%20us%20on&message=X&color=black&logo=x" alt="X"></a>
   </p>
 </p>
-   
-## What is Char?
 
-Char is an AI notetaking app specifically designed to take meeting notes. With Char, you can transcribe all kinds of meetings whether it be online or offline.
+# anarlog
 
-- **Listens** to your meetings so you can only jot down important stuff
-- **No bots** joining your meetings - Char listens directly to sounds coming in & out of your computer
-- Crafts perfect **summaries** based on your memos, right after the meeting is over
-- You can run Char completely **offline** by using LM Studio or Ollama
+The open-source AI meeting notetaker. Local-first. Privacy-first. Yours to fork.
 
-You can also use it for taking notes for lectures or organizing your thoughts.
+Granola, rearranged.
 
-## Installation
+## How to use it
 
-```bash
-brew install --cask fastrepl/fastrepl/char
-```
+Download the latest release for your platform:
 
-- [macOS](https://char.com/download) (public beta)
-- [Windows](https://github.com/fastrepl/char/issues/66) (q2 2026)
-- [Linux](https://github.com/fastrepl/char/issues/67) (q2 2026)
+→ [github.com/fastrepl/char/releases/latest](https://github.com/fastrepl/char/releases/latest)
 
-## Highlights
+Open it. Join a meeting. anarlog records, transcribes locally, and saves your notes as markdown on disk. Bring your own LLM (OpenAI, Anthropic, Gemini, OpenRouter, Ollama, LM Studio, anything OpenAI-compatible).
 
-### Notepad
+Self-host? Clone the repo, build, run.
 
-Char is designed to take notes easily during meetings. Just jot down stuff you think are important!
+## Why use it
 
-<img width="732" height="612" alt="Screenshot 2025-11-23 at 2 38 20 PM" src="https://github.com/user-attachments/assets/268ab859-a194-484b-b895-bc640df18dd4" />
+- **Your data, your disk.** Every meeting is a `.md` file. `cat` it. Grep it. Sync it via Dropbox / iCloud / Syncthing / git. There is no cloud lock-in because there is no cloud.
+- **Local transcription.** On-device speech models. Audio never leaves your machine.
+- **Bring your own AI.** Plug in any LLM provider. No vendor we picked for you.
+- **Open source, MIT.** Fork it. Sell it. Self-host it. We mean it.
+- **No accounts. No tracking. No "free tier."** Just the app.
 
-### Realtime Transcript
+## A short essay
 
-While you stay engaged in the conversation, Char captures every detail so you don't have to type frantically.
+We started this as **Hyprnote**. It became **char**. Now it's **anarlog**.
 
-<img width="688" height="568" alt="Screenshot 2025-11-23 at 2 35 47 PM" src="https://github.com/user-attachments/assets/e63ce73f-1a5f-49ce-a14d-dd8ba161e5bc" />
+Each name change came from a different reason — a legal one, a strategic one, a brand one. The product underneath kept getting clearer: a notetaker that respects your time, your data, and your right to walk away with both.
 
-### From Memos to Summaries
+We're now building [**char**](https://char.com) — a new product, productivity-focused, where most of our active development happens. **anarlog** isn't a sunset. It's the open-source companion we promised to keep alive, and we will. This repository keeps its full history, its stars, and its trajectory. Same team. Same standards. Just a clearer split between what's open and what's experimental.
 
-Once the meeting is over, Char will craft a personalized summary based on your memos — which is not mandatory. Char will still create great summaries without your notes.
+If you came here from Granola, welcome. If you came here from Hyprnote, welcome back.
 
-![offline enhancing-1](https://github.com/user-attachments/assets/13af787b-2f6e-4877-b90f-719edc45fb75)
+Either way: it's yours.
 
-### Truly Local
+---
 
-If you noticed the GIF above, you can see that Char works without any internet connection available. Just set up LM Studio or Ollama to operate Char in air-gapped environments!
-
-<img width="780" height="585" alt="no-wifi" src="https://github.com/user-attachments/assets/ecf08a9e-3b6c-4fb6-ab38-0bc572f54859" />
-
-> **Note on accounts:** During onboarding, Char creates an account so you can experience the full product — including cloud-powered transcription and summarization — at its best quality. All your notes, transcripts, and data are stored locally on your machine in a local SQLite database. If you prefer not to keep an account, you can request deletion anytime at [char.com/app/account](https://char.com/app/account). Char will continue to work fully offline with a local LLM.
-
-### Bring Your Own LLM
-
-Prefer something custom? You can swap in your own language model:
-
-- Run local models via Ollama
-- Use approved third-party APIs like Gemini, Claude, or Azure-hosted GPT
-- Stay compliant with whatever your org allows
-
-Char plays nice with whatever stack you're running.
-
-<img width="912" height="712" alt="Screenshot 2025-11-23 at 2 41 03 PM" src="https://github.com/user-attachments/assets/a6552c99-acbc-4d47-9d21-7f1925989344" />
-
-### Note Templates
-
-Prefer a certain style? Choose from predefined templates like bullet points, agenda-based, or paragraph summary. Or create your own.
-
-Check out our [template gallery](https://char.com/templates) and add your own [here](https://github.com/fastrepl/char/tree/main/apps/web/content/templates).
-
-### AI Chat
-
-Ask follow-ups right inside your notes:
-
-- "What were the action items?"
-- "Rewrite this in simpler language"
-- "Translate to Spanish"
-
-<img width="959" height="712" alt="image" src="https://github.com/user-attachments/assets/52b7dc14-906f-445f-91f9-b0089d40a495" />
-
-### Integrations
-
-- Apple Calendar, Contacts
-- Obsidian
-- Coming soon: Notion, Slack, Hubspot, Salesforce
-
-<img width="912" height="712" alt="image" src="https://github.com/user-attachments/assets/ab559e54-fda5-4c8c-97d7-ba1b9d134cc8" />
+**License:** MIT · **Maintainers:** [fastrepl](https://github.com/fastrepl)


### PR DESCRIPTION
Reframe the repository README around anarlog and clarify char as the team's primary active product.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that rewrites the README messaging and usage guidance; no runtime/code behavior is affected.
> 
> **Overview**
> The README is rewritten to **recenter the repository around `anarlog`** (local-first, privacy-first, Markdown-on-disk meeting notes) and to **clearly state `char` as the team’s primary active product** via a prominent note and links.
> 
> It replaces the previous Char-focused feature/installation marketing sections with a shorter `anarlog`-oriented “How to use it / Why use it” overview plus a brief narrative on the Hyprnote→char→anarlog naming history, and ends with explicit MIT license/maintainer info.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2da8f8278a4b7232b70b1f427300f0d43fc31466. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->