### PR TITLE
blog: Char Is Now Anarlog announcement + chip repoint

### DIFF
--- a/apps/web/content/articles/char-is-now-anarlog.mdx
+++ b/apps/web/content/articles/char-is-now-anarlog.mdx
@@ -1,0 +1,66 @@
+---
+meta_title: "Char Is Now Anarlog"
+display_title: "Char Is Now Anarlog"
+meta_description: "Why we renamed Char to Anarlog — a second name change in three months, and why this rebrand sharpens what we've always built: ownership."
+author: "John Jeong"
+coverImage: "/api/assets/blog/announcement.jpg"
+featured: true
+category: "Founders' notes"
+date: "2026-04-30"
+---
+
+We're renaming Char to Anarlog.
+
+Yes — again. Two name changes in three months. I owe you an explanation.
+
+### What happened
+
+In February, we [renamed Hyprnote to Char](/blog/hyprnote-is-now-char/) for legal reasons. We picked Char because it captured what we were really building — direct, ownable, the raw building block.
+
+In April, more legal complications came up around the name. We decided the cleanest path forward was to move on. So Char goes too.
+
+I know how this looks. Two renames in a row is the kind of thing that makes people quietly close the tab. If you're frustrated, that's fair — I'm frustrated too.
+
+### Why Anarlog
+
+It's an anagram of "granola."
+
+That's the joke and that's the point. The tools we're building against — Granola, Otter, Fireflies — all share an architecture: they take your meetings, send them to their cloud, store them in their database, and let you rent access back. We're doing the opposite. The anagram is the thesis written backwards.
+
+We almost picked something serious. Inklave. Artifact. Sovereign. Nothing landed. Anarlog did, because it doesn't take itself too seriously and the product doesn't need to. This isn't a SaaS we're trying to win on naming SEO. It's an open-source meeting notetaker that lives on your machine.
+
+A name you have to spell once and remember forever is fine for that.
+
+### What's not changing
+
+The product doesn't change. The thesis doesn't change. If anything, the rename clarifies it.
+
+What I wrote in February still holds:
+
+> We hadn't built just another privacy tool. We'd built something people couldn't get anywhere else — complete control. Control over which AI models process their data. Control over their notes as actual files on their machine, not entries in someone else's database. Control over whether their information ever touches the cloud.
+
+Privacy is a feature talk. **Ownership is the whole thing.** Your audio never leaves your laptop unless you choose to send it. Your notes are markdown files in a folder you control. You bring your own API keys, or run local models, or nothing at all. The repo is open source — MIT, fully auditable. If we disappeared tomorrow, your notes would still be there, in a format you can open in any editor, forever.
+
+That's what Anarlog is. That's what Char was. That's what Hyprnote was trying to be. The name changes; the conviction doesn't.
+
+### What's also changing — and being honest about it
+
+A few things worth naming directly:
+
+**The team isn't focusing here.** I'm maintaining Anarlog mostly solo, in the margins. Our team's product focus has moved to a separate, productivity-shaped product — also called Char, now living at [char.com](https://char.com). The two share a lineage but solve different problems for different people.
+
+**Anarlog stays open source. Forever.** MIT-licensed. Self-hostable. No commercial gating of core features. If you want a managed, hosted experience with more bells and whistles, that's what char.com is for. If you want to own everything end-to-end, you're already in the right place.
+
+**Existing paid lifetime users:** you keep lifetime access to **both** Anarlog *and* the new Char. You trusted us with money before either name existed in its current form — that trust doesn't get cheaper because we changed our minds about what we're building. You backed the team, not the brand. We honor that.
+
+**Things will move slower.** Weekly releases instead of nightly. Fewer features. More care. I want Anarlog to become a real community project — not solely directed by us, like Hyprnote and Char were.
+
+### What I'd ask of you
+
+If you've stuck with us through Hyprnote → Char → Anarlog, thank you. Genuinely. The early users of any tool are doing the company a favor, not the other way around, and we know it.
+
+If you're new and confused by all this — fair. Read the [Hyprnote is now Char](/blog/hyprnote-is-now-char/) post for the longer arc, or just download the app and decide for yourself. The product speaks more clearly than these posts ever will.
+
+Either way: the meeting notes still live on your machine. The code is still open. You still own everything. The name changed. Nothing else did.
+
+<CtaCard/>

--- a/apps/web/src/routes/_view/index.tsx
+++ b/apps/web/src/routes/_view/index.tsx
@@ -463,10 +463,10 @@ function SocialTestimonialsSection() {
       <h2 className="text-color border-color-brand mb-10 border-b pb-8 font-mono text-2xl tracking-wide md:text-4xl">
         <span className="mb-2 block">What people are saying</span>
         <span className="text-color-secondary block font-sans text-sm font-normal tracking-normal md:text-base">
-          Char was formerly Hyprnote.{" "}
+          Anarlog was formerly Char (and Hyprnote before that).{" "}
           <Link
             to="/blog/$slug/"
-            params={{ slug: "hyprnote-is-now-char" }}
+            params={{ slug: "char-is-now-anarlog" }}
             className="text-color underline underline-offset-4 transition-opacity hover:opacity-70"
           >
             Read about the rename.

--- a/apps/web/src/routes/_view/route.tsx
+++ b/apps/web/src/routes/_view/route.tsx
@@ -315,7 +315,7 @@ export function AnnouncementBanner() {
   return (
     <Link
       to="/blog/$slug/"
-      params={{ slug: "hyprnote-is-now-char" }}
+      params={{ slug: "char-is-now-anarlog" }}
       className={cn([
         "relative inline-flex w-fit items-center gap-2 rounded-full",
         "bg-stone-800 px-4 py-1.5",
@@ -324,7 +324,7 @@ export function AnnouncementBanner() {
       ])}
     >
       <span>
-        Hyprnote is now <strong>Char</strong>.
+        Char is now <strong>Anarlog</strong>.
       </span>
       <button
         type="button"


### PR DESCRIPTION
## Summary

New blog post announcing the Char → Anarlog rename. Repoints the homepage announcement chip and the social testimonials lineage line to the new post.

## What ships

- New article: `apps/web/content/articles/char-is-now-anarlog.mdx`
- Homepage chip: "Hyprnote is now **Char**" → "Char is now **Anarlog**" (link + copy)
- Social testimonials: "Char was formerly Hyprnote" → "Anarlog was formerly Char (and Hyprnote before that)" (link + copy)

## Tone

Matter-of-fact, slightly personal. Inherits the ownership thesis from `hyprnote-is-now-char.mdx` and extends it through the privacy/local-first frame. Source material:
- John's Apr 27 community message ("sorry for confusing you all...")
- Apr 28 Discord post on existing paid users
- Operation Supernova context

Three editorial calls John made before draft was finalized:
1. Legal phrasing softened — "for legal reasons" / "legal complications" (matches Feb post voice)
2. Dead link to hypothetical "team shape" post → removed
3. Lifetime users get **both** Anarlog *and* the new Char ("you backed the team, not the brand")

## Out of scope (separate PRs)

- Bigger rename pass across all 71 articles (Char → Anarlog where applicable)
- Content prune of off-thesis articles (productivity coaching listicles, etc.)
- Update `apps/web/content/AGENTS.md` positioning doc (still says "Always use Char")
- 301 redirect map / sitemap split (Operation Supernova Window 4)

## Verification

- `pnpm exec dprint fmt` — clean
- `pnpm -F @hypr/web typecheck` — pre-existing failures unrelated to these changes (missing `content-collections` codegen module + unrelated `/eval/` route type error)

## Related

- Operation Supernova: `~/charpedia/char/operations/operation-supernova.md`
- Predecessor post: `/blog/hyprnote-is-now-char/` (Feb 14, 2026)

Co-authored-by: John Jeong <john@fastrepl.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content and copy-only changes that repoint existing homepage links to a new blog post; no business logic or data flows are affected.
> 
> **Overview**
> Adds a new featured blog post `char-is-now-anarlog.mdx` announcing the Char → Anarlog rename.
> 
> Repoints the homepage announcement banner and the social testimonials rename line to the new post, updating the visible copy and `slug` link target accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92f0028e61f526a08ee44090fd6c1233e8ac5335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->