### PR TITLE
docs: update download links with platform-specific URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Granola, rearranged.
 
 Download the latest release for your platform:
 
-→ [github.com/fastrepl/char/releases/latest](https://github.com/fastrepl/char/releases/latest)
+<a href="https://github.com/fastrepl/anarlog/releases/latest/download/hyprnote-macos-aarch64.dmg">Download for Apple Silicon</a> · <a href="https://github.com/fastrepl/anarlog/releases/latest/download/hyprnote-macos-x86_64.dmg">Download for Apple Intel</a>
 
 Open it. Join a meeting. anarlog records, transcribes locally, and saves your notes as markdown on disk. Bring your own LLM (OpenAI, Anthropic, Gemini, OpenRouter, Ollama, LM Studio, anything OpenAI-compatible).
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that updates external URLs; no runtime code or behavior is affected.
> 
> **Overview**
> Updates `README.md` download instructions by replacing the generic “latest release” link (pointing at `fastrepl/char`) with **direct, platform-specific macOS DMG links** for Apple Silicon and Intel under `fastrepl/anarlog` releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f06d2a8e39e2280fb14471a4b734a55bdbb0257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->