### PR TITLE
fix: collapse live transcript bottom padding

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -93,7 +93,7 @@ describe("TranscriptViewer", () => {
       },
     ];
 
-    render(
+    const { container } = render(
       <TranscriptViewer
         transcriptIds={[]}
         liveSegments={liveSegments as never[]}
@@ -120,5 +120,10 @@ describe("TranscriptViewer", () => {
       expect.any(Function),
       expect.objectContaining({ enabled: false }),
     );
+    const transcriptContainer = container.querySelector(
+      "[data-transcript-container]",
+    );
+    expect(transcriptContainer?.classList.contains("pb-0")).toBe(true);
+    expect(transcriptContainer?.classList.contains("pb-16")).toBe(false);
   });
 });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -114,7 +114,8 @@ export function TranscriptViewer({
         data-transcript-container
         className={cn([
           "flex h-full flex-col gap-8 overflow-x-hidden overflow-y-auto",
-          "scrollbar-hide scroll-pb-32 pb-16",
+          "scrollbar-hide",
+          enablePlaybackControls ? "scroll-pb-32 pb-16" : "scroll-pb-4 pb-0",
         ])}
       >
         {transcriptEntries.map(({ transcriptId }, index) => (


### PR DESCRIPTION
Remove playback-only bottom reserve from live transcript rendering and cover the compact path in the renderer test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout tweak that only changes conditional padding behavior in the transcript scroller and adds a regression test for the non-playback path.
> 
> **Overview**
> Collapses the transcript viewer’s bottom padding when `enablePlaybackControls` is disabled, so the scroller no longer reserves playback-control space (`pb-0`/smaller `scroll-pb` instead of `pb-16`).
> 
> Updates the `TranscriptViewer` test to assert the compact container padding classes when rendering live segments without playback controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb389fa85c70010bc22b1ae634f237f6b7fb9d5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->