### PR TITLE
refactor: migrate local transcription to Soniqo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9680,6 +9680,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "transcribe-soniqo",
  "transcript",
  "uuid",
  "vad-masking",
@@ -9710,6 +9711,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "transcribe-soniqo",
 ]
 
 [[package]]
@@ -9807,6 +9809,7 @@ dependencies = [
  "model-downloader",
  "serde",
  "specta",
+ "transcribe-soniqo",
  "whisper-local-model",
 ]
 
@@ -16982,6 +16985,7 @@ dependencies = [
  "tower-http 0.6.8",
  "tracing",
  "transcribe-cactus",
+ "transcribe-soniqo",
  "transcribe-whisper-local",
  "whisper-local",
  "whisper-local-model",
@@ -17519,6 +17523,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "transcribe-soniqo",
  "transcript",
  "transcription-core",
 ]
@@ -18740,6 +18745,20 @@ dependencies = [
  "rodio",
  "serde_json",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "transcribe-soniqo"
+version = "0.1.0"
+dependencies = [
+ "language",
+ "owhisper-interface",
+ "serde",
+ "serde_json",
+ "specta",
+ "swift-rs 1.0.7 (git+https://github.com/yujonglee/swift-rs?rev=41a1605)",
+ "thiserror 2.0.18",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ hypr-ticket-interface = { path = "crates/ticket-interface", package = "ticket-in
 hypr-tiptap = { path = "crates/tiptap", package = "tiptap" }
 hypr-transcribe-cactus = { path = "crates/transcribe-cactus", package = "transcribe-cactus" }
 hypr-transcribe-core = { path = "crates/transcribe-core", package = "transcribe-core" }
+hypr-transcribe-soniqo = { path = "crates/transcribe-soniqo", package = "transcribe-soniqo" }
 hypr-transcribe-whisper-local = { path = "crates/transcribe-whisper-local", package = "transcribe-whisper-local" }
 hypr-transcript = { path = "crates/transcript", package = "transcript" }
 hypr-transcription-core = { path = "crates/transcription-core", package = "transcription-core" }

--- a/apps/desktop/src/contexts/notifications.tsx
+++ b/apps/desktop/src/contexts/notifications.tsx
@@ -38,6 +38,11 @@ const MODEL_DISPLAY_NAMES: Partial<Record<LocalModel, string>> = {
   "am-parakeet-v2": "Parakeet v2",
   "am-parakeet-v3": "Parakeet v3",
   "am-whisper-large-v3": "Whisper Large v3",
+  "soniqo-parakeet-streaming": "Soniqo Parakeet Streaming",
+  "soniqo-parakeet-batch": "Soniqo Parakeet Batch",
+  "soniqo-omnilingual": "Soniqo Omnilingual",
+  "soniqo-qwen3-small": "Soniqo Qwen3 0.6B",
+  "soniqo-qwen3-large": "Soniqo Qwen3 1.7B",
   QuantizedTinyEn: "Whisper Tiny (English)",
   QuantizedSmallEn: "Whisper Small (English)",
 };

--- a/apps/desktop/src/settings/ai/stt/configure.tsx
+++ b/apps/desktop/src/settings/ai/stt/configure.tsx
@@ -110,10 +110,15 @@ function HyprProviderCard({
 
   const whispercppModels =
     supportedModels.data?.filter((m) => m.model_type === "whispercpp") ?? [];
+  const soniqoModels =
+    supportedModels.data?.filter((m) => m.model_type === "soniqo") ?? [];
   const cactusModels =
     supportedModels.data?.filter((m) => m.model_type === "cactus") ?? [];
 
-  const hasLocalModels = whispercppModels.length > 0 || cactusModels.length > 0;
+  const hasLocalModels =
+    soniqoModels.length > 0 ||
+    whispercppModels.length > 0 ||
+    cactusModels.length > 0;
 
   const providerDef = PROVIDERS.find((p) => p.id === providerId);
   const isConfigured = providerDef?.requirements.length === 0;
@@ -155,11 +160,19 @@ function HyprProviderCard({
                 <div className="flex-1 border-t border-dashed border-neutral-300" />
               </div>
 
-              <StyledStreamdown>
-                {
-                  "We intentionally **disable realtime transcription** for local models to ensure the best experience.\n\nAudio will be **batch processed** after recording is done."
-                }
-              </StyledStreamdown>
+              {soniqoModels.length > 0 && (
+                <>
+                  <ModelGroupLabel label="Soniqo" />
+                  {soniqoModels.map((model) => (
+                    <HyprProviderLocalRow
+                      key={model.key as string}
+                      model={model.key}
+                      displayName={model.display_name}
+                      description={model.description}
+                    />
+                  ))}
+                </>
+              )}
 
               {cactusModels.filter((m) => String(m.key).includes("parakeet"))
                 .length > 0 && (
@@ -531,7 +544,11 @@ function HyprProviderLocalRow({
   } = useLocalModelDownload(model, handleSelectModel);
 
   const handleOpen = () => {
-    void localSttCommands.modelsDir().then((result) => {
+    const resultPromise = String(model).startsWith("soniqo-")
+      ? localSttCommands.soniqoModelDir(model)
+      : localSttCommands.modelsDir();
+
+    void resultPromise.then((result) => {
       if (result.status === "ok") {
         void openerCommands.openPath(result.data, null);
       }

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -337,9 +337,14 @@ function useConfiguredMapping(): Record<
 
   const cactusModels =
     supportedModels.data?.filter((m) => m.model_type === "cactus") ?? [];
+  const soniqoModels =
+    supportedModels.data?.filter((m) => m.model_type === "soniqo") ?? [];
 
   const cactusDownloaded = useQueries({
     queries: [...cactusModels.map((m) => sttModelQueries.isDownloaded(m.key))],
+  });
+  const soniqoDownloaded = useQueries({
+    queries: [...soniqoModels.map((m) => sttModelQueries.isDownloaded(m.key))],
   });
 
   return Object.fromEntries(
@@ -367,6 +372,17 @@ function useConfiguredMapping(): Record<
         ];
 
         if (isAppleSilicon) {
+          soniqoModels.forEach((model, i) => {
+            const isRecommended =
+              String(model.key) === "soniqo-parakeet-streaming";
+            models.push({
+              id: model.key,
+              isDownloaded: soniqoDownloaded[i]?.data ?? false,
+              displayName: model.display_name,
+              category: isRecommended ? "latest" : "experimental",
+            });
+          });
+
           const sorted = [...cactusModels].sort((a) =>
             String(a.key).includes("parakeet") ? -1 : 1,
           );

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -12,4 +12,10 @@ describe("getBatchProvider", () => {
   test("keeps openai mapped to the batch transcription provider", () => {
     expect(getBatchProvider("openai", "gpt-4o-transcribe")).toBe("openai");
   });
+
+  test("maps local soniqo models to soniqo batch provider", () => {
+    expect(getBatchProvider("hyprnote", "soniqo-parakeet-batch")).toBe(
+      "soniqo",
+    );
+  });
 });

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -51,6 +51,7 @@ export function getBatchProvider(
   model: string,
 ): TranscriptionParams["provider"] | null {
   if (provider === "hyprnote") {
+    if (model.startsWith("soniqo-")) return "soniqo";
     if (model.startsWith("am-")) return "am";
     if (model.startsWith("cactus-")) return "cactus";
     return "hyprnote";

--- a/crates/listener-core/Cargo.toml
+++ b/crates/listener-core/Cargo.toml
@@ -16,6 +16,7 @@ hypr-host = { workspace = true }
 hypr-language = { workspace = true }
 hypr-storage = { workspace = true }
 hypr-supervisor = { workspace = true }
+hypr-transcribe-soniqo = { workspace = true }
 hypr-transcript = { workspace = true }
 hypr-vad-masking = { workspace = true }
 

--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -31,7 +31,7 @@ pub(super) async fn spawn_rx_task(
     ),
     ActorProcessingErr,
 > {
-    if let Ok(model) = hypr_transcribe_soniqo::SoniqoModel::from_str(&args.model) {
+    if let Some(model) = soniqo_model_for_args(&args)? {
         if !model.supports_live() {
             return Err(actor_error(format!(
                 "provider_batch_only: {} only supports batch transcription",
@@ -87,6 +87,18 @@ pub(super) async fn spawn_rx_task(
     }, batch_only: [OpenAI, AquaVoice, Pyannote])?;
 
     Ok((result.0, result.1, result.2, adapter_kind.to_string()))
+}
+
+fn soniqo_model_for_args(
+    args: &ListenerArgs,
+) -> Result<Option<hypr_transcribe_soniqo::SoniqoModel>, ActorProcessingErr> {
+    if !hypr_transcribe_soniqo::is_local_base_url(&args.base_url) {
+        return Ok(None);
+    }
+
+    hypr_transcribe_soniqo::SoniqoModel::from_str(&args.model)
+        .map(Some)
+        .map_err(|e| actor_error(format!("soniqo_model_invalid: {e}")))
 }
 
 async fn spawn_soniqo_rx_task(
@@ -530,6 +542,38 @@ mod tests {
             participant_human_ids: vec![],
             self_human_id: None,
         }
+    }
+
+    #[test]
+    fn soniqo_model_detection_requires_local_base_url() {
+        let args = listener_args("https://api.deepgram.com/v1", "soniqo-parakeet-streaming");
+        assert_eq!(soniqo_model_for_args(&args).unwrap(), None);
+
+        let args = listener_args(
+            "https://api.deepgram.com/v1",
+            "aufklarer/Parakeet-EOU-120M-CoreML-INT8",
+        );
+        assert_eq!(soniqo_model_for_args(&args).unwrap(), None);
+    }
+
+    #[test]
+    fn soniqo_model_detection_accepts_local_base_url() {
+        let args = listener_args(
+            hypr_transcribe_soniqo::LOCAL_BASE_URL,
+            "soniqo-parakeet-streaming",
+        );
+
+        assert_eq!(
+            soniqo_model_for_args(&args).unwrap(),
+            Some(hypr_transcribe_soniqo::SoniqoModel::ParakeetStreaming)
+        );
+    }
+
+    #[test]
+    fn soniqo_model_detection_rejects_invalid_local_model() {
+        let args = listener_args(hypr_transcribe_soniqo::LOCAL_BASE_URL, "nova-3");
+
+        assert!(soniqo_model_for_args(&args).is_err());
     }
 
     #[test]

--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use std::time::{Duration, UNIX_EPOCH};
 
 use bytes::Bytes;
@@ -12,7 +13,10 @@ use owhisper_interface::stream::Extra;
 use owhisper_interface::{ControlMessage, MixedMessage};
 
 use super::stream::process_stream;
-use super::{ChannelSender, DEVICE_FINGERPRINT_HEADER, ListenerArgs, ListenerMsg, actor_error};
+use super::{
+    ChannelSender, DEVICE_FINGERPRINT_HEADER, ListenerArgs, ListenerMsg, SoniqoAudioMsg,
+    actor_error,
+};
 use crate::SessionErrorEvent;
 
 pub(super) async fn spawn_rx_task(
@@ -27,6 +31,18 @@ pub(super) async fn spawn_rx_task(
     ),
     ActorProcessingErr,
 > {
+    if let Ok(model) = hypr_transcribe_soniqo::SoniqoModel::from_str(&args.model) {
+        if !model.supports_live() {
+            return Err(actor_error(format!(
+                "provider_batch_only: {} only supports batch transcription",
+                model.as_str()
+            )));
+        }
+
+        let result = spawn_soniqo_rx_task(model, args, myself).await?;
+        return Ok((result.0, result.1, result.2, "soniqo".to_string()));
+    }
+
     let adapter_kind =
         AdapterKind::from_url_and_languages(&args.base_url, &args.languages, Some(&args.model));
     let is_dual = matches!(args.mode, crate::actors::ChannelMode::MicAndSpeaker);
@@ -71,6 +87,217 @@ pub(super) async fn spawn_rx_task(
     }, batch_only: [OpenAI, AquaVoice, Pyannote])?;
 
     Ok((result.0, result.1, result.2, adapter_kind.to_string()))
+}
+
+async fn spawn_soniqo_rx_task(
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    args: ListenerArgs,
+    myself: ActorRef<ListenerMsg>,
+) -> Result<
+    (
+        ChannelSender,
+        tokio::task::JoinHandle<()>,
+        tokio::sync::oneshot::Sender<()>,
+    ),
+    ActorProcessingErr,
+> {
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let (session_offset_secs, extra) = build_extra(&args);
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<SoniqoAudioMsg>(32);
+
+    let session = tokio::task::spawn_blocking(move || {
+        hypr_transcribe_soniqo::LiveTranscriptionSession::start(model)
+    })
+    .await
+    .map_err(|e| actor_error(format!("soniqo_live_start_join_failed: {e}")))?
+    .map_err(|e| actor_error(format!("soniqo_live_start_failed: {e}")))?;
+
+    let rx_task = tokio::spawn(async move {
+        let mut session = session;
+        let mut mic_buffer = Vec::<f32>::new();
+        let mut spk_buffer = Vec::<f32>::new();
+        let mut mic_cursor = 0.0;
+        let mut spk_cursor = 0.0;
+        let mut interval = tokio::time::interval(Duration::from_millis(250));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                _ = &mut shutdown_rx => {
+                    break;
+                }
+                maybe_msg = rx.recv() => {
+                    let Some(msg) = maybe_msg else {
+                        break;
+                    };
+
+                    match msg {
+                        SoniqoAudioMsg::Single(source, audio) => {
+                            match source {
+                                hypr_transcribe_soniqo::TranscriptSource::Microphone => {
+                                    mic_buffer.extend(i16_bytes_to_f32(&audio));
+                                }
+                                hypr_transcribe_soniqo::TranscriptSource::System => {
+                                    spk_buffer.extend(i16_bytes_to_f32(&audio));
+                                }
+                            }
+                        }
+                        SoniqoAudioMsg::Dual(mic, spk) => {
+                            mic_buffer.extend(i16_bytes_to_f32(&mic));
+                            spk_buffer.extend(i16_bytes_to_f32(&spk));
+                        }
+                    }
+                }
+                _ = interval.tick() => {
+                    if !mic_buffer.is_empty() {
+                        let samples = std::mem::take(&mut mic_buffer);
+                        let duration = samples.len() as f64 / super::super::SAMPLE_RATE as f64;
+                        let start = mic_cursor;
+                        mic_cursor += duration;
+
+                        match flush_soniqo_source(
+                            session,
+                            model,
+                            hypr_transcribe_soniqo::TranscriptSource::Microphone,
+                            samples,
+                            start,
+                            duration,
+                            myself.clone(),
+                            session_offset_secs,
+                            extra.clone(),
+                        )
+                        .await
+                        {
+                            Ok(next_session) => session = next_session,
+                            Err(error) => {
+                                let _ = myself.cast(ListenerMsg::StreamError(error));
+                                return;
+                            }
+                        }
+                    }
+
+                    if !spk_buffer.is_empty() {
+                        let samples = std::mem::take(&mut spk_buffer);
+                        let duration = samples.len() as f64 / super::super::SAMPLE_RATE as f64;
+                        let start = spk_cursor;
+                        spk_cursor += duration;
+
+                        match flush_soniqo_source(
+                            session,
+                            model,
+                            hypr_transcribe_soniqo::TranscriptSource::System,
+                            samples,
+                            start,
+                            duration,
+                            myself.clone(),
+                            session_offset_secs,
+                            extra.clone(),
+                        )
+                        .await
+                        {
+                            Ok(next_session) => session = next_session,
+                            Err(error) => {
+                                let _ = myself.cast(ListenerMsg::StreamError(error));
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if !mic_buffer.is_empty() {
+            let samples = std::mem::take(&mut mic_buffer);
+            let duration = samples.len() as f64 / super::super::SAMPLE_RATE as f64;
+            match flush_soniqo_source(
+                session,
+                model,
+                hypr_transcribe_soniqo::TranscriptSource::Microphone,
+                samples,
+                mic_cursor,
+                duration,
+                myself.clone(),
+                session_offset_secs,
+                extra.clone(),
+            )
+            .await
+            {
+                Ok(next_session) => session = next_session,
+                Err(error) => {
+                    tracing::warn!(%error, "soniqo_final_mic_flush_failed");
+                    return;
+                }
+            }
+        }
+
+        if !spk_buffer.is_empty() {
+            let samples = std::mem::take(&mut spk_buffer);
+            let duration = samples.len() as f64 / super::super::SAMPLE_RATE as f64;
+            match flush_soniqo_source(
+                session,
+                model,
+                hypr_transcribe_soniqo::TranscriptSource::System,
+                samples,
+                spk_cursor,
+                duration,
+                myself,
+                session_offset_secs,
+                extra,
+            )
+            .await
+            {
+                Ok(next_session) => session = next_session,
+                Err(error) => {
+                    tracing::warn!(%error, "soniqo_final_system_flush_failed");
+                    return;
+                }
+            }
+        }
+
+        let _ = tokio::task::spawn_blocking(move || session.stop()).await;
+    });
+
+    Ok((ChannelSender::Soniqo(tx), rx_task, shutdown_tx))
+}
+
+async fn flush_soniqo_source(
+    session: hypr_transcribe_soniqo::LiveTranscriptionSession,
+    model: hypr_transcribe_soniqo::SoniqoModel,
+    source: hypr_transcribe_soniqo::TranscriptSource,
+    samples: Vec<f32>,
+    start: f64,
+    duration: f64,
+    myself: ActorRef<ListenerMsg>,
+    session_offset_secs: f64,
+    extra: Extra,
+) -> Result<hypr_transcribe_soniqo::LiveTranscriptionSession, String> {
+    let joined = tokio::task::spawn_blocking(move || {
+        let mut session = session;
+        let result = session.append(source, &samples);
+        (session, result)
+    })
+    .await
+    .map_err(|e| format!("soniqo_live_append_join_failed: {e}"))?;
+
+    let (session, partials) = joined;
+    let partials = partials.map_err(|e| format!("soniqo_live_append_failed: {e}"))?;
+
+    for partial in partials {
+        let mut response = partial.into_stream_response(model, start, duration);
+        response.apply_offset(session_offset_secs);
+        response.set_extra(&extra);
+
+        let _ = myself.cast(ListenerMsg::StreamResponse(response));
+    }
+
+    Ok(session)
+}
+
+fn i16_bytes_to_f32(bytes: &Bytes) -> Vec<f32> {
+    bytes
+        .chunks_exact(2)
+        .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / i16::MAX as f32)
+        .collect()
 }
 
 fn build_listen_params(args: &ListenerArgs) -> owhisper_interface::ListenParams {

--- a/crates/listener-core/src/actors/listener/mod.rs
+++ b/crates/listener-core/src/actors/listener/mod.rs
@@ -61,6 +61,12 @@ pub struct ListenerState {
 pub(super) enum ChannelSender {
     Single(tokio::sync::mpsc::Sender<MixedMessage<Bytes, ControlMessage>>),
     Dual(tokio::sync::mpsc::Sender<MixedMessage<(Bytes, Bytes), ControlMessage>>),
+    Soniqo(tokio::sync::mpsc::Sender<SoniqoAudioMsg>),
+}
+
+pub(super) enum SoniqoAudioMsg {
+    Single(hypr_transcribe_soniqo::TranscriptSource, Bytes),
+    Dual(Bytes, Bytes),
 }
 
 pub struct ListenerActor;
@@ -176,17 +182,31 @@ impl Actor for ListenerActor {
         let _guard = span.enter();
 
         match message {
-            ListenerMsg::AudioSingle(audio) => {
-                if let ChannelSender::Single(tx) = &state.tx {
+            ListenerMsg::AudioSingle(audio) => match &state.tx {
+                ChannelSender::Single(tx) => {
                     let _ = tx.try_send(MixedMessage::Audio(audio));
                 }
-            }
+                ChannelSender::Soniqo(tx) => {
+                    let source =
+                        if matches!(state.args.mode, crate::actors::ChannelMode::SpeakerOnly) {
+                            hypr_transcribe_soniqo::TranscriptSource::System
+                        } else {
+                            hypr_transcribe_soniqo::TranscriptSource::Microphone
+                        };
+                    let _ = tx.try_send(SoniqoAudioMsg::Single(source, audio));
+                }
+                ChannelSender::Dual(_) => {}
+            },
 
-            ListenerMsg::AudioDual(mic, spk) => {
-                if let ChannelSender::Dual(tx) = &state.tx {
+            ListenerMsg::AudioDual(mic, spk) => match &state.tx {
+                ChannelSender::Dual(tx) => {
                     let _ = tx.try_send(MixedMessage::Audio((mic, spk)));
                 }
-            }
+                ChannelSender::Soniqo(tx) => {
+                    let _ = tx.try_send(SoniqoAudioMsg::Dual(mic, spk));
+                }
+                ChannelSender::Single(_) => {}
+            },
 
             ListenerMsg::StreamResponse(mut response) => {
                 if let StreamResponse::ErrorResponse {

--- a/crates/listener2-core/Cargo.toml
+++ b/crates/listener2-core/Cargo.toml
@@ -13,6 +13,7 @@ hypr-audio-utils = { workspace = true }
 hypr-denoise = { workspace = true, features = ["onnx"] }
 hypr-host = { workspace = true }
 hypr-language = { workspace = true }
+hypr-transcribe-soniqo = { workspace = true }
 
 bytes = { workspace = true }
 hound = { workspace = true }

--- a/crates/listener2-core/src/batch/mod.rs
+++ b/crates/listener2-core/src/batch/mod.rs
@@ -9,7 +9,7 @@ use owhisper_client::{AdapterKind, OpenAIAdapter};
 use crate::{BatchEvent, BatchRuntime};
 
 use progressive::run_progressive_batch_session;
-use simple::run_direct_batch_for_adapter_kind;
+use simple::{run_direct_batch_for_adapter_kind, run_soniqo_batch};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, strum::Display, strum::EnumString)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
@@ -33,6 +33,7 @@ pub enum BatchProvider {
     Hyprnote,
     Am,
     Cactus,
+    Soniqo,
     AquaVoice,
 }
 
@@ -51,7 +52,7 @@ impl BatchProvider {
             Self::Mistral => Some(AdapterKind::Mistral),
             Self::Hyprnote => Some(AdapterKind::Hyprnote),
             Self::AquaVoice => Some(AdapterKind::AquaVoice),
-            Self::Am | Self::WhisperLocal | Self::Cactus | Self::DashScope => None,
+            Self::Am | Self::WhisperLocal | Self::Cactus | Self::Soniqo | Self::DashScope => None,
         }
     }
 }
@@ -179,6 +180,7 @@ async fn run_batch_inner(
         BatchProvider::WhisperLocal | BatchProvider::Cactus => {
             run_progressive_batch_session(runtime, params, listen_params).await
         }
+        BatchProvider::Soniqo => run_soniqo_batch(params, listen_params).await,
         BatchProvider::OpenAI => {
             if OpenAIAdapter::supports_progressive_batch_model(listen_params.model.as_deref()) {
                 run_progressive_batch_session(runtime, params, listen_params).await

--- a/crates/listener2-core/src/batch/simple.rs
+++ b/crates/listener2-core/src/batch/simple.rs
@@ -89,3 +89,61 @@ async fn run_direct_batch<A: BatchSttAdapter>(
     .instrument(span)
     .await
 }
+
+pub(super) async fn run_soniqo_batch(
+    params: BatchParams,
+    listen_params: owhisper_interface::ListenParams,
+) -> crate::Result<BatchRunOutput> {
+    let span = session_span(&params.session_id);
+
+    async {
+        let model = listen_params
+            .model
+            .as_deref()
+            .ok_or_else(|| crate::BatchFailure::DirectRequestFailed {
+                provider: "soniqo".to_string(),
+                message: "Missing Soniqo model.".to_string(),
+            })?
+            .parse::<hypr_transcribe_soniqo::SoniqoModel>()
+            .map_err(|e| crate::BatchFailure::DirectRequestFailed {
+                provider: "soniqo".to_string(),
+                message: e.to_string(),
+            })?;
+
+        let file_path = params.file_path.clone();
+        let language = listen_params
+            .languages
+            .first()
+            .map(hypr_language::Language::bcp47_code);
+
+        let transcribed = tokio::task::spawn_blocking(move || {
+            hypr_transcribe_soniqo::transcribe_file(model, file_path, language.as_deref())
+        })
+        .await
+        .map_err(|e| crate::BatchFailure::DirectRequestFailed {
+            provider: "soniqo".to_string(),
+            message: format!("Soniqo transcription task failed: {e}"),
+        })?
+        .map_err(|e| {
+            let raw_error = e.to_string();
+            crate::BatchFailure::DirectRequestFailed {
+                provider: "soniqo".to_string(),
+                message: format_user_friendly_error(&raw_error),
+            }
+        })?;
+
+        let response = hypr_transcribe_soniqo::batch_response_from_text(
+            model,
+            transcribed.text,
+            transcribed.duration_seconds,
+        );
+
+        Ok(BatchRunOutput {
+            session_id: params.session_id,
+            mode: BatchRunMode::Direct,
+            response,
+        })
+    }
+    .instrument(span)
+    .await
+}

--- a/crates/listener2-core/src/lib.rs
+++ b/crates/listener2-core/src/lib.rs
@@ -21,7 +21,26 @@ pub fn is_supported_languages_batch(
     model: Option<&str>,
     languages: &[hypr_language::Language],
 ) -> std::result::Result<bool, String> {
-    if provider == "custom" || provider == "hyprnote" {
+    if provider == "custom" {
+        return Ok(true);
+    }
+
+    if provider == "soniqo" {
+        let model = model
+            .ok_or_else(|| "missing_model: soniqo".to_string())?
+            .parse::<hypr_transcribe_soniqo::SoniqoModel>()
+            .map_err(|e| e.to_string())?;
+
+        return Ok(model.supports_languages(languages));
+    }
+
+    if provider == "hyprnote" {
+        if let Some(model) =
+            model.and_then(|model| model.parse::<hypr_transcribe_soniqo::SoniqoModel>().ok())
+        {
+            return Ok(model.supports_languages(languages));
+        }
+
         return Ok(true);
     }
 
@@ -64,4 +83,47 @@ pub fn suggest_providers_for_languages_batch(languages: &[hypr_language::Languag
 
 pub fn list_documented_language_codes_batch() -> Vec<String> {
     owhisper_client::documented_language_codes_batch()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn soniqo_batch_rejects_non_english_for_parakeet() {
+        let languages = vec!["fr".parse().unwrap()];
+
+        assert_eq!(
+            is_supported_languages_batch("soniqo", Some("soniqo-parakeet-batch"), &languages)
+                .unwrap(),
+            false
+        );
+    }
+
+    #[test]
+    fn hyprnote_soniqo_batch_rejects_non_english_for_parakeet() {
+        let languages = vec!["fr".parse().unwrap()];
+
+        assert_eq!(
+            is_supported_languages_batch("hyprnote", Some("soniqo-parakeet-batch"), &languages)
+                .unwrap(),
+            false
+        );
+    }
+
+    #[test]
+    fn soniqo_batch_accepts_non_english_for_multilingual_models() {
+        let languages = vec!["fr".parse().unwrap()];
+
+        assert!(
+            is_supported_languages_batch("soniqo", Some("soniqo-omnilingual"), &languages).unwrap()
+        );
+    }
+
+    #[test]
+    fn hyprnote_non_soniqo_batch_keeps_existing_language_support() {
+        let languages = vec!["fr".parse().unwrap()];
+
+        assert!(is_supported_languages_batch("hyprnote", Some("cloud"), &languages).unwrap());
+    }
 }

--- a/crates/local-model/Cargo.toml
+++ b/crates/local-model/Cargo.toml
@@ -8,6 +8,7 @@ hypr-am = { workspace = true }
 hypr-cactus-model = { workspace = true }
 hypr-file = { workspace = true }
 hypr-model-downloader = { workspace = true }
+hypr-transcribe-soniqo = { workspace = true }
 hypr-whisper-local-model = { workspace = true }
 
 serde = { workspace = true }

--- a/crates/local-model/src/lib.rs
+++ b/crates/local-model/src/lib.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 pub use hypr_am::AmModel;
 pub use hypr_cactus_model::{CactusLlmModel, CactusModel, CactusModelSource, CactusSttModel};
 use hypr_model_downloader::{DownloadableModel, Error, extract_zip};
+pub use hypr_transcribe_soniqo::SoniqoModel;
 pub use hypr_whisper_local_model::WhisperModel;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type, Eq, Hash, PartialEq)]
@@ -78,6 +79,7 @@ pub enum LocalModelKind {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, specta::Type, Eq, Hash, PartialEq)]
 #[serde(untagged)]
 pub enum LocalModel {
+    Soniqo(SoniqoModel),
     Cactus(CactusSttModel),
     Whisper(WhisperModel),
     Am(AmModel),
@@ -88,6 +90,7 @@ pub enum LocalModel {
 impl std::fmt::Display for LocalModel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            LocalModel::Soniqo(model) => write!(f, "{model}"),
             LocalModel::Cactus(model) => write!(f, "{model}"),
             LocalModel::Whisper(model) => write!(f, "whisper-{model}"),
             LocalModel::Am(model) => write!(f, "am-{model}"),
@@ -99,7 +102,13 @@ impl std::fmt::Display for LocalModel {
 
 impl LocalModel {
     pub fn all() -> Vec<LocalModel> {
-        let mut models = vec![
+        let mut models = SoniqoModel::all()
+            .iter()
+            .copied()
+            .map(LocalModel::Soniqo)
+            .collect::<Vec<_>>();
+
+        models.extend([
             LocalModel::Whisper(WhisperModel::QuantizedTiny),
             LocalModel::Whisper(WhisperModel::QuantizedTinyEn),
             LocalModel::Whisper(WhisperModel::QuantizedBase),
@@ -110,7 +119,7 @@ impl LocalModel {
             LocalModel::Am(AmModel::ParakeetV2),
             LocalModel::Am(AmModel::ParakeetV3),
             LocalModel::Am(AmModel::WhisperLargeV3),
-        ];
+        ]);
 
         models.extend(
             CactusSttModel::all()
@@ -135,6 +144,7 @@ impl LocalModel {
 
     pub fn kind(&self) -> &'static str {
         match self {
+            LocalModel::Soniqo(_) => "stt-soniqo",
             LocalModel::Whisper(_) => "stt-whisper",
             LocalModel::Am(_) => "stt-am",
             LocalModel::Cactus(_) => "stt-cactus",
@@ -145,15 +155,17 @@ impl LocalModel {
 
     pub fn model_kind(&self) -> LocalModelKind {
         match self {
-            LocalModel::Whisper(_) | LocalModel::Am(_) | LocalModel::Cactus(_) => {
-                LocalModelKind::Stt
-            }
+            LocalModel::Soniqo(_)
+            | LocalModel::Whisper(_)
+            | LocalModel::Am(_)
+            | LocalModel::Cactus(_) => LocalModelKind::Stt,
             LocalModel::GgufLlm(_) | LocalModel::CactusLlm(_) => LocalModelKind::Llm,
         }
     }
 
     pub fn cli_name(&self) -> &'static str {
         match self {
+            LocalModel::Soniqo(model) => model.as_str(),
             LocalModel::Whisper(WhisperModel::QuantizedTiny) => "whisper-tiny",
             LocalModel::Whisper(WhisperModel::QuantizedTinyEn) => "whisper-tiny-en",
             LocalModel::Whisper(WhisperModel::QuantizedBase) => "whisper-base",
@@ -205,6 +217,7 @@ impl LocalModel {
 
     pub fn install_path(&self, models_base: &Path) -> PathBuf {
         match self {
+            LocalModel::Soniqo(model) => models_base.join("soniqo").join(model.as_str()),
             LocalModel::Whisper(model) => models_base.join("stt").join(model.file_name()),
             LocalModel::Am(model) => models_base.join("stt").join(model.model_dir()),
             LocalModel::Cactus(model) => models_base
@@ -219,6 +232,7 @@ impl LocalModel {
 
     pub fn display_name(&self) -> String {
         match self {
+            LocalModel::Soniqo(model) => model.display_name().to_string(),
             LocalModel::Whisper(model) => model.display_name().to_string(),
             LocalModel::Am(model) => model.display_name().to_string(),
             LocalModel::Cactus(model) => model.display_name().to_string(),
@@ -229,6 +243,7 @@ impl LocalModel {
 
     pub fn description(&self) -> String {
         match self {
+            LocalModel::Soniqo(model) => model.description().to_string(),
             LocalModel::Whisper(model) => model.description(),
             LocalModel::Am(model) => model.description().to_string(),
             LocalModel::Cactus(model) => model.description().to_string(),
@@ -242,6 +257,7 @@ impl LocalModel {
         let is_apple_silicon = cfg!(target_arch = "aarch64") && cfg!(target_os = "macos");
 
         match self {
+            LocalModel::Soniqo(_) => is_apple_silicon,
             LocalModel::Whisper(_) => is_macos,
             LocalModel::Am(_) => is_apple_silicon,
             LocalModel::Cactus(model) => {
@@ -307,6 +323,7 @@ impl DownloadableModel for GgufLlmModel {
 impl DownloadableModel for LocalModel {
     fn download_key(&self) -> String {
         match self {
+            LocalModel::Soniqo(model) => format!("soniqo:{}", model.as_str()),
             LocalModel::Cactus(model) => {
                 format!("cactus:{}", CactusModel::Stt(model.clone()).asset_id())
             }
@@ -321,6 +338,7 @@ impl DownloadableModel for LocalModel {
 
     fn download_url(&self) -> Option<String> {
         match self {
+            LocalModel::Soniqo(_) => None,
             LocalModel::Cactus(model) => CactusModel::Stt(model.clone())
                 .model_url()
                 .map(ToString::to_string),
@@ -335,6 +353,7 @@ impl DownloadableModel for LocalModel {
 
     fn download_checksum(&self) -> Option<u32> {
         match self {
+            LocalModel::Soniqo(_) => None,
             LocalModel::Cactus(model) => CactusModel::Stt(model.clone()).checksum(),
             LocalModel::Whisper(model) => Some(model.checksum()),
             LocalModel::Am(model) => Some(model.tar_checksum()),
@@ -345,6 +364,7 @@ impl DownloadableModel for LocalModel {
 
     fn download_destination(&self, models_base: &Path) -> PathBuf {
         match self {
+            LocalModel::Soniqo(model) => models_base.join("soniqo").join(model.as_str()),
             LocalModel::Cactus(model) => models_base
                 .join("cactus")
                 .join(CactusModel::Stt(model.clone()).zip_name()),
@@ -361,6 +381,8 @@ impl DownloadableModel for LocalModel {
 
     fn is_downloaded(&self, models_base: &Path) -> Result<bool, Error> {
         match self {
+            LocalModel::Soniqo(model) => hypr_transcribe_soniqo::is_model_downloaded(*model)
+                .map_err(|e| Error::OperationFailed(e.to_string())),
             LocalModel::Cactus(model) => {
                 let model_dir = models_base
                     .join("cactus")
@@ -391,6 +413,7 @@ impl DownloadableModel for LocalModel {
 
     fn finalize_download(&self, downloaded_path: &Path, models_base: &Path) -> Result<(), Error> {
         match self {
+            LocalModel::Soniqo(_) => Ok(()),
             LocalModel::Cactus(model) => {
                 let output_dir = models_base
                     .join("cactus")
@@ -418,6 +441,8 @@ impl DownloadableModel for LocalModel {
 
     fn delete_downloaded(&self, models_base: &Path) -> Result<(), Error> {
         match self {
+            LocalModel::Soniqo(model) => hypr_transcribe_soniqo::delete_model(*model)
+                .map_err(|e| Error::DeleteFailed(e.to_string())),
             LocalModel::Cactus(model) => {
                 let model_dir = models_base
                     .join("cactus")

--- a/crates/transcribe-soniqo/Cargo.toml
+++ b/crates/transcribe-soniqo/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "transcribe-soniqo"
+version = "0.1.0"
+edition = "2024"
+
+[build-dependencies]
+
+[dependencies]
+hypr-language = { workspace = true }
+owhisper-interface = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+specta = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.build-dependencies]
+swift-rs = { workspace = true, features = ["build"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+swift-rs = { workspace = true }

--- a/crates/transcribe-soniqo/build.rs
+++ b/crates/transcribe-soniqo/build.rs
@@ -1,0 +1,64 @@
+#[cfg(target_os = "macos")]
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[cfg(target_os = "macos")]
+fn swift_runtime_rpaths() -> Vec<String> {
+    let mut paths = BTreeSet::from([PathBuf::from("/usr/lib/swift")]);
+
+    if let Some(swift_bin) = swift_bin_path()
+        && let Some(toolchain_root) = swift_bin
+            .parent()
+            .and_then(Path::parent)
+            .and_then(Path::parent)
+    {
+        paths.insert(toolchain_root.join("lib/swift/macosx"));
+    }
+
+    paths
+        .into_iter()
+        .filter(|path| path.exists())
+        .map(|path| path.display().to_string())
+        .collect()
+}
+
+#[cfg(target_os = "macos")]
+fn swift_bin_path() -> Option<PathBuf> {
+    let output = Command::new("xcrun")
+        .args(["--find", "swift"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let path = String::from_utf8(output.stdout).ok()?;
+    let path = path.trim();
+    (!path.is_empty()).then(|| PathBuf::from(path))
+}
+
+fn main() {
+    #[cfg(target_os = "macos")]
+    {
+        swift_rs::SwiftLinker::new("15.0")
+            .with_package("soniqo-swift", "./swift-lib/")
+            .link();
+
+        for path in swift_runtime_rpaths() {
+            println!("cargo:rustc-link-arg=-Wl,-rpath,{path}");
+        }
+
+        println!("cargo:rustc-link-lib=c++");
+        println!("cargo:rerun-if-changed=swift-lib/src");
+        println!("cargo:rerun-if-changed=swift-lib/Package.swift");
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        println!("cargo:warning=Soniqo speech-swift linking is only available on macOS");
+    }
+}

--- a/crates/transcribe-soniqo/src/lib.rs
+++ b/crates/transcribe-soniqo/src/lib.rs
@@ -3,6 +3,12 @@ use std::str::FromStr;
 
 use owhisper_interface::{batch, stream};
 
+pub const LOCAL_BASE_URL: &str = "soniqo://local";
+
+pub fn is_local_base_url(base_url: &str) -> bool {
+    base_url.trim_end_matches('/') == LOCAL_BASE_URL
+}
+
 #[derive(
     Debug, Clone, Copy, serde::Serialize, serde::Deserialize, specta::Type, Eq, Hash, PartialEq,
 )]

--- a/crates/transcribe-soniqo/src/lib.rs
+++ b/crates/transcribe-soniqo/src/lib.rs
@@ -1,0 +1,700 @@
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use owhisper_interface::{batch, stream};
+
+#[derive(
+    Debug, Clone, Copy, serde::Serialize, serde::Deserialize, specta::Type, Eq, Hash, PartialEq,
+)]
+pub enum SoniqoModel {
+    #[serde(rename = "soniqo-parakeet-streaming")]
+    ParakeetStreaming,
+    #[serde(rename = "soniqo-parakeet-batch")]
+    ParakeetBatch,
+    #[serde(rename = "soniqo-omnilingual")]
+    Omnilingual,
+    #[serde(rename = "soniqo-qwen3-small")]
+    Qwen3Small,
+    #[serde(rename = "soniqo-qwen3-large")]
+    Qwen3Large,
+}
+
+impl SoniqoModel {
+    pub const fn all() -> &'static [Self] {
+        &[
+            Self::ParakeetStreaming,
+            Self::ParakeetBatch,
+            Self::Omnilingual,
+            Self::Qwen3Small,
+            Self::Qwen3Large,
+        ]
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ParakeetStreaming => "soniqo-parakeet-streaming",
+            Self::ParakeetBatch => "soniqo-parakeet-batch",
+            Self::Omnilingual => "soniqo-omnilingual",
+            Self::Qwen3Small => "soniqo-qwen3-small",
+            Self::Qwen3Large => "soniqo-qwen3-large",
+        }
+    }
+
+    pub const fn repo(self) -> &'static str {
+        match self {
+            Self::ParakeetStreaming => "aufklarer/Parakeet-EOU-120M-CoreML-INT8",
+            Self::ParakeetBatch => "aufklarer/Parakeet-TDT-v3-CoreML-INT8",
+            Self::Omnilingual => "aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s",
+            Self::Qwen3Small => "aufklarer/Qwen3-ASR-0.6B-MLX-4bit",
+            Self::Qwen3Large => "aufklarer/Qwen3-ASR-1.7B-MLX-8bit",
+        }
+    }
+
+    pub const fn display_name(self) -> &'static str {
+        match self {
+            Self::ParakeetStreaming => "Soniqo Parakeet Streaming",
+            Self::ParakeetBatch => "Soniqo Parakeet Batch",
+            Self::Omnilingual => "Soniqo Omnilingual",
+            Self::Qwen3Small => "Soniqo Qwen3 0.6B",
+            Self::Qwen3Large => "Soniqo Qwen3 1.7B",
+        }
+    }
+
+    pub const fn description(self) -> &'static str {
+        match self {
+            Self::ParakeetStreaming => "English realtime transcription.",
+            Self::ParakeetBatch => "English batch transcription.",
+            Self::Omnilingual => "Multilingual batch transcription.",
+            Self::Qwen3Small => "Multilingual batch transcription.",
+            Self::Qwen3Large => "Multilingual batch transcription.",
+        }
+    }
+
+    pub const fn size_bytes(self) -> u64 {
+        match self {
+            Self::ParakeetStreaming => 120 * 1024 * 1024,
+            Self::ParakeetBatch => 600 * 1024 * 1024,
+            Self::Omnilingual => 300 * 1024 * 1024,
+            Self::Qwen3Small => 600 * 1024 * 1024,
+            Self::Qwen3Large => 1_700 * 1024 * 1024,
+        }
+    }
+
+    pub const fn supports_live(self) -> bool {
+        matches!(self, Self::ParakeetStreaming)
+    }
+
+    pub fn supports_language(self, language: &hypr_language::Language) -> bool {
+        match self {
+            Self::ParakeetStreaming | Self::ParakeetBatch => {
+                language.iso639() == hypr_language::ISO639::En
+            }
+            Self::Omnilingual | Self::Qwen3Small | Self::Qwen3Large => true,
+        }
+    }
+
+    pub fn supports_languages(self, languages: &[hypr_language::Language]) -> bool {
+        languages
+            .iter()
+            .all(|language| self.supports_language(language))
+    }
+}
+
+impl std::fmt::Display for SoniqoModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for SoniqoModel {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        Self::all()
+            .iter()
+            .copied()
+            .find(|model| value == model.as_str() || value == model.repo())
+            .ok_or_else(|| Error::UnsupportedModel(value.to_string()))
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelDownloadState {
+    pub status: String,
+    pub current_file: Option<String>,
+    pub progress_percent: Option<u8>,
+    pub local_path: String,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileTranscript {
+    pub text: String,
+    pub duration_seconds: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TranscriptSource {
+    Microphone,
+    System,
+}
+
+impl TranscriptSource {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Microphone => "microphone",
+            Self::System => "system",
+        }
+    }
+
+    pub const fn channel_index(self) -> i32 {
+        match self {
+            Self::Microphone => 0,
+            Self::System => 1,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LivePartial {
+    pub source: String,
+    pub text: String,
+    pub is_final: bool,
+}
+
+impl LivePartial {
+    pub fn source(&self) -> TranscriptSource {
+        match self.source.as_str() {
+            "system" => TranscriptSource::System,
+            _ => TranscriptSource::Microphone,
+        }
+    }
+
+    pub fn into_stream_response(
+        self,
+        model: SoniqoModel,
+        start: f64,
+        duration: f64,
+    ) -> stream::StreamResponse {
+        let source = self.source();
+        stream_response_from_text(
+            model,
+            self.text,
+            start,
+            duration,
+            self.is_final,
+            &[source.channel_index(), 2],
+        )
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("unsupported Soniqo model: {0}")]
+    UnsupportedModel(String),
+    #[error("Soniqo is only available on macOS")]
+    UnsupportedPlatform,
+    #[error("Soniqo bridge failed: {0}")]
+    Bridge(String),
+    #[error("failed to parse Soniqo bridge response: {0}")]
+    ResponseParse(#[from] serde_json::Error),
+    #[error("failed to delete Soniqo model: {0}")]
+    Delete(std::io::Error),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub fn model_cache_dir(model: SoniqoModel) -> Result<PathBuf> {
+    platform::model_cache_dir(model)
+}
+
+pub fn model_download_state(model: SoniqoModel) -> Result<ModelDownloadState> {
+    platform::model_download_state(model)
+}
+
+pub fn start_model_download(model: SoniqoModel) -> Result<()> {
+    platform::start_model_download(model)
+}
+
+pub fn reset_model(model: SoniqoModel) -> Result<()> {
+    platform::reset_model(model)
+}
+
+pub fn is_model_downloaded(model: SoniqoModel) -> Result<bool> {
+    Ok(model_download_state(model)?.status == "ready")
+}
+
+pub fn is_model_downloading(model: SoniqoModel) -> Result<bool> {
+    Ok(model_download_state(model)?.status == "downloading")
+}
+
+pub fn delete_model(model: SoniqoModel) -> Result<()> {
+    reset_model(model)?;
+
+    let cache_dir = model_cache_dir(model)?;
+    if cache_dir.exists() {
+        std::fs::remove_dir_all(&cache_dir).map_err(Error::Delete)?;
+    }
+
+    Ok(())
+}
+
+pub fn transcribe_file(
+    model: SoniqoModel,
+    path: impl AsRef<Path>,
+    language: Option<&str>,
+) -> Result<FileTranscript> {
+    platform::transcribe_file(model, path.as_ref(), language.unwrap_or_default())
+}
+
+pub struct LiveTranscriptionSession {
+    model: SoniqoModel,
+    stopped: bool,
+}
+
+impl LiveTranscriptionSession {
+    pub fn start(model: SoniqoModel) -> Result<Self> {
+        if !model.supports_live() {
+            return Err(Error::Bridge(format!(
+                "{} does not support realtime transcription",
+                model.display_name()
+            )));
+        }
+
+        platform::live_start(model)?;
+        Ok(Self {
+            model,
+            stopped: false,
+        })
+    }
+
+    pub fn append(
+        &mut self,
+        source: TranscriptSource,
+        samples: &[f32],
+    ) -> Result<Vec<LivePartial>> {
+        platform::live_append(source, samples)
+    }
+
+    pub fn model(&self) -> SoniqoModel {
+        self.model
+    }
+
+    pub fn stop(mut self) -> Result<()> {
+        self.stopped = true;
+        platform::live_stop()
+    }
+}
+
+impl Drop for LiveTranscriptionSession {
+    fn drop(&mut self) {
+        if !self.stopped {
+            let _ = platform::live_stop();
+        }
+    }
+}
+
+pub fn stream_response_from_text(
+    model: SoniqoModel,
+    text: String,
+    start: f64,
+    duration: f64,
+    is_final: bool,
+    channel_index: &[i32],
+) -> stream::StreamResponse {
+    let duration = duration.max(0.05);
+    let words = stream_words_from_text(&text, start, duration);
+
+    stream::StreamResponse::TranscriptResponse {
+        start,
+        duration,
+        is_final,
+        speech_final: is_final,
+        from_finalize: false,
+        channel: stream::Channel {
+            alternatives: vec![stream::Alternatives {
+                transcript: text,
+                words,
+                confidence: 1.0,
+                languages: vec![],
+            }],
+        },
+        metadata: metadata(model),
+        channel_index: channel_index.to_vec(),
+    }
+}
+
+pub fn batch_response_from_text(
+    model: SoniqoModel,
+    text: String,
+    duration_seconds: f64,
+) -> batch::Response {
+    let duration_seconds = duration_seconds.max(0.05);
+    let metadata = metadata_json(model, duration_seconds, 1);
+    let words = batch_words_from_text(&text, duration_seconds, 0);
+
+    batch::Response {
+        metadata,
+        results: batch::Results {
+            channels: vec![batch::Channel {
+                alternatives: vec![batch::Alternatives {
+                    transcript: text,
+                    confidence: 1.0,
+                    words,
+                }],
+            }],
+        },
+    }
+}
+
+fn metadata(model: SoniqoModel) -> stream::Metadata {
+    stream::Metadata {
+        model_info: stream::ModelInfo {
+            name: model.as_str().to_string(),
+            version: "0.0.9".to_string(),
+            arch: "soniqo".to_string(),
+        },
+        extra: Some(stream::Extra::default().into()),
+        ..Default::default()
+    }
+}
+
+fn metadata_json(model: SoniqoModel, duration_seconds: f64, channels: u32) -> serde_json::Value {
+    let mut value = serde_json::to_value(metadata(model)).unwrap_or_else(|_| serde_json::json!({}));
+    if let Some(object) = value.as_object_mut() {
+        object.insert("duration".to_string(), serde_json::json!(duration_seconds));
+        object.insert("channels".to_string(), serde_json::json!(channels));
+    }
+    value
+}
+
+fn stream_words_from_text(text: &str, start: f64, duration: f64) -> Vec<stream::Word> {
+    let word_strs = split_words(text);
+    let count = word_strs.len();
+
+    if count == 0 {
+        return Vec::new();
+    }
+
+    word_strs
+        .into_iter()
+        .enumerate()
+        .map(|(index, word)| {
+            let word_start = start + (index as f64 / count as f64) * duration;
+            let word_end = if index + 1 == count {
+                (start + duration - 0.05).max(word_start + 0.05)
+            } else {
+                start + ((index + 1) as f64 / count as f64) * duration
+            };
+
+            stream::Word {
+                word: word.to_string(),
+                start: word_start,
+                end: word_end,
+                confidence: 1.0,
+                speaker: None,
+                punctuated_word: Some(word.to_string()),
+                language: None,
+            }
+        })
+        .collect()
+}
+
+fn batch_words_from_text(text: &str, duration: f64, channel: i32) -> Vec<batch::Word> {
+    let word_strs = split_words(text);
+    let count = word_strs.len();
+
+    if count == 0 {
+        return Vec::new();
+    }
+
+    word_strs
+        .into_iter()
+        .enumerate()
+        .map(|(index, word)| batch::Word {
+            word: word.to_string(),
+            start: (index as f64 / count as f64) * duration,
+            end: ((index + 1) as f64 / count as f64) * duration,
+            confidence: 1.0,
+            channel,
+            speaker: None,
+            punctuated_word: Some(word.to_string()),
+        })
+        .collect()
+}
+
+fn split_words(text: &str) -> Vec<&str> {
+    text.split_whitespace()
+        .filter(|word| !word.is_empty())
+        .collect()
+}
+
+#[cfg(target_os = "macos")]
+mod platform {
+    use super::*;
+    use swift_rs::{Bool, SRData, SRString, swift};
+
+    swift!(fn _soniqo_model_cache_dir(model_id: &SRString) -> SRString);
+    swift!(fn _soniqo_model_download_state(model_id: &SRString) -> SRString);
+    swift!(fn _soniqo_model_start_download(model_id: &SRString) -> Bool);
+    swift!(fn _soniqo_model_reset(model_id: &SRString) -> Bool);
+    swift!(fn _soniqo_transcribe_audio_file(
+        model_id: &SRString,
+        audio_path: &SRString,
+        language: &SRString
+    ) -> SRString);
+    swift!(fn _soniqo_live_start(model_id: &SRString) -> SRString);
+    swift!(fn _soniqo_live_append(source: &SRString, samples: &SRData) -> SRString);
+    swift!(fn _soniqo_live_stop() -> SRString);
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct FileTranscriptionPayload {
+        text: String,
+        duration_seconds: f64,
+        error: Option<String>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct LiveAppendPayload {
+        partials: Vec<LivePartial>,
+        error: Option<String>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct StatusPayload {
+        running: bool,
+        error: Option<String>,
+    }
+
+    pub(super) fn model_cache_dir(model: SoniqoModel) -> Result<PathBuf> {
+        let model_id = sr_string(model.as_str());
+        let path = unsafe { _soniqo_model_cache_dir(&model_id) };
+        let path = path.as_str().to_string();
+
+        if path.is_empty() {
+            return Err(Error::Bridge(format!(
+                "cache path unavailable for {}",
+                model.as_str()
+            )));
+        }
+
+        Ok(PathBuf::from(path))
+    }
+
+    pub(super) fn model_download_state(model: SoniqoModel) -> Result<ModelDownloadState> {
+        let model_id = sr_string(model.as_str());
+        let payload = unsafe { _soniqo_model_download_state(&model_id) };
+        let state: ModelDownloadState = serde_json::from_str(payload.as_str())?;
+
+        Ok(state)
+    }
+
+    pub(super) fn start_model_download(model: SoniqoModel) -> Result<()> {
+        let model_id = sr_string(model.as_str());
+        if unsafe { _soniqo_model_start_download(&model_id) } {
+            Ok(())
+        } else {
+            Err(Error::Bridge(format!(
+                "failed to start Soniqo download for {}",
+                model.as_str()
+            )))
+        }
+    }
+
+    pub(super) fn reset_model(model: SoniqoModel) -> Result<()> {
+        let model_id = sr_string(model.as_str());
+        if unsafe { _soniqo_model_reset(&model_id) } {
+            Ok(())
+        } else {
+            Err(Error::Bridge(format!(
+                "failed to reset Soniqo model {}",
+                model.as_str()
+            )))
+        }
+    }
+
+    pub(super) fn transcribe_file(
+        model: SoniqoModel,
+        path: &Path,
+        language: &str,
+    ) -> Result<FileTranscript> {
+        let model_id = sr_string(model.as_str());
+        let audio_path = sr_string(&path.to_string_lossy());
+        let language = sr_string(language);
+        let payload = unsafe { _soniqo_transcribe_audio_file(&model_id, &audio_path, &language) };
+        let result: FileTranscriptionPayload = serde_json::from_str(payload.as_str())?;
+
+        if let Some(error) = result.error {
+            return Err(Error::Bridge(error));
+        }
+
+        Ok(FileTranscript {
+            text: result.text,
+            duration_seconds: result.duration_seconds,
+        })
+    }
+
+    pub(super) fn live_start(model: SoniqoModel) -> Result<()> {
+        let model_id = sr_string(model.as_str());
+        let payload = unsafe { _soniqo_live_start(&model_id) };
+        let result: StatusPayload = serde_json::from_str(payload.as_str())?;
+
+        if result.running {
+            Ok(())
+        } else {
+            Err(Error::Bridge(result.error.unwrap_or_else(|| {
+                "failed to start Soniqo live session".to_string()
+            })))
+        }
+    }
+
+    pub(super) fn live_append(
+        source: TranscriptSource,
+        samples: &[f32],
+    ) -> Result<Vec<LivePartial>> {
+        let source = sr_string(source.as_str());
+        let samples = floats_to_sr_data(samples);
+        let payload = unsafe { _soniqo_live_append(&source, &samples) };
+        let result: LiveAppendPayload = serde_json::from_str(payload.as_str())?;
+
+        if let Some(error) = result.error {
+            return Err(Error::Bridge(error));
+        }
+
+        Ok(result.partials)
+    }
+
+    pub(super) fn live_stop() -> Result<()> {
+        let payload = unsafe { _soniqo_live_stop() };
+        let result: StatusPayload = serde_json::from_str(payload.as_str())?;
+
+        if let Some(error) = result.error {
+            return Err(Error::Bridge(error));
+        }
+
+        Ok(())
+    }
+
+    fn sr_string(value: &str) -> SRString {
+        SRString::from(value)
+    }
+
+    fn floats_to_sr_data(samples: &[f32]) -> SRData {
+        let bytes = samples
+            .iter()
+            .flat_map(|sample| sample.to_bits().to_le_bytes())
+            .collect::<Vec<_>>();
+        SRData::from(bytes.as_slice())
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+mod platform {
+    use super::*;
+
+    pub(super) fn model_cache_dir(_model: SoniqoModel) -> Result<PathBuf> {
+        Err(Error::UnsupportedPlatform)
+    }
+
+    pub(super) fn model_download_state(_model: SoniqoModel) -> Result<ModelDownloadState> {
+        Err(Error::UnsupportedPlatform)
+    }
+
+    pub(super) fn start_model_download(_model: SoniqoModel) -> Result<()> {
+        Err(Error::UnsupportedPlatform)
+    }
+
+    pub(super) fn reset_model(_model: SoniqoModel) -> Result<()> {
+        Err(Error::UnsupportedPlatform)
+    }
+
+    pub(super) fn transcribe_file(
+        _model: SoniqoModel,
+        _path: &Path,
+        _language: &str,
+    ) -> Result<FileTranscript> {
+        Err(Error::UnsupportedPlatform)
+    }
+
+    pub(super) fn live_start(_model: SoniqoModel) -> Result<()> {
+        Err(Error::UnsupportedPlatform)
+    }
+
+    pub(super) fn live_append(
+        _source: TranscriptSource,
+        _samples: &[f32],
+    ) -> Result<Vec<LivePartial>> {
+        Err(Error::UnsupportedPlatform)
+    }
+
+    pub(super) fn live_stop() -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_model_ids() {
+        assert_eq!(
+            "soniqo-parakeet-streaming".parse::<SoniqoModel>().unwrap(),
+            SoniqoModel::ParakeetStreaming
+        );
+    }
+
+    #[test]
+    fn parakeet_models_only_support_english() {
+        let english = "en-US".parse().unwrap();
+        let french = "fr".parse().unwrap();
+
+        assert!(SoniqoModel::ParakeetStreaming.supports_language(&english));
+        assert!(SoniqoModel::ParakeetBatch.supports_language(&english));
+        assert!(!SoniqoModel::ParakeetStreaming.supports_language(&french));
+        assert!(!SoniqoModel::ParakeetBatch.supports_language(&french));
+    }
+
+    #[test]
+    fn multilingual_models_support_non_english_languages() {
+        let french = "fr".parse().unwrap();
+
+        assert!(SoniqoModel::Omnilingual.supports_language(&french));
+        assert!(SoniqoModel::Qwen3Small.supports_language(&french));
+        assert!(SoniqoModel::Qwen3Large.supports_language(&french));
+    }
+
+    #[test]
+    fn batch_response_has_deepgram_shape() {
+        let response =
+            batch_response_from_text(SoniqoModel::ParakeetBatch, "hello world".to_string(), 2.0);
+
+        assert_eq!(
+            response.results.channels[0].alternatives[0].transcript,
+            "hello world"
+        );
+        assert_eq!(response.results.channels[0].alternatives[0].words.len(), 2);
+        assert_eq!(response.metadata["model_info"]["arch"], "soniqo");
+        assert_eq!(response.metadata["duration"], 2.0);
+    }
+
+    #[test]
+    fn live_response_keeps_source_channel() {
+        let partial = LivePartial {
+            source: "system".to_string(),
+            text: "hello".to_string(),
+            is_final: true,
+        };
+
+        let response = partial.into_stream_response(SoniqoModel::ParakeetStreaming, 0.0, 0.5);
+        let stream::StreamResponse::TranscriptResponse { channel_index, .. } = response else {
+            panic!("expected transcript response");
+        };
+
+        assert_eq!(channel_index, vec![1, 2]);
+    }
+}

--- a/crates/transcribe-soniqo/swift-lib/Package.resolved
+++ b/crates/transcribe-soniqo/swift-lib/Package.resolved
@@ -1,0 +1,328 @@
+{
+  "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
+      }
+    },
+    {
+      "identity" : "compress-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/adam-fowler/compress-nio.git",
+      "state" : {
+        "revision" : "e1caa19077dda4b00441142ef57da3db02acd466",
+        "version" : "1.4.2"
+      }
+    },
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "hummingbird",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hummingbird-project/hummingbird.git",
+      "state" : {
+        "revision" : "3ae359b1bb1e72378ed43b59fdcd4d44cac5d7a4",
+        "version" : "2.16.0"
+      }
+    },
+    {
+      "identity" : "hummingbird-websocket",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hummingbird-project/hummingbird-websocket.git",
+      "state" : {
+        "revision" : "716c54294152c6d3301a6239a1d74db57cbcd6dc",
+        "version" : "2.6.0"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift",
+      "state" : {
+        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
+        "version" : "0.31.3"
+      }
+    },
+    {
+      "identity" : "speech-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/soniqo/speech-swift",
+      "state" : {
+        "revision" : "03920e17671fc79d59da1573923958304e233c42",
+        "version" : "0.0.9"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "9d349bcc328ac3c31ce40e746b5882742a0d1272",
+        "version" : "1.1.3"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
+        "version" : "1.19.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
+        "version" : "2.3.5"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "d51c8d13fa366eec807eedb4e37daa60ff5bfdd5",
+        "version" : "2.10.1"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
+        "version" : "1.34.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
+        "version" : "1.43.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-rs",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Brendonovich/swift-rs",
+      "state" : {
+        "revision" : "01980f981bc642a6da382cc0788f18fdd4cde6df"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "revision" : "b38443e44d93eca770f2eb68e2a4d0fa100f9aa2",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-websocket",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hummingbird-project/swift-websocket.git",
+      "state" : {
+        "revision" : "ca48d46c25f8fa948d37eaa480c73172182cf90f",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/crates/transcribe-soniqo/swift-lib/Package.swift
+++ b/crates/transcribe-soniqo/swift-lib/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version:5.9
+
+import PackageDescription
+
+let package = Package(
+  name: "soniqo-swift",
+  platforms: [.macOS("15.0")],
+  products: [
+    .library(
+      name: "soniqo-swift",
+      type: .static,
+      targets: ["swift-lib"])
+  ],
+  dependencies: [
+    .package(
+      url: "https://github.com/Brendonovich/swift-rs",
+      revision: "01980f981bc642a6da382cc0788f18fdd4cde6df"),
+    .package(url: "https://github.com/soniqo/speech-swift", exact: "0.0.9"),
+  ],
+  targets: [
+    .target(
+      name: "swift-lib",
+      dependencies: [
+        .product(name: "AudioCommon", package: "speech-swift"),
+        .product(name: "OmnilingualASR", package: "speech-swift"),
+        .product(name: "ParakeetASR", package: "speech-swift"),
+        .product(name: "ParakeetStreamingASR", package: "speech-swift"),
+        .product(name: "Qwen3ASR", package: "speech-swift"),
+        .product(name: "SwiftRs", package: "swift-rs"),
+      ],
+      path: "src"
+    )
+  ]
+)

--- a/crates/transcribe-soniqo/swift-lib/src/lib.swift
+++ b/crates/transcribe-soniqo/swift-lib/src/lib.swift
@@ -1,0 +1,673 @@
+import AudioCommon
+import Foundation
+import OmnilingualASR
+import ParakeetASR
+import ParakeetStreamingASR
+import Qwen3ASR
+import SwiftRs
+
+private enum SoniqoBridgeError: LocalizedError {
+  case message(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .message(let message):
+      return message
+    }
+  }
+}
+
+private enum SpeechModelKind: String, CaseIterable {
+  case parakeetStreaming = "soniqo-parakeet-streaming"
+  case parakeetBatch = "soniqo-parakeet-batch"
+  case omnilingual = "soniqo-omnilingual"
+  case qwen3Small = "soniqo-qwen3-small"
+  case qwen3Large = "soniqo-qwen3-large"
+
+  static func resolve(_ identifier: String) -> Self? {
+    Self(rawValue: identifier) ?? Self.allCases.first(where: { $0.repo == identifier })
+  }
+
+  var label: String {
+    switch self {
+    case .parakeetStreaming:
+      return "Soniqo Parakeet Streaming"
+    case .parakeetBatch:
+      return "Soniqo Parakeet Batch"
+    case .omnilingual:
+      return "Soniqo Omnilingual"
+    case .qwen3Small:
+      return "Soniqo Qwen3 0.6B"
+    case .qwen3Large:
+      return "Soniqo Qwen3 1.7B"
+    }
+  }
+
+  var repo: String {
+    switch self {
+    case .parakeetStreaming:
+      return "aufklarer/Parakeet-EOU-120M-CoreML-INT8"
+    case .parakeetBatch:
+      return "aufklarer/Parakeet-TDT-v3-CoreML-INT8"
+    case .omnilingual:
+      return "aufklarer/Omnilingual-ASR-CTC-300M-CoreML-INT8-10s"
+    case .qwen3Small:
+      return "aufklarer/Qwen3-ASR-0.6B-MLX-4bit"
+    case .qwen3Large:
+      return "aufklarer/Qwen3-ASR-1.7B-MLX-8bit"
+    }
+  }
+
+  var isStreamingCapable: Bool {
+    self == .parakeetStreaming
+  }
+
+  func cacheDirectoryURL() throws -> URL {
+    try HuggingFaceDownloader.getCacheDirectory(for: repo)
+  }
+
+  func cacheDirectoryPath() -> String {
+    (try? cacheDirectoryURL().path) ?? ""
+  }
+
+  func filesReady() -> Bool {
+    guard let directory = try? cacheDirectoryURL() else {
+      return false
+    }
+
+    switch self {
+    case .parakeetStreaming, .parakeetBatch:
+      return Self.regularFileExists(at: directory.appendingPathComponent("config.json"))
+        && Self.regularFileExists(at: directory.appendingPathComponent("vocab.json"))
+        && Self.compiledCoreMLModelReady(at: directory.appendingPathComponent("encoder.mlmodelc"))
+        && Self.compiledCoreMLModelReady(at: directory.appendingPathComponent("decoder.mlmodelc"))
+        && Self.compiledCoreMLModelReady(at: directory.appendingPathComponent("joint.mlmodelc"))
+    case .omnilingual:
+      return Self.regularFileExists(at: directory.appendingPathComponent("config.json"))
+        && Self.regularFileExists(at: directory.appendingPathComponent("tokenizer.model"))
+        && Self.directoryContainsRegularFile(
+          at: directory.appendingPathComponent("omnilingual-ctc-300m-int8.mlpackage")
+        )
+    case .qwen3Small, .qwen3Large:
+      return Self.regularFileExists(at: directory.appendingPathComponent("vocab.json"))
+        && Self.regularFileExists(at: directory.appendingPathComponent("merges.txt"))
+        && Self.regularFileExists(at: directory.appendingPathComponent("tokenizer_config.json"))
+        && Self.directoryContainsFile(withExtension: "safetensors", in: directory)
+    }
+  }
+
+  func load(progressHandler: ((Double, String) -> Void)?) async throws -> LoadedSpeechModel {
+    let offlineMode = filesReady()
+
+    switch self {
+    case .parakeetStreaming:
+      return .streaming(
+        try await ParakeetStreamingASRModel.fromPretrained(
+          modelId: repo,
+          progressHandler: progressHandler
+        )
+      )
+    case .parakeetBatch:
+      return .parakeetBatch(
+        try await ParakeetASRModel.fromPretrained(
+          modelId: repo,
+          offlineMode: offlineMode,
+          progressHandler: progressHandler
+        )
+      )
+    case .omnilingual:
+      return .omnilingual(
+        try await OmnilingualASRModel.fromPretrained(
+          modelId: repo,
+          offlineMode: offlineMode,
+          progressHandler: progressHandler
+        )
+      )
+    case .qwen3Small, .qwen3Large:
+      return .qwen3(
+        try await Qwen3ASRModel.fromPretrained(
+          modelId: repo,
+          offlineMode: offlineMode,
+          progressHandler: progressHandler
+        )
+      )
+    }
+  }
+
+  private static func regularFileExists(at url: URL) -> Bool {
+    var isDirectory = ObjCBool(false)
+    return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+      && !isDirectory.boolValue
+  }
+
+  private static func compiledCoreMLModelReady(at directory: URL) -> Bool {
+    var isDirectory = ObjCBool(false)
+    guard FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory),
+      isDirectory.boolValue
+    else {
+      return false
+    }
+
+    return regularFileExists(at: directory.appendingPathComponent("model.mil"))
+      && directoryContainsRegularFile(at: directory.appendingPathComponent("weights"))
+  }
+
+  private static func directoryContainsFile(withExtension pathExtension: String, in directory: URL)
+    -> Bool
+  {
+    guard
+      let contents = try? FileManager.default.contentsOfDirectory(
+        at: directory,
+        includingPropertiesForKeys: [.isRegularFileKey]
+      )
+    else {
+      return false
+    }
+
+    return contents.contains { candidate in
+      guard
+        candidate.pathExtension == pathExtension,
+        let values = try? candidate.resourceValues(forKeys: [.isRegularFileKey])
+      else {
+        return false
+      }
+
+      return values.isRegularFile == true
+    }
+  }
+
+  private static func directoryContainsRegularFile(at directory: URL) -> Bool {
+    guard
+      let enumerator = FileManager.default.enumerator(
+        at: directory,
+        includingPropertiesForKeys: [.isRegularFileKey],
+        options: [.skipsHiddenFiles]
+      )
+    else {
+      return false
+    }
+
+    for case let candidate as URL in enumerator {
+      guard let values = try? candidate.resourceValues(forKeys: [.isRegularFileKey]) else {
+        continue
+      }
+
+      if values.isRegularFile == true {
+        return true
+      }
+    }
+
+    return false
+  }
+}
+
+private enum LoadedSpeechModel {
+  case streaming(ParakeetStreamingASRModel)
+  case parakeetBatch(ParakeetASRModel)
+  case omnilingual(OmnilingualASRModel)
+  case qwen3(Qwen3ASRModel)
+
+  func asStreamingModel() throws -> ParakeetStreamingASRModel {
+    guard case .streaming(let model) = self else {
+      throw SoniqoBridgeError.message(
+        "The selected Soniqo model does not support realtime transcription.")
+    }
+
+    return model
+  }
+
+  func transcribe(audio: [Float], sampleRate: Int, language: String?) throws -> String {
+    let normalizedLanguage = language?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let languageHint = (normalizedLanguage?.isEmpty == false) ? normalizedLanguage : nil
+
+    switch self {
+    case .streaming(let model):
+      return try model.transcribeAudio(audio, sampleRate: sampleRate)
+    case .parakeetBatch(let model):
+      return try model.transcribeAudio(audio, sampleRate: sampleRate, language: languageHint)
+    case .omnilingual(let model):
+      return try model.transcribeAudio(audio, sampleRate: sampleRate)
+    case .qwen3(let model):
+      return model.transcribe(audio: audio, sampleRate: sampleRate, language: languageHint)
+    }
+  }
+}
+
+private enum TranscriptSource: String, Codable, CaseIterable {
+  case microphone
+  case system
+}
+
+private struct ModelDownloadPayload: Codable {
+  var status: String
+  var currentFile: String?
+  var progressPercent: Int?
+  var localPath: String
+  var error: String?
+}
+
+private struct FileTranscriptionPayload: Codable {
+  var text: String
+  var durationSeconds: Double
+  var error: String?
+}
+
+private struct LivePartialPayload: Codable {
+  var source: String
+  var text: String
+  var isFinal: Bool
+}
+
+private struct LiveAppendPayload: Codable {
+  var partials: [LivePartialPayload]
+  var error: String?
+}
+
+private struct StatusPayload: Codable {
+  var running: Bool
+  var error: String?
+}
+
+private func encodeJSON<T: Encodable>(_ value: T) -> String {
+  guard let data = try? JSONEncoder().encode(value),
+    let string = String(data: data, encoding: .utf8)
+  else {
+    return "{}"
+  }
+
+  return string
+}
+
+private func waitForValue<T>(_ operation: @escaping () async -> T) -> T {
+  let semaphore = DispatchSemaphore(value: 0)
+  var result: T!
+
+  Task {
+    result = await operation()
+    semaphore.signal()
+  }
+
+  semaphore.wait()
+  return result
+}
+
+private func decodeFloatSamples(from data: Data) throws -> [Float] {
+  let stride = MemoryLayout<Float>.size
+  guard data.count.isMultiple(of: stride) else {
+    throw SoniqoBridgeError.message("Invalid audio chunk received by Soniqo.")
+  }
+
+  let count = data.count / stride
+  var samples = [Float]()
+  samples.reserveCapacity(count)
+
+  data.withUnsafeBytes { bytes in
+    for index in 0..<count {
+      let bits = bytes.loadUnaligned(fromByteOffset: index * stride, as: UInt32.self)
+      samples.append(Float(bitPattern: UInt32(littleEndian: bits)))
+    }
+  }
+
+  return samples
+}
+
+private actor SoniqoBridge {
+  static let shared = SoniqoBridge()
+
+  private var loadedModels: [SpeechModelKind: LoadedSpeechModel] = [:]
+  private var modelTasks: [SpeechModelKind: Task<LoadedSpeechModel, Error>] = [:]
+  private var downloadStates: [SpeechModelKind: ModelDownloadPayload] = [:]
+  private var activeStreamingSessions: [TranscriptSource: StreamingSession] = [:]
+
+  func cacheDirectory(modelId: String) -> String {
+    guard let kind = SpeechModelKind.resolve(modelId) else {
+      return ""
+    }
+
+    refreshReadyState(for: kind)
+    return kind.cacheDirectoryPath()
+  }
+
+  func modelDownloadStateJSON(modelId: String) -> String {
+    guard let kind = SpeechModelKind.resolve(modelId) else {
+      return encodeJSON(
+        ModelDownloadPayload(
+          status: "error",
+          currentFile: nil,
+          progressPercent: nil,
+          localPath: "",
+          error: "Unsupported Soniqo model."
+        )
+      )
+    }
+
+    refreshReadyState(for: kind)
+    return encodeJSON(downloadState(for: kind))
+  }
+
+  func startModelDownload(modelId: String) {
+    guard let kind = SpeechModelKind.resolve(modelId) else {
+      return
+    }
+
+    refreshReadyState(for: kind)
+    if kind.filesReady(), modelTasks[kind] == nil {
+      var state = downloadState(for: kind)
+      state.status = "ready"
+      state.currentFile = nil
+      state.error = nil
+      downloadStates[kind] = state
+      return
+    }
+
+    if modelTasks[kind] != nil {
+      var state = downloadState(for: kind)
+      state.status = "downloading"
+      downloadStates[kind] = state
+      return
+    }
+
+    var state = downloadState(for: kind)
+    state.status = "downloading"
+    state.currentFile = "Preparing \(kind.label)..."
+    state.progressPercent = nil
+    state.error = nil
+    downloadStates[kind] = state
+
+    let task = Task.detached(priority: .utility) {
+      try await kind.load { fraction, status in
+        Task {
+          await SoniqoBridge.shared.updateDownloadProgress(
+            kind: kind,
+            fraction: fraction,
+            status: status
+          )
+        }
+      }
+    }
+
+    modelTasks[kind] = task
+
+    Task.detached {
+      do {
+        let model = try await task.value
+        await SoniqoBridge.shared.finishModelLoad(kind: kind, model: model)
+      } catch {
+        await SoniqoBridge.shared.finishModelLoad(kind: kind, error: error)
+      }
+    }
+  }
+
+  func resetModel(modelId: String) {
+    guard let kind = SpeechModelKind.resolve(modelId) else {
+      return
+    }
+
+    loadedModels[kind] = nil
+    modelTasks[kind] = nil
+    refreshReadyState(for: kind)
+
+    var state = downloadState(for: kind)
+    if state.status != "ready" {
+      state.status = "idle"
+    }
+    state.currentFile = nil
+    state.progressPercent = nil
+    state.error = nil
+    downloadStates[kind] = state
+  }
+
+  func startLiveJSON(modelId: String) async -> String {
+    do {
+      guard let kind = SpeechModelKind.resolve(modelId) else {
+        throw SoniqoBridgeError.message("Unsupported Soniqo model: \(modelId)")
+      }
+      guard kind.isStreamingCapable else {
+        throw SoniqoBridgeError.message("\(kind.label) does not support realtime transcription.")
+      }
+
+      let model = try await ensureModelLoaded(kind).asStreamingModel()
+      activeStreamingSessions = [
+        .microphone: try model.createSession(),
+        .system: try model.createSession(),
+      ]
+      return encodeJSON(StatusPayload(running: true, error: nil))
+    } catch {
+      activeStreamingSessions = [:]
+      return encodeJSON(StatusPayload(running: false, error: error.localizedDescription))
+    }
+  }
+
+  func stopLiveJSON() -> String {
+    activeStreamingSessions = [:]
+    return encodeJSON(StatusPayload(running: false, error: nil))
+  }
+
+  func appendLiveJSON(source: String, samplesData: Data) -> String {
+    do {
+      guard let transcriptSource = TranscriptSource(rawValue: source) else {
+        throw SoniqoBridgeError.message("Unsupported Soniqo transcript source: \(source)")
+      }
+      guard let session = activeStreamingSessions[transcriptSource] else {
+        throw SoniqoBridgeError.message("No active Soniqo transcription session.")
+      }
+
+      let samples = try decodeFloatSamples(from: samplesData)
+      let partials = try session.pushAudio(samples).map { partial in
+        LivePartialPayload(
+          source: transcriptSource.rawValue,
+          text: partial.text,
+          isFinal: partial.isFinal
+        )
+      }
+      return encodeJSON(LiveAppendPayload(partials: partials, error: nil))
+    } catch {
+      return encodeJSON(LiveAppendPayload(partials: [], error: error.localizedDescription))
+    }
+  }
+
+  func transcribeAudioFileJSON(modelId: String, audioPath: String, language: String) async -> String
+  {
+    do {
+      guard let kind = SpeechModelKind.resolve(modelId) else {
+        throw SoniqoBridgeError.message("Unsupported Soniqo model: \(modelId)")
+      }
+
+      let trimmedLanguage = language.trimmingCharacters(in: .whitespacesAndNewlines)
+      let url = URL(fileURLWithPath: audioPath)
+      let audio = try AudioFileLoader.load(url: url, targetSampleRate: 16000)
+      let model = try await ensureModelLoaded(kind)
+      let text = try model.transcribe(
+        audio: audio,
+        sampleRate: 16000,
+        language: trimmedLanguage.isEmpty ? nil : trimmedLanguage
+      )
+
+      return encodeJSON(
+        FileTranscriptionPayload(
+          text: text,
+          durationSeconds: Double(audio.count) / 16000.0,
+          error: nil
+        )
+      )
+    } catch {
+      return encodeJSON(
+        FileTranscriptionPayload(
+          text: "",
+          durationSeconds: 0,
+          error: error.localizedDescription
+        )
+      )
+    }
+  }
+
+  private func ensureModelLoaded(_ kind: SpeechModelKind) async throws -> LoadedSpeechModel {
+    refreshReadyState(for: kind)
+
+    if let model = loadedModels[kind] {
+      return model
+    }
+
+    if let task = modelTasks[kind] {
+      let loaded = try await task.value
+      loadedModels[kind] = loaded
+      return loaded
+    }
+
+    let loaded = try await kind.load(progressHandler: nil)
+    loadedModels[kind] = loaded
+    refreshReadyState(for: kind)
+    return loaded
+  }
+
+  private func updateDownloadProgress(kind: SpeechModelKind, fraction: Double, status: String) {
+    var state = downloadState(for: kind)
+    state.status = "downloading"
+    state.localPath = kind.cacheDirectoryPath()
+    state.error = nil
+
+    let percent = Int(max(0.0, min(1.0, fraction)) * 100.0)
+    let statusText = status.trimmingCharacters(in: .whitespacesAndNewlines)
+    state.progressPercent = percent
+    state.currentFile = statusText.isEmpty ? "Preparing \(kind.label)..." : statusText
+    downloadStates[kind] = state
+  }
+
+  private func finishModelLoad(kind: SpeechModelKind, model: LoadedSpeechModel) {
+    loadedModels[kind] = model
+    modelTasks[kind] = nil
+
+    var state = downloadState(for: kind)
+    state.localPath = kind.cacheDirectoryPath()
+    state.status = "ready"
+    state.currentFile = nil
+    state.progressPercent = nil
+    state.error = nil
+    downloadStates[kind] = state
+  }
+
+  private func finishModelLoad(kind: SpeechModelKind, error: Error) {
+    modelTasks[kind] = nil
+
+    var state = downloadState(for: kind)
+    state.localPath = kind.cacheDirectoryPath()
+    state.status = "error"
+    state.currentFile = nil
+    state.progressPercent = nil
+    state.error = error.localizedDescription
+    downloadStates[kind] = state
+  }
+
+  private func refreshReadyState(for kind: SpeechModelKind) {
+    var state = downloadState(for: kind)
+    state.localPath = kind.cacheDirectoryPath()
+
+    guard modelTasks[kind] == nil else {
+      downloadStates[kind] = state
+      return
+    }
+
+    if kind.filesReady() {
+      state.status = "ready"
+      state.error = nil
+      state.currentFile = nil
+      state.progressPercent = nil
+    } else if state.status == "ready" {
+      state.status = "idle"
+      state.currentFile = nil
+      state.progressPercent = nil
+      state.error = nil
+      loadedModels[kind] = nil
+    } else if state.localPath.isEmpty {
+      state.status = "idle"
+    }
+
+    downloadStates[kind] = state
+  }
+
+  private func downloadState(for kind: SpeechModelKind) -> ModelDownloadPayload {
+    if let state = downloadStates[kind] {
+      return state
+    }
+
+    return ModelDownloadPayload(
+      status: "idle",
+      currentFile: nil,
+      progressPercent: nil,
+      localPath: kind.cacheDirectoryPath(),
+      error: nil
+    )
+  }
+}
+
+@_cdecl("_soniqo_model_cache_dir")
+public func _soniqo_model_cache_dir(modelId: SRString) -> SRString {
+  SRString(
+    waitForValue {
+      await SoniqoBridge.shared.cacheDirectory(modelId: modelId.toString())
+    })
+}
+
+@_cdecl("_soniqo_model_download_state")
+public func _soniqo_model_download_state(modelId: SRString) -> SRString {
+  SRString(
+    waitForValue {
+      await SoniqoBridge.shared.modelDownloadStateJSON(modelId: modelId.toString())
+    })
+}
+
+@_cdecl("_soniqo_model_start_download")
+public func _soniqo_model_start_download(modelId: SRString) -> Bool {
+  waitForValue {
+    await SoniqoBridge.shared.startModelDownload(modelId: modelId.toString())
+    return true
+  }
+}
+
+@_cdecl("_soniqo_model_reset")
+public func _soniqo_model_reset(modelId: SRString) -> Bool {
+  waitForValue {
+    await SoniqoBridge.shared.resetModel(modelId: modelId.toString())
+    return true
+  }
+}
+
+@_cdecl("_soniqo_transcribe_audio_file")
+public func _soniqo_transcribe_audio_file(
+  modelId: SRString,
+  audioPath: SRString,
+  language: SRString
+) -> SRString {
+  SRString(
+    waitForValue {
+      await SoniqoBridge.shared.transcribeAudioFileJSON(
+        modelId: modelId.toString(),
+        audioPath: audioPath.toString(),
+        language: language.toString()
+      )
+    })
+}
+
+@_cdecl("_soniqo_live_start")
+public func _soniqo_live_start(modelId: SRString) -> SRString {
+  SRString(
+    waitForValue {
+      await SoniqoBridge.shared.startLiveJSON(modelId: modelId.toString())
+    })
+}
+
+@_cdecl("_soniqo_live_append")
+public func _soniqo_live_append(source: SRString, samples: SRData) -> SRString {
+  SRString(
+    waitForValue {
+      await SoniqoBridge.shared.appendLiveJSON(
+        source: source.toString(),
+        samplesData: Data(samples.toArray())
+      )
+    })
+}
+
+@_cdecl("_soniqo_live_stop")
+public func _soniqo_live_stop() -> SRString {
+  SRString(waitForValue { await SoniqoBridge.shared.stopLiveJSON() })
+}

--- a/plugins/local-stt/Cargo.toml
+++ b/plugins/local-stt/Cargo.toml
@@ -44,6 +44,7 @@ hypr-host = { workspace = true }
 hypr-language = { workspace = true, features = ["whisper"] }
 hypr-local-model = { workspace = true }
 hypr-model-downloader = { workspace = true, features = ["specta"] }
+hypr-transcribe-soniqo = { workspace = true }
 hypr-transcribe-whisper-local = { workspace = true, optional = true }
 hypr-whisper-local = { workspace = true, optional = true }
 hypr-whisper-local-model = { workspace = true }

--- a/plugins/local-stt/js/bindings.gen.ts
+++ b/plugins/local-stt/js/bindings.gen.ts
@@ -22,6 +22,14 @@ async cactusModelsDir() : Promise<Result<string, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async soniqoModelDir(model: LocalModel) : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:local-stt|soniqo_model_dir", { model }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async isModelDownloaded(model: LocalModel) : Promise<Result<boolean, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("plugin:local-stt|is_model_downloaded", { model }) };
@@ -125,12 +133,13 @@ export type CactusSttModel = "cactus-whisper-small-int4" | "cactus-whisper-small
 export type DownloadProgressPayload = { model: LocalModel; status: DownloadStatus }
 export type DownloadStatus = { downloading: number } | "completed" | { failed: string }
 export type GgufLlmModel = "Llama3p2_3bQ4" | "Gemma3_4bQ4" | "HyprLLM"
-export type LocalModel = CactusSttModel | WhisperModel | AmModel | GgufLlmModel | CactusLlmModel
+export type LocalModel = SoniqoModel | CactusSttModel | WhisperModel | AmModel | GgufLlmModel | CactusLlmModel
 export type ServerInfo = { url: string | null; status: ServerStatus; model: LocalModel | null }
 export type ServerStatus = "unreachable" | "loading" | "ready"
 export type ServerType = "internal" | "external"
+export type SoniqoModel = "soniqo-parakeet-streaming" | "soniqo-parakeet-batch" | "soniqo-omnilingual" | "soniqo-qwen3-small" | "soniqo-qwen3-large"
 export type SttModelInfo = { key: LocalModel; display_name: string; description: string; size_bytes: number; model_type: SttModelType }
-export type SttModelType = "cactus" | "whispercpp" | "argmax"
+export type SttModelType = "soniqo" | "cactus" | "whispercpp" | "argmax"
 export type WhisperModel = "QuantizedTiny" | "QuantizedTinyEn" | "QuantizedBase" | "QuantizedBaseEn" | "QuantizedSmall" | "QuantizedSmallEn" | "QuantizedLargeTurbo"
 
 /** tauri-specta globals **/

--- a/plugins/local-stt/src/commands.rs
+++ b/plugins/local-stt/src/commands.rs
@@ -25,6 +25,21 @@ pub async fn cactus_models_dir<R: tauri::Runtime>(
 
 #[tauri::command]
 #[specta::specta]
+pub async fn soniqo_model_dir<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    model: LocalModel,
+) -> Result<String, String> {
+    Ok(app
+        .local_stt()
+        .soniqo_model_dir(&model)
+        .await
+        .map_err(|e| e.to_string())?
+        .to_string_lossy()
+        .to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
 pub async fn list_supported_models() -> Result<Vec<SttModelInfo>, String> {
     Ok(SUPPORTED_MODELS
         .iter()

--- a/plugins/local-stt/src/ext.rs
+++ b/plugins/local-stt/src/ext.rs
@@ -6,7 +6,7 @@ use tauri_specta::Event;
 use tauri::{Manager, Runtime};
 use tauri_plugin_sidecar2::Sidecar2PluginExt;
 
-use hypr_model_downloader::{ModelDownloadManager, ModelDownloaderRuntime};
+use hypr_model_downloader::{DownloadStatus, ModelDownloadManager, ModelDownloaderRuntime};
 
 #[cfg(feature = "whisper-cpp")]
 use crate::server::internal;
@@ -17,6 +17,8 @@ use crate::{
     server::{ServerInfo, ServerStatus, ServerType, external, supervisor},
     types::DownloadProgressPayload,
 };
+
+const SONIQO_LOCAL_URL: &str = "soniqo://local";
 
 struct TauriModelRuntime<R: Runtime> {
     app_handle: tauri::AppHandle<R>,
@@ -59,7 +61,10 @@ pub struct LocalStt<'a, R: Runtime, M: Manager<R>> {
 impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
     fn ensure_stt_model(model: &LocalModel) -> Result<(), crate::Error> {
         match model {
-            LocalModel::Am(_) | LocalModel::Whisper(_) | LocalModel::Cactus(_) => Ok(()),
+            LocalModel::Soniqo(_)
+            | LocalModel::Am(_)
+            | LocalModel::Whisper(_)
+            | LocalModel::Cactus(_) => Ok(()),
             LocalModel::GgufLlm(_) | LocalModel::CactusLlm(_) => {
                 Err(crate::Error::UnsupportedModelType)
             }
@@ -94,6 +99,20 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
             })
     }
 
+    pub async fn soniqo_model_dir(&self, model: &LocalModel) -> Result<PathBuf, crate::Error> {
+        match model {
+            LocalModel::Soniqo(model) => {
+                let model = *model;
+                run_soniqo_blocking(
+                    move || hypr_transcribe_soniqo::model_cache_dir(model),
+                    crate::Error::ServerStartFailed,
+                )
+                .await
+            }
+            _ => Err(crate::Error::UnsupportedModelType),
+        }
+    }
+
     pub async fn get_supervisor(&self) -> Result<supervisor::SupervisorRef, crate::Error> {
         let state = self.manager.state::<crate::SharedState>();
         let guard = state.lock().await;
@@ -105,6 +124,10 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
 
     pub async fn is_model_downloaded(&self, model: &LocalModel) -> Result<bool, crate::Error> {
         Self::ensure_stt_model(model)?;
+
+        if let LocalModel::Soniqo(model) = model {
+            return Ok(soniqo_download_state(*model).await?.status == "ready");
+        }
 
         let downloader = {
             let state = self.manager.state::<crate::SharedState>();
@@ -118,10 +141,23 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
     pub async fn start_server(&self, model: LocalModel) -> Result<String, crate::Error> {
         Self::ensure_stt_model(&model)?;
 
+        if let LocalModel::Soniqo(soniqo_model) = model {
+            if soniqo_download_state(soniqo_model).await?.status != "ready" {
+                return Err(crate::Error::ModelNotDownloaded);
+            }
+
+            let supervisor = self.get_supervisor().await?;
+            supervisor::stop_all_stt_servers(&supervisor)
+                .await
+                .map_err(|e| crate::Error::ServerStopFailed(e.to_string()))?;
+
+            return Ok(SONIQO_LOCAL_URL.to_string());
+        }
+
         let server_type = match &model {
             LocalModel::Am(_) => ServerType::External,
             LocalModel::Whisper(_) | LocalModel::Cactus(_) => ServerType::Internal,
-            LocalModel::GgufLlm(_) | LocalModel::CactusLlm(_) => {
+            LocalModel::Soniqo(_) | LocalModel::GgufLlm(_) | LocalModel::CactusLlm(_) => {
                 return Err(crate::Error::UnsupportedModelType);
             }
         };
@@ -223,10 +259,28 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
     ) -> Result<Option<ServerInfo>, crate::Error> {
         Self::ensure_stt_model(model)?;
 
+        if let LocalModel::Soniqo(soniqo_model) = model {
+            let state = soniqo_download_state(*soniqo_model).await?;
+            let downloaded = state.status == "ready";
+            let downloading = state.status == "downloading";
+
+            return Ok(Some(ServerInfo {
+                url: downloaded.then(|| SONIQO_LOCAL_URL.to_string()),
+                status: if downloaded {
+                    ServerStatus::Ready
+                } else if downloading {
+                    ServerStatus::Loading
+                } else {
+                    ServerStatus::Unreachable
+                },
+                model: Some(model.clone()),
+            }));
+        }
+
         let server_type = match model {
             LocalModel::Am(_) => ServerType::External,
             LocalModel::Whisper(_) | LocalModel::Cactus(_) => ServerType::Internal,
-            LocalModel::GgufLlm(_) | LocalModel::CactusLlm(_) => {
+            LocalModel::Soniqo(_) | LocalModel::GgufLlm(_) | LocalModel::CactusLlm(_) => {
                 return Err(crate::Error::UnsupportedModelType);
             }
         };
@@ -275,6 +329,17 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
     pub async fn download_model(&self, model: LocalModel) -> Result<(), crate::Error> {
         Self::ensure_stt_model(&model)?;
 
+        if let LocalModel::Soniqo(soniqo_model) = model.clone() {
+            run_soniqo_blocking(
+                move || hypr_transcribe_soniqo::start_model_download(soniqo_model),
+                crate::Error::ServerStartFailed,
+            )
+            .await?;
+
+            spawn_soniqo_progress_poller(self.manager.app_handle().clone(), model, soniqo_model);
+            return Ok(());
+        }
+
         let downloader = {
             let state = self.manager.state::<crate::SharedState>();
             let guard = state.lock().await;
@@ -288,6 +353,10 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
     pub async fn cancel_download(&self, model: LocalModel) -> Result<bool, crate::Error> {
         Self::ensure_stt_model(&model)?;
 
+        if matches!(model, LocalModel::Soniqo(_)) {
+            return Ok(false);
+        }
+
         let downloader = {
             let state = self.manager.state::<crate::SharedState>();
             let guard = state.lock().await;
@@ -299,6 +368,10 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
     #[tracing::instrument(skip_all)]
     pub async fn is_model_downloading(&self, model: &LocalModel) -> Result<bool, crate::Error> {
         Self::ensure_stt_model(model)?;
+
+        if let LocalModel::Soniqo(model) = model {
+            return Ok(soniqo_download_state(*model).await?.status == "downloading");
+        }
 
         let downloader = {
             let state = self.manager.state::<crate::SharedState>();
@@ -312,6 +385,15 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
     pub async fn delete_model(&self, model: &LocalModel) -> Result<(), crate::Error> {
         Self::ensure_stt_model(model)?;
 
+        if let LocalModel::Soniqo(model) = model {
+            let model = *model;
+            return run_soniqo_blocking(
+                move || hypr_transcribe_soniqo::delete_model(model),
+                crate::Error::ServerStopFailed,
+            )
+            .await;
+        }
+
         let downloader = {
             let state = self.manager.state::<crate::SharedState>();
             let guard = state.lock().await;
@@ -320,6 +402,80 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
         downloader.delete(model).await?;
         Ok(())
     }
+}
+
+async fn run_soniqo_blocking<T>(
+    task: impl FnOnce() -> hypr_transcribe_soniqo::Result<T> + Send + 'static,
+    map_error: fn(String) -> crate::Error,
+) -> Result<T, crate::Error>
+where
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(task)
+        .await
+        .map_err(|e| map_error(e.to_string()))?
+        .map_err(|e| map_error(e.to_string()))
+}
+
+async fn soniqo_download_state(
+    model: hypr_transcribe_soniqo::SoniqoModel,
+) -> Result<hypr_transcribe_soniqo::ModelDownloadState, crate::Error> {
+    run_soniqo_blocking(
+        move || hypr_transcribe_soniqo::model_download_state(model),
+        crate::Error::ServerStartFailed,
+    )
+    .await
+}
+
+fn spawn_soniqo_progress_poller<R: Runtime>(
+    app_handle: tauri::AppHandle<R>,
+    model: LocalModel,
+    soniqo_model: hypr_transcribe_soniqo::SoniqoModel,
+) {
+    tokio::spawn(async move {
+        for _ in 0..7200 {
+            let status = tokio::task::spawn_blocking(move || {
+                hypr_transcribe_soniqo::model_download_state(soniqo_model)
+            })
+            .await;
+
+            let download_status = match status {
+                Ok(Ok(state)) => match state.status.as_str() {
+                    "ready" => DownloadStatus::Completed,
+                    "error" => DownloadStatus::Failed(
+                        state
+                            .error
+                            .unwrap_or_else(|| "Soniqo model download failed".to_string()),
+                    ),
+                    _ => DownloadStatus::Downloading(state.progress_percent.unwrap_or(0)),
+                },
+                Ok(Err(error)) => DownloadStatus::Failed(error.to_string()),
+                Err(error) => DownloadStatus::Failed(error.to_string()),
+            };
+
+            let should_stop = matches!(
+                download_status,
+                DownloadStatus::Completed | DownloadStatus::Failed(_)
+            );
+            let _ = DownloadProgressPayload {
+                model: model.clone(),
+                status: download_status,
+            }
+            .emit(&app_handle);
+
+            if should_stop {
+                return;
+            }
+
+            tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        }
+
+        let _ = DownloadProgressPayload {
+            model,
+            status: DownloadStatus::Failed("Soniqo model download timed out".to_string()),
+        }
+        .emit(&app_handle);
+    });
 }
 
 pub trait LocalSttPluginExt<R: Runtime> {

--- a/plugins/local-stt/src/ext.rs
+++ b/plugins/local-stt/src/ext.rs
@@ -18,8 +18,6 @@ use crate::{
     types::DownloadProgressPayload,
 };
 
-const SONIQO_LOCAL_URL: &str = "soniqo://local";
-
 struct TauriModelRuntime<R: Runtime> {
     app_handle: tauri::AppHandle<R>,
 }
@@ -151,7 +149,7 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
                 .await
                 .map_err(|e| crate::Error::ServerStopFailed(e.to_string()))?;
 
-            return Ok(SONIQO_LOCAL_URL.to_string());
+            return Ok(hypr_transcribe_soniqo::LOCAL_BASE_URL.to_string());
         }
 
         let server_type = match &model {
@@ -265,7 +263,7 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
             let downloading = state.status == "downloading";
 
             return Ok(Some(ServerInfo {
-                url: downloaded.then(|| SONIQO_LOCAL_URL.to_string()),
+                url: downloaded.then(|| hypr_transcribe_soniqo::LOCAL_BASE_URL.to_string()),
                 status: if downloaded {
                     ServerStatus::Ready
                 } else if downloading {

--- a/plugins/local-stt/src/lib.rs
+++ b/plugins/local-stt/src/lib.rs
@@ -40,6 +40,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
         .commands(tauri_specta::collect_commands![
             commands::models_dir::<Wry>,
             commands::cactus_models_dir::<Wry>,
+            commands::soniqo_model_dir::<Wry>,
             commands::is_model_downloaded::<Wry>,
             commands::is_model_downloading::<Wry>,
             commands::download_model::<Wry>,

--- a/plugins/local-stt/src/model.rs
+++ b/plugins/local-stt/src/model.rs
@@ -1,6 +1,11 @@
-pub use hypr_local_model::{CactusSttModel, LocalModel, WhisperModel};
+pub use hypr_local_model::{CactusSttModel, LocalModel, SoniqoModel, WhisperModel};
 
-pub static SUPPORTED_MODELS: [LocalModel; 4] = [
+pub static SUPPORTED_MODELS: [LocalModel; 9] = [
+    LocalModel::Soniqo(SoniqoModel::ParakeetStreaming),
+    LocalModel::Soniqo(SoniqoModel::ParakeetBatch),
+    LocalModel::Soniqo(SoniqoModel::Omnilingual),
+    LocalModel::Soniqo(SoniqoModel::Qwen3Small),
+    LocalModel::Soniqo(SoniqoModel::Qwen3Large),
     LocalModel::Cactus(CactusSttModel::WhisperSmallInt8),
     LocalModel::Cactus(CactusSttModel::WhisperSmallInt8Apple),
     LocalModel::Cactus(CactusSttModel::ParakeetTdt0_6bV3Int8),
@@ -10,6 +15,7 @@ pub static SUPPORTED_MODELS: [LocalModel; 4] = [
 #[derive(serde::Serialize, serde::Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub enum SttModelType {
+    Soniqo,
     Cactus,
     Whispercpp,
     Argmax,
@@ -26,6 +32,13 @@ pub struct SttModelInfo {
 
 pub fn stt_model_info(model: &LocalModel) -> SttModelInfo {
     match model {
+        LocalModel::Soniqo(value) => SttModelInfo {
+            key: model.clone(),
+            display_name: value.display_name().to_string(),
+            description: value.description().to_string(),
+            size_bytes: value.size_bytes(),
+            model_type: SttModelType::Soniqo,
+        },
         LocalModel::Cactus(value) => SttModelInfo {
             key: model.clone(),
             display_name: value.display_name().to_string(),

--- a/plugins/transcription/Cargo.toml
+++ b/plugins/transcription/Cargo.toml
@@ -17,6 +17,7 @@ specta-typescript = { workspace = true }
 hypr-audio = { workspace = true }
 hypr-language = { workspace = true }
 hypr-storage = { workspace = true }
+hypr-transcribe-soniqo = { workspace = true }
 hypr-transcript = { workspace = true }
 hypr-transcription-core = { workspace = true, features = ["specta", "tauri-event"] }
 

--- a/plugins/transcription/js/bindings.gen.ts
+++ b/plugins/transcription/js/bindings.gen.ts
@@ -186,7 +186,7 @@ transcriptionEvent: "plugin:transcription:transcription-event"
 export type BatchAlternatives = { transcript: string; confidence: number; words?: BatchWord[] }
 export type BatchChannel = { alternatives: BatchAlternatives[] }
 export type BatchErrorCode = "unknown" | "timed_out" | "audio_metadata_join_failed" | "audio_metadata_read_failed" | "batch_capability_unsupported" | "direct_batch_unsupported" | "progressive_batch_unsupported" | "direct_request_failed" | "progressive_actor_spawn_failed" | "progressive_start_cancelled" | "progressive_stopped_without_completion_signal" | "progressive_finished_without_status" | "progressive_start_failed" | "progressive_stream_error" | "progressive_stream_timeout"
-export type BatchProvider = "argmax" | "whispercpp" | "deepgram" | "soniox" | "assemblyai" | "fireworks" | "openai" | "gladia" | "elevenlabs" | "pyannote" | "dashscope" | "mistral" | "hyprnote" | "am" | "cactus" | "aquavoice"
+export type BatchProvider = "argmax" | "whispercpp" | "deepgram" | "soniox" | "assemblyai" | "fireworks" | "openai" | "gladia" | "elevenlabs" | "pyannote" | "dashscope" | "mistral" | "hyprnote" | "am" | "cactus" | "soniqo" | "aquavoice"
 export type BatchResponse = { metadata: JsonValue; results: BatchResults }
 export type BatchResults = { channels: BatchChannel[] }
 export type BatchRunMode = "direct" | "streamed"

--- a/plugins/transcription/src/api.rs
+++ b/plugins/transcription/src/api.rs
@@ -26,6 +26,14 @@ pub struct CaptureParams {
 
 impl CaptureParams {
     fn default_transcription_mode(&self) -> listener::TranscriptionMode {
+        if let Ok(model) = self.model.parse::<hypr_transcribe_soniqo::SoniqoModel>() {
+            return if model.supports_live() {
+                listener::TranscriptionMode::Live
+            } else {
+                listener::TranscriptionMode::Batch
+            };
+        }
+
         let adapter_kind =
             AdapterKind::from_url_and_languages(&self.base_url, &self.languages, Some(&self.model));
 
@@ -396,6 +404,23 @@ mod tests {
             "http://localhost:50060/v1",
             "cactus-parakeet-tdt-0.6b-v3-int8",
         );
+
+        assert_eq!(
+            params.default_transcription_mode(),
+            TranscriptionMode::Batch
+        );
+    }
+
+    #[test]
+    fn defaults_soniqo_streaming_capture_to_live_mode() {
+        let params = capture_params("soniqo://local", "soniqo-parakeet-streaming");
+
+        assert_eq!(params.default_transcription_mode(), TranscriptionMode::Live);
+    }
+
+    #[test]
+    fn defaults_soniqo_batch_capture_to_batch_mode() {
+        let params = capture_params("soniqo://local", "soniqo-parakeet-batch");
 
         assert_eq!(
             params.default_transcription_mode(),

--- a/plugins/transcription/src/api.rs
+++ b/plugins/transcription/src/api.rs
@@ -26,12 +26,18 @@ pub struct CaptureParams {
 
 impl CaptureParams {
     fn default_transcription_mode(&self) -> listener::TranscriptionMode {
-        if let Ok(model) = self.model.parse::<hypr_transcribe_soniqo::SoniqoModel>() {
-            return if model.supports_live() {
-                listener::TranscriptionMode::Live
-            } else {
-                listener::TranscriptionMode::Batch
-            };
+        if hypr_transcribe_soniqo::is_local_base_url(&self.base_url) {
+            return self
+                .model
+                .parse::<hypr_transcribe_soniqo::SoniqoModel>()
+                .map(|model| {
+                    if model.supports_live() {
+                        listener::TranscriptionMode::Live
+                    } else {
+                        listener::TranscriptionMode::Batch
+                    }
+                })
+                .unwrap_or(listener::TranscriptionMode::Batch);
         }
 
         let adapter_kind =
@@ -421,6 +427,26 @@ mod tests {
     #[test]
     fn defaults_soniqo_batch_capture_to_batch_mode() {
         let params = capture_params("soniqo://local", "soniqo-parakeet-batch");
+
+        assert_eq!(
+            params.default_transcription_mode(),
+            TranscriptionMode::Batch
+        );
+    }
+
+    #[test]
+    fn defaults_soniqo_model_on_non_soniqo_provider_from_provider_mode() {
+        let params = capture_params("https://api.openai.com/v1", "soniqo-parakeet-streaming");
+
+        assert_eq!(
+            params.default_transcription_mode(),
+            TranscriptionMode::Batch
+        );
+    }
+
+    #[test]
+    fn defaults_invalid_soniqo_local_model_to_batch_mode() {
+        let params = capture_params("soniqo://local", "nova-3");
 
         assert_eq!(
             params.default_transcription_mode(),

--- a/plugins/transcription/src/listener/commands.rs
+++ b/plugins/transcription/src/listener/commands.rs
@@ -87,6 +87,24 @@ pub async fn is_supported_languages_live<R: tauri::Runtime>(
         .map(|s| hypr_language::Language::from_str(s))
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| format!("unknown_language: {}", e))?;
+
+    if provider == "soniqo" {
+        let model = model
+            .as_deref()
+            .ok_or_else(|| "missing_model: soniqo".to_string())?
+            .parse::<hypr_transcribe_soniqo::SoniqoModel>()
+            .map_err(|e| e.to_string())?;
+
+        return Ok(model.supports_live() && model.supports_languages(&languages_parsed));
+    }
+
+    if provider == "hyprnote"
+        && let Some(model) = model.as_deref()
+        && let Ok(model) = model.parse::<hypr_transcribe_soniqo::SoniqoModel>()
+    {
+        return Ok(model.supports_live() && model.supports_languages(&languages_parsed));
+    }
+
     let adapter_kind =
         AdapterKind::from_str(&provider).map_err(|_| format!("unknown_provider: {}", provider))?;
 


### PR DESCRIPTION
Add Soniqo on-device model management, live transcription routing, batch transcription support, desktop model selection, and workspace dependency wiring while keeping Cactus available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it introduces a new macOS Swift bridge and changes core live/batch transcription routing and local model management, which can affect capture stability and model downloads.
> 
> **Overview**
> Adds a new on-device STT backend, **Soniqo**, including a new `transcribe-soniqo` crate that bridges to a macOS Swift package (speech-swift) for model download state, file transcription, and live streaming sessions.
> 
> Updates the Rust transcription stack to route **live** audio to Soniqo when `base_url` is `soniqo://local` (with batch-only models rejected for live), and adds **batch** execution via a new `BatchProvider::Soniqo` path.
> 
> Extends local model plumbing (`local-model`, `local-stt` plugin, and generated TS bindings) to treat Soniqo models as first-class local models (download polling, delete, per-model cache dir), and updates the desktop UI to list/select Soniqo models, show download progress, and map `hyprnote` + `soniqo-*` models to the `soniqo` batch provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e3f9f2e33c8166a46d05540ea7349546116227b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5156 
- <kbd>&nbsp;1&nbsp;</kbd> #5153 👈 
<!-- GitButler Footer Boundary Bottom -->

