### PR TITLE
fix: remove blog cover image metadata

### DIFF
--- a/apps/web/content-collections.ts
+++ b/apps/web/content-collections.ts
@@ -17,7 +17,6 @@ const articles = defineCollection({
     meta_description: z.string().default(""),
     author: z.union([z.string(), z.array(z.string())]),
     date: z.string(),
-    coverImage: z.string().optional(),
     featured: z.boolean().optional(),
     ready_for_review: z.boolean().default(false),
     category: z

--- a/apps/web/content/articles/ai-meeting-summary-tools.mdx
+++ b/apps/web/content/articles/ai-meeting-summary-tools.mdx
@@ -4,7 +4,6 @@ display_title: "Best AI Meeting Summary Tools in 2026"
 meta_description: "Find the best AI meeting summary tool for your team. Compare 9 top solutions, including free options, bot-free tools, and enterprise platforms."
 author:
   - "John Jeong"
-coverImage: "/api/assets/blog/ai-meeting-summary-tools/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-10-06"

--- a/apps/web/content/articles/best-ai-meeting-assistant-for-taking-notes.mdx
+++ b/apps/web/content/articles/best-ai-meeting-assistant-for-taking-notes.mdx
@@ -2,7 +2,6 @@
 meta_title: "7 Best AI Meeting Assistants for Taking Notes in 2026"
 meta_description: "Discover the best AI meeting assistants for automated note-taking in 2026. Compare privacy, features & pricing to choose the right tool for your needs."
 author: "Harshika"
-coverImage: "/api/assets/blog/best-ai-meeting-assistant-for-taking-notes/cover.png"
 category: "Comparisons"
 date: "2025-08-04"
 ---

--- a/apps/web/content/articles/best-ai-notetaker-for-in-person-meetings.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-in-person-meetings.mdx
@@ -3,7 +3,6 @@ meta_title: "7 Best AI Notetakers for In-person Meetings"
 meta_description: "Compare the top AI notetakers for in-person meetings. Find tools with mobile apps, offline recording, speaker ID, and real-time transcription features"
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/best-ai-notetaker-for-in-person-meetings/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-09-03"

--- a/apps/web/content/articles/best-ai-notetaker-for-microsoft-teams.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-microsoft-teams.mdx
@@ -3,7 +3,6 @@ meta_title: "7 Best AI Notetakers for Microsoft Teams in 2026"
 meta_description: "Looking for the best AI notetaker for Microsoft Teams? Compare the top 7 solutions, including native and third-party options."
 author:
   - "John Jeong"
-coverImage: "/api/assets/blog/best-ai-notetaker-for-microsoft-teams/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-09-09"

--- a/apps/web/content/articles/best-ai-notetaker-for-zoom.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-zoom.mdx
@@ -2,7 +2,6 @@
 meta_title: "Best AI Notetaker for Zoom: Top 10 Options"
 meta_description: "Find the best AI notetaker for Zoom with our 2026 guide. Compare real-time transcription, privacy options, CRM integrations, and pricing plans."
 author: "Harshika"
-coverImage: "/api/assets/blog/best-ai-notetaker-for-zoom/cover.png"
 category: "Comparisons"
 date: "2025-09-06"
 ---

--- a/apps/web/content/articles/best-ai-notetakers-google-meet.mdx
+++ b/apps/web/content/articles/best-ai-notetakers-google-meet.mdx
@@ -2,7 +2,6 @@
 meta_title: "7 Best AI Notetakers for Google Meet in 2026"
 meta_description: "Google's native AI notes falling short? Find the right alternative by comparing the 7 best AI notetakers for Google Meet in 2026. Free & paid options included."
 author: "John Jeong"
-coverImage: "/api/assets/blog/best-ai-notetakers-google-meet/cover.png"
 featured: false
 category: "Comparisons"
 date: "2026-02-11"

--- a/apps/web/content/articles/bot-free-ai-meeting-assistants.mdx
+++ b/apps/web/content/articles/bot-free-ai-meeting-assistants.mdx
@@ -2,7 +2,6 @@
 meta_title: "2026's Best Bot-Free AI Meeting Assistants"
 meta_description: "Want AI meeting notes without bots joining your call? Here's a list of the best bot-free AI meeting assistants for secure, distraction-free note-taking."
 author: "John Jeong"
-coverImage: "/api/assets/blog/bot-free-ai-meeting-assistants/cover.png"
 category: "Comparisons"
 date: "2025-08-27"
 ---

--- a/apps/web/content/articles/can-you-transcribe-meetings-without-sending-data-to-cloud.mdx
+++ b/apps/web/content/articles/can-you-transcribe-meetings-without-sending-data-to-cloud.mdx
@@ -3,7 +3,6 @@ meta_title: "Can You Transcribe Meetings Without Sending Data to the Cloud?"
 meta_description: "Learn how to transcribe meetings without sending data to the cloud. Discover local AI tools like Anarlog that keep conversations on-device and completely private."
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/can-you-transcribe-meetings-without-sending-data-to-cloud/cover.png"
 featured: false
 category: "Guides"
 date: "2025-08-22"

--- a/apps/web/content/articles/char-is-now-anarlog.mdx
+++ b/apps/web/content/articles/char-is-now-anarlog.mdx
@@ -3,7 +3,6 @@ meta_title: "Char Is Now Anarlog"
 display_title: "Char Is Now Anarlog"
 meta_description: "The AI meeting notetaker you've been using is now Anarlog — open source, MIT, free forever, fully local. Char is a different product now: an AI notepad that finishes your todos. Two names because they're two different products."
 author: "John Jeong"
-coverImage: "/api/assets/blog/announcement.jpg"
 featured: true
 category: "Founders' notes"
 date: "2026-05-03"

--- a/apps/web/content/articles/chatgpt-for-meeting-notes.mdx
+++ b/apps/web/content/articles/chatgpt-for-meeting-notes.mdx
@@ -3,7 +3,6 @@ meta_title: "How to Use ChatGPT for Meeting Notes?"
 meta_description: "Learn how to use ChatGPT for meeting notes with Record Mode & manual upload. Get proven prompts, privacy tips & better alternatives for professional use."
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/chatgpt-for-meeting-notes/cover.png"
 featured: false
 category: "Guides"
 date: "2025-09-25"

--- a/apps/web/content/articles/enterprise-ai-notetaking-tools.mdx
+++ b/apps/web/content/articles/enterprise-ai-notetaking-tools.mdx
@@ -4,7 +4,6 @@ display_title: "AI Notetaking Tools for Enterprises: 5 Solutions Compared"
 meta_description: "Compare enterprise AI notetaking solutions on security, compliance, deployment options, and limitations. A practical guide for organizations with strict data policies."
 author:
   - "John Jeong"
-coverImage: "/api/assets/blog/enterprise-ai-notetaking-tools/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-10-02"

--- a/apps/web/content/articles/fathom-ai-alternatives.mdx
+++ b/apps/web/content/articles/fathom-ai-alternatives.mdx
@@ -2,7 +2,6 @@
 meta_title: "5 Best Fathom AI Alternatives in 2026"
 meta_description: "Discover the 5 best alternatives to Fathom AI in 2026. Get better conversation insights, stronger security, and truly unlimited note-taking."
 author: "John Jeong"
-coverImage: "/api/assets/blog/fathom-ai-alternatives/cover.png"
 category: "Comparisons"
 date: "2025-10-15"
 ---

--- a/apps/web/content/articles/fireflies-ai-alternatives.mdx
+++ b/apps/web/content/articles/fireflies-ai-alternatives.mdx
@@ -2,7 +2,6 @@
 meta_title: "9 Best Fireflies.ai Alternatives in 2026"
 meta_description: "Complete Fireflies.ai review plus 9 alternative comparisons. Compare AI meeting assistants by features, pricing, privacy, and platform support."
 author: "Harshika"
-coverImage: "/api/assets/blog/fireflies-ai-alternatives/cover.png"
 category: "Comparisons"
 date: "2025-09-23"
 ---

--- a/apps/web/content/articles/free-ai-notetakers.mdx
+++ b/apps/web/content/articles/free-ai-notetakers.mdx
@@ -3,7 +3,6 @@ meta_title: "9 Best Free AI Notetakers with Forever-Free Plans in 2026"
 meta_description: "Review of 9 genuinely free AI meeting assistants that provide transcription, summaries, and note-taking without expiration dates or payment pressure."
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/free-ai-notetakers/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-08-07"

--- a/apps/web/content/articles/free-transcription-software.mdx
+++ b/apps/web/content/articles/free-transcription-software.mdx
@@ -4,7 +4,6 @@ display_title: "Best Free Transcription Software in 2026"
 meta_description: "Find truly free transcription solutions in 2026 that offer real usability, privacy, and accuracy for all your speech-to-text needs. No surprises or limits."
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/free-transcription-software/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-10-08"

--- a/apps/web/content/articles/google-gemini-meeting-notes.mdx
+++ b/apps/web/content/articles/google-gemini-meeting-notes.mdx
@@ -3,7 +3,6 @@ meta_title: "I Tested Google Gemini Meeting Notes So You Don't Have To"
 meta_description: "Can Google Gemini take meeting notes? Yes, but only in Google Meet with paid plans. If you use Teams or Zoom, then you'll need workarounds. Know more."
 author:
   - "John Jeong"
-coverImage: "/api/assets/blog/google-gemini-meeting-notes/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-09-24"

--- a/apps/web/content/articles/granola-ai-alternatives.mdx
+++ b/apps/web/content/articles/granola-ai-alternatives.mdx
@@ -2,7 +2,6 @@
 meta_title: "6 Best Granola AI Alternatives in 2026"
 meta_description: "Looking for Granola AI alternatives? Compare top meeting assistants with better privacy, platform support, integrations & pricing."
 author: "John Jeong"
-coverImage: "/api/assets/blog/granola-ai-alternatives/cover.png"
 category: "Comparisons"
 date: "2025-08-15"
 ---

--- a/apps/web/content/articles/how-to-have-productive-one-on-one-meetings.mdx
+++ b/apps/web/content/articles/how-to-have-productive-one-on-one-meetings.mdx
@@ -3,7 +3,6 @@ meta_title: "How to Run Productive One-on-One Meetings as a Manager"
 display_title: "How to Have Productive One-on-One Meetings: A Guide for Managers"
 meta_description: "Stop wasting time on status updates disguised as 1:1s. Learn how to run one-on-one meetings that actually develop your team without burning you out."
 author: "John Jeong"
-coverImage: "/api/assets/blog/how-to-have-productive-one-on-one-meetings/cover.png"
 category: "Guides"
 date: "2025-11-10"
 ---

--- a/apps/web/content/articles/how-to-participate-in-meetings-effectively.mdx
+++ b/apps/web/content/articles/how-to-participate-in-meetings-effectively.mdx
@@ -3,7 +3,6 @@ meta_title: "Top 5 Strategies to Participate in Meetings Effectively"
 display_title: "How to Participate in Meetings Effectively?"
 meta_description: "Learn how to contribute meaningfully in meetings without exhausting your brain. Strategies for speaking strategically, building on context, and following through."
 author: "John Jeong"
-coverImage: "/api/assets/blog/how-to-participate-in-meetings-effectively/cover.png"
 featured: false
 category: "Guides"
 date: "2025-11-07"

--- a/apps/web/content/articles/how-to-reduce-meeting-fatigue.mdx
+++ b/apps/web/content/articles/how-to-reduce-meeting-fatigue.mdx
@@ -2,7 +2,6 @@
 meta_title: "How to Reduce Meeting Fatigue When Meetings Are Your Job"
 meta_description: "Can't cut meetings? Learn how AI note-taking and smart systems reduce meeting fatigue for sales, consulting, and customer-facing roles."
 author: "John Jeong"
-coverImage: "/api/assets/blog/how-to-reduce-meeting-fatigue/cover.png"
 category: "Guides"
 date: "2025-10-31"
 ---

--- a/apps/web/content/articles/how-to-transcribe-zoom-calls.mdx
+++ b/apps/web/content/articles/how-to-transcribe-zoom-calls.mdx
@@ -2,7 +2,6 @@
 meta_title: "How to Transcribe Zoom Calls Automatically?"
 meta_description: "Learn how to automatically transcribe Zoom calls using Zoom's built-in feature or powerful third-party AI tools. Step-by-step guide with accuracy comparisons."
 author: "Harshika"
-coverImage: "/api/assets/blog/how-to-transcribe-zoom-calls/cover.png"
 category: "Guides"
 date: "2025-09-16"
 ---

--- a/apps/web/content/articles/hyprnote-is-now-char.mdx
+++ b/apps/web/content/articles/hyprnote-is-now-char.mdx
@@ -3,7 +3,6 @@ meta_title: "Hyprnote Is Now Char"
 display_title: "Hyprnote Is Now Char"
 meta_description: "From sales notes to AI notepad — why we renamed Hyprnote to Char, the story behind the name, and what it means for our users."
 author: "John Jeong"
-coverImage: "/api/assets/blog/announcement.jpg"
 featured: true
 category: "Founders' notes"
 date: "2026-02-14"

--- a/apps/web/content/articles/is-ai-notetaking-legal.mdx
+++ b/apps/web/content/articles/is-ai-notetaking-legal.mdx
@@ -3,7 +3,6 @@ meta_title: "Is AI note-taking legal? Everything You Need to Know"
 meta_description: "AI note-taking is legal, but selecting the wrong tool or missing compliance requirements can expose you to privacy and compliance risks. Learn more."
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/is-ai-notetaking-legal/cover.png"
 featured: false
 category: "Guides"
 date: "2025-08-26"

--- a/apps/web/content/articles/is-fireflies-ai-safe.mdx
+++ b/apps/web/content/articles/is-fireflies-ai-safe.mdx
@@ -3,7 +3,6 @@ meta_title: "Is Fireflies AI Safe? The No BS Truth"
 meta_description: "Thinking about using Fireflies AI? We dug into their data collection practices and found some red flags you should know about."
 author:
   - "John Jeong"
-coverImage: "/api/assets/blog/is-fireflies-ai-safe/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-09-23"

--- a/apps/web/content/articles/is-otter-ai-safe.mdx
+++ b/apps/web/content/articles/is-otter-ai-safe.mdx
@@ -2,7 +2,6 @@
 meta_title: "Is Otter AI Safe: What You Need to Know"
 meta_description: "Otter AI faces a class-action lawsuit over privacy violations and secret recordings. Is it safe to use? Discover user complaints, data risks, and alternatives."
 author: "John Jeong"
-coverImage: "/api/assets/blog/is-otter-ai-safe/cover.png"
 category: "Comparisons"
 date: "2025-08-18"
 ---

--- a/apps/web/content/articles/local-ai-privacy-tools.mdx
+++ b/apps/web/content/articles/local-ai-privacy-tools.mdx
@@ -2,7 +2,6 @@
 meta_title: "The Rise of Local AI: How the Next Wave of Privacy Tools Will Be Built"
 meta_description: "From DuckDuckGo to Proton, privacy-first apps have earned user trust. Now, local AI is carrying that vision forward."
 author: "John Jeong"
-coverImage: "/api/assets/blog/local-ai-privacy-tools/cover.png"
 category: "Engineering"
 date: "2025-07-28"
 ---

--- a/apps/web/content/articles/meeting-minutes-software.mdx
+++ b/apps/web/content/articles/meeting-minutes-software.mdx
@@ -2,7 +2,6 @@
 meta_title: "Best Meeting Minutes Software in 2026"
 meta_description: "Compare the best meeting minutes software for 2026. We tested AI and manual tools to find the top solutions for note-taking, collaboration, and governance."
 author: "Harshika"
-coverImage: "/api/assets/blog/meeting-minutes-software/cover.png"
 featured: false
 category: "Comparisons"
 date: "2026-01-10"

--- a/apps/web/content/articles/meeting-preparation-checklist.mdx
+++ b/apps/web/content/articles/meeting-preparation-checklist.mdx
@@ -3,7 +3,6 @@ meta_title: "My Go-to Meeting Preparation Checklist"
 display_title: "Meeting Preparation Checklist: 7 Steps to Run More Productive Meetings"
 meta_description: "Use this meeting preparation checklist to walk into every call with clarity and confidence. Build a repeatable system to have productive meetings."
 author: "John Jeong"
-coverImage: "/api/assets/blog/meeting-preparation-checklist/cover.png"
 featured: false
 category: "Guides"
 date: "2025-11-03"

--- a/apps/web/content/articles/open-source-meeting-transcription-software.mdx
+++ b/apps/web/content/articles/open-source-meeting-transcription-software.mdx
@@ -4,7 +4,6 @@ display_title: "Open Source Alternatives to Otter AI and Fireflies"
 meta_description: "Review of the best open source meeting transcription tools you can fork, self-host, and customize. Compare features, pricing, and deployment options."
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/open-source-meeting-transcription-software/cover.png"
 featured: true
 category: "Comparisons"
 date: "2025-10-23"

--- a/apps/web/content/articles/otter-ai-alternatives.mdx
+++ b/apps/web/content/articles/otter-ai-alternatives.mdx
@@ -2,7 +2,6 @@
 meta_title: "14 Best Otter.ai Alternatives & Competitors in 2026"
 meta_description: "Discover 14 Otter AI alternatives that solve privacy, language, and accuracy issues. Compare features and pricing to find your perfect meeting assistant."
 author: "John Jeong"
-coverImage: "/api/assets/blog/otter-ai-alternatives/cover.png"
 category: "Comparisons"
 date: "2025-08-11"
 ---

--- a/apps/web/content/articles/otter-ai-review.mdx
+++ b/apps/web/content/articles/otter-ai-review.mdx
@@ -2,7 +2,6 @@
 meta_title: "Otter AI Review: Is It Worth It in 2026?"
 meta_description: "Complete Otter AI review covering features, pricing, security concerns, and user feedback. Compare alternatives and find the best AI notetaker for your needs."
 author: "Harshika"
-coverImage: "/api/assets/blog/otter-ai-review/cover.png"
 featured: false
 category: "Comparisons"
 ready_for_review: true

--- a/apps/web/content/articles/plaud-ai-alternatives.mdx
+++ b/apps/web/content/articles/plaud-ai-alternatives.mdx
@@ -4,7 +4,6 @@ display_title: "6 Plaud AI Alternatives Worth Considering in 2026"
 meta_description: "Looking beyond Plaud? Compare 6 AI voice recorder alternatives. Hardware, software & specialized AI recorders reviewed."
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/plaud-ai-alternatives/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-10-27"

--- a/apps/web/content/articles/sales-ai-note-takers.mdx
+++ b/apps/web/content/articles/sales-ai-note-takers.mdx
@@ -3,7 +3,6 @@ meta_title: "Best AI Notetakers for Sales Teams in 2026"
 display_title: "Which AI Tools Automate Sales Meeting Notes?"
 meta_description: "We tested 20+ AI meeting tools to find the 5 best options for sales teams. Compare features, pricing, and real-world value to find your perfect match."
 author: "Harshika"
-coverImage: "/api/assets/blog/sales-ai-note-takers/cover.png"
 category: "Comparisons"
 date: "2025-10-20"
 ---

--- a/apps/web/content/articles/see-zoom-meeting-history.mdx
+++ b/apps/web/content/articles/see-zoom-meeting-history.mdx
@@ -3,7 +3,6 @@ meta_title: "How to View Zoom Meeting History (Updated 2026)"
 display_title: "How to See Your Zoom Meeting History (And Actually Make It Useful)"
 meta_description: "Step-by-step guide to viewing Zoom meeting history. See what Zoom shows (and what it doesn't), plus how to make your meeting history actually searchable."
 author: "John Jeong"
-coverImage: "/api/assets/blog/see-zoom-meeting-history/cover.png"
 category: "Guides"
 date: "2025-11-05"
 ---

--- a/apps/web/content/articles/tldv-review.mdx
+++ b/apps/web/content/articles/tldv-review.mdx
@@ -3,7 +3,6 @@ meta_title: "tl;dv meeting notes software review 2026"
 display_title: "I Tested tl;dv So You Don't Have To [2026 Review]"
 meta_description: "Is tl;dv worth it? Complete 2026 review with pricing, feature tests, user complaints, and honest pros & cons to help you decide."
 author: "Harshika"
-coverImage: "/api/assets/blog/tldv-review/cover.png"
 category: "Comparisons"
 date: "2025-10-17"
 ---

--- a/apps/web/content/articles/using-ide-for-writing.mdx
+++ b/apps/web/content/articles/using-ide-for-writing.mdx
@@ -3,7 +3,6 @@ meta_title: "Why we use IDEs to write blog articles"
 display_title: "Why We Write Our Blog in an IDE (Not a WYSIWYG Editor)"
 meta_description: "Most teams write in a browser. We write in our IDE. Here's why treating content like code gives us more control, fewer surprises, and a workflow that actually scales."
 author: "John Jeong"
-coverImage: "/api/assets/blog/using-ide-for-writing/cover.png"
 featured: false
 category: "Engineering"
 date: "2025-11-24"

--- a/apps/web/content/articles/what-makes-reliable-ai-note-taker.mdx
+++ b/apps/web/content/articles/what-makes-reliable-ai-note-taker.mdx
@@ -4,7 +4,6 @@ display_title: "The Reliable AI Note-Taker Checklist"
 meta_description: "How to choose an AI notetaker? Use this guide to assess the 5 dependency risks in any AI note-taker before you commit to a platform."
 author:
   - "John Jeong"
-coverImage: "/api/assets/blog/what-makes-reliable-ai-note-taker/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-10-25"

--- a/apps/web/content/articles/why-our-cms-is-github.mdx
+++ b/apps/web/content/articles/why-our-cms-is-github.mdx
@@ -2,7 +2,6 @@
 meta_title: "Why Our CMS Is GitHub"
 meta_description: "Most teams store code in GitHub. We store everything — blog posts, docs, ideas — because Git already solves the hardest parts of publishing: versioning, reviews, portability, and scale."
 author: "John Jeong"
-coverImage: "/api/assets/blog/why-our-cms-is-github/cover.png"
 featured: false
 category: "Engineering"
 date: "2025-11-26"

--- a/apps/web/content/articles/zoom-ai-companion-review.mdx
+++ b/apps/web/content/articles/zoom-ai-companion-review.mdx
@@ -3,7 +3,6 @@ meta_title: "Zoom AI Companion Review: Is It Worth It in 2026?"
 meta_description: "Zoom AI Companion 2026 review: We tested features, analyzed user feedback, and compared costs. Find out when it works and when you should look for an alternative."
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/zoom-ai-companion-review/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-09-19"

--- a/apps/web/scripts/mdx-format-core.js
+++ b/apps/web/scripts/mdx-format-core.js
@@ -7,7 +7,6 @@ export const ARTICLE_FIELD_ORDER = [
   "author",
   "created",
   "updated",
-  "coverImage",
   "featured",
   "category",
 ];

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -30,9 +30,6 @@ export const Route = createFileRoute("/blog/$slug")({
         { property: "og:description", content: article.meta_description },
         { property: "og:url", content: url },
         { property: "og:type", content: "article" },
-        ...(article.coverImage
-          ? [{ property: "og:image", content: article.coverImage }]
-          : []),
       ],
     };
   },
@@ -69,14 +66,6 @@ function Component() {
           </time>
         </div>
       </header>
-
-      {article.coverImage && (
-        <img
-          src={article.coverImage}
-          alt={article.title}
-          className="mb-10 w-full rounded-md border border-neutral-200"
-        />
-      )}
 
       <article className="prose prose-stone prose-headings:font-mono prose-headings:text-stone-800 prose-a:text-stone-800 prose-a:underline hover:prose-a:text-stone-600 prose-img:rounded-md prose-img:border prose-img:border-neutral-200 max-w-none">
         <MDXContent code={article.mdx} components={mdxComponents} />


### PR DESCRIPTION
Remove per-article coverImage frontmatter, schema support, formatter ordering, and route OG/cover rendering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content/schema cleanup that removes optional metadata and associated rendering; main risk is unintended loss of per-article social preview images if anything still relied on `coverImage`.
> 
> **Overview**
> Removes `coverImage` support from the blog content pipeline: the `articles` collection schema no longer accepts it, the MDX frontmatter formatter no longer orders it, and existing articles drop the `coverImage` field.
> 
> The blog post route (`/blog/$slug`) stops rendering a cover image and no longer emits per-article `og:image` meta tags, leaving social previews to rely on site-level defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cc1c851220b189b6a010d8f4bc09ea06299a2b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->