### PR TITLE
chore: remove landing page extras

### DIFF
--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -12,8 +12,8 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as AuthRouteImport } from './routes/auth'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
-import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 import { Route as LegalSlugRouteImport } from './routes/legal/$slug'
+import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 import { Route as ApiAssetsSplatRouteImport } from './routes/api/assets.$'
 
 const AuthRoute = AuthRouteImport.update({
@@ -31,14 +31,14 @@ const BlogIndexRoute = BlogIndexRouteImport.update({
   path: '/blog/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const BlogSlugRoute = BlogSlugRouteImport.update({
-  id: '/blog/$slug',
-  path: '/blog/$slug',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const LegalSlugRoute = LegalSlugRouteImport.update({
   id: '/legal/$slug',
   path: '/legal/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BlogSlugRoute = BlogSlugRouteImport.update({
+  id: '/blog/$slug',
+  path: '/blog/$slug',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiAssetsSplatRoute = ApiAssetsSplatRouteImport.update({
@@ -51,16 +51,16 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
   '/blog/$slug': typeof BlogSlugRoute
-  '/blog/': typeof BlogIndexRoute
   '/legal/$slug': typeof LegalSlugRoute
+  '/blog/': typeof BlogIndexRoute
   '/api/assets/$': typeof ApiAssetsSplatRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
   '/blog/$slug': typeof BlogSlugRoute
-  '/blog': typeof BlogIndexRoute
   '/legal/$slug': typeof LegalSlugRoute
+  '/blog': typeof BlogIndexRoute
   '/api/assets/$': typeof ApiAssetsSplatRoute
 }
 export interface FileRoutesById {
@@ -68,24 +68,37 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
   '/blog/$slug': typeof BlogSlugRoute
-  '/blog/': typeof BlogIndexRoute
   '/legal/$slug': typeof LegalSlugRoute
+  '/blog/': typeof BlogIndexRoute
   '/api/assets/$': typeof ApiAssetsSplatRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/auth' | '/blog/$slug' | '/blog/' | '/legal/$slug' | '/api/assets/$'
+  fullPaths:
+    | '/'
+    | '/auth'
+    | '/blog/$slug'
+    | '/legal/$slug'
+    | '/blog/'
+    | '/api/assets/$'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/auth' | '/blog/$slug' | '/blog' | '/legal/$slug' | '/api/assets/$'
-  id: '__root__' | '/' | '/auth' | '/blog/$slug' | '/blog/' | '/legal/$slug' | '/api/assets/$'
+  to: '/' | '/auth' | '/blog/$slug' | '/legal/$slug' | '/blog' | '/api/assets/$'
+  id:
+    | '__root__'
+    | '/'
+    | '/auth'
+    | '/blog/$slug'
+    | '/legal/$slug'
+    | '/blog/'
+    | '/api/assets/$'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthRoute: typeof AuthRoute
   BlogSlugRoute: typeof BlogSlugRoute
-  BlogIndexRoute: typeof BlogIndexRoute
   LegalSlugRoute: typeof LegalSlugRoute
+  BlogIndexRoute: typeof BlogIndexRoute
   ApiAssetsSplatRoute: typeof ApiAssetsSplatRoute
 }
 
@@ -112,18 +125,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BlogIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/blog/$slug': {
-      id: '/blog/$slug'
-      path: '/blog/$slug'
-      fullPath: '/blog/$slug'
-      preLoaderRoute: typeof BlogSlugRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/legal/$slug': {
       id: '/legal/$slug'
       path: '/legal/$slug'
       fullPath: '/legal/$slug'
       preLoaderRoute: typeof LegalSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/blog/$slug': {
+      id: '/blog/$slug'
+      path: '/blog/$slug'
+      fullPath: '/blog/$slug'
+      preLoaderRoute: typeof BlogSlugRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/assets/$': {
@@ -140,8 +153,8 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthRoute: AuthRoute,
   BlogSlugRoute: BlogSlugRoute,
-  BlogIndexRoute: BlogIndexRoute,
   LegalSlugRoute: LegalSlugRoute,
+  BlogIndexRoute: BlogIndexRoute,
   ApiAssetsSplatRoute: ApiAssetsSplatRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -14,7 +14,7 @@ const manifestoLetter = [
   "Most AI tools ask you to move your memory into their ecosystem, their models, and their rules. We think meeting notes should move in the other direction: back to files, back to your disk, and back to software you can run fully offline.",
   "Files endure. Interfaces change. Your notes should survive us. AI should be available through on-device models or your own keys, not through a service you cannot inspect.",
   "Anarlog is our attempt to build that kind of meeting notepad.",
-  "John Jeong",
+  "John Jeong, Yujong Lee",
 ];
 
 const featureList = [
@@ -72,7 +72,7 @@ export const Route = createFileRoute("/")({
 function Component() {
   return (
     <main className="min-h-screen bg-white text-[#181613]">
-      <div className="mx-auto grid w-full max-w-6xl gap-10 px-5 py-8 md:grid-cols-[minmax(0,1fr)_22rem] md:px-8 md:py-12">
+      <div className="mx-auto w-full max-w-[700px] px-5 py-8 md:px-8 md:py-12">
         <div className="min-w-0">
           <header className="flex items-center justify-between gap-6">
             <Link to="/" aria-label="Anarlog home">
@@ -94,12 +94,6 @@ function Component() {
                 className="inline-flex rounded-full bg-[#181613] px-5 py-3 font-medium text-white transition-colors hover:bg-[#4f4940]"
               >
                 Download app
-              </a>
-              <a
-                href="mailto:hello@anarlog.so"
-                className="inline-flex items-center text-[#4f4940] hover:text-[#181613]"
-              >
-                hello@anarlog.so
               </a>
             </div>
           </section>
@@ -134,46 +128,30 @@ function Component() {
                 ))}
               </div>
               <div className="mt-10">
-                <p className="font-signature text-4xl leading-none font-normal">
+                <p className="font-signature text-3xl leading-none font-normal">
                   {manifestoLetter.at(-1)}
                 </p>
-                <p className="font-crisp-serif mt-3 text-lg leading-none font-normal text-[#4f4940]">
-                  Co-founder and CEO at fastrepl
+                <p className="font-crisp-serif mt-5 text-base leading-none font-normal text-[#4f4940]">
+                  Fastrepl, Inc.
                 </p>
               </div>
             </div>
           </section>
         </div>
-
-        <aside className="hidden pl-8 md:block">
-          <div className="sticky top-10">
-            <img src="/logo.svg" alt="Anarlog" className="mb-10 h-11 w-auto" />
-            <div className="py-6">
-              <p className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
-                Now
-              </p>
-              <p className="mt-4 text-lg leading-8">
-                Meeting notes without the meeting bot.
-              </p>
-            </div>
-            <div className="py-6">
-              <p className="font-hand text-3xl leading-none font-semibold text-[#756b5d]">
-                Default
-              </p>
-              <p className="mt-4 text-lg leading-8">
-                Fully offline files, open source foundations, on-device or
-                bring-your-own-key AI.
-              </p>
-            </div>
-          </div>
-        </aside>
       </div>
 
-      <footer className="mx-auto flex w-full max-w-6xl flex-col gap-5 px-5 py-8 text-sm text-[#4f4940] md:flex-row md:items-center md:justify-between md:px-8">
-        <Link to="/" aria-label="Anarlog home">
+      <footer className="mx-auto grid w-full max-w-[700px] gap-5 px-5 py-8 text-sm text-[#4f4940] md:grid-cols-[1fr_auto_1fr] md:items-center md:px-8">
+        <Link
+          to="/"
+          aria-label="Anarlog home"
+          className="md:justify-self-start"
+        >
           <img src="/logo.svg" alt="Anarlog" className="h-9 w-auto" />
         </Link>
-        <nav className="flex flex-wrap gap-x-5 gap-y-2">
+        <p className="text-xs text-[#756b5d] md:justify-self-center">
+          Fastrepl © 2026
+        </p>
+        <nav className="flex flex-wrap gap-x-5 gap-y-2 md:justify-self-end">
           <a
             href="https://github.com/fastrepl/anarlog"
             className="hover:text-[#181613]"


### PR DESCRIPTION
Remove the hero email link and desktop side rail from the landing page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes to the landing page markup/styles plus a regenerated TanStack Router file; no business logic or data flow changes.
> 
> **Overview**
> Simplifies the landing page by removing the hero email link and the desktop right-side rail, and tightening the layout to a single centered column.
> 
> Updates the manifesto signature block (names and typography) and redesigns the footer into a 3-column grid that includes a centered copyright line.
> 
> Regenerates `routeTree.gen.ts` with reordered route declarations/types (no route behavior changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82e62de3779b6cf3f1a6b7601e4e95b6dec76fad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->