### PR TITLE
chore: align blog with landing page tone

### DIFF
--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -1,0 +1,25 @@
+import { Link } from "@tanstack/react-router";
+
+export function SiteFooter() {
+  return (
+    <footer className="mx-auto grid w-full max-w-[700px] gap-5 px-5 py-8 text-sm text-[#4f4940] md:grid-cols-[1fr_auto_1fr] md:items-center md:px-8">
+      <Link to="/" aria-label="Anarlog home" className="md:justify-self-start">
+        <img src="/logo.svg" alt="Anarlog" className="h-9 w-auto" />
+      </Link>
+      <p className="text-xs text-[#756b5d] md:justify-self-center">
+        Fastrepl © 2026
+      </p>
+      <nav className="flex flex-wrap gap-x-5 gap-y-2 md:justify-self-end">
+        <a
+          href="https://github.com/fastrepl/anarlog"
+          className="hover:text-[#181613]"
+        >
+          GitHub
+        </a>
+        <a href="mailto:founders@fastrepl.com" className="hover:text-[#181613]">
+          Contact
+        </a>
+      </nav>
+    </footer>
+  );
+}

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { type Article, allArticles } from "content-collections";
 
 import { mdxComponents } from "@/components/mdx-components";
+import { SiteFooter } from "@/components/site-footer";
 import { CHAR_SITE_URL } from "@/lib/seo";
 
 export const Route = createFileRoute("/blog/$slug")({
@@ -40,36 +41,59 @@ function Component() {
   const authors = Array.isArray(article.author)
     ? article.author.join(", ")
     : article.author;
+  const tldr = article.meta_description.trim();
 
   return (
-    <main className="mx-auto max-w-3xl px-6 py-16">
-      <Link
-        to="/blog/"
-        className="mb-8 inline-block text-sm text-neutral-500 hover:text-neutral-800"
-      >
-        ← Blog
-      </Link>
+    <main className="min-h-screen bg-white text-[#181613]">
+      <div className="mx-auto w-full max-w-[700px] px-5 py-8 md:px-8 md:py-12">
+        <header className="flex items-center justify-between gap-6">
+          <Link to="/" aria-label="Anarlog home">
+            <img src="/logo.svg" alt="Anarlog" className="h-9 w-auto" />
+          </Link>
+        </header>
 
-      <header className="mb-10">
-        <h1 className="mb-4 font-mono text-3xl leading-tight text-stone-800 sm:text-4xl">
-          {article.title}
-        </h1>
-        <div className="flex items-center gap-2 text-sm text-neutral-500">
-          <span>{authors}</span>
-          <span>·</span>
-          <time dateTime={article.date}>
-            {new Date(article.date).toLocaleDateString("en-US", {
-              month: "long",
-              day: "numeric",
-              year: "numeric",
-            })}
-          </time>
-        </div>
-      </header>
+        <Link
+          to="/blog/"
+          className="mt-16 inline-block text-sm text-[#756b5d] hover:text-[#181613]"
+        >
+          ← Blog
+        </Link>
 
-      <article className="prose prose-stone prose-headings:font-mono prose-headings:text-stone-800 prose-a:text-stone-800 prose-a:underline hover:prose-a:text-stone-600 prose-img:rounded-md prose-img:border prose-img:border-neutral-200 max-w-none">
-        <MDXContent code={article.mdx} components={mdxComponents} />
-      </article>
+        <header className="pt-10 pb-12">
+          <h1 className="font-hand text-5xl leading-[1.02] font-semibold tracking-normal text-balance md:text-7xl">
+            {article.title}
+          </h1>
+          <div className="mt-6 flex items-center gap-2 text-sm text-[#756b5d]">
+            <span>{authors}</span>
+            <span>·</span>
+            <time dateTime={article.date}>
+              {new Date(article.date).toLocaleDateString("en-US", {
+                month: "long",
+                day: "numeric",
+                year: "numeric",
+              })}
+            </time>
+          </div>
+        </header>
+
+        {tldr && (
+          <aside
+            aria-label="TLDR"
+            className="mb-12 border-y border-[#eee8df] py-5"
+          >
+            <p className="font-mono text-xs font-medium tracking-[0.14em] text-[#756b5d] uppercase">
+              TL;DR
+            </p>
+            <p className="mt-3 text-lg leading-8 text-[#363029]">{tldr}</p>
+          </aside>
+        )}
+
+        <article className="prose prose-stone prose-headings:font-hand prose-headings:font-semibold prose-headings:text-[#181613] prose-p:text-[#363029] prose-a:text-[#181613] prose-a:underline hover:prose-a:text-[#4f4940] prose-strong:text-[#181613] prose-li:text-[#363029] prose-img:rounded-md prose-img:border prose-img:border-[#eee8df] max-w-none">
+          <MDXContent code={article.mdx} components={mdxComponents} />
+        </article>
+      </div>
+
+      <SiteFooter />
     </main>
   );
 }

--- a/apps/web/src/routes/blog/index.tsx
+++ b/apps/web/src/routes/blog/index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { allArticles } from "content-collections";
 
+import { SiteFooter } from "@/components/site-footer";
 import { CHAR_SITE_URL } from "@/lib/seo";
 
 export const Route = createFileRoute("/blog/")({
@@ -26,51 +27,64 @@ function Component() {
   );
 
   return (
-    <main className="mx-auto max-w-3xl px-6 py-16">
-      <header className="mb-12 border-b border-neutral-200 pb-8">
-        <h1 className="mb-3 font-mono text-4xl text-stone-800">Blog</h1>
-        <p className="text-lg text-neutral-600">
-          Guides, comparisons, and engineering notes from the Anarlog team.
-        </p>
-      </header>
+    <main className="min-h-screen bg-white text-[#181613]">
+      <div className="mx-auto w-full max-w-[700px] px-5 py-8 md:px-8 md:py-12">
+        <header className="flex items-center justify-between gap-6">
+          <Link to="/" aria-label="Anarlog home">
+            <img src="/logo.svg" alt="Anarlog" className="h-9 w-auto" />
+          </Link>
+        </header>
 
-      <ul className="divide-y divide-neutral-100">
-        {sortedArticles.map((article) => (
-          <li key={article.slug}>
-            <Link
-              to="/blog/$slug/"
-              params={{ slug: article.slug }}
-              className="group block py-5 transition-colors hover:bg-stone-50/50"
-            >
-              <div className="flex flex-col gap-1">
-                <h2 className="font-mono text-lg text-stone-800 group-hover:text-stone-600">
-                  {article.title}
-                </h2>
-                {article.meta_description && (
-                  <p className="line-clamp-2 text-sm text-neutral-600">
-                    {article.meta_description}
-                  </p>
-                )}
-                <div className="mt-1 flex items-center gap-2 text-xs text-neutral-500">
-                  <span>
-                    {Array.isArray(article.author)
-                      ? article.author.join(", ")
-                      : article.author}
-                  </span>
-                  <span>·</span>
-                  <time dateTime={article.date}>
-                    {new Date(article.date).toLocaleDateString("en-US", {
-                      month: "short",
-                      day: "numeric",
-                      year: "numeric",
-                    })}
-                  </time>
-                </div>
-              </div>
-            </Link>
-          </li>
-        ))}
-      </ul>
+        <section className="pt-24 pb-16 md:pt-32">
+          <h1 className="font-hand text-6xl leading-[0.98] font-semibold tracking-normal text-balance md:text-8xl">
+            Blog
+          </h1>
+          <p className="mt-6 max-w-2xl text-xl leading-9 text-[#363029]">
+            Notes on private meetings, local files, open source, and AI you can
+            run on your own terms.
+          </p>
+        </section>
+
+        <ul className="grid gap-9">
+          {sortedArticles.map((article) => (
+            <li key={article.slug}>
+              <Link
+                to="/blog/$slug/"
+                params={{ slug: article.slug }}
+                className="group block"
+              >
+                <article className="grid gap-3 border-t border-[#eee8df] pt-6">
+                  <h2 className="text-xl leading-7 font-medium text-[#181613] group-hover:text-[#4f4940]">
+                    {article.title}
+                  </h2>
+                  {article.meta_description && (
+                    <p className="line-clamp-2 leading-7 text-[#4f4940]">
+                      {article.meta_description}
+                    </p>
+                  )}
+                  <div className="flex items-center gap-2 text-xs text-[#756b5d]">
+                    <span>
+                      {Array.isArray(article.author)
+                        ? article.author.join(", ")
+                        : article.author}
+                    </span>
+                    <span>·</span>
+                    <time dateTime={article.date}>
+                      {new Date(article.date).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                      })}
+                    </time>
+                  </div>
+                </article>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <SiteFooter />
     </main>
   );
 }


### PR DESCRIPTION
Restyle blog index and article pages with the landing page palette, width, logo header, and footer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly presentational changes, but the article page now calls `article.meta_description.trim()`, which could throw at runtime if any article lacks `meta_description`.
> 
> **Overview**
> Aligns the blog index and article pages with the landing-page look and feel (new palette/typography, constrained `max-w-[700px]` layout, and a logo header).
> 
> Introduces a reusable `SiteFooter` with GitHub/Contact links and adds it to both `/blog` and `/blog/$slug`. The article page also adds an optional TL;DR section sourced from `meta_description` and updates the blog index hero copy and post list styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 169745ca0d90b0b16c9a78cdd04bc83274a89993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->