### PR TITLE
chore: use Wikimedia GitHub icon

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -95,6 +95,18 @@ function Component() {
               >
                 Download app
               </a>
+              <a
+                href="https://github.com/fastrepl/anarlog"
+                className="inline-flex items-center gap-2 rounded-full border border-[#d8d0c5] px-5 py-3 font-medium text-[#181613] transition-colors hover:border-[#b8aea0] hover:bg-[#f7f4ef]"
+              >
+                <img
+                  src="https://upload.wikimedia.org/wikipedia/commons/9/91/Octicons-mark-github.svg"
+                  alt=""
+                  className="size-4"
+                  aria-hidden="true"
+                />
+                GitHub
+              </a>
             </div>
           </section>
 


### PR DESCRIPTION
Use the Wikimedia-hosted Octicons GitHub SVG for the landing page GitHub CTA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds an external image asset dependency (Wikimedia-hosted SVG) on the landing page.
> 
> **Overview**
> Adds a secondary **GitHub** CTA next to the existing *Download app* button on the landing page (`apps/web/src/routes/index.tsx`), including an icon loaded from Wikimedia-hosted Octicons SVG.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 699df873034aea8147a85eec0a1babd6dcb15ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->