### PR TITLE
fix: add web content collection type fallback

### DIFF
--- a/apps/web/src/types/content-collections.d.ts
+++ b/apps/web/src/types/content-collections.d.ts
@@ -1,0 +1,9 @@
+import type { GetTypeByName } from "@content-collections/core";
+
+import type configuration from "../../content-collections";
+
+export type Article = GetTypeByName<typeof configuration, "articles">;
+export declare const allArticles: Array<Article>;
+
+export type Legal = GetTypeByName<typeof configuration, "legal">;
+export declare const allLegals: Array<Legal>;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -28,7 +28,10 @@
     "noUncheckedSideEffectImports": true,
     "paths": {
       "@/*": ["./src/*"],
-      "content-collections": ["./.content-collections/generated"]
+      "content-collections": [
+        "./.content-collections/generated",
+        "./src/types/content-collections"
+      ]
     }
   }
 }


### PR DESCRIPTION
Add a committed content-collections declaration fallback so web typecheck passes in clean CI workspaces without generated Vite output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: TypeScript-only changes that adjust module path resolution and add `.d.ts` fallbacks, with no runtime behavior changes.
> 
> **Overview**
> Adds a committed `content-collections` type declaration fallback (`src/types/content-collections.d.ts`) so `Article`/`Legal` types and `allArticles`/`allLegals` exports are available even when generated output is missing.
> 
> Updates `apps/web/tsconfig.json` path mapping for `content-collections` to prefer the generated types but fall back to the committed declarations, improving typechecks in clean CI workspaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea4c61e793f2f3fcc72c7b921b1497483f5cfc36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->