### PR TITLE
fix: redirect char.com to anarlog.so

### DIFF
--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -203,28 +203,51 @@ status = 301
 force = true
 
 # Domain migration: char.com -> anarlog.so (301 for SEO)
-# Char is shut down except for /blog/* and /legal/* which redirect to anarlog.so
 
 [[redirects]]
-from = "https://char.com/blog/*"
-to = "https://anarlog.so/blog/:splat"
+from = "https://char.com"
+to = "https://anarlog.so"
 status = 301
 force = true
 
 [[redirects]]
-from = "https://www.char.com/blog/*"
-to = "https://anarlog.so/blog/:splat"
+from = "https://www.char.com"
+to = "https://anarlog.so"
 status = 301
 force = true
 
 [[redirects]]
-from = "https://char.com/legal/*"
-to = "https://anarlog.so/legal/:splat"
+from = "http://char.com"
+to = "https://anarlog.so"
 status = 301
 force = true
 
 [[redirects]]
-from = "https://www.char.com/legal/*"
-to = "https://anarlog.so/legal/:splat"
+from = "http://www.char.com"
+to = "https://anarlog.so"
+status = 301
+force = true
+
+[[redirects]]
+from = "https://char.com/*"
+to = "https://anarlog.so/:splat"
+status = 301
+force = true
+
+[[redirects]]
+from = "https://www.char.com/*"
+to = "https://anarlog.so/:splat"
+status = 301
+force = true
+
+[[redirects]]
+from = "http://char.com/*"
+to = "https://anarlog.so/:splat"
+status = 301
+force = true
+
+[[redirects]]
+from = "http://www.char.com/*"
+to = "https://anarlog.so/:splat"
 status = 301
 force = true


### PR DESCRIPTION
Map char.com and www.char.com root and catch-all routes to anarlog.so while preserving path splats.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Netlify redirect-only changes, but mistakes could misroute traffic or create redirect loops for `char.com`/`www.char.com` (http/https) paths.
> 
> **Overview**
> Updates Netlify redirect rules to **fully migrate `char.com` to `anarlog.so`** by adding explicit root-domain redirects for `char.com`/`www.char.com` over both HTTP and HTTPS.
> 
> Replaces the prior limited `/blog/*` and `/legal/*` mappings with **catch-all `/*` redirects** that preserve path splats to `anarlog.so/:splat`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8755224e5ea53323ed8cdb25ac29e248abbff405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->