### PR TITLE
chore: add GitHub star count to CTA

### DIFF
--- a/apps/web/src/functions/github.ts
+++ b/apps/web/src/functions/github.ts
@@ -1,0 +1,49 @@
+import { fetchWithCache, HOUR } from "@netlify/cache";
+import { createServerFn } from "@tanstack/react-start";
+
+import { env } from "../env";
+
+const GITHUB_ORG_REPO = "fastrepl/anarlog";
+const GITHUB_REPO_API_URL = `https://api.github.com/repos/${GITHUB_ORG_REPO}`;
+const LAST_SEEN_STARS = 8355;
+
+function getGitHubHeaders() {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "Anarlog-Web",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  if (env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${env.GITHUB_TOKEN}`;
+  }
+
+  return headers;
+}
+
+async function fetchGitHubStars() {
+  try {
+    const response = await fetchWithCache(
+      GITHUB_REPO_API_URL,
+      { headers: getGitHubHeaders() },
+      { ttl: HOUR, durable: true },
+    );
+
+    if (!response.ok) {
+      console.error("Failed to fetch GitHub repo stats:", response.status);
+      return null;
+    }
+
+    const data = (await response.json()) as { stargazers_count?: unknown };
+    return typeof data.stargazers_count === "number"
+      ? data.stargazers_count
+      : null;
+  } catch (error) {
+    console.error("Failed to fetch GitHub repo stats:", error);
+    return null;
+  }
+}
+
+export const getGitHubStars = createServerFn({ method: "GET" }).handler(
+  async () => (await fetchGitHubStars()) ?? LAST_SEEN_STARS,
+);

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { Icon } from "@iconify-icon/react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ChevronDown } from "lucide-react";
 
+import { getGitHubStars } from "@/functions/github";
 import {
   CHAR_SITE_URL,
   ROOT_DESCRIPTION,
@@ -57,6 +58,9 @@ const appleIntelDownloadUrl =
 
 export const Route = createFileRoute("/")({
   component: Component,
+  loader: async () => ({
+    githubStars: await getGitHubStars(),
+  }),
   head: () => ({
     links: [{ rel: "canonical", href: CHAR_SITE_URL }],
     scripts: [
@@ -77,6 +81,9 @@ export const Route = createFileRoute("/")({
 });
 
 function Component() {
+  const { githubStars } = Route.useLoaderData();
+  const formattedGithubStars = githubStars.toLocaleString("en-US");
+
   return (
     <main className="min-h-screen bg-white text-[#181613]">
       <div className="mx-auto w-full max-w-[700px] px-5 py-8 md:px-8 md:py-12">
@@ -107,7 +114,10 @@ function Component() {
                   className="size-4"
                   aria-hidden="true"
                 />
-                GitHub
+                <span>GitHub</span>
+                <span className="text-[#756b5d]">
+                  {formattedGithubStars} stars
+                </span>
               </a>
             </div>
           </section>
@@ -189,7 +199,7 @@ function DownloadButton() {
     <div className="relative inline-flex text-sm font-medium">
       <a
         href={appleSiliconDownloadUrl}
-        className="inline-flex items-center gap-2 rounded-l-full bg-[#181613] px-4 py-3 text-[13px] text-white transition-colors hover:bg-[#4f4940] sm:px-5 sm:text-sm"
+        className="inline-flex items-center gap-1.5 rounded-l-full bg-[#181613] px-4 py-3 text-[13px] text-white sm:px-5 sm:text-sm"
       >
         <Icon icon="simple-icons:apple" className="size-4" aria-hidden="true" />
         <span>Download for Apple Silicon</span>
@@ -197,7 +207,7 @@ function DownloadButton() {
       <details className="group">
         <summary
           aria-label="Choose download platform"
-          className="inline-flex h-full cursor-pointer list-none items-center rounded-r-full border-l border-white/20 bg-[#181613] px-3 py-3 text-white transition-colors hover:bg-[#4f4940] sm:px-4 [&::-webkit-details-marker]:hidden"
+          className="inline-flex h-full cursor-pointer list-none items-center rounded-r-full bg-[#181613] px-3 py-3 text-white sm:px-4 [&::-webkit-details-marker]:hidden"
         >
           <ChevronDown size={17} strokeWidth={2.2} aria-hidden="true" />
         </summary>


### PR DESCRIPTION
Show the repository star count in the homepage GitHub button.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/marketing change that adds a cached GitHub API call in the homepage loader; main failure mode is displaying a fallback count if the API/token is unavailable or rate-limited.
> 
> **Overview**
> Adds a new server function `getGitHubStars` that fetches `stargazers_count` from the GitHub repo API using `fetchWithCache` (1-hour durable TTL), optionally authenticating via `GITHUB_TOKEN`, and falling back to a hardcoded last-seen star count on error.
> 
> Updates the homepage route loader to call this function and displays the formatted star count next to the GitHub button, with minor CTA styling tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fc1882399e319b1d36a2bb372375f08728899c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->