### PR TITLE
fix: gate local realtime transcription to Apple Silicon

### DIFF
--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -32,6 +32,12 @@ pub(super) async fn spawn_rx_task(
     ActorProcessingErr,
 > {
     if let Some(model) = soniqo_model_for_args(&args)? {
+        if !model.is_available_on_current_platform() {
+            return Err(actor_error(
+                "unsupported_platform: Soniqo realtime transcription requires macOS Apple Silicon",
+            ));
+        }
+
         if !model.supports_live() {
             return Err(actor_error(format!(
                 "provider_batch_only: {} only supports batch transcription",

--- a/crates/local-model/src/lib.rs
+++ b/crates/local-model/src/lib.rs
@@ -255,7 +255,7 @@ impl LocalModel {
         let is_apple_silicon = cfg!(target_arch = "aarch64") && cfg!(target_os = "macos");
 
         match self {
-            LocalModel::Soniqo(_) => is_apple_silicon,
+            LocalModel::Soniqo(model) => model.is_available_on_current_platform(),
             LocalModel::Whisper(_) => is_macos,
             LocalModel::Am(_) => is_apple_silicon,
             LocalModel::Cactus(model) => {

--- a/crates/transcribe-soniqo/src/lib.rs
+++ b/crates/transcribe-soniqo/src/lib.rs
@@ -90,6 +90,14 @@ impl SoniqoModel {
         matches!(self, Self::ParakeetStreaming)
     }
 
+    pub const fn is_available_on_current_platform(self) -> bool {
+        cfg!(all(target_os = "macos", target_arch = "aarch64"))
+    }
+
+    pub const fn supports_live_on_current_platform(self) -> bool {
+        self.supports_live() && self.is_available_on_current_platform()
+    }
+
     pub fn supports_language(self, language: &hypr_language::Language) -> bool {
         match self {
             Self::ParakeetStreaming | Self::ParakeetBatch => {
@@ -201,7 +209,7 @@ impl LivePartial {
 pub enum Error {
     #[error("unsupported Soniqo model: {0}")]
     UnsupportedModel(String),
-    #[error("Soniqo is only available on macOS")]
+    #[error("Soniqo is only available on macOS Apple Silicon")]
     UnsupportedPlatform,
     #[error("Soniqo bridge failed: {0}")]
     Bridge(String),
@@ -213,19 +221,31 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+fn ensure_supported_platform(model: SoniqoModel) -> Result<()> {
+    if model.is_available_on_current_platform() {
+        Ok(())
+    } else {
+        Err(Error::UnsupportedPlatform)
+    }
+}
+
 pub fn model_cache_dir(model: SoniqoModel) -> Result<PathBuf> {
+    ensure_supported_platform(model)?;
     platform::model_cache_dir(model)
 }
 
 pub fn model_download_state(model: SoniqoModel) -> Result<ModelDownloadState> {
+    ensure_supported_platform(model)?;
     platform::model_download_state(model)
 }
 
 pub fn start_model_download(model: SoniqoModel) -> Result<()> {
+    ensure_supported_platform(model)?;
     platform::start_model_download(model)
 }
 
 pub fn reset_model(model: SoniqoModel) -> Result<()> {
+    ensure_supported_platform(model)?;
     platform::reset_model(model)
 }
 
@@ -253,6 +273,7 @@ pub fn transcribe_file(
     path: impl AsRef<Path>,
     language: Option<&str>,
 ) -> Result<FileTranscript> {
+    ensure_supported_platform(model)?;
     platform::transcribe_file(model, path.as_ref(), language.unwrap_or_default())
 }
 
@@ -263,6 +284,8 @@ pub struct LiveTranscriptionSession {
 
 impl LiveTranscriptionSession {
     pub fn start(model: SoniqoModel) -> Result<Self> {
+        ensure_supported_platform(model)?;
+
         if !model.supports_live() {
             return Err(Error::Bridge(format!(
                 "{} does not support realtime transcription",
@@ -672,6 +695,15 @@ mod tests {
         assert!(SoniqoModel::Omnilingual.supports_language(&french));
         assert!(SoniqoModel::Qwen3Small.supports_language(&french));
         assert!(SoniqoModel::Qwen3Large.supports_language(&french));
+    }
+
+    #[test]
+    fn live_support_is_gated_by_platform() {
+        assert_eq!(
+            SoniqoModel::ParakeetStreaming.supports_live_on_current_platform(),
+            cfg!(all(target_os = "macos", target_arch = "aarch64")),
+        );
+        assert!(!SoniqoModel::ParakeetBatch.supports_live_on_current_platform());
     }
 
     #[test]

--- a/plugins/transcription/src/api.rs
+++ b/plugins/transcription/src/api.rs
@@ -31,7 +31,7 @@ impl CaptureParams {
                 .model
                 .parse::<hypr_transcribe_soniqo::SoniqoModel>()
                 .map(|model| {
-                    if model.supports_live() {
+                    if model.supports_live_on_current_platform() {
                         listener::TranscriptionMode::Live
                     } else {
                         listener::TranscriptionMode::Batch
@@ -418,10 +418,15 @@ mod tests {
     }
 
     #[test]
-    fn defaults_soniqo_streaming_capture_to_live_mode() {
+    fn defaults_soniqo_streaming_capture_to_platform_mode() {
         let params = capture_params("soniqo://local", "soniqo-parakeet-streaming");
+        let expected = if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+            TranscriptionMode::Live
+        } else {
+            TranscriptionMode::Batch
+        };
 
-        assert_eq!(params.default_transcription_mode(), TranscriptionMode::Live);
+        assert_eq!(params.default_transcription_mode(), expected);
     }
 
     #[test]

--- a/plugins/transcription/src/listener/commands.rs
+++ b/plugins/transcription/src/listener/commands.rs
@@ -95,14 +95,16 @@ pub async fn is_supported_languages_live<R: tauri::Runtime>(
             .parse::<hypr_transcribe_soniqo::SoniqoModel>()
             .map_err(|e| e.to_string())?;
 
-        return Ok(model.supports_live() && model.supports_languages(&languages_parsed));
+        return Ok(model.supports_live_on_current_platform()
+            && model.supports_languages(&languages_parsed));
     }
 
     if provider == "hyprnote"
         && let Some(model) = model.as_deref()
         && let Ok(model) = model.parse::<hypr_transcribe_soniqo::SoniqoModel>()
     {
-        return Ok(model.supports_live() && model.supports_languages(&languages_parsed));
+        return Ok(model.supports_live_on_current_platform()
+            && model.supports_languages(&languages_parsed));
     }
 
     let adapter_kind =


### PR DESCRIPTION
Keep Soniqo realtime capability platform-aware and block local Soniqo bridge access on unsupported machines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes platform-gating logic for local Soniqo transcription, which can alter runtime behavior (mode selection and error paths) across listener, model management, and plugin commands, especially on non-Apple-Silicon machines.
> 
> **Overview**
> **Gates local Soniqo realtime transcription and related bridge operations to macOS Apple Silicon.** The listener now rejects starting Soniqo live sessions on unsupported platforms with a clearer `unsupported_platform` error.
> 
> Soniqo model/platform capability checks are centralized: `SoniqoModel` adds `is_available_on_current_platform`/`supports_live_on_current_platform`, and `transcribe-soniqo` now blocks non-supported platforms from calling model download/reset/cache and `transcribe_file`/`LiveTranscriptionSession::start`.
> 
> The UI/plugin layer updates default mode selection and `is_supported_languages_live` to use platform-aware live support, with tests updated/added to cover the new gating behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c607d406cb8168d3cd212ce107902aa7ef90828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->