### PR TITLE
chore: add rename blog chip

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "@iconify-icon/react";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { ChevronDown } from "lucide-react";
+import { ArrowRight, ChevronDown } from "lucide-react";
 
 import { getGitHubStars } from "@/functions/github";
 import {
@@ -95,6 +95,14 @@ function Component() {
           </header>
 
           <section className="pt-24 pb-16 md:pt-32">
+            <Link
+              to="/blog/$slug/"
+              params={{ slug: "char-is-now-anarlog" }}
+              className="mb-5 inline-flex max-w-full items-center gap-2 rounded-full border border-[#d8d0c5] px-5 py-3 text-base font-semibold text-[#756b5d] transition-colors hover:border-[#b8aea0] hover:bg-[#f7f4ef] hover:text-[#181613] sm:px-6 sm:text-xl"
+            >
+              <span>Char is now Anarlog</span>
+              <ArrowRight size={20} strokeWidth={2.4} aria-hidden="true" />
+            </Link>
             <h1 className="font-hand max-w-3xl text-6xl leading-[0.98] font-semibold tracking-normal text-balance md:text-8xl">
               AI notepad for private meetings.
             </h1>


### PR DESCRIPTION
Add a homepage announcement chip linking to the Char-to-Anarlog blog post.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change adding a new homepage link; minimal chance of issues beyond styling/layout or an incorrect blog route/slug.
> 
> **Overview**
> Adds a prominent announcement chip on the homepage hero linking to the `char-is-now-anarlog` blog post, including an `ArrowRight` icon.
> 
> Updates the icon import to include `ArrowRight` alongside the existing `ChevronDown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e829df4391e06141998cf4808da3ae3da642a41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->