### PR TITLE
fix: shrink homepage rename chip

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -99,10 +99,10 @@ function Component() {
             <Link
               to="/blog/$slug/"
               params={{ slug: "char-is-now-anarlog" }}
-              className="mb-5 inline-flex max-w-full items-center gap-2 rounded-full border border-[#d8d0c5] px-5 py-3 text-base font-semibold text-[#756b5d] transition-colors hover:border-[#b8aea0] hover:bg-[#f7f4ef] hover:text-[#181613] sm:px-6 sm:text-xl"
+              className="mb-5 inline-flex max-w-full items-center gap-1.5 rounded-full border border-[#d8d0c5] px-2.5 py-1.5 text-[11px] leading-none font-semibold text-[#756b5d] transition-colors hover:border-[#b8aea0] hover:bg-[#f7f4ef] hover:text-[#181613]"
             >
               <span>Char is now Anarlog</span>
-              <ArrowRight size={20} strokeWidth={2.4} aria-hidden="true" />
+              <ArrowRight size={12} strokeWidth={2.4} aria-hidden="true" />
             </Link>
             <h1 className="font-hand max-w-3xl text-6xl leading-[0.98] font-semibold tracking-normal text-balance md:text-8xl">
               AI notepad for private meetings.


### PR DESCRIPTION
Reduce the homepage announcement chip padding, text size, and arrow scale.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely presentational Tailwind class tweaks to the homepage announcement link with no logic, data, or routing changes.
> 
> **Overview**
> Shrinks the homepage announcement chip linking to `char-is-now-anarlog` by reducing padding, font size/line height, and icon size, and slightly tightening the icon/text gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de451952a9fa08457ce577702e8685370338e6a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->