### PR TITLE
fix: align footer copyright

### DIFF
--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -1,15 +1,8 @@
-import { Link } from "@tanstack/react-router";
-
 export function SiteFooter() {
   return (
-    <footer className="mx-auto grid w-full max-w-[700px] gap-5 px-5 py-8 text-sm text-[#4f4940] md:grid-cols-[1fr_auto_1fr] md:items-center md:px-8">
-      <Link to="/" aria-label="Anarlog home" className="md:justify-self-start">
-        <img src="/logo.svg" alt="Anarlog" className="h-9 w-auto" />
-      </Link>
-      <p className="text-xs text-[#756b5d] md:justify-self-center">
-        Fastrepl © 2026
-      </p>
-      <nav className="flex flex-wrap gap-x-5 gap-y-2 md:justify-self-end">
+    <footer className="mx-auto flex w-full max-w-[700px] flex-wrap items-center justify-between gap-5 px-5 py-8 text-sm text-[#4f4940] md:px-8">
+      <p className="text-[#756b5d]">Fastrepl © 2026</p>
+      <nav className="flex flex-wrap gap-x-5 gap-y-2">
         <a
           href="https://github.com/fastrepl/anarlog"
           className="hover:text-[#181613]"

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -173,18 +173,9 @@ function Component() {
         </div>
       </div>
 
-      <footer className="mx-auto grid w-full max-w-[700px] gap-5 px-5 py-8 text-sm text-[#4f4940] md:grid-cols-[1fr_auto_1fr] md:items-center md:px-8">
-        <Link
-          to="/"
-          aria-label="Anarlog home"
-          className="md:justify-self-start"
-        >
-          <img src="/logo.svg" alt="Anarlog" className="h-9 w-auto" />
-        </Link>
-        <p className="text-xs text-[#756b5d] md:justify-self-center">
-          Fastrepl © 2026
-        </p>
-        <nav className="flex flex-wrap gap-x-5 gap-y-2 md:justify-self-end">
+      <footer className="mx-auto flex w-full max-w-[700px] flex-wrap items-center justify-between gap-5 px-5 py-8 text-sm text-[#4f4940] md:px-8">
+        <p className="text-[#756b5d]">Fastrepl © 2026</p>
+        <nav className="flex flex-wrap gap-x-5 gap-y-2">
           <a
             href="https://github.com/fastrepl/anarlog"
             className="hover:text-[#181613]"


### PR DESCRIPTION
Remove the footer logo and place the Fastrepl copyright at the left with matching link text size.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change that removes the footer logo/link and adjusts layout/text sizing; no data, routing, or logic changes.
> 
> **Overview**
> Updates the site footer layout to a simpler flex row, **removing the home/logo link** and left-aligning `Fastrepl © 2026` with consistent text sizing.
> 
> Applies the same footer markup/style update both in `SiteFooter` and the homepage (`routes/index.tsx`) so link spacing and alignment match across pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fbe2facd140c00742523bc154fdab6518d6bdbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->