### PR TITLE
fix: align website footer links

### DIFF
--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -1,7 +1,9 @@
+import { Link } from "@tanstack/react-router";
+
 export function SiteFooter() {
   return (
     <footer className="mx-auto flex w-full max-w-[700px] flex-wrap items-center justify-between gap-5 px-5 py-8 text-sm text-[#4f4940] md:px-8">
-      <p className="text-[#756b5d]">Fastrepl © 2026</p>
+      <p className="text-sm text-[#756b5d]">Fastrepl © 2026</p>
       <nav className="flex flex-wrap gap-x-5 gap-y-2">
         <a
           href="https://github.com/fastrepl/anarlog"
@@ -9,6 +11,9 @@ export function SiteFooter() {
         >
           GitHub
         </a>
+        <Link to="/blog/" className="hover:text-[#181613]">
+          Blog
+        </Link>
         <a href="mailto:founders@fastrepl.com" className="hover:text-[#181613]">
           Contact
         </a>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowRight, ChevronDown } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
+import { SiteFooter } from "@/components/site-footer";
 import { getGitHubStars } from "@/functions/github";
 import {
   ANARLOG_SITE_URL,
@@ -173,23 +174,7 @@ function Component() {
         </div>
       </div>
 
-      <footer className="mx-auto flex w-full max-w-[700px] flex-wrap items-center justify-between gap-5 px-5 py-8 text-sm text-[#4f4940] md:px-8">
-        <p className="text-[#756b5d]">Fastrepl © 2026</p>
-        <nav className="flex flex-wrap gap-x-5 gap-y-2">
-          <a
-            href="https://github.com/fastrepl/anarlog"
-            className="hover:text-[#181613]"
-          >
-            GitHub
-          </a>
-          <a
-            href="mailto:founders@fastrepl.com"
-            className="hover:text-[#181613]"
-          >
-            Contact
-          </a>
-        </nav>
-      </footer>
+      <SiteFooter />
     </main>
   );
 }


### PR DESCRIPTION
Add Blog to the site footer and reuse the shared footer on the homepage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that updates footer markup/links and factors the homepage footer into the shared `SiteFooter` component.
> 
> **Overview**
> Updates the shared `SiteFooter` to include an internal `Blog` link (via `@tanstack/react-router` `Link`) and tweaks the copyright text styling.
> 
> Replaces the homepage’s inline footer markup in `routes/index.tsx` with the shared `SiteFooter` component to keep footer links consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 495dfcd0019d945ed75beb63d6cc7f96d50385ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->