### PR TITLE
fix: use raw SVGs for platform logos in download dropdown

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,4 +1,3 @@
-import { Icon } from "@iconify-icon/react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowRight, ChevronDown } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
@@ -215,7 +214,12 @@ function DownloadButton() {
         href={appleSiliconDownloadUrl}
         className="inline-flex items-center gap-1 rounded-l-full bg-[#181613] py-3 pr-1 pl-4 text-[13px] text-white sm:pl-5 sm:text-sm"
       >
-        <Icon icon="simple-icons:apple" className="size-4" aria-hidden="true" />
+        <img
+          src="https://upload.wikimedia.org/wikipedia/commons/f/fa/Apple_logo_black.svg"
+          alt=""
+          className="size-4"
+          aria-hidden="true"
+        />
         <span>Download for Apple Silicon</span>
       </a>
       <button
@@ -237,8 +241,9 @@ function DownloadButton() {
             href={appleIntelDownloadUrl}
             className="flex items-center gap-3 rounded-xl px-3 py-3 text-[#181613] transition-colors hover:bg-[#f7f4ef]"
           >
-            <Icon
-              icon="simple-icons:apple"
+            <img
+              src="https://upload.wikimedia.org/wikipedia/commons/f/fa/Apple_logo_black.svg"
+              alt=""
               className="size-5"
               aria-hidden="true"
             />
@@ -248,8 +253,9 @@ function DownloadButton() {
             aria-disabled="true"
             className="flex items-center gap-3 rounded-xl px-3 py-3 text-[#756b5d]"
           >
-            <Icon
-              icon="simple-icons:windows"
+            <img
+              src="https://upload.wikimedia.org/wikipedia/commons/5/5f/Windows_logo_-_2012.svg"
+              alt=""
               className="size-5"
               aria-hidden="true"
             />
@@ -260,8 +266,9 @@ function DownloadButton() {
             aria-disabled="true"
             className="flex items-center gap-3 rounded-xl px-3 py-3 text-[#756b5d]"
           >
-            <Icon
-              icon="simple-icons:linux"
+            <img
+              src="https://upload.wikimedia.org/wikipedia/commons/3/35/Tux.svg"
+              alt=""
               className="size-5"
               aria-hidden="true"
             />

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -217,7 +217,7 @@ function DownloadButton() {
         <img
           src="https://upload.wikimedia.org/wikipedia/commons/f/fa/Apple_logo_black.svg"
           alt=""
-          className="size-4"
+          className="size-4 invert"
           aria-hidden="true"
         />
         <span>Download for Apple Silicon</span>


### PR DESCRIPTION
Replaces the iconify glyphs (apple, windows, linux) in the hero download button + dropdown with raw Wikimedia SVGs via `<img>` — matching the existing octocat pattern in the same section. Fixes a ~1px vertical misalignment between the apple glyph and "Download for Apple Silicon" text, caused by iconify-icon's shadow-DOM SVG bearing not centering against the text cap-height. Windows and Linux keep their natural colors. Iconify import dropped from this file (still used by auth.tsx).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that swaps icon rendering in the home download button/dropdown; main risk is minor visual/CSP/regression due to external SVG image URLs.
> 
> **Overview**
> Updates the home page download CTA to stop using `@iconify-icon/react` for Apple/Windows/Linux logos and instead render raw SVGs via `<img>` (removing the `Icon` import from `index.tsx`).
> 
> This adjusts sizing/styling (e.g., Apple icon inversion) to improve alignment/consistency with the existing GitHub logo approach while keeping the download links and menu behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d41a21d1f1131d371fe8fbabcb56a0dede1d3d5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->