### PR TITLE
fix: restore desktop auth deeplink handoff

### DIFF
--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -292,10 +292,15 @@ function DesktopTokenView({
   refreshToken: string;
 }) {
   const [copied, setCopied] = useState(false);
+  const hasOpenedRef = useRef(false);
   const deeplink = `${scheme}://auth/callback?${new URLSearchParams({
     access_token: accessToken,
     refresh_token: refreshToken,
   }).toString()}`;
+
+  const handleOpen = () => {
+    window.location.href = deeplink;
+  };
 
   const handleCopy = async () => {
     await navigator.clipboard.writeText(deeplink);
@@ -303,13 +308,26 @@ function DesktopTokenView({
     window.setTimeout(() => setCopied(false), 2000);
   };
 
+  useMountEffect(() => {
+    if (hasOpenedRef.current) {
+      return;
+    }
+
+    hasOpenedRef.current = true;
+    handleOpen();
+  });
+
   return (
     <div className="flex flex-col gap-4 px-8 pb-8">
       <p className="text-center text-sm text-[#5d5549]">
-        Click the button below to return to the desktop app.
+        Anarlog should open automatically. If it does not, click the button
+        below to return to the desktop app.
       </p>
       <a
         href={deeplink}
+        onClick={() => {
+          hasOpenedRef.current = true;
+        }}
         className="flex w-full items-center justify-center rounded-full bg-[#181613] px-4 py-2 font-sans text-white transition-colors hover:bg-[#373128]"
       >
         Open Anarlog

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,8 +1,10 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 import { ArrowRight, ChevronDown } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { z } from "zod";
 
 import { SiteFooter } from "@/components/site-footer";
+import { desktopSchemeSchema } from "@/functions/desktop-flow";
 import { getGitHubStars } from "@/functions/github";
 import {
   ANARLOG_SITE_URL,
@@ -57,7 +59,54 @@ const appleSiliconDownloadUrl =
 const appleIntelDownloadUrl =
   "https://cdn.crabnebula.app/download/fastrepl/hyprnote2/latest/platform/dmg-x86_64?channel=stable";
 
+const authCallbackSearchSchema = z.object({
+  code: z.string().optional(),
+  token_hash: z.string().optional(),
+  type: z
+    .enum([
+      "email",
+      "recovery",
+      "magiclink",
+      "signup",
+      "invite",
+      "email_change",
+    ])
+    .optional()
+    .catch(undefined),
+  flow: z.enum(["desktop", "web"]).optional().catch("desktop"),
+  scheme: desktopSchemeSchema.optional().catch("hyprnote"),
+  redirect: z.string().optional(),
+  error: z.string().optional(),
+  error_description: z.string().optional(),
+});
+
 export const Route = createFileRoute("/")({
+  validateSearch: authCallbackSearchSchema,
+  beforeLoad: ({ search }) => {
+    const hasAuthCallback =
+      !!search.code || !!search.error || (!!search.token_hash && !!search.type);
+
+    if (!hasAuthCallback) {
+      return;
+    }
+
+    const flow = search.flow ?? "desktop";
+    const scheme = search.scheme ?? "hyprnote";
+
+    throw redirect({
+      to: "/auth/",
+      search: {
+        flow,
+        scheme,
+        code: search.code,
+        token_hash: search.token_hash,
+        type: search.type,
+        redirect: search.redirect,
+        error: search.error,
+        error_description: search.error_description,
+      } as any,
+    });
+  },
   component: Component,
   loader: async () => ({
     githubStars: await getGitHubStars(),


### PR DESCRIPTION
Route bare auth callback params from the homepage into the auth flow and auto-open the desktop app after token handoff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth callback routing and desktop deeplink handoff, so regressions could break sign-in or cause redirect loops across providers/flows. Scope is limited to client-side routing and link opening behavior.
> 
> **Overview**
> Restores the desktop auth handoff by **forwarding bare auth callback query params from `/` to `/auth/`** via a new `validateSearch` schema and `beforeLoad` redirect on the homepage route.
> 
> Updates the desktop token success screen to **auto-open the desktop app deeplink on mount** (with a guard to avoid repeated opens) and adjusts copy to reflect the automatic behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0926b9d1b6a052d001344502863ce80eac678a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->