### PR TITLE
chore: audit blog posts for AI tells

### DIFF
--- a/apps/web/content/articles/ai-meeting-summary-tools.mdx
+++ b/apps/web/content/articles/ai-meeting-summary-tools.mdx
@@ -17,7 +17,7 @@ This list is about tools that actually compress information: decisions, action i
 
 ## AI meeting summary tools comparison: quick overview
 
-Here's a quick comparison of the best AI meeting summary tools to help you decide:
+A quick comparison of the tools below:
 
 | Tool | Best For | Starting Price |
 | --------- | -------------------------------------------- | ----------------------------------------- |
@@ -43,7 +43,7 @@ What matters for summary generation:
 - **Customization for different meeting types.** Sales calls need different structures than customer interviews or team standups. Templates should adapt to your use case.
 - **Speed.** You need summaries within seconds of the meeting ending, not 10 minutes later when you're already in the next call.
 - **Data control and privacy.** Some organizations can't send conversations to the cloud. Understand where your data goes and who processes it before you commit.
-- **Useful AI.** The summary should distill key points, not merely reiterate the transcript in bullet points.
+- **Useful AI.** The summary should distill the meeting, not just reiterate the transcript in bullet points.
 
 That is the standard we used for the tools below.
 
@@ -100,7 +100,7 @@ Free forever for local transcription, BYOK, and all core features. **Managed clo
 
 ### 2. Read AI: the unified meeting intelligence platform
 
-Read AI is a cloud-based AI meeting assistant that goes beyond individual meetings to provide unified search across meetings, emails, and messages. Think of it as an intelligence layer connecting all your communication platforms.
+Read AI is a cloud-based AI meeting assistant with unified search across meetings, emails, and messages — an intelligence layer connecting your communication platforms.
 
 ![read ai summaries review](/api/assets/blog/ai-meeting-summary-tools/summary-3.webp)
 
@@ -219,7 +219,7 @@ Paid plans start at **€24/user/month** (approximately $26 USD) for unlimited A
 
 ### 5. Fellow: the privacy-focused AI meeting assistant
 
-Fellow is a cloud-based meeting workflow platform that emphasizes security and granular privacy controls, making it popular with organizations that need rigorous data protection.
+Fellow is a cloud-based meeting workflow platform built around security and granular privacy controls, popular with organizations that need rigorous data protection.
 
 ![Fellow AI meeting summaries review](/api/assets/blog/ai-meeting-summary-tools/summary-6.webp)
 
@@ -227,7 +227,7 @@ Fellow is a cloud-based meeting workflow platform that emphasizes security and g
 
 Fellow joins meetings as a bot to record and transcribe conversations. It generates AI summaries that cover key takeaways, action items, and decisions, then links everything directly to your meeting notes and calendar events.
 
-The platform stands out with its focus on internal meetings with recording permissions that give managers fine-grained control over what gets captured.
+It focuses on internal meetings, with recording permissions that give managers fine-grained control over what gets captured.
 
 #### Summary features
 
@@ -263,7 +263,7 @@ The platform stands out with its focus on internal meetings with recording permi
 
 ### 6. Fireflies: the conversation intelligence platform
 
-Fireflies.ai positions itself as more than just a transcription tool. It's a conversation intelligence solution focused on analytics, searchability, and deep insights across all your meetings.
+Fireflies.ai is more than a transcription tool. It's a conversation intelligence platform built around analytics, search, and insights across all your meetings.
 
 ![fireflies ai meeting summaries review](/api/assets/blog/ai-meeting-summary-tools/summary-7.webp)
 
@@ -271,7 +271,7 @@ Fireflies.ai positions itself as more than just a transcription tool. It's a con
 
 Fireflies joins your meetings as a bot participant called "Fred" that records and transcribes conversations. After the meeting, it automatically generates AI summaries and can push them to designated channels like Slack or your CRM.
 
-The platform emphasizes analytics, tracking speaker talk time, sentiment, and conversation themes to give you insights beyond basic summaries.
+It tracks speaker talk time, sentiment, and conversation themes for insights beyond a basic summary.
 
 #### Summary features
 
@@ -302,7 +302,7 @@ The platform emphasizes analytics, tracking speaker talk time, sentiment, and co
 
 ### 7. Otter AI: AI summary tool with real-time collaboration
 
-Otter AI is probably the most well-known AI meeting assistant, offering cloud-based meeting intelligence with real-time collaboration features and established cross-platform support.
+Otter AI is probably the most well-known AI meeting assistant. Cloud-based, with real-time collaboration and broad cross-platform support.
 
 ![Otter ai meeting summaries review](/api/assets/blog/ai-meeting-summary-tools/summary-8.webp)
 
@@ -342,7 +342,7 @@ The summaries are organized into chapters with timestamps, making it easy to jum
 
 ### 8. Avoma: the revenue team meeting assistant
 
-Avoma is an AI-powered meeting platform specifically built for sales and customer success teams. It combines meeting intelligence with revenue operations, automatically extracting insights that matter for deal progression.
+Avoma is an AI meeting platform built for sales and customer success teams. It combines meeting intelligence with revenue operations and pulls out the insights that matter for deal progression.
 
 ![avoma ai summaries review](/api/assets/blog/ai-meeting-summary-tools/summary-9.webp)
 
@@ -383,7 +383,7 @@ After meetings, summaries sync directly to your CRM with automatic field updates
 
 ### 9. MeetGeek: the automated meeting workflow platform
 
-MeetGeek is a cloud-based conversation intelligence platform that goes beyond basic summaries with sophisticated automation, meeting type detection, and team-level analytics.
+MeetGeek is a cloud-based conversation intelligence platform with automation, meeting type detection, and team-level analytics on top of basic summaries.
 
 ![Meetgeek ai summaries review](/api/assets/blog/ai-meeting-summary-tools/summary-10.webp)
 
@@ -427,11 +427,11 @@ Summaries are delivered immediately after meetings with key topics, decisions, a
 
 ## My take
 
-This category is getting crowded, but most products still make the same assumption: your meeting data should live in their cloud and your summary format should adapt to them.
+This category is crowded, but most products still make the same assumption: your meeting data lives in their cloud and your summary format adapts to them.
 
 If that trade-off works for you, there are decent options here.
 
-If it does not, Anarlog is the one that breaks the pattern. The notes stay on your device, the AI stack stays flexible, and the summary layer is something you control instead of rent.
+If it doesn't, Anarlog breaks the pattern. The notes stay on your device, the AI stack stays flexible, and the summary layer is something you control instead of rent.
 
 [Download Anarlog for macOS](https://anarlog.so) if you want meeting summaries without handing over the whole system.
 

--- a/apps/web/content/articles/anthropic-data-retention-policy.mdx
+++ b/apps/web/content/articles/anthropic-data-retention-policy.mdx
@@ -16,7 +16,7 @@ If you're evaluating AI providers right now, this is the context you need.
 
 ## What Does Claude Store by Default?
 
-For consumer accounts, that are Claude Free, Pro, and Max, conversations are saved to your account until you delete them. Once deleted, they're removed from your chat history immediately but remain on Anthropic's back-end systems for up to 30 days before being permanently deleted.
+For consumer accounts (Claude Free, Pro, and Max), conversations are saved to your account until you delete them. Once deleted, they're removed from your chat history immediately but stay on Anthropic's back-end systems for up to 30 days before being permanently deleted.
 
 That's the standard case. A few exceptions matter:
 
@@ -32,11 +32,11 @@ Anthropic's previous stance was clean: consumer chats would not be used for trai
 
 If you opted in, Anthropic could retain your conversations in de-identified form for up to 5 years and use them for model training. If you opted out, nothing changed. There's still a 30-day retention, no training use.
 
-The reaction was immediate. Security researchers and privacy advocates flagged it as a "privacy pivot." The opt-in training setting extends data retention from 30 days to 5 years, a 60x increase in how long your conversations can sit in Anthropic's training pipeline.
+The reaction was immediate. Security researchers and privacy advocates flagged it as a "privacy pivot". The opt-in training setting extends data retention from 30 days to 5 years — a 60x increase in how long your conversations can sit in Anthropic's training pipeline.
 
 ## How to Check and Change Your Settings
 
-To see where your account stands: Claude.ai → Settings → Privacy → "Improve Claude for everyone."
+To see where your account stands: Claude.ai → Settings → Privacy → "Improve Claude for everyone".
 
 If the toggle is on, your new conversations are eligible for training and retained for up to 5 years. Turning it off returns you to the 30-day retention standard.
 
@@ -48,7 +48,7 @@ The consumer product and the API have meaningfully different data policies, and 
 
 As of September 14, 2025, Anthropic reduced API log retention from 30 days to 7 days. API inputs and outputs are automatically deleted after 7 days. They are never used for model training.
 
-If your organization needs longer retention for auditing purposes, you can opt in to the 30-day window via your Data Processing Addendum. But the default is 7 days, which is stricter than most providers.
+If your organization needs longer retention for auditing, you can opt in to the 30-day window via your Data Processing Addendum. The default of 7 days is stricter than most providers.
 
 For enterprise API customers who qualify, Anthropic also offers a Zero Data Retention agreement. Under ZDR, inputs and outputs are not stored at all beyond what's needed to screen for abuse. One caveat: Anthropic still retains User Safety classifier results even under ZDR, to enforce their usage policy.
 
@@ -68,7 +68,7 @@ GDPR: Anthropic supports GDPR compliance for commercial customers through a Data
 
 In June 2025, [Reddit filed a lawsuit against Anthropic](https://ppc.land/reddit-files-lawsuit-against-anthropic-over-unauthorized-claude-ai-training/) alleging that Anthropic scraped more than 100,000 Reddit posts and comments without authorization to train Claude. Reddit presented evidence that Claude reproduced deleted Reddit posts with near-perfect accuracy.
 
-This isn't about your personal data directly. But it's relevant context for how Anthropic has approached training data acquisition, and it matters when evaluating whether a company's stated privacy values match their actual behavior.
+This isn't about your personal data directly. But it's context for how Anthropic has approached training data acquisition, and it matters when evaluating whether a company's stated privacy values match its behavior.
 
 ## How Claude.ai Compares to Using Claude Through Anarlog
 
@@ -86,6 +86,6 @@ This isn't about your personal data directly. But it's relevant context for how 
 
 And if Anthropic's policy trajectory gives you pause, you're not locked in. Anarlog supports OpenAI, Mistral, Google Gemini, and local models via Ollama. Your notes stay on your device regardless of which AI processes them. Switching providers doesn't mean starting over.
 
-That's what actual control looks like. It's not just a privacy toggle that defaults to whatever Anthropic decides next quarter.
+That's what actual control looks like — not a privacy toggle that defaults to whatever Anthropic decides next quarter.
 
 [Download Anarlog for macOS](https://anarlog.so/download/apple-silicon) and use the AI provider your security team actually trusts.

--- a/apps/web/content/articles/azure-open-ai-data-retention-policy.mdx
+++ b/apps/web/content/articles/azure-open-ai-data-retention-policy.mdx
@@ -10,7 +10,7 @@ date: "2026-03-19"
 
 Azure OpenAI runs the same underlying models as the consumer ChatGPT product. GPT-4o, GPT-4 Turbo, o1, and others are all available through both. But the data policy is not the same.
 
-When you access OpenAI's models through Microsoft Azure, your data stays within your Azure tenant, Microsoft does not use it to train any models, and you gain access to enterprise compliance frameworks that the consumer product does not offer. The models are identical. The data handling is not.
+When you access OpenAI's models through Microsoft Azure, your data stays within your Azure tenant, Microsoft does not use it to train any models, and you get enterprise compliance frameworks the consumer product does not offer. The models are identical. The data handling is not.
 
 Here is what that means in practice.
 
@@ -22,7 +22,7 @@ Your prompts and completions are retained for up to 30 days for abuse monitoring
 
 ## Who at Microsoft Can Actually See Your Data?
 
-Microsoft employs automated systems for abuse monitoring. Human reviewers can access flagged content, but only content that has been specifically flagged by the automated system, and only through Secure Access Workstations with Just-In-Time approval from team managers. It is not open-access review.
+Microsoft uses automated systems for abuse monitoring. Human reviewers can access flagged content, but only content the automated system has flagged, and only through Secure Access Workstations with Just-In-Time approval from team managers. It is not open-access review.
 
 This is a materially different setup from [Google Gemini's human review policy](https://anarlog.so/blog/google-gemini-data-retention-policy/#human-review-in-plain-terms), where reviewers can access conversations more broadly for quality evaluation.
 
@@ -46,7 +46,7 @@ For GDPR, Microsoft offers an EU Data Zone option that processes and stores your
 
 Both Azure OpenAI and [OpenAI's direct API](https://anarlog.so/blog/chatgpt-data-retention-policy/#the-openai-api-has-meaningfully-better-data-controls) offer enterprise-grade data controls including ZDR. The practical differences come down to infrastructure and compliance coverage.
 
-Azure OpenAI sits inside your existing Azure environment, which means it integrates with your Azure Active Directory, your private virtual networks, your logging infrastructure, and your existing Microsoft compliance agreements. If your organization is already on Azure, adding Azure OpenAI does not introduce a new vendor relationship.
+Azure OpenAI sits inside your existing Azure environment. It integrates with your Azure Active Directory, private virtual networks, logging infrastructure, and existing Microsoft compliance agreements. If your organization is already on Azure, adding Azure OpenAI does not introduce a new vendor relationship.
 
 ## What This Means for Your Evaluation
 

--- a/apps/web/content/articles/best-ai-meeting-assistant-for-taking-notes.mdx
+++ b/apps/web/content/articles/best-ai-meeting-assistant-for-taking-notes.mdx
@@ -19,10 +19,10 @@ The gap between products shows up in the second step. Some tools stop at transcr
 Core capabilities include:
 
 - **Real-time transcription** with speaker identification
-- **Automated note-taking** that extracts key points and decisions
+- **Automated note-taking** that extracts the points and decisions
 - **Action item extraction** that identifies tasks and deadlines
-- **Intelligent summarization** that distills hours of discussion into digestible insights
-- **Searchable archives** that make historical meeting data instantly accessible
+- **Summarization** that compresses an hour of discussion into something scannable
+- **Searchable archives** for getting back to historical meeting data quickly
 
 ## Why This Article Focuses on AI Note-Taking Capabilities
 
@@ -58,7 +58,7 @@ _If you're specifically looking for budget-friendly options, check out our compr
 
 ### 1. Anarlog: Best for Zero Lock-in and Complete Control
 
-[Anarlog](/) is an open-source AI notepad for meetings built for high-agency people who demand complete control over their data and AI stack.
+[Anarlog](/) is an open-source AI notepad for meetings, built for people who want complete control over their data and AI stack.
 
 Everything is stored as plain markdown files—not in proprietary databases. You choose your AI: bring your own keys or run local models.
 
@@ -178,13 +178,13 @@ Also check: [Top Otter AI's Alternatives](/blog/otter-ai-alternatives)
 
 ### 4. Fireflies: Best for Conversation Analytics and Team Insights
 
-[Fireflies](https://fireflies.ai) is a comprehensive AI meeting assistant that offers deep conversation analytics and team collaboration features beyond basic transcription. With over 16 million users and a recent $1 billion valuation, it positions itself as an enterprise-grade solution.
+[Fireflies](https://fireflies.ai) is an AI meeting assistant with conversation analytics and team collaboration features on top of transcription. With over 16 million users and a recent $1 billion valuation, it pitches itself as an enterprise-grade solution.
 
 <Image src="/api/assets/blog/best-ai-meeting-assistant-for-taking-notes/fireflies.webp" alt="Fireflies"/>
 
 #### About Fireflies.ai's note-taking capabilities:
 
-Its AI assistant "Fred" automatically joins your meetings and creates detailed transcripts, then generates structured summaries with action items and decisions automatically extracted. Fireflies excels in conversation analytics by tracking speaker talk time, monitoring sentiment, identifying key topics, and providing team performance insights.
+Its AI assistant "Fred" joins your meetings, creates detailed transcripts, then generates summaries with action items and decisions extracted. Fireflies tracks speaker talk time, sentiment, topics, and team performance.
 
 **Other notable features:**
 
@@ -216,7 +216,7 @@ Also check: [Top Fireflies AI Alternatives](/blog/fireflies-ai-alternatives)
 
 ### 5. Krisp: Best for Audio Quality Plus AI Note-Taking
 
-[Krisp](https://krisp.ai/) is primarily an AI-powered noise cancellation tool that has expanded into meeting note-taking, making it unique among AI assistants.
+[Krisp](https://krisp.ai/) started as an AI-powered noise cancellation tool and expanded into meeting note-taking, which makes it unusual in this category.
 
 <Image src="/api/assets/blog/best-ai-meeting-assistant-for-taking-notes/krisp.webp" alt="Krisp"/>
 
@@ -295,7 +295,7 @@ Jamie AI offers a generous free plan with all premium features and reasonable us
 
 #### About Avoma's AI note-taking capabilities:
 
-Avoma's AI automatically records, transcribes, and analyzes meetings while organizing discussions into "Smart Chapters" that break down conversations by topic. These chapters identify key themes like business needs, pain points, and competitor mentions with timestamps, allowing you to jump directly to specific segments.
+Avoma records, transcribes, and analyzes meetings, organizing discussions into "Smart Chapters" by topic. The chapters surface themes like business needs, pain points, and competitor mentions with timestamps, so you can jump directly to specific segments.
 
 **Other notable features:**
 

--- a/apps/web/content/articles/best-ai-notetaker-for-in-person-meetings.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-in-person-meetings.mdx
@@ -10,7 +10,7 @@ date: "2025-09-03"
 
 In-person meetings are where a lot of AI notetakers fall apart.
 
-Most of these products were designed around video calls, calendar links, separate audio channels, and stable internet. Real conversations happen in conference rooms, cafes, hallways, cars, and client offices. The constraints are different.
+Most of these products were designed around video calls: calendar links, separate audio channels, stable internet. Real conversations happen in conference rooms, cafes, hallways, cars, and client offices. The constraints are different.
 
 We looked for tools that could survive that mess.
 
@@ -54,9 +54,9 @@ How many languages can it handle accurately? International teams and diverse wor
 
 ### 1. Anarlog
 
-[Anarlog](/) is an open-source AI notepad for meetings built for high-agency people who demand complete control over their data and AI stack. Everything is stored as plain markdown files—not in proprietary databases. You choose your AI: bring your own keys or run local models.
+[Anarlog](/) is an open-source AI notepad for meetings, built for people who want complete control over their data and AI stack. Everything is stored as plain markdown files—not in proprietary databases. You choose your AI: bring your own keys or run local models.
 
-The interface feels like Apple Notes but with AI superpowers. Start a meeting, and it transcribes in real-time. When you hang up, you get structured summaries with decisions and action items automatically extracted.
+The interface feels like Apple Notes with an AI layer. Start a meeting and it transcribes in real-time. When you hang up, you get structured summaries with decisions and action items extracted.
 
 Zero lock-in—your files work with any tool (Obsidian, Notion, VS Code) and you can switch AI providers anytime.
 
@@ -86,7 +86,7 @@ Free forever for local transcription, BYOK, and all core features.
 
 ### 2. Jamie AI
 
-[Jamie](https://www.meetjamie.ai) records audio locally on Windows or Mac computers, then uploads recordings to German servers for AI processing. The system automatically deletes audio files after generating transcripts and summaries, emphasizing privacy through data minimization rather than local processing.
+[Jamie](https://www.meetjamie.ai) records audio locally on Windows or Mac, then uploads recordings to German servers for AI processing. It deletes audio files after generating transcripts and summaries, betting on data minimization rather than local processing.
 
 ![jamie ai for in person meetings](/api/assets/blog/best-ai-notetaker-for-in-person-meetings/inperson-2.webp)
 
@@ -114,7 +114,7 @@ Free plan with 10 meetings/month. Paid plans start at €24/month (~$25) with hi
 
 ### 3. Fireflies AI
 
-Fireflies uses a bot system for online meetings but shifts to mobile-first recording for in-person conversations. The platform emphasizes team analytics and workflow automation alongside transcription.
+Fireflies uses a bot for online meetings but shifts to mobile-first recording for in-person conversations. It pushes team analytics and workflow automation alongside transcription.
 
 ![Fireflies ai for in person meetings](/api/assets/blog/best-ai-notetaker-for-in-person-meetings/inperson-3.webp)
 
@@ -172,7 +172,7 @@ Basic plan offers 300 free minutes monthly. Pro costs $19 monthly, Business $39 
 
 ### 5. Otter AI
 
-Otter specializes in live transcription as meetings occur. However, the platform faces significant privacy concerns, including ongoing federal litigation.
+Otter does live transcription as meetings happen. It also faces real privacy concerns, including ongoing federal litigation.
 
 ![Otter ai for in person meetings](/api/assets/blog/best-ai-notetaker-for-in-person-meetings/inperson-5.webp)
 
@@ -200,7 +200,7 @@ Free plan provides 300 monthly minutes with conversation limits. Paid plans star
 
 ### 6. Granola AI
 
-Granola encourages users to take notes manually during meetings, then uses AI to enhance and structure those notes afterward. The platform records locally but processes content in the cloud for intelligent analysis.
+Granola encourages you to take notes manually during meetings, then uses AI to clean them up afterward. It records locally but processes content in the cloud.
 
 ![granola ai for in person meetings](/api/assets/blog/best-ai-notetaker-for-in-person-meetings/inperson-6.webp)
 
@@ -227,7 +227,7 @@ Free trial with up to 25 meetings to test the full feature set. Paid plans start
 
 ### 7. Read AI
 
-Read AI focuses on analyzing meeting dynamics and participant engagement alongside transcription. The platform recently introduced mobile capabilities for in-person meeting recording and analysis.
+Read AI analyzes meeting dynamics and participant engagement alongside transcription. It recently added mobile capabilities for in-person meeting recording.
 
 ![read ai for in person meetings](/api/assets/blog/best-ai-notetaker-for-in-person-meetings/inperson-7.webp)
 

--- a/apps/web/content/articles/best-ai-notetaker-for-microsoft-teams.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-microsoft-teams.mdx
@@ -39,7 +39,7 @@ Microsoft doesn't offer a free way to get AI-powered meeting notes, summaries, o
 
 ![Microsoft 365 Copilot](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-2.webp)
 
-[Microsoft 365 Copilot](https://support.microsoft.com/en-us/office/use-copilot-in-microsoft-teams-meetings-0bf9dd3c-96f7-44e2-8bb8-790bedf066b1) is an AI assistant that works across Word, Excel, PowerPoint, Outlook, and Teams, powered by large language models. For Teams specifically, it transforms how you handle meeting preparation, participation, and follow-up.
+[Microsoft 365 Copilot](https://support.microsoft.com/en-us/office/use-copilot-in-microsoft-teams-meetings-0bf9dd3c-96f7-44e2-8bb8-790bedf066b1) is an AI assistant that works across Word, Excel, PowerPoint, Outlook, and Teams. In Teams, it handles meeting preparation, participation, and follow-up.
 
 **Important Note:** Microsoft 365 Copilot is different from the [free Copilot](https://copilot.microsoft.com) available in browsers and Bing. Copilot does not record meetings itself—you need to provide it with a meeting transcription to generate a summary and AI notes.
 
@@ -108,15 +108,15 @@ Teams Premium is priced at $10 per user per month.
 
 ## Best Third-Party AI Notetakers for Microsoft Teams
 
-While Microsoft's native solutions work well for many organizations, third-party tools often provide specialized features, better privacy controls, or more competitive pricing.
+Microsoft's native options work well for many organizations, but third-party tools often offer specialized features, better privacy controls, or more competitive pricing.
 
 ### 1. Anarlog: The Zero Lock-in AI Notepad
 
-Anarlog is an open-source AI notepad for meetings built for high-agency people who demand complete control over their data and AI stack. Everything is stored as plain markdown files—not in proprietary databases.
+Anarlog is an open-source AI notepad for meetings, built for people who want complete control over their data and AI stack. Everything is stored as plain markdown files—not in proprietary databases.
 
 **Full Disclosure:** I'm the co-founder of Anarlog, so I'll try to be as objective as possible in this review.
 
-**How It Works with Microsoft Teams:** Anarlog doesn't join your Teams meetings as a bot. Instead, it captures both your microphone input and your computer's system audio, so it hears both sides of the conversation. It transcribes your call in real-time. After the meeting ends, you get structured summaries with decisions and action items automatically extracted. No bots to invite, no meeting links to manage.
+**How It Works with Microsoft Teams:** Anarlog doesn't join your Teams meetings as a bot. It captures both your microphone input and your computer's system audio, so it hears both sides of the conversation. The call is transcribed in real-time. When the meeting ends, you get structured summaries with decisions and action items extracted. No bots to invite, no meeting links to manage.
 
 ![best ai notetaker for microsoft teams](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-4.webp)
 
@@ -150,7 +150,7 @@ Anarlog is [free forever](/blog/free-ai-notetakers) for local transcription, BYO
 
 ### 2. Otter AI: The Established Cloud-Based Solution
 
-[Otter AI](https://otter.ai) is one of the most well-known names in AI transcription, offering cloud-based meeting intelligence that works across Microsoft Teams, [Zoom](/blog/best-ai-notetaker-for-zoom/), and Google Meet.
+[Otter AI](https://otter.ai) is one of the most well-known names in AI transcription. It's cloud-based and works across Microsoft Teams, [Zoom](/blog/best-ai-notetaker-for-zoom/), and Google Meet.
 
 **How It Works with Microsoft Teams:** Otter joins your Teams meetings as a participant. It records the audio, generates real-time transcripts, and creates meeting summaries automatically. Setup involves account creation, calendar connection, and bot invitation. The bot can be invited manually or set to auto-join meetings based on your calendar integration. Recent privacy concerns indicate that Otter sometimes joins meetings without proper consent. Also check: [Is Otter AI Safe?](/blog/is-otter-ai-safe)
 
@@ -228,7 +228,7 @@ Free plan: 10 meetings/month and 5 AI credits. Paid plans start at $12/user/mont
 
 ### 4. Fireflies AI: The Conversation Intelligence Platform
 
-[Fireflies](https://fireflies.ai) positions itself as a full conversation intelligence solution for sales teams and growing businesses.
+[Fireflies](https://fireflies.ai) pitches itself as a full conversation intelligence platform for sales teams and growing businesses.
 
 **How It Works with Microsoft Teams:** Fireflies joins your Teams meetings as a bot. You can invite it manually to specific meetings or set it to auto-join based on your calendar integration. The bot records, transcribes, and processes the entire conversation, then automatically sends meeting summaries to designated Teams channels. Setup involves creating a Fireflies account, verifying email, connecting your Microsoft calendar, configuring auto-join preferences, setting up Teams channel integrations for receiving summaries, and potentially getting IT approval for the bot.
 
@@ -307,7 +307,7 @@ Free forever plan with unlimited recordings. Pro plans start at $29/month for ad
 
 If your company is already deep in Microsoft procurement and wants the most familiar path, start with Copilot.
 
-If you want something that is not trapped inside Teams, start with Anarlog. It works with Teams, but it is not dependent on Teams. That matters if you care about keeping the notes as files, keeping the AI stack flexible, or keeping the same workflow across Zoom, Meet, and in-person conversations.
+If you want something that isn't trapped inside Teams, start with Anarlog. It works with Teams but doesn't depend on it. That matters if you care about keeping notes as files, keeping the AI stack flexible, or running the same workflow across Zoom, Meet, and in-person conversations.
 
 You can [download and start using Anarlog](https://anarlog.so) without calendar connections, account setup, or a meeting bot.
 

--- a/apps/web/content/articles/best-ai-notetaker-for-zoom.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-zoom.mdx
@@ -48,11 +48,11 @@ We prioritized:
 
 <Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-1.webp" alt="Best ai notetaker for zoom" />
 
-[Anarlog](/) is an open-source AI notepad for meetings built for high-agency people who demand complete control. Everything is stored as plain markdown files on your device—not in proprietary databases. You choose your AI: bring your own keys or run local models.
+[Anarlog](/) is an open-source AI notepad for meetings, built for people who want complete control. Everything is stored as plain markdown files on your device—not in proprietary databases. You choose your AI: bring your own keys or run local models.
 
-The interface works like Apple Notes with AI superpowers. Start a meeting and it transcribes in real-time. When you hang up, you get structured summaries with decisions and action items automatically extracted.
+The interface works like Apple Notes with an AI layer. Start a meeting and it transcribes in real-time. When you hang up, you get structured summaries with decisions and action items extracted.
 
-The AI can work completely hands-off, generating organized notes without any input from you. Or you can collaborate by jotting down key points, and the AI will expand your rough notes with context you might have missed while actively participating.
+The AI can work completely hands-off, generating organized notes without any input from you. Or you can collaborate by jotting down key points, and the AI will expand your rough notes with context you missed while actively participating.
 
 #### Key features
 
@@ -132,7 +132,7 @@ Also, check out our detailed [Zoom AI Companion review](/blog/zoom-ai-companion-
 
 <Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-3.webp" alt="Fathom for zoom" />
 
-[Fathom](https://www.fathom.ai) joins your Zoom calls as a bot and emphasizes speed—you get meeting summaries within 30 seconds of hanging up. Its main strength is handling the post-meeting workflow, automatically pushing notes and action items into your CRM without manual work.
+[Fathom](https://www.fathom.ai) joins your Zoom calls as a bot and is built around speed — you get meeting summaries within 30 seconds of hanging up. Its main strength is the post-meeting workflow: it pushes notes and action items into your CRM without manual work.
 
 During calls, you can click buttons to highlight important moments or mark action items. After the meeting, everything gets organized into a summary you can immediately forward to colleagues or sync with Salesforce.
 
@@ -170,9 +170,9 @@ Free plan includes unlimited recordings and basic summaries. Premium costs $19/m
 
 [Otter AI](https://otter.ai) is probably the most well-known AI meeting assistant—though not always for the right reasons, which we'll address.
 
-Otter pioneered many features that are now standard in the industry. It joins your Zoom, Google Meet, and Teams calls as a visible bot and delivers solid real-time transcription with speaker identification. You can assign action items directly in the transcript, and everyone gets access to searchable meeting notes immediately after calls end.
+Otter pioneered features that are now standard in the category. It joins your Zoom, Google Meet, and Teams calls as a visible bot and delivers solid real-time transcription with speaker identification. You can assign action items directly in the transcript, and everyone gets access to searchable meeting notes immediately after calls end.
 
-However, Otter has developed a reputation for privacy issues that have made headlines. Users have reported the bot joining meetings without proper consent and spamming all participants with meeting notes. An [ongoing class-action lawsuit](/blog/is-otter-ai-safe) addresses these privacy practices.
+Otter has also developed a reputation for privacy issues. Users have reported the bot joining meetings without proper consent and spamming all participants with meeting notes. An [ongoing class-action lawsuit](/blog/is-otter-ai-safe) addresses these practices.
 
 #### Key features
 
@@ -208,7 +208,7 @@ Free plan with 300 monthly minutes. Paid plans start at $16.99/user/month.
 
 [tl;dv](https://tldv.io) is a video-focused meeting assistant that records your Zoom, Google Meet, and Teams meetings and creates shareable video clips from longer recordings.
 
-What makes tl;dv different is its emphasis on post-meeting workflow automation. It can automatically update your CRM with call details, draft follow-up emails based on conversation content, and generate aggregated insights across multiple meetings. For sales teams, it tracks playbook adherence and objection handling to improve performance.
+What sets tl;dv apart is its post-meeting workflow automation. It updates your CRM with call details, drafts follow-up emails based on conversation content, and generates aggregated insights across multiple meetings. For sales teams, it tracks playbook adherence and objection handling.
 
 #### Key features
 
@@ -244,7 +244,7 @@ Free forever plan with unlimited recordings. Pro plans start at $29/month for ad
 
 [Fireflies.ai](https://fireflies.ai) works similarly to Otter AI—its AI assistant "Fred" automatically joins your meetings and creates detailed transcripts. When meetings end, it generates structured summaries with clear action items, decisions, and next steps automatically extracted.
 
-Fireflies stands out for multilingual support across 100+ languages and conversation analytics. It tracks speaker talk time, monitors sentiment, identifies key topics, and provides team performance insights to optimize meeting effectiveness.
+Fireflies stands out for multilingual support across 100+ languages and its conversation analytics. It tracks speaker talk time, sentiment, topics, and team performance.
 
 #### Key features
 
@@ -279,7 +279,7 @@ Free plan with 800 minutes of storage and limited AI credits. Paid plans start a
 
 <Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-7.webp" alt="meetgeek for zoom" />
 
-[MeetGeek](https://meetgeek.ai/?r=0) automatically joins your meetings, records them, and syncs content directly into tools like Slack, HubSpot, or project management apps. The focus is reducing the manual work that happens after meetings—no more copying notes between systems or forgetting to update your CRM.
+[MeetGeek](https://meetgeek.ai/?r=0) joins your meetings, records them, and syncs content directly into tools like Slack, HubSpot, or project management apps. The focus is reducing post-meeting busywork — no more copying notes between systems or forgetting to update your CRM.
 
 #### Key features
 
@@ -312,7 +312,7 @@ Free plan with 300 minutes monthly. Pro at $19/month for unlimited transcription
 
 <Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-8.webp" alt="avoma for zoom" />
 
-[Avoma](https://www.avoma.com) focuses on sales coaching and deal intelligence. The platform provides AI-powered scorecards for call performance, tracks talk patterns and engagement, and offers deal risk analysis. It can automatically update CRM fields based on conversation content and provides win-loss analysis to improve sales strategies.
+[Avoma](https://www.avoma.com) focuses on sales coaching and deal intelligence. It provides AI scorecards for call performance, tracks talk patterns and engagement, and offers deal risk analysis. It updates CRM fields based on conversation content and runs win-loss analysis to inform sales strategy.
 
 #### Key features
 
@@ -344,9 +344,9 @@ Offers a 14-day free trial, with paid plans starting at $29/month per recorder. 
 
 <Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-9.webp" alt="tactiq for zoom" />
 
-Unlike the standalone apps we've covered so far, [Tactiq](https://tactiq.io) works as a Chrome extension. This means no separate software to install—it just lives in your browser and captures audio directly from Google Meet, Zoom, and Teams tabs.
+Unlike the standalone apps above, [Tactiq](https://tactiq.io) works as a Chrome extension. No separate software to install — it lives in your browser and captures audio directly from Google Meet, Zoom, and Teams tabs.
 
-The integration ecosystem is where Tactiq shines. It pushes meeting insights to Slack, HubSpot, Jira, and everywhere you actually work. You can turn frequent AI prompts into one-click actions, so you don't have to start from scratch every time you need follow-up tasks.
+The integration ecosystem is where Tactiq shines. It pushes meeting insights to Slack, HubSpot, Jira, and everywhere you actually work. You can turn frequent AI prompts into one-click actions instead of starting from scratch every time.
 
 #### Key features
 
@@ -378,9 +378,9 @@ Free plan with 10 meetings/month and 5 AI credits. Paid plans start at $12/user/
 
 <Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-10.webp" alt="krisp ai for zoom" />
 
-[Krisp](https://krisp.ai) cancels background noise AND takes meeting notes. The platform removes background noises, voices, and echoes from both sides of calls while transcribing meetings in real-time across all communication apps.
+[Krisp](https://krisp.ai) cancels background noise and takes meeting notes. It removes noise, voices, and echoes from both sides of calls while transcribing in real-time across communication apps.
 
-The AI meeting notes are more basic than enhanced summaries from other tools, but they capture the essentials without fuss.
+The AI notes are more basic than what other tools produce, but they capture the essentials.
 
 #### Key features
 
@@ -409,7 +409,7 @@ Offers a free plan with unlimited transcripts and 2 daily meeting notes. Paid pl
 
 If you already live entirely inside Zoom and want the path of least resistance, Zoom AI Companion may be enough.
 
-If you want notes you can keep, move, audit, and run outside Zoom's ecosystem, the list gets much shorter. That is why Anarlog is the one I would start with. The notes stay as files, the AI layer stays flexible, and the workflow does not collapse if you change providers later.
+If you want notes you can keep, move, audit, and run outside Zoom's ecosystem, the list gets much shorter. That's why Anarlog is the one I'd start with. The notes stay as files, the AI layer stays flexible, and the workflow doesn't collapse if you change providers later.
 
 [Download Anarlog for macOS](https://anarlog.so) if that is the setup you want to own.
 

--- a/apps/web/content/articles/best-ai-notetaker.mdx
+++ b/apps/web/content/articles/best-ai-notetaker.mdx
@@ -12,11 +12,11 @@ I am a big believer in jotting things down.
 
 If I have an idea, I capture it. The problem is I capture everything. At one point, my note-taking app had so many half-baked ideas that nothing made sense anymore. Then AI changed that.
 
-Those random notes could suddenly be summarized, searched, and connected. I could ask questions across everything I'd written. Turn messy thoughts into clear insights. Find an idea from three months ago in seconds. It's made a real difference.
+Those random notes could suddenly be summarized, searched, and connected. I could ask questions across everything I'd written. Find an idea from three months ago in seconds. It's made a real difference.
 
-But AI note-taking apps aren't all built the same.
+But AI note-taking apps aren't built the same.
 
-I've spent considerable time testing these tools. I even built one myself. If you're looking for an AI note-taking app, I've done the research. This guide breaks down the popular options so you can pick the right one.
+I've spent a lot of time testing these tools. I even built one myself. This guide breaks down the popular options so you can pick the right one.
 
 ## What Are the Best AI Note Taker Apps? A Quick Comparison
 
@@ -33,9 +33,9 @@ I've spent considerable time testing these tools. I even built one myself. If yo
 
 ## What Is an AI Note Taker?
 
-An AI note taker uses artificial intelligence to help you capture, organize, and make sense of information. It applies large language models to turn raw input—typed notes, voice recordings, or transcribed conversations—into something useful.
+An AI note taker uses AI to help you capture, organize, and make sense of information. It applies large language models to turn raw input—typed notes, voice recordings, or transcribed conversations—into something useful.
 
-The best ones do more than transcribe or summarize. They let you search across everything you've captured, connect related ideas, answer questions about your notes, and surface insights you'd find difficult to locate manually. The AI extends your note-taking workflow rather than replacing it.
+The good ones do more than transcribe or summarize. They let you search across everything you've captured, connect related ideas, answer questions about your notes, and surface things you'd struggle to find manually. The AI extends your workflow instead of replacing it.
 
 ## Types of AI Note Takers
 
@@ -47,9 +47,9 @@ Some join meetings as bots (Otter), while others record your system audio direct
 
 ### PKM Note-Taking Apps with AI
 
-Notion and Obsidian were built for personal knowledge management, not meetings—a place to externalize your thinking. They've added AI features to help you write, organize, search, and connect ideas across your notes.
+Notion and Obsidian were built for personal knowledge management, not meetings—a place to externalize your thinking. They've bolted on AI features to help you write, organize, search, and connect ideas across your notes.
 
-The AI assists with drafting, summarizing long documents, answering questions about your knowledge base, and surfacing related notes. These tools work with whatever you type, not just meeting audio.
+The AI helps with drafting, summarizing long documents, answering questions about your knowledge base, and surfacing related notes. These tools work with whatever you type, not just meeting audio.
 
 ## Reviews of the Best AI Note Taker Apps
 
@@ -248,9 +248,9 @@ A generous free tier includes basic CRM sync. Team $18/month/user (minimum 2 use
 
 ![](/api/assets/blog/articles/best-ai-notetaker/1768756076581-image-6.png)
 
-[Reflect](https://www.google.com/url?q=https://reflect.app/&sa=D&source=editors&ust=1768759307567541&usg=AOvVaw1PCJnKZNiP0tu7xN0mhzXX) is a daily notes app with backlinks and AI. You get a new note each day. You write. It links. The AI (GPT-4 and Whisper) can transcribe voice notes, generate summaries, answer questions about your notes. Google Calendar integration puts your meetings in the sidebar, ready for notes.
+[Reflect](https://www.google.com/url?q=https://reflect.app/&sa=D&source=editors&ust=1768759307567541&usg=AOvVaw1PCJnKZNiP0tu7xN0mhzXX) is a daily notes app with backlinks and AI. You get a new note each day. You write. It links. The AI (GPT-4 and Whisper) transcribes voice notes, generates summaries, and answers questions about your notes. Google Calendar integration puts your meetings in the sidebar, ready for notes.
 
-It's built for people who think in connections rather than folders. Everything is chronological by default. Backlinks surface automatically. End-to-end encryption means only you read your notes. Fast, minimal, opinionated—there's essentially one way to use it.
+It's built for people who think in connections rather than folders. Everything is chronological by default. Backlinks surface automatically. End-to-end encryption means only you read your notes. Fast, minimal, opinionated — there's basically one way to use it.
 
 #### Key Features:
 
@@ -285,9 +285,9 @@ $10/month (must pay $120 annually). 14-day free trial.
 
 ![](/api/assets/blog/articles/best-ai-notetaker/1768756076836-image-7.png)
 
-[Otter](https://www.google.com/url?q=https://otter.ai/&sa=D&source=editors&ust=1768759307570156&usg=AOvVaw1ShKuIeVNtQTONf80caVdW) has been in the AI note-taking space longer than most competitors. The product is feature-rich with extensive integrations (Salesforce, HubSpot, Slack, Notion) and solid team collaboration tools. The bot joins your meetings, transcribes, learns speaker voices, captures slides automatically. AI chat lets you query transcripts.
+[Otter](https://www.google.com/url?q=https://otter.ai/&sa=D&source=editors&ust=1768759307570156&usg=AOvVaw1ShKuIeVNtQTONf80caVdW) has been in the AI note-taking space longer than most competitors. The product is feature-rich, with integrations (Salesforce, HubSpot, Slack, Notion) and solid team collaboration tools. The bot joins your meetings, transcribes, learns speaker voices, captures slides automatically. AI chat lets you query transcripts.
 
-However, there are significant concerns. A [federal lawsuit](https://anarlog.so/blog/is-otter-ai-safe) alleges Otter records without proper consent. Users report the bot automatically inviting colleagues and joining meetings uninvited. Transcripts get shared externally. Customer support is slow and account cancellations are difficult. Your data gets shared with third parties for AI training. The free tier is deliberately limited to push users toward paid plans.
+There are real concerns though. A [federal lawsuit](https://anarlog.so/blog/is-otter-ai-safe) alleges Otter records without proper consent. Users report the bot automatically inviting colleagues and joining meetings uninvited. Transcripts get shared externally. Customer support is slow and account cancellations are difficult. Your data gets shared with third parties for AI training. The free tier is deliberately limited to push users toward paid plans.
 
 If you're comfortable with cloud-only recording, bot-based capture, and the privacy tradeoffs, Otter delivers on features. If data control matters or you work with sensitive information, the problems outweigh the polish.
 
@@ -368,7 +368,7 @@ Offers a free tier, but real use requires Pro at $12/month.
 
 ### 1. Can I use AI for note-taking?
 
-Yes. AI note-taking tools transcribe conversations, generate summaries, extract action items, and help you search across everything you've captured. They're particularly useful for meetings, lectures, interviews, or anytime you need to focus on the conversation instead of frantically typing notes.
+Yes. AI note-taking tools transcribe conversations, generate summaries, extract action items, and help you search across everything you've captured. They're useful for meetings, lectures, interviews, or anytime you need to focus on the conversation instead of frantically typing notes.
 
 The right tool depends on your needs. If you want zero lock-in and complete control, use Anarlog. If you need CRM integration, use something built for sales (Fathom). If you want AI to organize your messy thoughts, try Mem.ai.
 

--- a/apps/web/content/articles/best-ai-notetakers-google-meet.mdx
+++ b/apps/web/content/articles/best-ai-notetakers-google-meet.mdx
@@ -68,7 +68,7 @@ Free forever, fully local + BYOK, open source.
 
 ### 2. Fireflies AI: the conversation intelligence platform
 
-**[Fireflies](http://fireflies.ai/)** positions itself as more than just a transcription tool—it's a full conversation intelligence solution for sales teams and growing businesses.
+**[Fireflies](http://fireflies.ai/)** is more than a transcription tool — it's a full conversation intelligence platform for sales teams and growing businesses.
 
 #### How it works with Google Meet
 
@@ -103,7 +103,7 @@ Free forever with unlimited transcription but limited AI features. Paid plans st
 
 ### 3. Sembly AI: the workflow integration specialist
 
-**[Sembly](https://www.sembly.ai/)** transforms meetings into actionable business deliverables like project plans, requirements documents, and reports. Beyond transcription, it analyzes patterns across multiple meetings, automatically generates artifacts tailored to specific roles, and provides enterprise-grade analytics for team productivity.
+**[Sembly](https://www.sembly.ai/)** turns meetings into business deliverables like project plans, requirements documents, and reports. It analyzes patterns across multiple meetings, generates artifacts tailored to specific roles, and provides enterprise-grade analytics for team productivity.
 
 #### How it works with Google Meet
 
@@ -137,7 +137,7 @@ Free trial available, with paid plans starting at $15/user/month.
 
 ### 4. tl;dv: the video-first meeting assistant
 
-**[tl;dv](https://tldv.io/)** turns meeting notes into clickable timestamps, making it easy to navigate directly to specific moments in recordings while providing advanced sales coaching features.
+**[tl;dv](https://tldv.io/)** turns meeting notes into clickable timestamps, so you can jump directly to specific moments in recordings. It also has sales coaching features built in.
 
 #### How it works with Google Meet
 
@@ -172,7 +172,7 @@ Free forever plan with unlimited recordings. Pro plans start at $29/month for ad
 
 ### 5. Tactiq: the Chrome extension solution
 
-**[Tactiq](https://tactiq.io/)** works as a Chrome extension rather than a standalone app. It provides live transcription directly in your browser during Google Meet, with powerful workflow automation capabilities.
+**[Tactiq](https://tactiq.io/)** works as a Chrome extension rather than a standalone app. It runs live transcription directly in your browser during Google Meet, with workflow automation built in.
 
 #### How it works with Google Meet
 
@@ -207,7 +207,7 @@ Free plan with 10 meetings/month and 5 AI credits. Paid plans start at $12/user/
 
 ### 6. Krisp: noise cancellation plus AI notes
 
-**[Krisp](https://krisp.ai/)** combines background noise cancellation with meeting transcription. The platform removes background noises, voices, and echoes from both sides of calls while transcribing meetings in real-time.
+**[Krisp](https://krisp.ai/)** combines background noise cancellation with meeting transcription. It strips noise, voices, and echoes from both sides of a call while transcribing in real-time.
 
 #### How it works with Google Meet
 
@@ -243,7 +243,7 @@ Free plan with unlimited transcripts and 2 daily meeting notes. Paid plans start
 
 ### 7. Otter AI: the established cloud solution
 
-**[Otter AI](https://otter.ai/)** is a well-known AI meeting assistant offering cloud-based meeting intelligence that works across Google Meet, [Zoom](/blog/best-ai-notetaker-for-zoom/), and Microsoft Teams with established real-time collaboration features.
+**[Otter AI](https://otter.ai/)** is a well-known AI meeting assistant that runs in the cloud and works across Google Meet, [Zoom](/blog/best-ai-notetaker-for-zoom/), and Microsoft Teams, with real-time collaboration built in.
 
 #### How it works with Google Meet
 

--- a/apps/web/content/articles/bot-free-ai-meeting-assistants.mdx
+++ b/apps/web/content/articles/bot-free-ai-meeting-assistants.mdx
@@ -6,11 +6,11 @@ category: "Comparisons"
 date: "2025-08-27"
 ---
 
-I'm tired of AI bots crashing my meetings uninvited. You know the drill - you're in a sensitive client call, and suddenly "OtterPilot has joined the meeting." Awkward silence. "Who invited the bot?"
+I'm tired of AI bots crashing my meetings uninvited. You're in a sensitive client call, and suddenly "OtterPilot has joined the meeting" pops up. Awkward silence. "Who invited the bot?"
 
-That's why I've been testing bot-free alternatives that capture your meetings without sending virtual party crashers. These tools record directly from your device or browser, so your calls stay natural while you still get AI-powered notes.
+I've been testing bot-free alternatives that capture meetings without sending a stranger to the call. These tools record from your device or browser, so the call stays natural and you still get AI notes.
 
-According to my research, here are the 12 bot-free meeting assistants worth trying:
+Here are the 12 bot-free meeting assistants worth trying:
 
 - **Anarlog** → Local, offline, open-source, max privacy
 - **Jamie AI** → GDPR-compliant AI with executive recall
@@ -38,11 +38,11 @@ According to my research, here are the 12 bot-free meeting assistants worth tryi
 
 ### 1. Anarlog
 
-[Anarlog](/) is an open-source AI notepad for meetings that gives you complete control over your data and AI stack. Everything is stored as plain markdown files—not in proprietary databases. You choose your AI: bring your own keys or run local models.
+[Anarlog](/) is an open-source AI notepad for meetings that gives you control over your data and AI stack. Everything is stored as plain markdown files, not in a proprietary database. You pick the AI: bring your own keys or run local models.
 
-The interface feels like Apple Notes but with AI superpowers running in the background. Start a meeting and it transcribes in real-time. When you hang up, you get structured summaries with decisions and action items automatically extracted.
+The interface feels like Apple Notes with AI running in the background. Start a meeting and it transcribes in real-time. When you hang up, you get a structured summary with decisions and action items extracted.
 
-Anarlog's Smart Consent Management Package for enterprises stands out. It handles consent legally and transparently with multiple options: simple pop-ups, voice recognition that listens for verbal consent, and customizable policies.
+Anarlog's Smart Consent Management Package handles consent legally and transparently: pop-ups, voice recognition that listens for verbal consent, and customizable policies.
 
 **Pricing:** Free forever for local transcription, BYOK, and all core features. Managed cloud $25/month. Enterprise with custom pricing for consent management and on-premises deployment.
 
@@ -78,9 +78,9 @@ Anarlog's Smart Consent Management Package for enterprises stands out. It handle
 
 ### 2. Jamie AI
 
-[Jamie AI](https://www.meetjamie.ai/) takes privacy seriously but differently than Anarlog. Instead of keeping everything local, they process your audio in Germany under strict GDPR rules, then immediately delete the recordings. It's like having a very discreet German assistant who forgets everything after writing your notes.
+[Jamie AI](https://www.meetjamie.ai/) handles privacy differently than Anarlog. Instead of keeping everything local, it processes audio in Germany under GDPR, then deletes the recordings. Discreet German assistant who forgets everything after writing your notes.
 
-What makes Jamie special is the Executive Assistant feature. Hit Ctrl+J and you get an AI sidebar that remembers everything from past meetings. Ask "What did Sarah say about the Q4 budget?" and it knows instantly.
+The Executive Assistant feature is the differentiator. Hit Ctrl+J and an AI sidebar pulls context from past meetings. Ask "what did Sarah say about the Q4 budget?" and it answers.
 
 **Pricing:** Free plan with 10 meetings/month. Paid plans start at €24/month (~$25) with higher tiers available.
 
@@ -108,7 +108,7 @@ What makes Jamie special is the Executive Assistant feature. Hit Ctrl+J and you 
 
 ### 3. Granola AI
 
-[Granola](https://www.granola.ai/) operates similarly to Anarlog's note-taking approach but sends your data to the cloud instead of processing it locally. You jot down key points during calls, and after the meeting ends, Granola expands your rough notes into actionable summaries.
+[Granola](https://www.granola.ai/) takes a similar approach to Anarlog but sends your data to the cloud instead of processing it locally. You jot down points during the call, and after the meeting ends, Granola expands your rough notes into a summary.
 
 **Pricing:** 25 free meetings (lifetime), then $18/month individual or $14/user/month for teams.
 
@@ -136,9 +136,9 @@ What makes Jamie special is the Executive Assistant feature. Hit Ctrl+J and you 
 
 ### 4. Tactiq
 
-[Tactiq](https://tactiq.io/) takes a completely different approach from the previous tools. Instead of post-meeting summaries, it shows live transcription as people speak. Watching words appear in real-time is satisfying and surprisingly useful for catching names or technical terms you might miss.
+[Tactiq](https://tactiq.io/) does something the others don't: live transcription as people speak. Watching words appear in real-time is satisfying and useful for catching names or technical terms you'd otherwise miss.
 
-Tactiq's integration ecosystem is where it really shines. It pushes meeting insights to Slack, HubSpot, Jira—basically everywhere you actually work.
+The integration ecosystem is the real draw. Tactiq pushes meeting insights to Slack, HubSpot, and Jira.
 
 **Pricing:** Free plan with 10 meetings/month and 5 AI credits. Paid plans start at $12/user/month.
 
@@ -168,9 +168,9 @@ Tactiq's integration ecosystem is where it really shines. It pushes meeting insi
 
 ### 5. Krisp
 
-[Krisp](https://krisp.ai/) handles two jobs at once—it cancels background noise AND takes meeting notes. If you're working from cafes or dealing with construction next door, this dual functionality is genuinely valuable.
+[Krisp](https://krisp.ai/) does two things at once: cancels background noise and takes meeting notes. If you work from cafes or live next to construction, that combination is useful.
 
-The meeting notes are more basic than the AI-enhanced summaries from Anarlog or Granola, but they capture the essentials without fuss.
+The notes are more basic than what Anarlog or Granola produce, but they capture the essentials.
 
 **Pricing:** Free plan with 60 minutes/day noise cancellation, and paid plans start at $16/user/month.
 
@@ -199,9 +199,9 @@ The meeting notes are more basic than the AI-enhanced summaries from Anarlog or 
 
 ### 6. Superpowered
 
-[Superpowered](https://superpowered.me/) focuses specifically on multilingual teams—something most other tools handle as an afterthought. With 50+ languages and automatic language detection, it's built for organizations where English isn't everyone's first language.
+[Superpowered](https://superpowered.me/) is built for multilingual teams, which most other tools treat as an afterthought. 50+ languages with automatic detection, aimed at orgs where English isn't everyone's first language.
 
-Like Jamie, it emphasizes privacy through data minimization, automatically deleting audio after generating notes.
+Like Jamie, it deletes audio after generating notes.
 
 **Pricing:** Offers a limited free plan, with paid plans ranging between $36-$108/month.
 
@@ -228,9 +228,9 @@ Like Jamie, it emphasizes privacy through data minimization, automatically delet
 
 ### 7. Circleback AI
 
-[Circleback AI](https://circleback.ai/) provides both bot-free and bot-based recording options, with a strong focus on CRM integration. While tools like Tactiq integrate broadly across many platforms, Circleback is built specifically for sales teams who need meeting insights to flow directly into their CRM.
+[Circleback AI](https://circleback.ai/) offers both bot-free and bot-based recording, with a focus on CRM integration. Tactiq integrates broadly; Circleback is built for sales teams who need meeting insights to flow into their CRM.
 
-The tool captures audio via its desktop app or browser extension and automatically pushes structured data—contact details, deal stages, next steps—into systems like Salesforce and HubSpot.
+It captures audio via desktop app or browser extension and pushes structured data — contacts, deal stages, next steps — into Salesforce and HubSpot.
 
 **Pricing:** Free trial available, then paid plans start at $25/month.
 
@@ -257,9 +257,9 @@ The tool captures audio via its desktop app or browser extension and automatical
 
 ### 8. Notta Chrome Extension
 
-[Notta's](https://www.notta.ai) browser extension brings multilingual capabilities to the bot-free world. While Tactiq supports 60+ languages, Notta focuses specifically on accuracy across different languages and dialects within the same meeting—something international teams really need.
+[Notta's](https://www.notta.ai) browser extension brings multilingual capability to bot-free recording. Tactiq supports 60+ languages; Notta focuses on accuracy across multiple languages and dialects within the same meeting.
 
-The extension works similarly to other Chrome-based solutions but with stronger emphasis on translation and cross-language understanding. Think of it as Tactiq's multilingual specialist cousin.
+The extension works like other Chrome-based options but emphasizes translation and cross-language understanding. Tactiq's multilingual specialist cousin.
 
 **Pricing:** Free plan with 120 minutes/month, Pro from $13.49/month.
 
@@ -287,9 +287,9 @@ The extension works similarly to other Chrome-based solutions but with stronger 
 
 ### 9. Bluedot
 
-[Bluedot](https://www.bluedothq.com/) is another Chrome extension positioned as the quiet alternative to more visible tools. Like Circleback, it focuses on workflow integration but with broader scope—pushing meeting insights to both CRM systems like Salesforce and productivity tools like Notion.
+[Bluedot](https://www.bluedothq.com/) is another Chrome extension, positioned as the quiet alternative to more visible tools. Like Circleback, it focuses on workflow integration, but with broader scope: meeting insights flow to both CRMs like Salesforce and productivity tools like Notion.
 
-Users appreciate that it works without announcing itself, similar to how Granola operates discretely. The template system helps structure different types of meetings automatically.
+Users like that it works without announcing itself, similar to Granola. The template system structures different types of meetings automatically.
 
 **Pricing:** Very limited free tier (5 meetings total), then Basic at $18/month, Pro at $25/month, Business at $39/month.
 
@@ -316,9 +316,9 @@ Users appreciate that it works without announcing itself, similar to how Granola
 
 ### 10. Voicenotes
 
-[Voicenotes](https://voicenotes.com/) takes a different approach from all the meeting-focused tools above. It's designed as a "second brain" that captures both meetings and voice memos in one unified system. Think of it as Jamie's meeting capabilities combined with a personal voice note system.
+[Voicenotes](https://voicenotes.com/) takes a different angle than the meeting-focused tools above. It's a "second brain" that captures both meetings and voice memos in one place. Jamie's meeting capability combined with a personal voice note system.
 
-The tool supports an impressive 100+ languages (more than Superpowered's 50+) and lets you query your entire voice history—meetings, personal notes, random thoughts—through AI search.
+It supports 100+ languages (more than Superpowered's 50+) and lets you query your full voice history — meetings, personal notes, random thoughts — through AI search.
 
 **Pricing:** Offers a free trial, with paid plans starting at $14.99/month.
 
@@ -345,9 +345,9 @@ The tool supports an impressive 100+ languages (more than Superpowered's 50+) an
 
 ### 11. Meeting.ai
 
-[Meeting.ai](https://meeting.ai) focuses specifically on compliance-heavy industries where data handling is critical. With 30+ language support and emphasis on regulatory compliance, it's positioned as the enterprise-safe alternative to consumer-focused tools.
+[Meeting.ai](https://meeting.ai) is built for compliance-heavy industries where data handling is the whole game. 30+ languages with regulatory compliance baked in, positioned as the enterprise-safe alternative to consumer tools.
 
-The platform is designed for organizations that need meeting intelligence but can't use tools with unclear data policies or overseas processing. It finds middle ground between Anarlog's local processing and cloud-based tools.
+It's designed for orgs that need meeting intelligence but can't use tools with unclear data policies or overseas processing. Middle ground between Anarlog's local processing and cloud-based tools.
 
 **Pricing:** No free plans. Paid pricing starts at USD 19.99/month.
 
@@ -374,9 +374,9 @@ The platform is designed for organizations that need meeting intelligence but ca
 
 ### 12. Sonnet AI
 
-[Sonnet](https://www.sonnetai.com/) is the CRM specialist of bot-free tools, designed specifically for sales teams who live in systems like Salesforce and HubSpot. While Circleback offers CRM integration, Sonnet goes deeper—it's built primarily for automating the entire sales meeting workflow.
+[Sonnet](https://www.sonnetai.com/) is the CRM specialist of bot-free tools, built for sales teams who live in Salesforce or HubSpot. Circleback offers CRM integration; Sonnet goes deeper, automating the whole sales meeting workflow.
 
-The tool captures meetings without bots and automatically updates deal stages, contact information, and next steps directly in your CRM. It's like having a dedicated sales assistant who never forgets to log activities.
+It captures meetings without bots and updates deal stages, contact info, and next steps directly in your CRM. A dedicated sales assistant who never forgets to log activities.
 
 **Pricing:** Free plan with 5 meetings/month and 30-minute limit, Plus at $25/month, Pro at $35/month.
 
@@ -406,7 +406,7 @@ The tool captures meetings without bots and automatically updates deal stages, c
 
 ## How to choose the best bot-free meeting assistant
 
-Picking from 12 tools can get overwhelming fast. I've grouped them into clear categories based on what really matters when you're picking an AI meeting assistant.
+Picking from 12 tools gets overwhelming fast. I've grouped them by what actually matters when choosing one.
 
 ### 1. Privacy & Compliance
 

--- a/apps/web/content/articles/building-editorial-workflow-github-slack.mdx
+++ b/apps/web/content/articles/building-editorial-workflow-github-slack.mdx
@@ -7,13 +7,13 @@ category: "Engineering"
 date: "2026-01-26"
 ---
 
-We recently rebuilt our entire editorial workflow from scratch.
+We rebuilt our editorial workflow from scratch.
 
-And the question we kept getting was: "Why didn't you just use Payload? Or Sanity? Or any of the existing CMS products?"
+The question we kept getting: "Why didn't you just use Payload? Or Sanity? Or any of the existing CMS products?"
 
-The answer goes deeper than "we wanted more control." It connects to something we've been thinking about since we started Anarlog: the belief that content should live as files, not database rows.
+The answer goes deeper than "we wanted more control." It connects to something we've been thinking about since we started Anarlog: content should live as files, not database rows.
 
-This is Part 7 of our publishing series, and it's probably the most philosophical one. We'll explain the "why" first, then break down exactly what we built.
+This is Part 7 of our publishing series, and it's the most philosophical one. We'll explain the "why" first, then break down what we built.
 
 ## The filesystem is the cortex
 
@@ -23,27 +23,27 @@ We wrote about this in [The Filesystem Is the Coretex](/blog/filesystem-is-coret
 
 Humans have organized information spatially for centuries. Drawers. Cabinets. Folders. We remember where something is. Location is recall. Structure is memory.
 
-When notes—or blog posts—live as files, they feel like part of you. When they live as opaque blobs behind an API, they feel like someone else's product.
+When notes — or blog posts — live as files, they feel like part of you. When they live as opaque blobs behind an API, they feel like someone else's product.
 
-This is a belief about the future:
+A belief about the future:
 
 > If AI is going to help humans think, it needs access to artifacts humans can own, inspect, move, and understand.
 
 Markdown. Plain text. Files.
 
-The filesystem is the cortex—and in the AI era, it becomes even more important, not less.
+The filesystem is the cortex, and in the AI era it matters more, not less.
 
 ## Why not Payload, Sanity, or other CMS products?
 
-We evaluated them all. Payload is excellent. Sanity is powerful. But every CMS we looked at had the same fundamental issue: they want your content to live in their system.
+We evaluated them all. Payload is excellent. Sanity is powerful. But every CMS we looked at had the same problem: they want your content to live in their system.
 
 Even the "open source" ones. Even the "self-hosted" ones. Your content becomes structured JSON in a database, mediated through schemas, accessed via APIs.
 
-That's fine for some use cases. For us, it violated the core principle:
+Fine for some use cases. For us it violated the core principle:
 
 > Content should be files. Files in a repo. Diffable. Portable. Ownable forever.
 
-We already wrote about this in [Why Our CMS Is GitHub](/blog/why-our-cms-is-github). GitHub gives us everything a CMS promises—versioning, collaboration, review workflows, rollback—without the lock-in.
+We already wrote about this in [Why Our CMS Is GitHub](/blog/why-our-cms-is-github). GitHub gives us everything a CMS promises — versioning, collaboration, review workflows, rollback — without the lock-in.
 
 But there was one gap: editorial workflows for non-engineers.
 
@@ -69,9 +69,9 @@ The system has three layers:
 
 ### 1. Draft PRs by default
 
-Every change—new post, edit, unpublish—creates a **draft pull request**.
+Every change — new post, edit, unpublish — creates a **draft pull request**.
 
-Draft PRs are GitHub's best-kept secret. They don't notify reviewers. They don't show up in review queues. They signal "I'm still working on this." And they can be converted to "ready for review" with one API call.
+Draft PRs are GitHub's best-kept secret. They don't notify reviewers. They don't show up in review queues. They signal "I'm still working on this", and they convert to "ready for review" with one API call.
 
 When a writer creates a new post, it lives on a draft PR. They can edit, save, walk away, come back. The PR stays invisible until they're ready.
 
@@ -147,7 +147,7 @@ Just GitHub, Slack, and a few hundred lines of glue code.
 
 ## Button states: small details matter
 
-Getting button states right is crucial for clarity:
+Button state is where clarity lives or dies:
 
 | Scenario | Save | Submit for Review | Status |
 |----------|------|-------------------|--------|
@@ -161,17 +161,17 @@ Writers don't need a "Publish" button. They need to know if something is publish
 
 ## Why this matters for open source
 
-We're an open source company. Anarlog is open source. And we believe this editorial workflow should be open source too.
+We're an open source company. Anarlog is open source. This editorial workflow should be open source too.
 
-Not just "source available". Actually usable by other teams.
+Not "source available". Actually usable by other teams.
 
-The vision: bring your own repository and S3 bucket. Get a complete editorial workflow with draft PRs, auto-save, Slack notifications, and one-click merge. Zero vendor lock-in. Zero data migration. Forever portable.
+The vision: bring your own repository and S3 bucket. Get the full editorial workflow — draft PRs, auto-save, Slack notifications, one-click merge. Zero vendor lock-in. Zero data migration. Forever portable.
 
-Imagine content living in your GitHub repo instead of ours. Images in your S3 bucket instead of ours. You get the entire workflow without being locked into our system.
+Content lives in your GitHub repo. Images in your S3 bucket. You get the workflow without being locked into our system.
 
-This is the opposite of what CMS products offer. They want you to put content in their system. We want to give you tools that work with the systems you already have.
+The opposite of what CMS products offer. They want you to put content in their system. We want to give you tools that work with the systems you already have.
 
-We're not there yet. But the architecture is designed for it. The code is written to be extractable. And we're committed to open sourcing it when it's ready.
+We're not there yet. The architecture is designed for it, the code is written to be extractable, and we'll open source it when it's ready.
 
 ## What we learned
 
@@ -197,15 +197,15 @@ Every design decision was easier because we started with files. No schema migrat
 
 ## The philosophy behind it
 
-We built this because we believe content should be owned, not rented. Your words should live in your repo, not in a SaaS database.
+Content should be owned, not rented. Your words should live in your repo, not in a SaaS database.
 
 Tools should compose, not capture. GitHub, Slack, and Netlify already exist. We connected them instead of replacing them.
 
-Simplicity survives. Markdown files will outlive every CMS platform launched this decade.
+Markdown files will outlive every CMS platform launched this decade.
 
-Open source means open data. If the software is open, the content should be portable.
+If the software is open, the content should be portable.
 
-This editorial workflow is one piece of that vision. It's how we publish our blog, our docs, our changelog. And eventually, it's something we want to share with every team that believes content should be files.
+This editorial workflow is one piece of that. It's how we publish our blog, our docs, our changelog. And eventually, it's something we want to share with every team that believes content should be files.
 
 ---
 

--- a/apps/web/content/articles/can-you-transcribe-meetings-without-sending-data-to-cloud.mdx
+++ b/apps/web/content/articles/can-you-transcribe-meetings-without-sending-data-to-cloud.mdx
@@ -8,25 +8,25 @@ category: "Guides"
 date: "2025-08-22"
 ---
 
-**Short answer: Absolutely. And with Anarlog, you choose exactly how.**
+**Short answer: yes. And with Anarlog, you choose exactly how.**
 
-Most people don't realize that every time you use cloud-based transcription tools, you're uploading your most sensitive conversations to someone else's servers. Your client calls, strategy sessions, and confidential discussions sit in databases you'll never see. Recent privacy concerns with tools like Otter AI show just how risky this can be.
+Every time you use a cloud-based transcription tool, you're uploading your most sensitive conversations to someone else's servers. Client calls, strategy sessions, confidential discussions, all sitting in databases you'll never see. Recent privacy concerns with tools like Otter AI show how risky this gets.
 
-But the answer isn't to give up on AI-powered meeting notes. It's to take control of how they work.
+The answer isn't to give up on AI-powered meeting notes. It's to control how they work.
 
 ## What happens to your data with cloud-based transcription tools?
 
-With cloud-based tools, your sensitive discussions, client information, and strategic planning sessions are processed by third-party vendors with varying privacy standards.
+Your sensitive discussions, client info, and strategy sessions get processed by third-party vendors with varying privacy standards.
 
-Your audio and transcripts may be stored on servers across different countries, used for AI training, and subject to the provider's changing privacy policies.
+Audio and transcripts can be stored on servers across different countries, used for AI training, and subject to the provider's changing privacy policies.
 
-For organizations in regulated industries, this creates real compliance complexity. You're not just ensuring your own systems meet HIPAA, GDPR, or SOC 2 requirements — you're now responsible for your vendor's compliance across multiple jurisdictions.
+For regulated industries, this creates real compliance overhead. You're not just ensuring your own systems meet HIPAA, GDPR, or SOC 2 — you're responsible for your vendor's compliance across multiple jurisdictions.
 
-Giving teams control over their AI stack reduces dependency on cloud vendors, makes audits easier, and puts data handling decisions with the people who understand the risk.
+Letting teams control their own AI stack reduces vendor dependency, makes audits easier, and puts data decisions in the hands of the people who understand the risk.
 
-## **Enter Anarlog: the AI notepad built around your choice**
+## **Anarlog: the AI notepad built around your choice**
 
-[Anarlog](https://anarlog.so) is an open-source AI notepad for meetings with zero lock-in and complete control over your data and AI stack.
+[Anarlog](https://anarlog.so) is an open-source AI notepad for meetings with zero lock-in and full control over your data and AI stack.
 
 ### **You control how your data is processed**
 
@@ -46,11 +46,11 @@ Everything saves as plain markdown on your device. Open them in Obsidian, Notion
 
 ## **Does more control mean worse performance?**
 
-No. Anarlog delivers real-time transcription, AI summaries with action items and key decisions, custom templates for different meeting types, AI chat to query your transcripts, search across your meeting history, and support for 45+ languages including English, Spanish, French, German, Japanese, Portuguese, Italian, Dutch, Korean, and Chinese.
+No. Anarlog delivers real-time transcription, AI summaries with action items and decisions, custom templates for different meeting types, AI chat to query your transcripts, search across meeting history, and support for 45+ languages including English, Spanish, French, German, Japanese, Portuguese, Italian, Dutch, Korean, and Chinese.
 
 ## **Anarlog's privacy vs. performance spectrum**
 
-**Full Local Mode:** Everything runs on your device. Your conversations never touch the internet. Works well for lawyers, doctors, or anyone handling sensitive information.
+**Full Local Mode:** Everything runs on your device. Your conversations never touch the internet. For lawyers, doctors, or anyone handling sensitive information.
 
 *Uses: Local transcription + Local AI models (Ollama, LM Studio) + Device-only storage*
 
@@ -58,13 +58,13 @@ No. Anarlog delivers real-time transcription, AI summaries with action items and
 
 *Uses: Local transcription + Cloud LLM (OpenAI, Anthropic, etc.) + Hybrid storage*
 
-**Performance Mode:** Cloud APIs handle both transcription and AI. You get better accuracy and speed, and you still choose which providers handle your data.
+**Performance Mode:** Cloud APIs handle both transcription and AI. Better accuracy and speed, and you still pick which providers see your data.
 
 *Uses: Cloud STT (Deepgram, AssemblyAI) + Your own Cloud LLM + Hybrid storage*
 
 ### **Enterprise options**
 
-Companies can run everything on their own servers — transcription, AI, and storage. No vendor dependency, full compliance control, and your IT and security teams can audit every part of the stack.
+Companies can run everything on their own servers: transcription, AI, and storage. No vendor dependency, full compliance control, and IT and security teams can audit every part of the stack.
 
 *Uses: On-premise transcription + Company LLM endpoints + Self-hosted storage*
 
@@ -74,9 +74,9 @@ Want help configuring your setup? [Get in touch with our team](https://anarlog.s
 
 ### **1. Is there a tool that will listen to meetings via an app and transcribe the notes?**
 
-Yes. Tools like Otter AI and Fireflies send your audio to remote servers for processing. They're convenient, but you don't get a say in how your data is handled.
+Yes. Tools like Otter AI and Fireflies send your audio to remote servers for processing. Convenient, but you don't get a say in how your data is handled.
 
-Anarlog lets you decide — local, hybrid, or cloud with your own API keys — with full visibility into what's happening, backed by open-source code you can inspect.
+Anarlog lets you decide — local, hybrid, or cloud with your own API keys — with full visibility into what's happening, backed by open-source code you can read.
 
 ### **2. Can you transcribe without recording a meeting?**
 

--- a/apps/web/content/articles/char-is-now-anarlog.mdx
+++ b/apps/web/content/articles/char-is-now-anarlog.mdx
@@ -22,7 +22,7 @@ The meeting notetaker is finished software in the best sense — system audio ca
 
 The new Char is the opposite of finished. It's a thesis: that your todo list should finish itself. Type a checkbox, an agent picks it up — researches, drafts, schedules — while you stay in command of what matters. It's a delegation product, not a transcription one. Different mechanic. Different problem. Different people.
 
-We tried to ship both as "Char." The homepage was a mess. The roadmap was a coin flip on every feature. Worst of all: people who came for the meeting notetaker kept getting confused by the agent stuff, and people interested in delegation kept asking "wait, do I have to take meeting notes?"
+We tried to ship both as "Char". The homepage was a mess. The roadmap was a coin flip on every feature. Worst of all: people who came for the meeting notetaker kept getting confused by the agent stuff, and people interested in delegation kept asking "wait, do I have to take meeting notes?"
 
 Two products, two names. That's the whole story.
 
@@ -48,7 +48,7 @@ Char is the AI notepad that knows and works for you. **Your todos, on autopilot.
 
 Type a checkbox in your daily note. An agent picks it up — researches a company before your call, drafts a follow-up email, schedules a meeting, books the flight. You stay in command of what matters. The work moves on its own. Char remembers your projects, contacts, and how you work, so week one it helps and month one it knows you.
 
-The category Char competes in isn't "meeting notetaker." It's the todo list — Things, Todoist, Notion — and the new wave of delegation agents (Yutori, AirJelly, Manus). Notetakers stop where the meeting ends. Char starts there: every action item becomes a checkbox that finishes itself.
+The category Char competes in isn't "meeting notetaker". It's the todo list — Things, Todoist, Notion — and the new wave of delegation agents (Yutori, AirJelly, Manus). Notetakers stop where the meeting ends. Char starts there: every action item becomes a checkbox that finishes itself.
 
 It's a different product. Private alpha right now, paid SaaS when it ships. Same company. Same conviction that humans deserve to stay in command of their own work. Different shape.
 
@@ -64,7 +64,7 @@ Both are valid. They want different things. Now they get different things.
 
 ### why "anarlog"
 
-It's an anagram of *granola*. The product everyone keeps comparing us to — and the one we keep beating on the things that matter (no bots, local files, your stack). "Granola, rearranged." We liked the joke and the name stuck.
+It's an anagram of *granola*. The product everyone keeps comparing us to — and the one we keep beating on the things that matter (no bots, local files, your stack). "Granola, rearranged". We liked the joke and the name stuck.
 
 It also reads as **anar + log** — anar for autonomy, log for the artifact. Your stack, your keys, your files. A log you keep, not one we host.
 

--- a/apps/web/content/articles/char-vs-meetily.mdx
+++ b/apps/web/content/articles/char-vs-meetily.mdx
@@ -10,9 +10,9 @@ date: "2026-04-15"
 
 Anarlog and Meetily were both created in December 2024. Both are written in Rust. Both capture system audio without a bot. Both are open-source and local-first. 
 
-They look like the same product. They are not.
+They look like the same product. They aren't.
 
-Meetily is a private transcription recorder. It records, transcribes locally, and generates a summary. Anarlog is a meeting notepad. Its bet is that meetings are part of your workflow, not a separate activity. Transcription is one component of that.
+Meetily is a private transcription recorder. It records, transcribes locally, and generates a summary. Anarlog is a meeting notepad. The bet is that meetings are part of your workflow, not a separate activity. Transcription is one component.
 
 ## **TL;DR: Anarlog vs Meetily**
 
@@ -36,7 +36,7 @@ Meetily is a private transcription recorder. It records, transcribes locally, an
 
 ## **Similarities Between Anarlog and Meetily**
 
-Both tools were built as a direct reaction to cloud meeting tools like Otter and Fireflies. They share the same foundational decisions:
+Both tools were built in direct reaction to cloud meeting tools like Otter and Fireflies. They share the same foundational decisions:
 
 - System audio capture. No bot joins your call. No calendar permissions required.
 - 100% local processing available. Audio never has to leave your device.
@@ -45,23 +45,23 @@ Both tools were built as a direct reaction to cloud meeting tools like Otter and
 - Bot-free recording. No visible recording participant in your meetings.
 - Built in Rust.
 
-If your primary requirement is "no cloud, no bot, open-source," both tools satisfy it. The differences start after that.
+If your primary requirement is "no cloud, no bot, open-source", both tools satisfy it. The differences start after that.
 
 ## **Differences Between Anarlog and Meetily**
 
 ### **1. Platform support**
 
-Meetily runs on macOS and Windows. Anarlog runs on macOS and Linux. If you are on Windows, Meetily is your only option today. Anarlog has Windows on its roadmap but it is not available yet.
+Meetily runs on macOS and Windows. Anarlog runs on macOS and Linux. If you're on Windows, Meetily is your only option today. Anarlog has Windows on the roadmap but it's not available yet.
 
 ### **2. What each tool is built to do**
 
 Meetily is a recorder. Record, transcribe with Whisper or Parakeet via Ollama, get a summary. The product loop is short and intentional.
 
-Anarlog is a meeting notepad. It connects to your calendar (Google, Apple, Outlook), tracks your contacts, gives you a rich editor for notes, ships an AI assistant called Charlie that can edit your notes directly, and has daily notes in preview with task carry-forward. Meetings in Anarlog connect to the rest of your work. 
+Anarlog is a meeting notepad. It connects to your calendar (Google, Apple, Outlook), tracks contacts, gives you a rich editor for notes, ships an AI assistant called Charlie that edits your notes directly, and has daily notes in preview with task carry-forward. Meetings in Anarlog connect to the rest of your work. 
 
 ### **3. Taking notes during a meeting**
 
-Meetily is passive. You get a transcript and summary after the call. There is no editor.
+Meetily is passive. You get a transcript and summary after the call. No editor.
 
 Anarlog has a built-in editor. You write notes before the meeting starts: agenda items, context, things you need to close on. You take notes during the call. After the meeting, the AI folds your notes and the transcript into a structured summary. Your pre-meeting context shapes the output.
 

--- a/apps/web/content/articles/chatgpt-data-retention-policy.mdx
+++ b/apps/web/content/articles/chatgpt-data-retention-policy.mdx
@@ -8,40 +8,40 @@ category: "Guides"
 date: "2026-03-10"
 ---
 
-In May 2025, a federal judge ordered OpenAI to preserve every ChatGPT conversation including the ones you deleted. Not just temporarily. Indefinitely, until further notice. 
+In May 2025, a federal judge ordered OpenAI to preserve every ChatGPT conversation, including the ones you deleted. Not temporarily. Indefinitely, until further notice.
 
-Most users had no idea this happened. If you're evaluating AI providers before plugging one into your workflow, this is exactly the kind of detail that matters. 
+Most users had no idea this happened. If you're evaluating AI providers before plugging one into your workflow, this is the detail that matters.
 
-Here's a full breakdown of OpenAI's data retention policy: what they keep, how long, and what you can actually do about it.
+Here's the breakdown of OpenAI's data retention policy: what they keep, how long, and what you can actually do about it.
 
 ## What ChatGPT Stores Data by Default
 
-When you use ChatGPT on a free, Plus, Pro, or Team plan, your conversations are saved to your account automatically. They sit there indefinitely until you delete them. 
+On Free, Plus, Pro, or Team plans, your conversations save to your account automatically. They sit there indefinitely until you delete them.
 
-Once you delete a conversation, it disappears from your view immediately. But according to [OpenAI's own help documentation](https://help.openai.com/en/articles/8983778-chat-and-file-retention-policies-in-chatgpt), the data isn't actually removed from their servers for another 30 days and that's under normal circumstances. 
+When you delete a conversation, it disappears from your view immediately. But per [OpenAI's own help documentation](https://help.openai.com/en/articles/8983778-chat-and-file-retention-policies-in-chatgpt), the data isn't removed from their servers for another 30 days under normal circumstances.
 
-One thing most users don't realize: if you've enabled ChatGPT's Memory feature, stored memories are retained separately from your chat history. Deleting a conversation doesn't wipe the memories extracted from it. You have to clear those manually through Settings.
+If you've enabled ChatGPT's Memory feature, stored memories are retained separately from your chat history. Deleting a conversation doesn't wipe the memories extracted from it. Clear those manually through Settings.
 
 ## The Court Order You Probably Missed
 
-In May 2025, a federal judge issued a preservation order requiring OpenAI to retain all ChatGPT user logs as part of the *New York Times* copyright lawsuit. The ruling was explicit: preserve and segregate all output log data that would otherwise be deleted. This includes conversations users had already removed. 
+In May 2025, a federal judge issued a preservation order requiring OpenAI to retain all ChatGPT user logs as part of the *New York Times* copyright lawsuit. The ruling was explicit: preserve and segregate all output log data that would otherwise be deleted. That includes conversations users had already removed.
 
-[Bloomberg Law reported](https://news.bloomberglaw.com/ip-law/openai-must-turn-over-20-million-chatgpt-logs-judge-affirms) that by November 2025, the judge further ordered OpenAI to hand over 20 million de-identified ChatGPT logs to the Times and other news plaintiffs. 
+[Bloomberg Law reported](https://news.bloomberglaw.com/ip-law/openai-must-turn-over-20-million-chatgpt-logs-judge-affirms) that by November 2025, the judge further ordered OpenAI to hand over 20 million de-identified ChatGPT logs to the Times and other news plaintiffs.
 
-The preservation order itself was lifted in late September 2025. OpenAI resumed normal deletion practices after that point. But conversations from the April–September 2025 window remain in secure storage pending the ongoing litigation. 
+The preservation order was lifted in late September 2025. OpenAI resumed normal deletion practices after that. But conversations from the April–September 2025 window remain in secure storage pending the litigation.
 
-OpenAI says access to that data is restricted to a small, audited legal and security team. The Times and other plaintiffs don't have open access—any disclosure goes through court-approved discovery procedures. Still, data you thought was gone is sitting in a server somewhere.
+OpenAI says access to that data is restricted to a small, audited legal and security team. The Times and other plaintiffs don't have open access — any disclosure goes through court-approved discovery. Still, data you thought was gone is sitting on a server somewhere.
 
 ## The "Opt Out of Training" Setting and What It Actually Does
 
-ChatGPT uses your conversations to improve its models by default. You can turn this off: **Settings → Data Controls → toggle off "Improve model for everyone."** 
+ChatGPT uses your conversations to improve its models by default. Turn it off: **Settings → Data Controls → toggle off "Improve model for everyone".**
 
-Two important caveats:
+Two caveats:
 
 - It only affects future conversations. Any data already used for training stays in the training set. Disabling the toggle doesn't reach back.
 - It doesn't change how long your data is stored. Even with the setting off, OpenAI still keeps conversations on their servers for 30 days after deletion. They retain them during this window to screen for abuse and policy violations.
 
-Temporary Chat mode works somewhat differently. Conversations in Temporary Chat are never used for training and are scheduled for deletion within 30 days automatically. You don't need to manually delete them but they're still on OpenAI's servers during that window.
+Temporary Chat mode works differently. Conversations in Temporary Chat are never used for training and get auto-deleted within 30 days. You don't need to delete them manually, but they're still on OpenAI's servers during that window.
 
 ## How ChatGPT's Data Retention Policy Differs by Plan
 
@@ -53,7 +53,7 @@ Conversations are retained indefinitely until deleted. After deletion, they rema
 
 ### 2. ChatGPT Enterprise and Edu
 
-Conversations are not used to train OpenAI's models by default—no opt-out required. Workspace admins control retention settings. Deleted conversations are removed within 30 days unless legally required to be kept.
+Conversations are not used to train OpenAI's models by default — no opt-out required. Workspace admins control retention settings. Deleted conversations are removed within 30 days unless legally required to be kept.
 
 ### 3. API (Standard)
 
@@ -65,31 +65,31 @@ Inputs and outputs are never logged. There's no retention period because there's
 
 ## What About GDPR and HIPAA?
 
-If you're in a regulated industry or dealing with sensitive data, the consumer-facing ChatGPT product is not the right tool. OpenAI has been explicit about this. 
+If you're in a regulated industry or handling sensitive data, the consumer ChatGPT product is not the right tool. OpenAI has been explicit about this.
 
-Standard ChatGPT (Free, Plus, Pro, Team) does not offer a Business Associate Agreement, which means it cannot be used with Protected Health Information under HIPAA. Using it with patient data is a compliance violation. 
+Standard ChatGPT (Free, Plus, Pro, Team) doesn't offer a Business Associate Agreement, which means it can't be used with Protected Health Information under HIPAA. Using it with patient data is a compliance violation.
 
-For GDPR, OpenAI offers a Data Processing Addendum (DPA) for ChatGPT Team, Enterprise, and API customers, not for consumer accounts. If you're in the EU and not on one of those plans, GDPR compliance is your own responsibility to figure out. 
+For GDPR, OpenAI offers a Data Processing Addendum (DPA) for ChatGPT Team, Enterprise, and API customers, not for consumer accounts. If you're in the EU and not on one of those plans, GDPR compliance is your own problem.
 
-There's also a jurisdiction question worth flagging. Reddit's r/privacy community has noted that because OpenAI's servers are primarily US-based, data transferred from the EU to process through ChatGPT is subject to cross-border data transfer rules under GDPR. This has compliance implications for European organizations that aren't using a DPA.
+One jurisdiction issue to flag: because OpenAI's servers are primarily US-based, data transferred from the EU through ChatGPT is subject to cross-border data transfer rules under GDPR. That has compliance implications for European organizations not using a DPA.
 
 ## So What's the Practical Risk?
 
-For most individual users, the day-to-day risk is limited. OpenAI doesn't sell your conversations, and the data isn't publicly accessible. 
+For most individual users, the day-to-day risk is limited. OpenAI doesn't sell your conversations, and the data isn't publicly accessible.
 
-The risk is more nuanced:
+The real risk is more nuanced:
 
-- **Legal exposure**: The court order showed that data you delete can be preserved and disclosed through legal proceedings. If you've had sensitive conversations through ChatGPT, there's a window of time where that data exists outside your control.
-- **Training data reuse**: Unless you've explicitly opted out, your conversations have likely contributed to model training. That data doesn't get unlearned when you opt out later.
-- **Compliance liability**: In healthcare, legal, finance, and other regulated fields, using consumer ChatGPT with client or patient information creates compliance risk regardless of what OpenAI promises about their security practices.
+- **Legal exposure**: the court order showed that data you delete can be preserved and disclosed through legal proceedings. If you've had sensitive conversations through ChatGPT, there's a window where that data exists outside your control.
+- **Training data reuse**: unless you've explicitly opted out, your conversations have likely contributed to model training. That data doesn't get unlearned when you opt out later.
+- **Compliance liability**: in healthcare, legal, finance, and other regulated fields, using consumer ChatGPT with client or patient information creates compliance risk regardless of what OpenAI promises about their security practices.
 
 ## The OpenAI API Has Meaningfully Better Data Controls
 
-If you're building with OpenAI or using a tool that lets you bring your own API key, then the data situation is materially different from the consumer product. 
+If you're building with OpenAI or using a tool that lets you bring your own API key, the data situation is materially different from the consumer product.
 
-With the standard API, OpenAI retains inputs and outputs for 30 days for abuse monitoring, then deletes them. There's no default use of your data for model training. If you qualify for Zero Data Retention endpoints, OpenAI never logs your data at all. 
+With the standard API, OpenAI retains inputs and outputs for 30 days for abuse monitoring, then deletes them. No default use of your data for model training. If you qualify for Zero Data Retention endpoints, OpenAI never logs your data at all.
 
-This is relevant if you're evaluating how OpenAI fits into a broader AI workflow where you want control over which provider sees what data. 
+This matters if you're evaluating how OpenAI fits into a broader AI workflow where you want control over which provider sees what data.
 
 ## BTW, Your OpenAI API Key Works for Meeting Notes Too
 
@@ -101,9 +101,9 @@ If even API-level retention is too much, Anarlog also runs fully offline with lo
 
 No bot in your call. Anarlog captures audio directly from your computer's input and output. No third-party bot joins your Zoom or Google Meet, so no intermediary service handles your meeting data.
 
-Notes stay on your device. Transcripts and summaries are stored as plain markdown files locally—no cloud-synced account storage retaining data on someone else's servers.
+Notes stay on your device. Transcripts and summaries are stored as plain markdown files locally — no cloud-synced account storage retaining data on someone else's servers.
 
-More than a transcription tool. Anarlog does real-time transcription while you jot down what matters, then generates summaries from your memos once the meeting ends. Built-in AI chat lets you ask follow-ups—action items, rewrites, translations. It supports customizable note templates and integrates with Apple Calendar, Contacts, and Obsidian, with Notion, Slack, HubSpot, and Salesforce on the way.
+More than a transcription tool. Anarlog does real-time transcription while you jot down what matters, then generates summaries from your memos once the meeting ends. Built-in AI chat lets you ask follow-ups: action items, rewrites, translations. It supports customizable note templates and integrates with Apple Calendar, Contacts, and Obsidian, with Notion, Slack, HubSpot, and Salesforce on the way.
 
 You're not locked into one provider. If your security team approves a different model next quarter, switch the key. Your notes stay on your device either way.
 

--- a/apps/web/content/articles/chatgpt-for-meeting-notes.mdx
+++ b/apps/web/content/articles/chatgpt-for-meeting-notes.mdx
@@ -12,18 +12,18 @@ date: "2025-09-25"
 
 If you use ChatGPT like your life depends on it, you've probably wondered whether it can also take meeting notes for you.
 
-Yes. There are two ways to do it:
+Yes. Two ways:
 
-1. Using ChatGPT Record Mode
-2. Manually uploading transcription and using the right prompt to generate notes
+1. ChatGPT Record Mode
+2. Manually uploading a transcript and prompting ChatGPT to generate notes
 
-Let's look at both of these methods in detail.
+Let's look at both.
 
 ## Method 1: using ChatGPT record mode
 
 ![chatgpt record mode](/api/assets/blog/chatgpt-for-meeting-notes/chatgpt-2.webp)
 
-When ChatGPT Record mode launched, the AI Twitter crowd lost it. The actual feature, though, feels like a beta that escaped into production. Before I get into that, let's see how it works.
+When ChatGPT Record mode launched, the AI Twitter crowd lost it. The actual feature feels like a beta that escaped into production. First, how it works.
 
 ### Prerequisites of ChatGPT record mode
 
@@ -43,21 +43,21 @@ Here's the step-by-step process:
 Important details:
 
 - Each session can run up to 120 minutes and ends with an editable summary that includes time-stamped citations and suggested action items.
-- ChatGPT doesn't join your meetings as a bot, so no one knows you're recording. Make sure to explicitly ask for consent.
-- Record mode works with all meeting types—virtual, in-person, or playback of recorded conversations—because it captures microphone and system-level audio.
+- ChatGPT doesn't join your meetings as a bot, so no one knows you're recording. Ask for consent explicitly.
+- Record mode works with all meeting types — virtual, in-person, or playback of recorded conversations — because it captures microphone and system-level audio.
 
 #### Pros of record mode:
 
-- **The 120-minute limit is generous.** Most meetings don't reach this. I've recorded entire workshop sessions without running out of time. Compare that to tools capping you at 30 minutes on free tiers.
-- **Canvas integration is genuinely useful.** Once you get your summary, you can edit it collaboratively, ask ChatGPT to reformat it, or transform it into other documents. I've turned meeting notes into project plans, emails, and slide outlines without leaving the interface.
-- **It handles interruptions gracefully.** You can pause mid-meeting to take a phone call, resume when you're back, and it treats it as one continuous session. No weird gaps or formatting issues.
+- **The 120-minute limit is generous.** Most meetings don't hit it. I've recorded full workshop sessions without running out. Compare that to tools capping you at 30 minutes on the free tier.
+- **Canvas integration is useful.** Once you get the summary, you can edit it, ask ChatGPT to reformat it, or turn it into something else. I've turned meeting notes into project plans, emails, and slide outlines without leaving the interface.
+- **It handles interruptions well.** You can pause mid-meeting for a phone call, resume after, and it treats it as one continuous session. No weird gaps or formatting issues.
 
 #### Cons of record mode:
 
-- **The reliability issue is real.** I've had it stop mid-recording randomly (network hiccup, even though it's supposed to be local processing), and once it simply forgot a 20-minute chunk of a client call.
-- **AI hallucination creates false meeting records.** ChatGPT will confidently invent details that never happened. I've seen it fabricate entire action items, claim people said things they didn't, or create follow-up meetings that were never scheduled.
-- **Speaker identification is basically broken.** It can tell the difference between your microphone and system audio, which works for one-on-one calls. But it gets confused with multiple speakers. If someone joins late, it doesn't identify them as a new speaker.
-- **No explicit GDPR compliance workflow.** OpenAI basically shrugs and says, "make sure you have consent." That's it. If you're dealing with European clients or employees, Record mode puts you in a legally gray area.
+- **The reliability issue is real.** I've had it stop mid-recording randomly (network hiccup, even though it's supposed to be local processing), and once it forgot a 20-minute chunk of a client call.
+- **Hallucinations create false meeting records.** ChatGPT will confidently invent details that never happened. I've seen it fabricate entire action items, claim people said things they didn't, or create follow-up meetings that were never scheduled.
+- **Speaker identification is basically broken.** It can tell the difference between your microphone and system audio, which works for one-on-one calls. With multiple speakers, it gets confused. If someone joins late, it doesn't identify them as a new speaker.
+- **No explicit GDPR compliance workflow.** OpenAI shrugs and says "make sure you have consent". That's it. If you're dealing with European clients or employees, Record mode puts you in a legally gray area.
 
 ### How much does ChatGPT record mode cost?
 
@@ -73,17 +73,17 @@ When you delete a conversation, the canvas and transcript are removed from their
 
 ### Is ChatGPT record mode worth trying?
 
-If you're already paying for a ChatGPT Team plan and want to experiment with AI note-taking for casual internal meetings, it's worth trying. For client calls, legal discussions, or anything where accuracy matters, the risk of losing or corrupting your meeting record outweighs the convenience.
+If you're already paying for a ChatGPT Team plan and want to experiment with AI note-taking for casual internal meetings, sure, try it. For client calls, legal discussions, or anything where accuracy matters, the risk of losing or corrupting your meeting record outweighs the convenience.
 
-You still have to verify everything it produces, which defeats most of the time-saving benefits. It's a preview of what meeting AI could be, but it's not ready for professional use yet.
+You still have to verify everything it produces, which defeats most of the time-saving benefit. A preview of what meeting AI could be, not yet ready for professional use.
 
 ## Method 2: manually uploading transcription + smart prompting
 
 ![chatgpt meeting notes](/api/assets/blog/chatgpt-for-meeting-notes/chatgpt-3.webp)
 
-This is where I found better results. It's more manual, but you get way better control and outcomes.
+This got me better results. More manual, but the control and output are much better.
 
-I use my phone's voice recorder for in-person meetings and let Zoom transcribe virtual ones. Then I copy-paste into ChatGPT with specific prompts I've refined through trial and error.
+I use my phone's voice recorder for in-person meetings and let Zoom transcribe virtual ones. Then I copy-paste into ChatGPT with prompts I've refined through trial and error.
 
 ### ChatGPT prompts for meeting notes that worked for me
 
@@ -139,36 +139,36 @@ Only include items that have clear action items or decisions. Ignore general dis
 
 #### Pro tips
 
-- **Chunk long transcripts** -- ChatGPT has limits. If your meeting was over an hour, break the transcript into 30-minute chunks and process them separately. I learned this after getting "that's too long" errors.
-- **Clean your transcript first** -- Take 2 minutes to fix obvious transcription errors—especially names and technical terms. "John" becoming "Jon" throughout screws up action item assignments.
-- **Be specific about format** -- Don't just say "make a list." Say "create a numbered list," or "use bullet points," or "make a table." ChatGPT defaults to paragraph form, which doesn't work for action items.
+- **Chunk long transcripts** -- ChatGPT has limits. If your meeting was over an hour, break the transcript into 30-minute chunks and process them separately. I learned this after hitting "that's too long" errors.
+- **Clean your transcript first** -- Take 2 minutes to fix obvious transcription errors, especially names and technical terms. "John" becoming "Jon" throughout screws up action-item assignments.
+- **Be specific about format** -- Don't say "make a list". Say "create a numbered list", "use bullet points", or "make a table". ChatGPT defaults to paragraph form, which doesn't work for action items.
 - **Test your prompts** -- I keep a doc with my best-working prompts because what works varies by meeting type. Sales calls need different output than technical planning meetings.
 
 ### How does the manual upload method use your data?
 
 When you copy-paste transcripts into regular ChatGPT conversations, different privacy rules apply than in Record Mode. By default, OpenAI may use your content to train its models unless you opt out through the "Improve the model for everyone" toggle in Settings > Data Controls.
 
-The biggest trap is the feedback system. Even if you've opted out everywhere, giving a single thumbs up or thumbs down on any response means the entire conversation, including your meeting transcript, can be used for model training.
+The biggest trap is the feedback system. Even if you've opted out everywhere, a single thumbs up or thumbs down on any response means the whole conversation, including your meeting transcript, can be used for model training.
 
-One accidental click can override all your privacy settings and make your sensitive meeting data part of ChatGPT's training dataset.
+One accidental click overrides all your privacy settings and puts your sensitive meeting data into ChatGPT's training dataset.
 
 ### Is the manual upload method worth your time?
 
-- **The good** -- You get complete control. You can run the same transcript through different prompts to get summaries for different audiences—detailed minutes for the file, an executive summary for your boss, and action items for the team.
+- **The good** -- Full control. You can run the same transcript through different prompts to get summaries for different audiences: detailed minutes for the file, an executive summary for your boss, action items for the team.
 - **The annoying** -- Sometimes ChatGPT decides to be "helpful" and adds context that wasn't in the meeting. I once had it infer that we "probably decided" something we absolutely did not. Always double-check.
-- **The weird** -- It occasionally misses obvious action items while perfectly capturing random side conversations. It seems to get drawn to interesting tangents.
+- **The weird** -- It occasionally misses obvious action items while perfectly capturing random side conversations. It gets drawn to interesting tangents.
 
 &nbsp;
 
 ## Is there a better alternative to ChatGPT for meeting notes?
 
-Bot-based AI notetakers like Otter or Fireflies can feel intrusive and may not offer privacy advantages. For bot-free options, we recommend [Anarlog](/). Here's why:
+Bot-based AI notetakers like Otter or Fireflies feel intrusive and don't always offer privacy advantages. For bot-free options, we recommend [Anarlog](/). Here's why:
 
 Anarlog listens to system audio like ChatGPT and runs on Mac, but that's where the similarities end.
 
-Anarlog is an open-source AI notepad for meetings that gives you complete control over your data and AI stack. Everything is stored as plain markdown files. You choose your AI: bring your own keys or run local models. Zero lock-in, zero compromises.
+Anarlog is an open-source AI notepad for meetings that gives you control over your data and AI stack. Everything is stored as plain markdown files. You pick the AI: bring your own keys or run local models. Zero lock-in.
 
-It's also open-source, so you can inspect every line of code, modify any component, and self-host on your infrastructure. No licensing servers or usage tracking.
+Open source, so you can read every line, modify any component, and self-host on your own infrastructure. No licensing servers or usage tracking.
 
 Anarlog's note-taking features include:
 
@@ -176,12 +176,12 @@ Anarlog's note-taking features include:
 
 - Take notes and let AI enhance them based on the transcript, or let AI do the entire summary without hallucinations.
 - Set custom vocabulary for industry jargon, client names, project codenames, or technical terms so transcription gets them right every time.
-- Familiar interface that just works. Feels like Apple Notes with powerful AI running locally in the background.
+- Familiar interface that just works. Feels like Apple Notes with AI running locally in the background.
 - Universal platform support. Works with any meeting software and in-person conversations without bots or restrictions.
-- Custom templates for every situation—therapy sessions, legal meetings, job interviews, or casual conversations.
-- Search your meeting history naturally. Ask "What did Sarah say about the budget?" instead of scrolling through months of notes.
-- AI chat for instant clarification. Get immediate answers about action items, deadlines, or who said what.
-- Control how much AI changes your notes. Choose minimal improvements to your original thoughts or complete restructuring.
+- Custom templates for every situation: therapy sessions, legal meetings, job interviews, casual conversations.
+- Search your meeting history naturally. Ask "what did Sarah say about the budget?" instead of scrolling through months of notes.
+- AI chat for instant clarification. Get answers about action items, deadlines, or who said what.
+- Control how much AI changes your notes. Pick minimal improvements to your original thoughts or full restructuring.
 - Verify everything with source analysis. Hover over summaries to see the exact transcript quote behind every point.
 
 Also, Anarlog is free forever, fully local, BYOK, and open source.
@@ -192,7 +192,7 @@ Also, Anarlog is free forever, fully local, BYOK, and open source.
 
 ### 1. Can ChatGPT record meeting minutes?
 
-Yes, if you have the right plan and setup. But "can" and "should" are different questions. It works great for internal team meetings and completely fails on important client calls.
+Yes, if you have the right plan and setup. "Can" and "should" are different questions. It works for internal team meetings and fails on important client calls.
 
 ### 2. How long can ChatGPT record audio?
 
@@ -213,6 +213,6 @@ No. Business features like data analysis, record mode, canvas, projects, tasks, 
 
 ### 5. Is ChatGPT record mode secure?
 
-Your audio gets deleted after transcription, but the transcript can be used for AI training unless you're on Enterprise or opt out. For sensitive meetings, this should raise concerns.
+Your audio gets deleted after transcription, but the transcript can be used for AI training unless you're on Enterprise or opt out. For sensitive meetings, that's a concern.
 
 &nbsp;

--- a/apps/web/content/articles/choosing-a-cms.mdx
+++ b/apps/web/content/articles/choosing-a-cms.mdx
@@ -11,11 +11,11 @@ date: "2025-11-28"
 
 If you're building a blog, docs, or a knowledge base in 2026, the options are overwhelming.
 
-Sanity or Payload? Nextra or GitBook? Git-based CMS like Keystatic? Or just raw MDX in GitHub with zero CMS at all?
+Sanity or Payload? Nextra or GitBook? Git-based CMS like Keystatic? Or raw MDX in GitHub with zero CMS at all?
 
-We went through the same decision for Anarlog. This post maps the territory so you don't have to burn as many cycles on it.
+We went through this for Anarlog. This post maps the territory so you don't have to burn the same cycles.
 
-I won't tell you "X is the best CMS." Instead, I'll show you what each category is good at, what it quietly locks you into, and when you probably don't need a CMS at all.
+I won't tell you "X is the best CMS". I'll show you what each category is good at, what it quietly locks you into, and when you probably don't need a CMS at all.
 
 **This is Part 3 of our publishing series.**
 
@@ -79,7 +79,7 @@ Cons:
 - No drag-and-drop media UI out of the box
 - No built-in content dashboard, workflows, or roles
 
-If your team is very technical and you're early-stage, this is almost always the correct default. You can always add a Git-based or headless CMS later without throwing anything away.
+If your team is technical and you're early-stage, this is the right default. You can add a Git-based or headless CMS later without throwing anything away.
 
 ## 2. Git-based CMS: "UI for your repo" (Keystatic & friends)
 
@@ -104,7 +104,7 @@ Cons:
 - You're tied into their config models and upgrade cycle
 - Not as "enterprise omnichannel" as big headless CMSs
 
-Use this when you like the Git + MDX approach but want PMs, designers, or marketing to tweak copy and metadata without opening an IDE.
+Use this when you like Git + MDX but want PMs, designers, or marketing to tweak copy and metadata without opening an IDE.
 
 ---
 
@@ -147,17 +147,17 @@ Sometimes you don't need a CMS. You need a **docs product**.
 
 ### GitBook
 
-GitBook positions itself as a documentation + knowledge base platform for technical teams, with a polished block-based editor, site customization options, and Git Sync that lets you connect to GitHub/GitLab for a docs-as-code workflow. [GitBook](https://gitbook.com/docs)
+GitBook is a documentation + knowledge base platform for technical teams, with a block-based editor, site customization, and Git Sync that lets you connect to GitHub/GitLab for a docs-as-code workflow. [GitBook](https://gitbook.com/docs)
 
-It works well if you want a hosted, beautiful docs site with search, navigation, versioning, and collaboration. It supports optional Git synchronization for teams that still want Markdown in repos.
+It works if you want a hosted docs site with search, navigation, versioning, and collaboration, and supports optional Git sync for teams that still want Markdown in repos.
 
-Notion, Confluence, and similar tools live in the same category but less focused on developers.
+Notion, Confluence, and similar tools live in the same category but are less focused on developers.
 
 Pros:
 
-- Fastest path to a polished docs or knowledge base
+- Fastest path to a docs or knowledge base
 - Low setup cost, almost no infrastructure
-- Very friendly for non-technical stakeholders
+- Friendly for non-technical stakeholders
 - Often have built-in AI-assisted search and summaries
 
 Cons:
@@ -183,11 +183,11 @@ Use this when you want a **docs site ready tomorrow**, UX matters more than cont
 
 ## 5. Special case: Nextra & friends (frameworks, not CMSs)
 
-Tools like **Nextra** are not CMS platforms but content-focused frameworks built on Next.js that make it easy to build docs and blog sites with Markdown/MDX and opinionated themes. [Nextra](https://nextra.site/docs)
+Tools like **Nextra** aren't CMS platforms. They're content-focused frameworks built on Next.js that make it easy to ship docs and blog sites with Markdown/MDX and opinionated themes. [Nextra](https://nextra.site/docs)
 
-Nextra gives you prebuilt docs/blog UI (sidebar, nav, search glue), MDX-first authoring, and works well for developer docs and personal blogs.
+Nextra gives you prebuilt docs/blog UI (sidebar, nav, search glue), MDX-first authoring, and works for developer docs and personal blogs.
 
-You still choose how to manage content: plain files, a Git-based CMS, a headless CMS feeding MDX remotely, etc.
+You still pick how to manage content: plain files, a Git-based CMS, a headless CMS feeding MDX remotely, etc.
 
 This is the category Anarlog's stack resembles: modern React/MDX frontend with content-first in Git.
 
@@ -203,7 +203,7 @@ This is the category Anarlog's stack resembles: modern React/MDX frontend with c
 | You just need a docs/KB site ASAP | **Docs platform** (GitBook, maybe Notion early) |
 | You want fine control over UI + MDX, but not heavy infra | **Nextra or similar framework** on top of Git |
 
-If you're not sure, default to Git + MDX now. Add a Git-based or headless CMS later only if reality forces you to.
+If you're not sure, default to Git + MDX. Add a Git-based or headless CMS later only if reality forces you to.
 
 Most teams overestimate how much CMS infrastructure they need in the first 2–3 years.
 

--- a/apps/web/content/articles/company-handbook-in-public.mdx
+++ b/apps/web/content/articles/company-handbook-in-public.mdx
@@ -32,7 +32,7 @@ Most startups explain what they're building. Very few explain how they think.
 
 Culture, expectations, and definitions of success are often left implicit. People are expected to "pick it up" over time. But when expectations live only in people's heads, everyone fills in the gaps differently — and misalignment is almost guaranteed.
 
-This problem compounds in open-source companies. Our code is public by default. Anyone can read it, audit it, or contribute to it. But the thinking behind the code — the standards, the trade-offs, the way decisions are made — usually stays hidden.
+This problem compounds in open-source companies. Our code is public by default. Anyone can read it, audit it, or contribute to it. But the thinking behind the code, the standards, the trade-offs, the way decisions are made, usually stays hidden.
 
 We didn't want that asymmetry.
 
@@ -40,7 +40,7 @@ We didn't want that asymmetry.
 
 Publishing a company handbook publicly builds trust. In the early days, people don't engage with companies because they're perfect. They engage because they feel real. They want to know how the founders see the world, how they make trade-offs, and what kind of future they're trying to build.
 
-Some of the most respected open-source companies — like GitLab, Cal.com, and PostHog — treat their handbooks not as internal policy, but as living documents. Not slogans. Not posters. Just honest clarity.
+Some of the most respected open-source companies, like GitLab, Cal.com, and PostHog, treat their handbooks not as internal policy, but as living documents. Not slogans. Not posters. Just honest clarity.
 
 Authentic writing creates more meaningful engagement than polished marketing copy. Especially early on.
 
@@ -54,7 +54,7 @@ Writing this down is slightly uncomfortable. That's exactly why it matters.
 
 ## An Invitation
 
-If you're building a company — especially an open-source one — ask yourself: What expectations exist in your company that everyone "just knows," but have never been written down?
+If you're building a company, especially an open-source one, ask yourself: What expectations exist in your company that everyone "just knows", but have never been written down?
 
 If you're reading this as a contributor, user, or future teammate, this handbook is our attempt to show how we think, not just what we build.
 

--- a/apps/web/content/articles/developer-documentation-tools.mdx
+++ b/apps/web/content/articles/developer-documentation-tools.mdx
@@ -7,13 +7,13 @@ category: "Engineering"
 date: "2025-12-02"
 ---
 
-Documentation is not the same thing as blogging.
+Documentation is not blogging.
 
-Docs are a product. People rely on them to unblock themselves, integrate with you, debug issues, and understand how your system actually works. So the tools you'd use for blog posts don't always work for docs.
+Docs are a product. People rely on them to unblock themselves, integrate with you, debug issues, and understand how your system actually works. The tools you'd use for blog posts don't always work for docs.
 
 Docs need structure, navigation, versioning, API examples, sidebars, and searchable knowledge. They also need to be maintainable by a real team — engineers, PMs, support, devrel — not just whoever has access to the CMS.
 
-This post breaks down what tools you should consider in 2026 if you're building developer documentation from scratch.
+This post breaks down what to consider in 2026 if you're building developer documentation from scratch.
 
 ## There are really only five kinds of docs systems
 
@@ -38,7 +38,7 @@ Each has a different cost model, maintenance profile, and failure mode.
 
 ## 1. Pure file-based docs (MDX) — the default for technical teams
 
-This includes Docusaurus, Nextra, MkDocs / Material for MkDocs, Astro + MDX, and TanStack Start + MDX. This is the modern "docs-as-code" standard.
+This includes Docusaurus, Nextra, MkDocs / Material for MkDocs, Astro + MDX, and TanStack Start + MDX. The modern "docs-as-code" standard.
 
 ### Pros
 
@@ -61,7 +61,7 @@ This includes Docusaurus, Nextra, MkDocs / Material for MkDocs, Astro + MDX, and
 
 Use this if you're a technical team that wants control without premature complexity. It works well if you don't have 15 PMs writing docs every day.
 
-For 80% of startups, file-based MDX docs will be the right answer. Vercel, Supabase, Clerk, Planetscale, PostHog, and most modern OSS projects use this approach.
+For 80% of startups, file-based MDX is the right answer. Vercel, Supabase, Clerk, Planetscale, PostHog, and most modern OSS projects use this approach.
 
 ## 2. Git-based CMS layer — best middle ground
 
@@ -106,7 +106,7 @@ Using Sanity, Payload, or Contentful to power docs.
 
 ### When to use it
 
-Use this if you're a larger organization with multiple products, multiple locales, and multiple teams updating docs. Think Stripe-level documentation needs. If you're under 100 employees, this is almost always unnecessary.
+Use this if you're a larger organization with multiple products, locales, and teams updating docs. Think Stripe-level documentation. If you're under 100 employees, this is almost always unnecessary.
 
 ## 4. Hosted docs platforms — fastest to deploy, most lock-in
 
@@ -134,7 +134,7 @@ Use this if you need docs fast, your team is mixed-technical, and you don't mind
 
 ## 5. Custom in-product docs — the future for some teams
 
-Many modern companies (Linear, Raycast, Warp, Replit) embed docs directly into their product or create heavily customized documentation systems with React/MDX component libraries, interactive playgrounds, copyable codeblocks, live components, search tied into product data, custom navigation patterns, and AI-assisted docs generation.
+Linear, Raycast, Warp, and Replit embed docs directly into their product or build heavily customized systems: React/MDX component libraries, interactive playgrounds, copyable codeblocks, live components, search tied into product data, custom navigation, AI-assisted docs generation.
 
 ### Pros
 
@@ -152,7 +152,7 @@ Many modern companies (Linear, Raycast, Warp, Replit) embed docs directly into t
 
 ### When to use it
 
-Use this if you're building a developer platform and your docs are part of your differentiation. This is the final evolution stage.
+Use this if you're building a developer platform and your docs are part of your differentiation.
 
 ## So… Which Should You Use in 2026?
 
@@ -164,7 +164,7 @@ Use this if you're building a developer platform and your docs are part of your 
 
 **If you need something live tomorrow:** use GitBook or Mintlify Cloud. Accept the lock-in for speed.
 
-**If your docs are part of your product:** build custom. This is where world-class developer tooling systems end up.
+**If your docs are part of your product:** build custom. That's where world-class developer tooling ends up.
 
 ## Things most teams don't realize about docs
 
@@ -174,7 +174,7 @@ Use this if you're building a developer platform and your docs are part of your 
 
 **Search matters more than design.** Your docs UI can be plain, but your search must be excellent. Algolia DocSearch, Pagefind, or a custom hybrid all work well.
 
-**Docs need to survive your future rewrites.** Your framework will change. Your content shouldn't break with it. This is why MDX in Git is the gold standard.
+**Docs need to survive your future rewrites.** Your framework will change. Your content shouldn't break with it. MDX in Git is the gold standard for that reason.
 
 ## What we're betting on at Anarlog
 

--- a/apps/web/content/articles/devin-ai-review.mdx
+++ b/apps/web/content/articles/devin-ai-review.mdx
@@ -9,9 +9,7 @@ category: "Engineering"
 date: "2026-02-13"
 ---
 
-In the last two months, my two-person team spent over $5,000 running roughly 1,000 tasks in **[Devin](https://devin.ai/)**, the AI software engineer. We weren't spinning up 10 Claude Code instances to burn tokens as fast as possible. This is what actually happened when we integrated AI agents into our real-world workflow while building Anarlog.
-
-Here's what we learned.
+In the last two months, my two-person team spent over $5,000 running roughly 1,000 tasks in **[Devin](https://devin.ai/)**, the AI software engineer. We weren't spinning up 10 Claude Code instances to burn tokens. This is what actually happened when we integrated AI agents into our workflow while building Anarlog.
 
 ## Not a Reader? Watch the Video Instead
 
@@ -21,9 +19,9 @@ Here's what we learned.
 
 ## Running AI Agents Where Your Team Already Works
 
-The single most powerful decision we made was running Devin inside Slack, not our IDE.
+The best decision we made was running Devin inside Slack, not our IDE.
 
-Slack is where discussions already happen. We're already getting alerts from Zendesk, Sentry, and Discord. Launching an agent directly inside a thread where the problem is being discussed eliminates the friction of switching contexts.
+Slack is where discussions already happen. We already get alerts from Zendesk, Sentry, and Discord there. Launching an agent inside the thread where a problem is being discussed kills the friction of switching contexts.
 
 **Real example:** John, my co-founder, identified an issue with our AI prompts and tagged Devin to fix it. Devin fixed it, but the approach was non-optimal. Since AI prompting is something I work on, I jumped into the same thread with more context. Devin figured it out based on my additional input, finished the PR, and it got merged. We stayed in the same Slack thread the whole time, with no copy-pasting between tools.
 
@@ -33,23 +31,23 @@ The agent participates in the same Slack threads where we discuss the problem.
 
 ## AI Agents Enable Non-Technical Teams to Ship Code
 
-Having an agent accessible from Slack opened up tasks that don't necessarily require technical skills. For instance, understanding what we're tracking in analytics or making small adjustments to better understand user behavior.
+Having an agent accessible from Slack opened up tasks that don't require technical skills—understanding what we're tracking in analytics, or making small adjustments to better understand user behavior.
 
-John attached some PostHog docs and asked questions about what we're tracking and what we should be tracking long-term. Devin made the changes. Now both John and I know we have analytics updates—super helpful for staying aligned.
+John attached some PostHog docs and asked questions about what we're tracking and what we should be tracking long-term. Devin made the changes. Now both of us know we have analytics updates—helpful for staying aligned.
 
 Since we use GitHub as a CMS for Anarlog, we can even update landing pages or blog content directly from Slack. John attached a PDF from an internal discussion, and Devin updated our docs based on the actual conversation we had.
 
 ## Three Types of Tasks to Delegate to Devin AI
 
-As a small early-stage startup, there's always a lot going on. We're handling day-to-day work while thinking about what's next—new features, product direction, how the codebase should evolve. Dumping all of this into an async coding agent lets us explore solutions without blocking other work.
+As a small early-stage startup, there's always a lot going on. We're handling day-to-day work while thinking about new features, product direction, how the codebase should evolve. Dumping all of that into an async coding agent lets us explore solutions without blocking the work in front of us.
 
 ### Degree 1: Exploration (Not Shipping Anytime Soon)
 
-This is work that isn't planned for the immediate future. We're not going to ship it or even merge it right now, but exploring it helps us understand what the work would look like, how complex it is, and roughly how long it might take.
+Work we're not planning to ship soon. We won't merge it right now, but exploring it tells us what the work looks like, how complex it is, and roughly how long it might take.
 
 **Example:** Even though we're focusing on our macOS desktop app, we had ideas around building a Chrome extension. I asked Devin to research how to make a Chrome extension that works with a desktop app. We learned how 1Password does it and got a rough plan.
 
-Then we cloned the repository of a popular Chrome extension framework. Based on the docs and actual code examples, we implemented it to see how it would look. We didn't merge it, but it's useful to see how it'll look in the future.
+Then we cloned the repository of a popular Chrome extension framework. Using the docs and code examples, we implemented it to see how it would look. We didn't merge it, but the prototype is useful to have around.
 
 ### Degree 2: Preparation (Relevant, But Not Right Now)
 
@@ -63,7 +61,7 @@ We did research to see if there was any existing work on that. There was, so we 
 
 This is work we'll definitely look at, but spawning the agent right now lets us avoid context switching. Maybe we're traveling or about to go to sleep.
 
-**Example:** We needed to update test cases around our Tinybase utils—very relevant and important work. We asked Devin to clone the repo, inspect the codebase, and write the test cases.
+**Example:** We needed to update test cases around our Tinybase utils. We asked Devin to clone the repo, inspect the codebase, and write the test cases.
 
 One trick: we asked Devin to use the Claude CLI that we already installed on Devin's machine. This way we can offload some AI inference to our Anthropic account and use some credits.
 
@@ -71,11 +69,11 @@ One trick: we asked Devin to use the Claude CLI that we already installed on Dev
 
 ## Good Documentation Enables AI Agents to Ship Code Faster
 
-In Anarlog, we focus on supporting multiple providers for language and speech model inference as part of our open-source effort. Early on, we spent time designing and documenting flexible, clean interfaces. This worked well for future contributions and community involvement, and the same benefits apply when working with coding agents.
+In Anarlog, we support multiple providers for language and speech model inference as part of our open-source effort. Early on, we spent time designing and documenting clean interfaces. That paid off for community contributions, and the same benefits apply when working with coding agents.
 
 **Example: ElevenLabs Support**
 
-We support both WebSocket-based real-time transcription and file upload-based batch transcription. We had a very detailed prompt on how models should be handled, how language should be handled, and other API references in the docs.
+We support both WebSocket-based real-time transcription and file upload-based batch transcription. We had a detailed prompt on how models should be handled, how language should be handled, and other API references in the docs.
 
 Since we have end-to-end testing support in place, we sent the ElevenLabs API key as credentials (this can be passed in the prompt or through Infisical CLI). With all the documentation, test cases, and API key in place, Devin implemented it in almost one shot, and we safely merged it.
 
@@ -91,7 +89,7 @@ The pattern: good docs, clean interfaces, and test infrastructure make it possib
 
 ## Automating Code Maintenance with AI Agents
 
-Once a codebase reaches a certain size and age, maintenance work alone can consume significant engineering time and slow the team down. Coding agents let us offload much of that work.
+Once a codebase reaches a certain size and age, maintenance alone can eat most of your engineering time. Coding agents let us offload most of it.
 
 ### Single-Prompt Migrations
 
@@ -104,7 +102,7 @@ One common example is doing migrations that have clear documentation. In Anarlog
 
 Things can get more complicated and may require multiple PRs or concurrent work.
 
-A good example is applying Vercel's recent React best practices agent skills. We attached Vercel's React best practices document, and Devin figured out what changes should be done. Since there was a lot of isolatable work, we prompted Devin to do this concurrently by spawning concurrent Devin sessions.
+A good example: applying Vercel's recent React best practices agent skills. We attached Vercel's document, and Devin figured out what changes were needed. Since most of the work was isolatable, we prompted Devin to spawn concurrent sessions.
 
 One way to do this is to ask Devin to make actual API calls. But there's a better way: use the analyze-session task. This lets you spawn concurrent Devin sessions to run work concurrently and generate separate PRs per task.
 
@@ -112,15 +110,15 @@ One way to do this is to ask Devin to make actual API calls. But there's a bette
 
 Migrations and new guidelines don't happen every day, but pairing an agent with an automated linting tool can be applied daily.
 
-In Anarlog, we have a large Rust codebase, and since Cargo Clippy is pretty good, we set up a GitHub Action to run Cargo Clippy daily and spawn Devin to apply any fixes based on the output.
+We have a large Rust codebase, and Cargo Clippy is pretty good, so we set up a GitHub Action to run Clippy daily and spawn Devin to apply any fixes based on the output.
 
-This saves a lot of time applying these guidelines or Clippy warnings in an async manner, since running Clippy and Cargo check takes a long time.
+Clippy and Cargo check take a while to run, so doing this async saves us real time.
 
 ## When Devin Works and When It Doesn't
 
 If you're expecting AI agents to replace developers, you'll be disappointed. We're not there yet.
 
-But if you're looking to meaningfully extend what a small team can accomplish, it's absolutely worth it.
+If you're looking to extend what a small team can accomplish, it's worth the spend.
 
 **Devin AI is worth the investment when you:**
 
@@ -137,8 +135,8 @@ But if you're looking to meaningfully extend what a small team can accomplish, i
 - Want it to make architectural decisions
 - Need it to work in complete isolation without human oversight
 
-After 1,000 tasks, the pattern is clear: You're not buying code generation. You're buying the ability to delegate work and parallelize effort across your team.
+After 1,000 tasks, the pattern is clear. You're not buying code generation. You're buying the ability to delegate work and parallelize effort across your team.
 
-The best ROI came from tasks we could delegate async—exploration work at 2 AM, maintenance work during travel, migrations while focusing on core features. The agent didn't replace our judgment; it multiplied our capacity to act on it.
+The best ROI came from tasks we could delegate async—exploration at 2 AM, maintenance during travel, migrations while we focus on core features. The agent didn't replace our judgment. It multiplied our capacity to act on it.
 
-**Our recommendation:** Start with one well-defined use case (like automated linting or simple migrations), measure the time saved, then expand. Don't try to use it for everything on day one.
+**Our recommendation:** Start with one well-defined use case (automated linting, simple migrations), measure the time saved, then expand. Don't try to use it for everything on day one.

--- a/apps/web/content/articles/dont-use-a-cms.mdx
+++ b/apps/web/content/articles/dont-use-a-cms.mdx
@@ -7,13 +7,13 @@ category: "Engineering"
 date: "2025-11-29"
 ---
 
-There's a recurring mistake I see early teams make: they pick a CMS way too early.
+Early teams keep making the same mistake: they pick a CMS way too early.
 
-They adopt one because it feels official, not because they need it or because their content is genuinely complicated. It's the same instinct that leads to setting up Jira before you have 5 engineers, or building a microservice before you have users. The structure feels mature and professional.
+They adopt one because it feels official, not because they need it or because their content is genuinely complicated. It's the same instinct that leads to Jira before you have 5 engineers, or microservices before you have users. The structure feels mature and professional.
 
 But it's unnecessary work that slows you down.
 
-This post is Part 4 of our publishing series, and it's probably the most direct one: don't use a CMS until you actually need one. Most teams don't, and you probably don't either.
+This post is Part 4 of our publishing series, and it's the most direct one: don't use a CMS until you actually need one. Most teams don't, and you probably don't either.
 
 ## 1. CMS complexity creeps up slowly and quietly
 
@@ -43,7 +43,7 @@ When you're small, content comes from whoever feels like writing that week: foun
 
 Early-stage content has one job: communicate clearly, ship quickly, correct later, and move on.
 
-A CMS inverts this. You spend time defining models, configuring schemas, deciding fields, arranging layouts, creating environments, and publishing through abstraction layers. You end up spending more time setting up the publishing pipeline than actually writing.
+A CMS inverts this. You spend time defining models, configuring schemas, arranging layouts, creating environments, and publishing through abstraction layers. You end up spending more time on the publishing pipeline than the writing.
 
 The best writing stacks make writing feel like thinking. A CMS makes it feel like filing a ticket.
 
@@ -51,13 +51,13 @@ The best writing stacks make writing feel like thinking. A CMS makes it feel lik
 
 You don't feel lock-in in Month 1. You feel it in Year 2 when you want to redesign the site, migrate to a new framework, or reduce technical debt—and you discover exports with weird block formats, "portable text" that isn't portable, HTML blobs with inline attributes, API rate limits, broken image references, and schema migrations that silently fail.
 
-That's when your CMS quietly tells you: "By the way, you can't leave."
+That's when your CMS quietly tells you "by the way, you can't leave".
 
 ## 6. Every CMS introduces a second reality
 
-A CMS creates two worlds: the content world (editor UI, schema models, drafts) and the code world (MDX, components, styling, deployment). You maintain a mental bridge between both, and every change travels across two systems.
+A CMS creates two worlds: the content world (editor UI, schema models, drafts) and the code world (MDX, components, styling, deployment). You maintain a mental bridge between them, and every change has to travel across two systems.
 
-Early teams can't absorb that cognitive cost. You need one world, not two.
+Early teams can't absorb that cost. You need one world, not two.
 
 ## 7. Git + MDX + IDE will take you much further than you think
 
@@ -86,7 +86,7 @@ A CMS is structure. Structure is stability. Stability is for late-stage companie
 
 Don't over-engineer your publishing stack. Don't imitate companies 100x your size. Don't install enterprise workflows into a tiny team.
 
-Just write and ship in the simplest system that respects your time. You can add complexity later. You cannot subtract it.
+Write and ship in the simplest system that respects your time. You can add complexity later. You can't subtract it.
 
 ---
 

--- a/apps/web/content/articles/enterprise-ai-notetaking-tools.mdx
+++ b/apps/web/content/articles/enterprise-ai-notetaking-tools.mdx
@@ -9,11 +9,11 @@ category: "Comparisons"
 date: "2025-10-02"
 ---
 
-If you're evaluating AI notetaking tools for your organization, you're probably dealing with questions like: "Can our legal team actually use this?" "What happens to our data?" or "Will IT have a meltdown when I suggest this?"
+If you're evaluating AI notetaking tools for your organization, you're probably stuck on questions like "can our legal team actually use this?", "what happens to our data?", or "will IT have a meltdown when I suggest this?"
 
-Most AI notetaking tools weren't built for enterprises. They were built for individuals, then scaled up with "enterprise features" bolted on later. This creates predictable friction during procurement: the tool technically works, but it violates data policies, lacks the right deployment options, or creates compliance headaches nobody anticipated.
+Most AI notetaking tools weren't built for enterprises. They were built for individuals, then scaled up with "enterprise features" bolted on later. The result is predictable friction during procurement: the tool technically works, but it violates data policies, lacks the right deployment options, or creates compliance headaches nobody anticipated.
 
-This guide cuts through the marketing noise and covers five notetaking solutions that work for enterprises.
+This guide covers five notetaking tools that work for enterprises.
 
 ## AI Notetakers For Enterprises: At a Glance
 
@@ -27,12 +27,12 @@ This guide cuts through the marketing noise and covers five notetaking solutions
 
 We evaluated dozens of tools and narrowed the list to five based on what procurement teams actually need to see:
 
-- **Security and compliance readiness**: Does the tool have the certifications, architectural design, or deployment options that let it pass your legal and security review?
+- **Security and compliance readiness**: Does the tool have the certifications, architecture, or deployment options that pass your legal and security review?
 - **Administrative control**: We prioritized tools with SSO, role-based permissions, audit trails, user provisioning, and data retention policies that work across hundreds or thousands of users.
 - **Integration depth**: Does it plug into your existing stack (CRMs, collaboration tools, document repos)? We focused on tools that meet teams where they work.
 - **Production-proven**: We prioritized tools already deployed at Fortune 500 companies, healthcare systems, legal firms, and government agencies.
 
-The five tools we're covering represent fundamentally different architectural approaches. If one doesn't fit your requirements, another likely will.
+These five tools take genuinely different architectural approaches. If one doesn't fit your requirements, another likely will.
 
 ## Top Enterprise AI Notetaking Solutions: Detailed Reviews
 
@@ -40,13 +40,13 @@ The five tools we're covering represent fundamentally different architectural ap
 
 ![Best ai note taker for enteprises](/api/assets/blog/enterprise-ai-notetaking-tools/enterprise-1.webp)
 
-[Anarlog](/) is an open-source AI notepad for meetings built for high-agency organizations that demand complete control over their data, AI stack, and workflow. Everything is stored as plain markdown files—not in proprietary databases. You choose your AI: bring your own keys or run local models. Zero lock-in fundamentally changes what's possible from both a compliance and ownership perspective.
+[Anarlog](/) is an open-source AI notepad for meetings built for organizations that demand complete control over their data, AI stack, and workflow. Everything is stored as plain markdown files—not in proprietary databases. You choose your AI: bring your own keys or run local models. Zero lock-in changes what's possible on both compliance and ownership.
 
 #### Deployment Options
 
-- **Edge-only**: All processing happens locally with zero external connections—maximum creative IP protection
-- **All-prem**: Complete organizational control with all components running on your infrastructure
-- **Prem-hybrid**: STT and database on-premises while LLM workloads run in controlled environments—balances compliance with powerful AI capabilities
+- **Edge-only**: All processing happens locally with zero external connections—maximum IP protection
+- **All-prem**: Every component runs on your infrastructure
+- **Prem-hybrid**: STT and database on-premises while LLM workloads run in controlled environments—balances compliance with stronger AI capabilities
 
 #### Pricing
 
@@ -56,31 +56,31 @@ Enterprise pricing applies when your organization needs an on-premises deploymen
 
 #### Enterprise Features
 
-- **End-to-end encryption**: Zero-trust architecture with hardware security module support protects data at every stage—from capture to storage to processing.
-- **Multi-framework compliance**: Built-in support for HIPAA, SOC 2, ISO 27001, GDPR, and CCPA without requiring new certifications or security reviews. Works with existing compliance frameworks.
-- **Smart consent management**: Built-in recording consent collection with audit logs for all acknowledgments, ensuring compliance with one-party, two-party, or all-party consent laws.
-- **Enterprise authentication**: SSO (SAML 2.0/OIDC) and Multi-Factor Authentication (MFA) with seamless integration into your existing identity provider.
-- **Access management**: Advanced role-based permissions and granular controls for managing who can record, access, and share meeting data across the organization.
-- **Audit and monitoring**: Comprehensive audit trails and real-time monitoring track all access and usage, with a custom admin dashboard builder for visibility.
-- **Team collaboration**: Securely share notes with team-level controls, ensuring information flows to the right people while maintaining governance.
-- **Universal meeting compatibility**: Works with all platforms (Zoom, Teams, Meet, etc.) without requiring bots—captures both microphone and system audio directly.
-- **Vendor-agnostic AI**: Connect to OpenAI, Mistral, Ollama (via LM Studio), or any custom endpoint—no vendor lock-in for LLM processing.
-- **Workflow integrations**: Current integrations with Obsidian and Attio, with enterprise customers driving additional integration priorities based on their tech stack.
+- **End-to-end encryption**: Zero-trust architecture with hardware security module support protects data from capture to storage to processing.
+- **Multi-framework compliance**: HIPAA, SOC 2, ISO 27001, GDPR, and CCPA support without requiring new certifications or security reviews. Works with your existing compliance frameworks.
+- **Smart consent management**: Recording consent collection with audit logs for every acknowledgment, covering one-party, two-party, and all-party consent laws.
+- **Enterprise authentication**: SSO (SAML 2.0/OIDC) and MFA that integrate with your existing identity provider.
+- **Access management**: Role-based permissions and granular controls for who can record, access, and share meeting data.
+- **Audit and monitoring**: Audit trails and real-time monitoring across all access and usage, with a custom admin dashboard builder.
+- **Team collaboration**: Share notes with team-level controls so information flows to the right people without losing governance.
+- **Universal meeting compatibility**: Works with Zoom, Teams, Meet, and others without bots—captures microphone and system audio directly.
+- **Vendor-agnostic AI**: Connect to OpenAI, Mistral, Ollama (via LM Studio), or any custom endpoint. No vendor lock-in for LLM processing.
+- **Workflow integrations**: Obsidian and Attio today, with enterprise customers driving the next integrations based on their stack.
 - **Custom model support**: Bring your own speech-to-text and language models, plus calendar integration for automatic meeting detection.
 
 #### How it works
 
 Anarlog uses two types of models: speech-to-text (STT) and large language models (LLMs).
 
-For transcription, Anarlog uses the Whisper series from Hugging Face, which ranges from the lightweight Tiny and Base models to the V3 Large Turbo. Users choose based on their accuracy vs. speed requirements.
+For transcription, Anarlog uses the Whisper series from Hugging Face, ranging from the lightweight Tiny and Base models to V3 Large Turbo. You pick based on your accuracy vs. speed requirements.
 
-For summarization and intelligence, Anarlog developed HyperLLM-V1, a custom model based on Qwen 1.7B architecture. At just 1.1GB (compared to LLaMA's 2.0GB), it delivers high-quality summaries optimized for English while being extremely fast.
+For summarization, Anarlog ships HyperLLM-V1, a custom model based on Qwen 1.7B. At 1.1GB (vs. LLaMA's 2.0GB), it produces fast, English-tuned summaries.
 
-All of this happens locally. Anarlog captures both microphone input and system audio output, allowing it to work universally across various meeting platforms without requiring bots. No internet required for core functionality.
+All of this runs locally. Anarlog captures both microphone input and system audio output, so it works across meeting platforms without bots. No internet needed for core functionality.
 
-Your transcription and note data never touch external servers unless you explicitly choose to connect an LLM provider for additional features. Speaker identification works automatically for one-on-one calls by distinguishing between the microphone and system audio.
+Your transcription and note data never touch external servers unless you explicitly connect an LLM provider. Speaker identification works automatically for one-on-one calls by distinguishing microphone from system audio.
 
-For group meetings, users manually tag speakers using the transcript editor. Real-time transcription is supported with latency varying based on model size and hardware capabilities. Export options include Markdown, PDF, and Rich Text.
+For group meetings, you tag speakers manually in the transcript editor. Real-time transcription latency depends on model size and hardware. Exports: Markdown, PDF, Rich Text.
 
 #### Limitations & Trade-offs
 
@@ -94,7 +94,7 @@ For group meetings, users manually tag speakers using the transcript editor. Rea
 
 ![Read AI for enterprises](/api/assets/blog/enterprise-ai-notetaking-tools/enterprise-4.webp)
 
-[Read AI](https://www.read.ai) is a cloud-based AI copilot that transforms meetings, emails, and messages into searchable insights across your entire workspace. It functions as a unified intelligence layer connecting all your communication platforms.
+[Read AI](https://www.read.ai) is a cloud-based AI copilot that turns meetings, emails, and messages into searchable insights across your workspace. It's a unified layer across your communication platforms.
 
 **Deployment options**: Cloud-based (SaaS only)
 
@@ -123,7 +123,7 @@ Read AI joins meetings as a visible bot that announces itself and requires host 
 
 ![meetgeek for enterprises](/api/assets/blog/enterprise-ai-notetaking-tools/enterprise-5.webp)
 
-[MeetGeek](https://meetgeek.ai/) is a cloud-based conversation intelligence platform focused on tracking meeting performance across teams and departments. It emphasizes analytics, measuring things like engagement, sentiment, and meeting effectiveness at an organizational scale.
+[MeetGeek](https://meetgeek.ai/) is a cloud-based conversation intelligence platform that tracks meeting performance across teams and departments. The focus is analytics: engagement, sentiment, and meeting effectiveness at organizational scale.
 
 **Deployment options**: Cloud-based (SaaS), with private data storage on Enterprise
 
@@ -154,7 +154,7 @@ Bot-based assistant with automatic language detection across 100+ languages and 
 
 ![fellow ai for enterprises](/api/assets/blog/enterprise-ai-notetaking-tools/enterprise-6.webp)
 
-[Fellow](https://fellow.ai) is a cloud-based meeting assistant designed around internal meeting workflows, particularly manager tools like one-on-ones, team meetings, and collaborative agendas. Its distinguishing feature is granular recording controls for internal conversations.
+[Fellow](https://fellow.ai) is a cloud-based meeting assistant built around internal workflows—one-on-ones, team meetings, collaborative agendas. The distinguishing feature is granular recording controls for internal conversations.
 
 **Deployment options**: Cloud-based (SaaS)
 
@@ -189,7 +189,7 @@ Fellow operates as a bot that joins meetings to record and transcribe. It suppor
 
 ![plaud](/api/assets/blog/enterprise-ai-notetaking-tools/enterprise-7.webp)
 
-[Plaud](https://www.plaud.ai) takes a completely different approach: hardware-first AI notetaking. Instead of bots joining meetings, you get physical devices that capture conversations anywhere, anytime.
+[Plaud](https://www.plaud.ai) takes a different approach: hardware-first AI notetaking. Instead of bots joining meetings, you get physical devices that capture conversations anywhere.
 
 **Deployment options**: Cloud-based with hardware devices
 
@@ -197,14 +197,14 @@ Fellow operates as a bot that joins meetings to record and transcribe. It suppor
 
 #### Enterprise Features
 
-- **Hardware-based capture**: Plaud leverages dedicated sensors to capture conversations in multiple scenarios, unlocking previously untapped real-life data.
-- **Security & compliance**: HIPAA and SOC 2 compliant with GDPR and EN18031 certification. End-to-end encryption with custom data storage options for where your meeting data lives.
-- **Multi-language transcription**: AI transcription in 112 languages with automatic speaker labels and custom vocabulary that learns industry-specific terminology for better accuracy.
-- **Template library**: Over 3,000+ summary templates for generating multidimensional summaries, mind maps, and structured outputs for different meeting types and use cases.
-- **Ask Plaud AI**: Chatbot provides timestamped insights across all recordings—query meetings in natural language and get answers with exact timestamps to the original audio.
-- **Cross-platform access**: Record on physical devices, then access transcripts and summaries on the mobile app, web browser, and desktop with unlimited cloud storage.
-- **Dual-mode recording**: One-button switch between phone call recording mode and in-person conversation mode for different capture scenarios.
-- **Multimodal input**: Combine audio recording with typed notes, images, and press-to-highlight key moments for richer context and documentation.
+- **Hardware-based capture**: Dedicated sensors capture conversations across scenarios that software bots can't reach.
+- **Security & compliance**: HIPAA and SOC 2 compliant with GDPR and EN18031 certification. End-to-end encryption with custom data storage options.
+- **Multi-language transcription**: 112 languages with automatic speaker labels and custom vocabulary for industry terminology.
+- **Template library**: 3,000+ summary templates for summaries, mind maps, and structured outputs across meeting types.
+- **Ask Plaud AI**: Chatbot returns timestamped insights across recordings—query in natural language, get answers with exact timestamps to the original audio.
+- **Cross-platform access**: Record on the device, then access transcripts and summaries on mobile, web, and desktop with unlimited cloud storage.
+- **Dual-mode recording**: One-button switch between phone call mode and in-person mode.
+- **Multimodal input**: Audio plus typed notes, images, and press-to-highlight key moments.
 
 #### How it works
 
@@ -220,10 +220,10 @@ Hardware sensors capture high-quality audio locally (up to 64GB) then sync to cl
 
 ## Why Choose Anarlog
 
-Every enterprise has unique compliance requirements, workflow needs, and technical constraints. Anarlog's flexible architecture adapts to all three. Whether you need edge-only deployment for maximum IP protection, all-prem for complete infrastructure control, or prem-hybrid to balance compliance with powerful AI, there's a configuration that fits.
+Every enterprise has different compliance requirements, workflows, and technical constraints. Anarlog's architecture adapts to all three. Edge-only for maximum IP protection, all-prem for complete infrastructure control, or prem-hybrid to balance compliance with stronger AI—pick the configuration that fits.
 
 Our team works with Fortune 500 companies, healthcare systems, legal firms, financial institutions, and government agencies to deploy AI notetaking that fits their security posture.
 
-Ready to see how zero-lock-in AI works in practice? [Contact Sales](https://char.com) to discuss your specific needs, explore deployment options, and schedule a demo tailored to your organization's use cases.
+Want to see how zero-lock-in AI works in practice? [Contact Sales](https://char.com) to discuss your needs, explore deployment options, and schedule a demo for your use cases.
 
 &nbsp;

--- a/apps/web/content/articles/fathom-ai-alternatives.mdx
+++ b/apps/web/content/articles/fathom-ai-alternatives.mdx
@@ -6,11 +6,11 @@ category: "Comparisons"
 date: "2025-10-15"
 ---
 
-If bots make you nervous, privacy is on your mind, and you want more than simple note-taking and unlimited free recordings, you should look beyond Fathom AI.
+If bots make you nervous, privacy is on your mind, and you want more than transcription with unlimited free recordings, look beyond Fathom AI.
 
 ## Quick Fathom AI review
 
-I tested Fathom AI for weeks. It does what it says on the tin—a meeting bot that transcribes your Zoom, Meet, or Teams calls and generates summaries in about 30 seconds after the call ends. The CRM sync works well for sales teams.
+I tested Fathom AI for weeks. It does what it says on the tin: a meeting bot that transcribes your Zoom, Meet, or Teams calls and generates summaries about 30 seconds after the call ends. The CRM sync works well for sales teams.
 
 But the limitations become apparent quickly:
 
@@ -19,7 +19,7 @@ But the limitations become apparent quickly:
 - **The desktop app is just a recording widget.** There's nowhere to write down your thoughts during the meeting.
 - **No real-time transcription.** You're flying blind during calls, and it doesn't work without internet. Dead WiFi means a dead tool.
 - **The bot is always visible.** For sensitive client calls or therapy sessions, having "Fathom Notetaker" in your participant list changes the dynamic.
-- **The unlimited free plan is actually quite limited.** You get unlimited transcription and recordings, but AI summaries cap out at five per month.
+- **The unlimited free plan isn't really unlimited.** You get unlimited transcription and recordings, but AI summaries cap at five per month.
 
 If any of that bothers you, here are the top Fathom AI alternatives.
 
@@ -39,9 +39,9 @@ If any of that bothers you, here are the top Fathom AI alternatives.
 
 Full disclosure—I'm the co-founder of [Anarlog](/). I built it because every other tool locked you into their cloud, their models, their rules. No way to switch, no way out.
 
-Anarlog is an open-source AI notepad for meetings. Everything is stored as plain markdown files on your device—not in proprietary databases. You choose which AI processes your data: bring your own API keys or run local models.
+Anarlog is an open-source AI notepad for meetings. Everything is stored as plain markdown files on your device, not in proprietary databases. You choose which AI processes your data: bring your own API keys or run local models.
 
-You get a real notepad interface. Open Anarlog and you see a notepad. Type notes during meetings, and the AI enhances them with context from the transcript. Real-time transcription appears while people are talking, not after.
+The interface is a real notepad. Open Anarlog and you see a notepad. Type during meetings, and the AI enhances your notes with context from the transcript. Real-time transcription appears while people are talking, not after.
 
 **Best For:** Engineers, developers, and technical founders. Privacy-conscious professionals in healthcare, legal, and finance. People who already use tools like Obsidian or local-first workflows. Anyone whose company has banned cloud tools like Otter or Granola.
 
@@ -81,9 +81,9 @@ Free forever for local transcription, BYOK, and all core features. No usage caps
 
 ### 2. Avoma: if you're serious about sales
 
-[Avoma](https://www.avoma.com) is a complete revenue intelligence platform that actually helps your sales team improve.
+[Avoma](https://www.avoma.com) is a revenue intelligence platform that actually helps your sales team improve.
 
-It joins meetings as a bot, but unlike Fathom's basic summaries, it automatically structures notes around what matters for sales—pain points, budget, decision criteria, next steps. If you're using MEDDIC or SPICED frameworks, it populates those fields automatically.
+It joins meetings as a bot, but unlike Fathom's basic summaries, it structures notes around what matters for sales—pain points, budget, decision criteria, next steps. If you're using MEDDIC or SPICED, it populates those fields automatically.
 
 **Best For:** Sales teams needing coaching analytics, deal intelligence, and automated CRM updates. Works best for teams of 10+ reps who need scalable coaching.
 
@@ -124,9 +124,9 @@ Starts at $19/user/month base, but you'll need add-ons ($35-70/user/month) for c
 
 ### 3. Read AI: the everything-everywhere tool
 
-[Read AI](https://www.read.ai) takes a completely different approach than Fathom. Instead of just doing meetings, it connects meetings, emails, and messages into one searchable knowledge base.
+[Read AI](https://www.read.ai) takes a different approach than Fathom. Instead of just meetings, it connects meetings, emails, and messages into one searchable knowledge base.
 
-Read's Search Copilot works across everything. Ask "What did the engineering team say about the API redesign?" and it pulls answers from meetings, Slack threads, and email chains. This is genuinely useful when you're piecing together decisions made across multiple channels.
+Read's Search Copilot works across all of it. Ask "what did the engineering team say about the API redesign?" and it pulls answers from meetings, Slack threads, and email chains. Genuinely useful when you're piecing together decisions made across multiple channels.
 
 **Best For:** Teams who need unified search across all communications, not just meetings. Works well for product teams, executives, and anyone coordinating across multiple platforms.
 
@@ -169,7 +169,7 @@ Free plan offers 5 meetings per month with basic features. Paid plans start at $
 
 [Fireflies.ai](https://fireflies.ai) has been around longer than most competitors, and it shows in the analytics depth.
 
-The conversation analytics go way deeper than Fathom. Speaker talk time, sentiment analysis, topic tracking, even monitoring for specific keywords across all calls. If you're tracking how often competitors get mentioned or what objections keep coming up, Fireflies surfaces those patterns automatically.
+Conversation analytics go deeper than Fathom: speaker talk time, sentiment analysis, topic tracking, keyword monitoring across all calls. If you're tracking how often competitors get mentioned or what objections keep coming up, Fireflies surfaces those patterns automatically.
 
 **Best For:** Teams needing conversation analytics, sales teams tracking objections, product teams monitoring feature requests, or anyone managing high meeting volume.
 
@@ -216,7 +216,7 @@ Free plan includes unlimited transcription with 800 minutes of storage and limit
 
 [Sembly AI](https://www.sembly.ai) built its reputation on one thing: meeting the compliance requirements that make procurement teams happy. SOC 2 Type II, HIPAA, GDPR—Sembly checks boxes that most meeting assistants ignore.
 
-Fathom gives you basic summaries and expects you to handle compliance yourself. Sembly was designed from the ground up for regulated industries. Healthcare, finance, legal—teams that can't afford to mess around with data security.
+Fathom gives you basic summaries and expects you to handle compliance yourself. Sembly was designed for regulated industries from the start. Healthcare, finance, legal—teams that can't afford to mess around with data security.
 
 **Best For:** Enterprise organizations needing strict compliance, regulated industries (healthcare, finance, legal), teams building secure knowledge bases, or anyone where HIPAA/SOC 2 certification isn't optional.
 
@@ -257,13 +257,13 @@ Free plan offers 60 minutes of transcription per month. Paid plans start at $15/
 
 ## Which is the best Fathom AI alternative?
 
-**If control and zero lock-in matter, use Anarlog.** Plain markdown files, your choice of AI stack, and complete ownership. Engineers, developers, privacy-conscious professionals in healthcare and legal, or anyone whose company has banned cloud tools—Anarlog gives you ownership at the foundational level. You also get real-time transcription and offline support that Fathom can't match.
+**If control and zero lock-in matter, use Anarlog.** Plain markdown files, your choice of AI stack, complete ownership. Engineers, developers, privacy-conscious professionals in healthcare and legal, or anyone whose company has banned cloud tools—Anarlog gives you ownership at the foundational level. Real-time transcription and offline support that Fathom can't match.
 
-**If you're running a sales team and budget allows, go with Avoma.** The automated CRM updates and call scoring actually improve team performance. The coaching analytics are worth the price if you're serious about revenue. Budget realistically—you'll need $70-110/user/month for features you actually want.
+**If you're running a sales team and budget allows, go with Avoma.** The automated CRM updates and call scoring actually move performance. The coaching analytics are worth the price if you're serious about revenue. Budget realistically—you'll need $70-110/user/month for the features you actually want.
 
-**If you need unified search across all communications, Read AI is worth exploring.** The ability to query meetings, emails, and Slack in one place is genuinely useful for product teams and executives tracking decisions across channels. Negotiate the Pro pricing—don't accept the first quote.
+**If you need unified search across all communications, Read AI is worth exploring.** Querying meetings, emails, and Slack in one place is genuinely useful for product teams and executives tracking decisions across channels. Negotiate the Pro pricing—don't accept the first quote.
 
-**If you want conversation analytics on a budget, Fireflies works.** The unlimited free transcription beats Fathom's 5-summary cap, and the pattern recognition across meetings is deeper. Watch the storage limits and disable auto-sharing to all participants.
+**If you want conversation analytics on a budget, Fireflies works.** Unlimited free transcription beats Fathom's 5-summary cap, and pattern recognition across meetings is deeper. Watch the storage limits and disable auto-sharing.
 
-**If compliance certifications are required, Sembly is your answer.** SOC 2, HIPAA, GDPR out of the box. Regulated industries can't use tools without these certifications, and Sembly was built for that purpose.
+**If compliance certifications are required, Sembly is your answer.** SOC 2, HIPAA, GDPR out of the box. Regulated industries can't use tools without these, and Sembly was built for it.
 

--- a/apps/web/content/articles/filesystem-is-coretex.mdx
+++ b/apps/web/content/articles/filesystem-is-coretex.mdx
@@ -9,17 +9,17 @@ date: "2025-12-30"
 
 Most businesses win not because they have more features, but because they communicate a clearer philosophy—a picture of the future that some people want to live inside.
 
-In older eras, religion acted as the gravity of communities. Today, we're still pulled by gravity, just different kinds: interests, crafts, identities, missions. People want to become good at something. They want to enjoy something deeply. They want to find tools that make their journey feel coherent.
+In older eras, religion was the gravity of communities. Today, we're still pulled by gravity, just different kinds: interests, crafts, identities, missions. People want to get good at something. They want to enjoy it. They want tools that make the journey feel coherent.
 
-A startup's job is to make a specific journey possible and to make it feel inevitable.
+A startup's job is to make a specific journey possible and make it feel inevitable.
 
 ## Notes Are Not Productivity. They're Mind Extension.
 
-Note-taking is one of the most underestimated categories in software because it looks simple. But notes aren't documents or content. They're closer to memory, and memory is closer to identity. A note-taking system is an extension of your mind: a place where thoughts land, take shape, connect, and return later as insight.
+Note-taking is one of the most underestimated categories in software because it looks simple. But notes aren't documents or content. They're closer to memory, and memory is closer to identity. A note-taking system is an extension of your mind—a place where thoughts land, take shape, connect, and come back later as insight.
 
-The mind operates in modes. There's private thinking—personal thoughts, half-formed ideas, internal reflections. There's work mode—decisions, planning, collaboration, outcomes. There's publishing mode—writing for other people, making ideas legible, shipping something public.
+The mind operates in modes. Private thinking is personal thoughts, half-formed ideas, internal reflection. Work mode is decisions, planning, collaboration, outcomes. Publishing mode is writing for other people, making ideas legible, shipping something public.
 
-Good note-taking tools don't force those modes into a single abstraction. They let them coexist.
+Good note-taking tools don't force those modes into one abstraction. They let them coexist.
 
 This is why many serious note-takers end up with multiple tools:
 
@@ -33,21 +33,21 @@ These aren't competing products. They're compatible because they share a common 
 
 File-based systems are a cognitive model, not a relic. Humans have organized information spatially for centuries: drawers, cabinets, boxes, folders. We remember where something is. Location is recall. Structure is memory.
 
-This is why the terminal still feels natural. `ls`, `pwd`, `grep`—these commands mirror how people already understand information. There's a place, there's a name, there's content, there's a way to find it. Computers didn't invent this model. They adopted it.
+That's why the terminal still feels natural. `ls`, `pwd`, `grep` mirror how people already understand information. There's a place, there's a name, there's content, there's a way to find it. Computers didn't invent this model. They adopted it.
 
-When we talk about "local-first" and "file-based," we're discussing something beyond implementation: trust. A note-taking system is a memory prosthetic. Memory needs to feel owned, reliable, and genuinely yours. When notes live as files, they feel like part of you. When notes live as opaque blobs behind an API, they feel like someone else's product.
+When we talk about "local-first" and "file-based", we're talking about trust, not implementation. A note-taking system is a memory prosthetic. Memory has to feel owned, reliable, and yours. When notes live as files, they feel like part of you. When notes live as opaque blobs behind an API, they feel like someone else's product.
 
 ## Why AI Works So Well in Coding (and Why Writing Is Following)
 
-Coding agents feel effective right now partly because models are capable, but also because code is file-based. Software lives as artifacts—foo.tsx, bar.py, main.rs, README.md—not rows in a database or JSON stuffed inside Postgres fields. Real files with real names, clear structure, readable content.
+Coding agents feel effective right now partly because the models are capable, but mostly because code is file-based. Software lives as artifacts—foo.tsx, bar.py, main.rs, README.md—not rows in a database or JSON stuffed into Postgres fields. Real files with real names, clear structure, readable content.
 
 AI agents can traverse repositories, read context, understand conventions, search across files, and generate changes that fit the existing structure. The agent sees the artifact, diffs it, rewrites it, reasons about it.
 
 The best coding tools work because they're not inventing a new abstraction. They ride the filesystem—the same abstraction humans have used to manage complexity for decades.
 
-Writing is following the same pattern. People draft blog posts and essays inside coding environments. It seems odd on the surface, but writing and coding are closer than we admit. In both cases you're composing, shaping intent into an artifact, embedding values into structure, turning a vague thought into something executable—either by machines (code) or by humans (writing).
+Writing is following the same path. People draft blog posts and essays inside coding environments. It seems odd on the surface, but writing and coding are closer than we admit. In both, you're composing, shaping intent into an artifact, embedding values into structure, turning a vague thought into something executable—by machines (code) or by humans (writing).
 
-"Agents for writing" are happening inside code tools because those tools are file-native. They treat writing as a first-class artifact, not as a database record.
+"Agents for writing" are happening inside code tools because those tools are file-native. They treat writing as a first-class artifact, not a database record.
 
 ## The Endgame: Less Folder Worship, More Meaning
 
@@ -57,20 +57,20 @@ In the AI era, titles matter less than content. Location matters less than meani
 
 ## Where Anarlog Fits
 
-In the note-taking ecosystem, Obsidian communicates a clearer picture of the future than most. It's an incredible interface on top of a file-based knowledge base, and it has influenced how an entire generation thinks about notes. I've subscribed for years because of what it represents, not because of one feature.
+In the note-taking ecosystem, Obsidian communicates a clearer picture of the future than most. It's a great interface on top of a file-based knowledge base, and it has shaped how a generation of users thinks about notes. I've paid for it for years because of what it represents, not because of one feature.
 
-We don't want to replace Obsidian. We want to be part of the same movement: tools that respect files, respect ownership, and respect the mind.
+We don't want to replace Obsidian. We want to be part of the same movement: tools that respect files, ownership, and the mind.
 
-Anarlog is built to become the best interface for meeting notes and a connector across the full meeting workflow. Before the meeting: context, agenda, prep. During: capture, audio, real-time structure. After: summaries, decisions, action items, follow-ups. Eventually, a command center where you can direct AI instead of being replaced by it.
+Anarlog is built to be the best interface for meeting notes and a connector across the full meeting workflow. Before the meeting: context, agenda, prep. During: capture, audio, real-time structure. After: summaries, decisions, action items, follow-ups. Eventually, a command center where you direct AI instead of being replaced by it.
 
-Because Anarlog is file-based and local-first, it can sit alongside your existing vault. It can read from your knowledge base and write back into it. It treats meetings as a specialized region of your brain—deeply integrated, but not controlling everything else.
+Because Anarlog is file-based and local-first, it can sit alongside your existing vault. It reads from your knowledge base and writes back into it. It treats meetings as a specialized region of your brain—deeply integrated, but not controlling everything else.
 
-That's the direction that matters: building a tool that fits into the cortex, not another walled garden.
+That's the direction that matters: a tool that fits into the cortex, not another walled garden.
 
 ## Closing
 
-This isn't nostalgia for old-school files. It's a belief about the future: if AI is going to help humans think, it needs access to artifacts humans can own, inspect, move, and understand. Markdown, plain text, files.
+This isn't nostalgia for old-school files. It's a belief about the future. If AI is going to help humans think, it needs access to artifacts humans can own, inspect, move, and understand. Markdown, plain text, files.
 
-The filesystem is the cortex. In the AI era, it becomes even more important, not less.
+The filesystem is the cortex. In the AI era, it becomes more important, not less.
 
 Anarlog is our contribution to that future: a meeting-native interface inside a file-native world.

--- a/apps/web/content/articles/fireflies-ai-alternatives.mdx
+++ b/apps/web/content/articles/fireflies-ai-alternatives.mdx
@@ -8,9 +8,9 @@ date: "2025-09-23"
 
 Fireflies is easy to adopt, which is why so many teams try it first.
 
-It is also one of those products that feels different after the novelty wears off. The complaints are consistent: a bot people do not always want in the room, pricing that gets messy, multilingual performance that sounds better on the landing page than in practice, and upsells that show up once your team depends on it.
+It's also one of those products that feels different once the novelty wears off. The complaints are consistent: a bot people don't always want in the room, pricing that gets messy, multilingual performance that sounds better on the landing page than in practice, and upsells that show up once your team depends on it.
 
-So this list is for a specific buyer. Not someone new to the category. Someone who already understands what Fireflies gets right and wants a better trade-off.
+This list is for a specific buyer—not someone new to the category, but someone who already knows what Fireflies gets right and wants a better trade-off.
 
 ## Quick Fireflies AI review
 
@@ -20,25 +20,25 @@ Fireflies is an AI meeting assistant that automatically joins your Zoom, Google 
 
 ### The good stuff
 
-**Setup is genuinely easy:** Connect your calendar, and the bot starts auto-joining your scheduled meetings without any extra work from you. For people managing tons of meetings, this automation is a significant timesaver.
+**Setup is genuinely easy:** Connect your calendar and the bot starts auto-joining your scheduled meetings without extra work. For people managing tons of meetings, the automation is a real timesaver.
 
-**Transcription quality is decent:** In good conditions—clear audio, minimal background noise—you're looking at around 85-90% accuracy. That's solid enough to capture the gist of conversations and make them searchable later.
+**Transcription quality is decent:** In good conditions—clear audio, minimal background noise—you get 85-90% accuracy. Solid enough to capture the gist of conversations and make them searchable later.
 
-**AI summaries save time:** When they work well, the auto-generated summaries do capture key discussion points and action items. No more scrambling to remember what was decided three meetings ago.
+**AI summaries save time:** When they work, the auto-generated summaries do capture key discussion points and action items. No more scrambling to remember what was decided three meetings ago.
 
-**The search feature is actually useful:** Being able to type in keywords and instantly find where specific topics were discussed months ago is valuable, especially for sales teams tracking client conversations over time.
+**The search feature is actually useful:** Typing in keywords and instantly finding where a topic was discussed months ago matters, especially for sales teams tracking client conversations.
 
-**Integrations work well:** If you're using a CRM, having meeting notes automatically sync there saves a ton of manual work. The Slack integration is particularly handy for team updates.
+**Integrations work well:** If you use a CRM, having meeting notes sync automatically saves a lot of manual work. The Slack integration is handy for team updates.
 
-**Mobile app is convenient:** You can record and transcribe conversations on the go, which is useful for interviews or in-person meetings.
+**Mobile app is convenient:** Record and transcribe on the go, useful for interviews or in-person meetings.
 
 ### Where things get messy
 
-**The billing situation is concerning:** Multiple users report being charged for plans they didn't knowingly sign up for. The trial cancellation process seems deliberately confusing, and many people only discover unexpected charges when reviewing their credit card statements. Some users even mention being unable to remove their payment information from the platform.
+**The billing situation is concerning:** Multiple users report being charged for plans they didn't knowingly sign up for. The trial cancellation process seems deliberately confusing, and people often discover unexpected charges only when reviewing their credit card statements. Some users report being unable to remove their payment information from the platform.
 
 <Image src="/api/assets/blog/fireflies-ai-alternatives/fireflies-1.webp" alt="Fireflies 1"/>
 
-**Privacy issues are real:** By default, Fireflies shares meeting summaries with all attendees without asking first. You have to manually opt out of this behavior. For sensitive business discussions, that's problematic. We've covered [Fireflies' safety and data practices in detail](/blog/is-fireflies-ai-safe/). Even more concerning, several users report the bot continuing to join meetings even after they've cancelled their accounts and deleted everything.
+**Privacy issues are real:** By default, Fireflies shares meeting summaries with all attendees without asking first. You have to manually opt out. For sensitive business discussions, that's a problem. We've covered [Fireflies' safety and data practices in detail](/blog/is-fireflies-ai-safe/). Worse, several users report the bot continuing to join meetings after they've cancelled their accounts and deleted everything.
 
 <Image src="/api/assets/blog/fireflies-ai-alternatives/fireflies-2.webp" alt="Fireflies 2"/>
 
@@ -46,17 +46,17 @@ Fireflies is an AI meeting assistant that automatically joins your Zoom, Google 
 
 <Image src="/api/assets/blog/fireflies-ai-alternatives/fireflies-3.webp" alt="Fireflies 3"/>
 
-**Hidden costs add up quickly:** Those fancy AI features like smart summaries and action items require additional "AI credits" that aren't included in your base subscription. What looks like a $29/month Business plan can easily become much more expensive once you factor in the credits needed for core functionality.
+**Hidden costs add up quickly:** AI features like smart summaries and action items require "AI credits" that aren't included in your base subscription. A $29/month Business plan gets expensive fast once you factor in the credits needed for core functionality.
 
 <Image src="/api/assets/blog/fireflies-ai-alternatives/fireflies-4.webp" alt="Fireflies 4"/>
 
-**Aggressive upselling tactics:** Users report extremely aggressive upselling tactics for non-pro accounts. The combination of storage restrictions and AI credits creates constant pressure to upgrade to higher-tier plans.
+**Aggressive upselling tactics:** Users report aggressive upsells on non-pro accounts. The combination of storage restrictions and AI credits creates constant pressure to upgrade.
 
 <Image src="/api/assets/blog/fireflies-ai-alternatives/fireflies-5.webp" alt="Fireflies 5"/>
 
 ### The bottom line on Fireflies
 
-Fireflies does what it promises for basic transcription and automation, especially if you're working in English and don't mind having a bot in your meetings. But between the billing issues, privacy concerns, and accuracy limitations, there are serious trade-offs to consider. You have other options available.
+Fireflies does what it promises for basic transcription and automation, especially in English, if you don't mind a bot in your meetings. But between the billing issues, privacy concerns, and accuracy limits, the trade-offs are real. You have other options.
 
 ## Top Fireflies AI alternatives: at a glance
 
@@ -76,7 +76,7 @@ Fireflies does what it promises for basic transcription and automation, especial
 
 ### 1. Anarlog
 
-Anarlog is an open-source AI notepad for meetings built for high-agency people who demand complete control over their data and AI stack. Everything is stored as plain markdown files—not in proprietary databases. It works like Apple Notes with AI superpowers, capturing audio from any meeting platform without joining as a bot.
+Anarlog is an open-source AI notepad for meetings built for people who want complete control over their data and AI stack. Everything is stored as plain markdown files, not in proprietary databases. It works like Apple Notes with AI on top, capturing audio from any meeting platform without joining as a bot.
 
 <Image src="/api/assets/blog/fireflies-ai-alternatives/anarlog.webp" alt="Anarlog"/>
 
@@ -117,13 +117,13 @@ Anarlog is free forever, fully local, BYOK, and open source.
 
 ### 2. Avoma
 
-Avoma is a conversation intelligence platform designed specifically for revenue teams, combining meeting transcription with sales coaching, deal tracking, and revenue analytics.
+Avoma is a conversation intelligence platform built for revenue teams. It combines meeting transcription with sales coaching, deal tracking, and revenue analytics.
 
 <Image src="/api/assets/blog/fireflies-ai-alternatives/avoma.webp" alt="Avoma"/>
 
 #### How it compares to Fireflies
 
-While Fireflies provides basic conversation analytics, Avoma focuses on sales-specific insights like objection handling, talk time analysis, and deal progression tracking. It's built for revenue optimization rather than general meeting documentation.
+Fireflies provides basic conversation analytics. Avoma focuses on sales-specific insights: objection handling, talk time analysis, deal progression. It's built for revenue, not general meeting documentation.
 
 #### Top features
 
@@ -154,7 +154,7 @@ Base plans run $19-$39/user/month, with add-ons for sales features costing $35-$
 
 ### 3. Otter AI
 
-Otter AI is an established cloud-based AI meeting assistant that automatically joins video calls to record, transcribe, and summarize conversations with team collaboration features.
+Otter AI is a cloud-based AI meeting assistant that automatically joins video calls to record, transcribe, and summarize conversations, with team collaboration features.
 
 <Image src="/api/assets/blog/fireflies-ai-alternatives/otter.webp" alt="Otter AI"/>
 
@@ -193,13 +193,13 @@ Also check: Top Otter AI's Alternatives
 
 ### 4. MeetGeek
 
-MeetGeek is an AI meeting assistant that automatically detects meeting types and applies context-aware templates, workflows, and insights based on whether you're in sales calls, interviews, or team meetings.
+MeetGeek is an AI meeting assistant that detects meeting types and applies context-aware templates, workflows, and insights for sales calls, interviews, or team meetings.
 
 <Image src="/api/assets/blog/fireflies-ai-alternatives/meetgeek.webp" alt="MeetGeek"/>
 
 #### How it compares to Fireflies
 
-While Fireflies treats all meetings similarly, MeetGeek intelligently categorizes meetings and provides specialized insights for different contexts like hiring, sales, or project discussions.
+Fireflies treats all meetings similarly. MeetGeek categorizes them and provides specialized insights for hiring, sales, or project discussions.
 
 #### Key features
 
@@ -228,13 +228,13 @@ Starts at $19/user/month with meeting type detection and workflow automation.
 
 ### 5. Read AI
 
-Read AI is a comprehensive AI platform that provides meeting intelligence alongside unified search across emails, messages, and CRM data, treating meetings as part of broader business communications.
+Read AI is an AI platform that combines meeting intelligence with unified search across emails, messages, and CRM data. Meetings are part of broader business communications.
 
 <Image src="/api/assets/blog/fireflies-ai-alternatives/read-ai.webp" alt="Read AI"/>
 
 #### How it compares to Fireflies
 
-Fireflies focuses specifically on meeting intelligence, while Read.ai connects meeting insights with your entire communication ecosystem for unified knowledge management.
+Fireflies focuses on meeting intelligence. Read.ai connects meeting insights with your entire communication ecosystem for unified knowledge management.
 
 #### Top features
 
@@ -265,7 +265,7 @@ Free plan includes 5 monthly meeting reports. Paid plans start at $19.75/user/mo
 
 ### 6. Tactiq
 
-Tactiq operates as a Chrome extension providing real-time transcription directly in your browser during Google Meet, Zoom, and Teams meetings without requiring separate app downloads.
+Tactiq is a Chrome extension that provides real-time transcription in your browser during Google Meet, Zoom, and Teams meetings. No separate app to download.
 
 <Image src="/api/assets/blog/fireflies-ai-alternatives/tactiq.webp" alt="Tactiq"/>
 

--- a/apps/web/content/articles/free-ai-notetakers.mdx
+++ b/apps/web/content/articles/free-ai-notetakers.mdx
@@ -20,7 +20,7 @@ We evaluated each free AI notetaker based on:
 - **Privacy and security** -- Data handling practices and compliance considerations
 - **User experience** -- Interface design, reliability, and ease of use
 
-**Note:** If you're interested in premium options or tools with free trials, check out our comprehensive guide on the [best AI meeting assistants for taking notes](/blog/best-ai-meeting-assistant-for-taking-notes) that covers all available options.
+**Note:** If you're interested in premium options or tools with free trials, check out our guide on the [best AI meeting assistants for taking notes](/blog/best-ai-meeting-assistant-for-taking-notes) that covers all available options.
 
 ## Top 9 Truly Free AI Notetakers for Meetings
 
@@ -31,7 +31,7 @@ We evaluated each free AI notetaker based on:
 ![Anarlog](/api/assets/blog/free-ai-notetakers/free-1.webp)
 
 **Best for:**
-Anyone who wants enterprise-grade AI note-taking without vendor lock-in, cloud dependency, or data privacy compromises.
+Anyone who wants AI note-taking without vendor lock-in, cloud dependency, or data privacy compromises.
 
 #### What's Free Forever
 
@@ -149,7 +149,7 @@ The "Fred" bot captures meetings and provides detailed speaker analytics, sentim
 ![fireflies.ai](/api/assets/blog/free-ai-notetakers/free-9.webp)
 
 **Best for:**
-Teams and organizations that want comprehensive conversation analytics, speaker insights, and detailed team performance metrics alongside basic transcription and summaries.
+Teams and organizations that want conversation analytics, speaker insights, and detailed team performance metrics alongside basic transcription and summaries.
 
 #### What's Free Forever
 
@@ -212,7 +212,7 @@ The 300-minute monthly limit is hit quickly by regular users, making the $16.99 
 ![MeetGeek](/api/assets/blog/free-ai-notetakers/free-13.webp)
 
 **Best for:**
-Teams that want automated meeting workflows with smart templates that adapt to different meeting types, plus robust action item tracking and automated follow-up processes.
+Teams that want automated meeting workflows with smart templates that adapt to different meeting types, plus action item tracking and automated follow-up processes.
 
 #### What's Free Forever
 
@@ -264,7 +264,7 @@ The 120 monthly minutes (3 minutes per conversation) means regular users need th
 
 ### 9. Sonnet AI: Best for Automatic CRM Updates
 
-[Sonnet AI](https://www.sonnetai.com) is a bot-free AI meeting assistant that focuses on the complete meeting lifecycle—from pre-meeting participant research to automatic CRM updates after calls.
+[Sonnet AI](https://www.sonnetai.com) is a bot-free AI meeting assistant that focuses on the full meeting lifecycle—from pre-meeting participant research to automatic CRM updates after calls.
 
 It records device audio without visible meeting bots and emphasizes relationship management with automatic contact enrichment and conversation history tracking.
 
@@ -293,13 +293,13 @@ Sales professionals typically exceed 5 monthly recordings quickly, requiring the
 
 ## Why Anarlog May Be Your Best Choice
 
-These 9 tools offer genuine value without upfront costs—unlimited transcription from Fireflies, solid team features from Otter, multilingual support from Notta, and reliable recording from tl;dv.
+These 9 tools offer real value without upfront costs—unlimited transcription from Fireflies, solid team features from Otter, multilingual support from Notta, and reliable recording from tl;dv.
 
 But there's a catch in every "free" offering: your privacy and data. Fireflies analyzes your conversation patterns. Fathom's bot joins sensitive client calls. Tactiq processes confidential discussions on remote servers. You're paying with access to your most private conversations.
 
 Anarlog operates entirely on your device. No cloud processing, no data collection, no privacy trade-offs. It delivers unlimited AI summaries, real-time transcription, and meeting intelligence on your hardware.
 
-When "free" means no cost and no compromise, that's when you've found the right choice.
+When "free" means no cost and no compromise, that's the right choice.
 
 [Download Anarlog for macOS](https://anarlog.so) to experience meeting intelligence that costs nothing and compromises nothing (Windows and Linux versions coming in Q2 2026).
 

--- a/apps/web/content/articles/free-transcription-software.mdx
+++ b/apps/web/content/articles/free-transcription-software.mdx
@@ -33,7 +33,7 @@ We evaluated dozens of transcription tools using these criteria:
 - **Automatic transcription only**: Manual transcription assistants help you type faster while listening to audio, but don't transcribe automatically. This guide focuses on software that actually transcribes for you.
 - **Genuine free access**: We prioritized tools with permanent free plans, not trials disguised as "free" offerings.
 - **Usable limitations**: Many "free" tools impose restrictions that make them unusable—10-minute one-time trials or 3-minute recording limits. We focused on tools where the free tier actually works for real-world use.
-- **Transcription quality**: All selected tools use modern AI models (primarily OpenAI's Whisper) that deliver genuine accuracy.
+- **Transcription quality**: All selected tools use modern AI models (primarily OpenAI's Whisper) that deliver real accuracy.
 - **Privacy and data handling**: We noted whether tools process locally or in the cloud, and whether your data gets used for AI training.
 - **No hidden costs**: We clearly documented where free plans end and paid features begin.
 
@@ -55,7 +55,7 @@ We evaluated dozens of transcription tools using these criteria:
 
 [Sonix](https://sonix.ai) only offers a 30-minute one-time trial with no ongoing free plan. After that, you must pay $10/hour for transcription.
 
-**Consider for**: Multi-language support across 53+ languages and team collaboration features with shared folders.
+**Consider for**: Multi-language support across 53+ languages and team features with shared folders.
 
 ### 4. Trint
 
@@ -67,7 +67,7 @@ We evaluated dozens of transcription tools using these criteria:
 
 [Happy Scribe](https://www.happyscribe.com) offers only 10 minutes of transcription total (one-time, not monthly) and doesn't allow file exports on the free tier.
 
-**Consider for**: Subtitle creation with support for 120+ languages and automated translation capabilities.
+**Consider for**: Subtitle creation with support for 120+ languages and automated translation.
 
 You can check detailed reviews of these tools in our guide to [best transcription software for Mac](/blog/transcription-software-mac).
 
@@ -77,7 +77,7 @@ You can check detailed reviews of these tools in our guide to [best transcriptio
 
 ![Anarlog](/api/assets/blog/free-transcription-software/transcription-1.webp)
 
-[Anarlog](/) is an open-source AI notepad for meetings that gives you complete control over your data and AI stack. Everything is stored as plain markdown files—not in proprietary databases. You choose your AI: bring your own keys or run local models.
+[Anarlog](/) is an open-source AI notepad for meetings that gives you full control over your data and AI stack. Everything is stored as plain markdown files—not in proprietary databases. You choose your AI: bring your own keys or run local models.
 
 Zero lock-in means you can switch AI providers anytime and your files work with any tool (Obsidian, Notion, VS Code).
 
@@ -254,7 +254,7 @@ MacWhisper Pro ($29-35 one-time payment, no subscription) unlocks better accurac
 
 If data privacy matters and you need truly unlimited transcription without hidden costs, Anarlog is the clear choice.
 
-Unlike most transcription tools that lock you into their cloud, Anarlog stores everything as plain markdown files and lets you choose your AI stack. Zero lock-in, complete control.
+Unlike most transcription tools that lock you into their cloud, Anarlog stores everything as plain markdown files and lets you choose your AI stack. Zero lock-in, full control.
 
 Ready to take control of your transcription data? **[Download Anarlog for macOS](https://anarlog.so)** and get unlimited private transcription (Windows and Linux versions coming in Q2 2026).
 

--- a/apps/web/content/articles/google-gemini-data-retention-policy.mdx
+++ b/apps/web/content/articles/google-gemini-data-retention-policy.mdx
@@ -8,7 +8,7 @@ category: "Guides"
 date: "2026-03-13"
 ---
 
-Every AI provider in this series stores your conversations to some degree. Google Gemini does that too. But Gemini sits inside an ecosystem that already holds your email, your calendar, your location history, and your search activity. That changes the risk profile entirely.
+Every AI provider in this series stores your conversations to some degree. Google Gemini does that too. But Gemini sits inside an ecosystem that already holds your email, your calendar, your location history, and your search activity. That changes the risk profile.
 
 When you evaluate [OpenAI](/blog/chatgpt-data-retention-policy/) or Anthropic, you're asking what they do with your AI conversations. When you evaluate Google, you're asking what they do with your AI conversations and everything else they already know about you.
 
@@ -35,7 +35,7 @@ Google says it tries to anonymize or disconnect reviewed chats before humans see
 
 ## The Gmail Access Story
 
-In late 2025, Google enabled Gemini access to Gmail, Google Chat, and Google Meet by default for US users. By early 2026, Google rebranded this cross-app data flow under the name "Personal Intelligence," which now manages how Gemini connects to Gmail, Drive, Maps, and other Google services. When enabled, Gemini can read your entire email history to power features like email summarization, draft suggestions, and surfacing relevant information across your inbox.
+In late 2025, Google enabled Gemini access to Gmail, Google Chat, and Google Meet by default for US users. By early 2026, Google rebranded this cross-app data flow under the name "Personal Intelligence", which now manages how Gemini connects to Gmail, Drive, Maps, and other Google services. When enabled, Gemini can read your entire email history to power features like email summarization, draft suggestions, and surfacing relevant information across your inbox.
 
 In the US, this was opt-out. You had to actively turn it off. In Europe, the same feature required an opt-in before Gemini could access your Gmail, because GDPR places stricter requirements on default data sharing.
 
@@ -51,7 +51,7 @@ With activity off, future conversations will not be sent for human review and wi
 
 To control Gmail and cross-app access: as of early 2026, Google groups these permissions under a Personal Intelligence dashboard inside the Gemini interface. This is the central place to control which Google services Gemini can read across Gmail, Drive, Maps, and Calendar. You can also disable Gmail access specifically via Gmail Settings → See all settings → General → Gemini for Gmail without affecting the rest of your account.
 
-To adjust the default 18-month retention: open Gemini Apps Activity in your Google Account, select "Auto-delete," and choose your preferred window.
+To adjust the default 18-month retention: open Gemini Apps Activity in your Google Account, select "Auto-delete", and choose your preferred window.
 
 ## Human Review in Plain Terms
 

--- a/apps/web/content/articles/google-gemini-meeting-notes.mdx
+++ b/apps/web/content/articles/google-gemini-meeting-notes.mdx
@@ -8,7 +8,7 @@ category: "Comparisons"
 date: "2025-09-24"
 ---
 
-If you've come to rely on Gemini for day-to-day admin tasks, you're probably wondering whether it can handle meeting notes. It can, but there are significant limitations.
+If you've come to rely on Gemini for day-to-day admin tasks, you're probably wondering whether it can handle meeting notes. It can, but only inside Google Meet on a paid Workspace plan. Everywhere else, you're doing the work yourself.
 
 ## Can Google Gemini take meeting notes?
 
@@ -63,13 +63,13 @@ Zoom includes cloud recording with transcription on paid plans. Teams automatica
 💡 Try this prompt:
 "Please summarize this meeting transcript. Include key decisions, action items, and next steps. Format it professionally with clear sections for main topics discussed, decisions made, and follow-up tasks assigned."
 
-Gemini does excel at taking messy transcripts and turning them into clean, organized notes. This approach requires more work than the automated Google Meet solution, and it won't give you real-time transcription.
+Gemini is good at turning messy transcripts into clean notes. But this approach is more work than the automated Google Meet solution, and you don't get real-time transcription.
 
 ## What are the pros and cons of using Gemini to take meeting notes?
 
 ### The good stuff
 
-**It produces strong summaries.** When Gemini works, it catches key decisions, identifies action items, and organizes everything in a clean format you can actually use.
+**It produces strong summaries.** When Gemini works, it catches decisions, pulls action items, and organizes them in a format you can actually use.
 
 **Real-time summaries help during calls.** The "Summary so far" feature during Google Meet is handy if you want to glance over and check what you might have missed without interrupting the conversation.
 
@@ -79,7 +79,7 @@ Gemini does excel at taking messy transcripts and turning them into clean, organ
 
 **Subscription costs are steep.** Google Workspace plans with this feature run $12-18 per user per month. A 20-person company pays $2,880-4,320 annually just to take meeting notes.
 
-**Privacy concerns matter.** Every word spoken gets uploaded to Google's servers. That works fine for internal team meetings, but client consultations, legal discussions, or healthcare conversations pose real risk. Many organizations can't justify it.
+**Every word goes to Google's servers.** Fine for internal standups. Not fine for client consultations, legal discussions, or healthcare conversations. A lot of organizations can't justify it.
 
 **Manual workflows defeat the purpose.** For non-Google Meet platforms, you download transcripts, copy text, craft prompts, and organize results yourself. You're doing the AI's job.
 
@@ -87,7 +87,7 @@ Gemini does excel at taking messy transcripts and turning them into clean, organ
 
 ### Should you use it?
 
-After testing Google Gemini meeting notes extensively, it works well only if you meet three specific criteria:
+After spending real time with it, Google Gemini meeting notes work well only if all three of these are true:
 
 - Your entire organization uses Google Meet exclusively
 - You're comfortable with Google processing sensitive conversations
@@ -97,13 +97,11 @@ Most teams don't meet all three. You'll likely find yourself working around limi
 
 ## What is the best alternative to Gemini for note-taking?
 
-The list of alternatives is substantial—any decent AI meeting assistant does a better job. We have guides for [Google Meet](/blog/best-ai-notetakers-google-meet), [Zoom](/blog/best-ai-notetaker-for-zoom), and [Microsoft Teams](/blog/best-ai-notetaker-for-microsoft-teams).
+Almost any decent AI meeting assistant does this better. We have guides for [Google Meet](/blog/best-ai-notetakers-google-meet), [Zoom](/blog/best-ai-notetaker-for-zoom), and [Microsoft Teams](/blog/best-ai-notetaker-for-microsoft-teams).
 
-If I have to recommend one platform that works universally, is free, and keeps your data local, it's Anarlog.
+If I have to pick one tool that works on every platform, is free, and keeps your data local, it's Anarlog.
 
-Quick note: I'm the co-founder of Anarlog, but my recommendation isn't just personal bias—the platform delivers results.
-
-Here's what it does:
+I'm the co-founder, so take that as you will. But here's what it actually does.
 
 - Real-time transcription with no bots or calendar permissions required
 - Works with Zoom, Teams, Google Meet, and in-person meetings without any setup
@@ -121,7 +119,7 @@ Anarlog's note-taking features specifically:
 - **AI chat for clarification.** Get immediate answers about action items, deadlines, or who said what.
 - **Verify with source analysis.** Hover over summaries to see the exact transcript quote behind every AI-generated point.
 
-The difference is substantial. Instead of hoping Google's limited solution works with your workflow, you get a tool that adapts to how your team actually meets.
+Instead of hoping Google's narrow solution fits your workflow, you get a tool that adapts to how your team actually meets.
 
 Want to try Anarlog? [Download it for free](https://anarlog.so)!
 

--- a/apps/web/content/articles/granola-ai-alternatives.mdx
+++ b/apps/web/content/articles/granola-ai-alternatives.mdx
@@ -61,13 +61,13 @@ Granola's $18/month individual plan and limited free tier prompted us to look fo
 
 ### 1. Anarlog: The Open-Source Granola Alternative
 
-**Best for:** High-agency professionals who demand complete control over their data, AI stack, and workflow—especially engineers, developers, and teams in regulated industries.
+**Best for:** People who want full control over their data, AI stack, and workflow—engineers, developers, and teams in regulated industries.
 
 <Image src="/api/assets/blog/granola-ai-alternatives/granola-3.webp" alt="Anarlog"/>
 
-[Anarlog](/) is an open-source AI notepad for meetings that gives you complete control over your data, AI stack, and workflow. Everything is stored as plain markdown files on your device—not in proprietary databases or cloud servers.
+[Anarlog](/) is an open-source AI notepad for meetings. Your notes are plain markdown files on your device—not rows in a vendor's database.
 
-You can inspect the code, customize functionality, and choose which AI processes your data. Zero lock-in, zero compromises.
+You can read the code, change it, and pick which AI touches your data. No lock-in.
 
 #### Key Features
 
@@ -108,11 +108,11 @@ You take notes, the AI enhances them with transcript insights, and you get polis
 
 #### Jamie AI vs Granola
 
-[Jamie AI](https://www.meetjamie.ai/) creates comprehensive meeting notes and action items across any meeting platform without using visible bots. It hosts all data in Europe and supports offline capabilities and 100+ languages for global teams.
+[Jamie AI](https://www.meetjamie.ai/) creates meeting notes and action items across any platform without sending a visible bot. Data stays in Europe, it works offline, and it supports 100+ languages.
 
 #### Jamie vs Granola Strengths
 
-Both tools deliver intelligent meeting assistance by combining transcription with AI-powered enhancement. Jamie focuses on privacy and European data hosting, while Granola prioritizes simplicity.
+Both combine transcription with AI summaries. Jamie's edge is privacy and European data hosting. Granola's edge is simplicity.
 
 | Feature | Jamie | Granola |
 | ------------------------ | ----------------------------------------------------------- | ------------------------------------------------ |
@@ -139,11 +139,11 @@ Both tools deliver intelligent meeting assistance by combining transcription wit
 
 #### Tactiq vs Granola
 
-[Tactiq](https://tactiq.io/) provides real-time AI meeting transcription for Google Meet, Zoom, and Microsoft Teams. It runs directly in your browser without requiring software installation, capturing live transcripts with speaker identification and generating AI-powered summaries and action items after meetings.
+[Tactiq](https://tactiq.io/) is a real-time meeting transcriber for Google Meet, Zoom, and Microsoft Teams. It runs in your browser, no install required, captures live transcripts with speaker labels, and generates summaries and action items after the call.
 
 #### Tactiq vs Granola Strengths
 
-Both tools provide intelligent meeting assistance. Tactiq operates as a Chrome extension and offers real-time transcription, while Granola requires a native desktop app installation.
+Tactiq is a Chrome extension with real-time transcription. Granola is a native desktop app that processes after the meeting.
 
 | Feature | Tactiq | Granola |
 | ------------------------- | --------------------------------------------------- | ---------------------------------------- |
@@ -170,11 +170,11 @@ Both tools provide intelligent meeting assistance. Tactiq operates as a Chrome e
 
 #### Krisp vs Granola AI
 
-[Krisp](https://krisp.ai/) combines strong AI noise cancellation with meeting transcription, delivering clear audio quality and accurate meeting documentation without visible bots.
+[Krisp](https://krisp.ai/) pairs AI noise cancellation with meeting transcription. You get clear audio and notes, no bot in the room.
 
 #### Krisp vs Granola Strengths
 
-Both tools provide bot-free meeting assistance. Krisp's unique focus on audio quality sets it apart from purely transcription-focused solutions.
+Both are bot-free. Krisp's edge is audio quality — most transcription tools ignore that side completely.
 
 | Feature | Krisp | Granola |
 | --------------------------- | ----------------------------------------------------------- | --------------------------------- |
@@ -203,11 +203,11 @@ Both tools provide bot-free meeting assistance. Krisp's unique focus on audio qu
 
 #### Sonnet AI vs Granola AI
 
-[Sonnet AI](https://www.sonnetai.com/) is an end-to-end meeting assistant that specializes in automatically updating CRM systems with meeting insights. Founded by Y Combinator alumni, Sonnet records device audio without visible bots and transforms conversations into structured CRM data, eliminating manual data entry while providing customizable AI-generated meeting notes.
+[Sonnet AI](https://www.sonnetai.com/) is a meeting assistant built around CRM automation. Founded by Y Combinator alumni, it records device audio without a visible bot and pushes the conversation into your CRM as structured data, so you stop typing it in by hand.
 
 #### Sonnet AI vs Granola Strengths
 
-Both tools provide bot-free meeting assistance. Sonnet AI's focus on CRM automation and relationship management sets it apart from general note-taking solutions.
+Both are bot-free. Sonnet's edge is CRM automation and relationship tracking — not just notes.
 
 | Feature | Sonnet AI | Granola |
 | --------------------------- | -------------------------------------------------------- | ----------------------------- |
@@ -236,7 +236,7 @@ Both tools provide bot-free meeting assistance. Sonnet AI's focus on CRM automat
 
 #### tl;dv vs Granola AI
 
-[tl;dv](https://tldv.io/) is a comprehensive AI meeting assistant that records video, provides sales coaching, and analyzes multiple meetings for patterns. It goes beyond simple note-taking to transform conversations into actionable insights with enterprise-grade video capabilities that bot-free alternatives cannot match.
+[tl;dv](https://tldv.io/) records video, runs sales coaching, and analyzes patterns across multiple meetings. The video recording is the part bot-free alternatives can't match — it requires a bot in the call.
 
 > **Note:** tl;dv is the only bot-based tool in this comparison list. Unlike the other bot-free alternatives, tl;dv sends a visible bot to join your meetings to enable video recording and advanced features that aren't possible with device-level audio capture alone.
 >
@@ -244,7 +244,7 @@ Both tools provide bot-free meeting assistance. Sonnet AI's focus on CRM automat
 
 #### tl;dv vs Granola Strengths
 
-While both tools provide meeting intelligence, tl;dv's bot-based approach enables video capabilities and advanced features that device-level solutions cannot offer.
+Both summarize meetings. tl;dv's bot-based approach unlocks video recording and features that device-level capture can't reach.
 
 | Feature | tl;dv | Granola |
 | ------------------------------ | -------------------------------------------------------------------- | -------------------------------------- |

--- a/apps/web/content/articles/how-to-have-productive-one-on-one-meetings.mdx
+++ b/apps/web/content/articles/how-to-have-productive-one-on-one-meetings.mdx
@@ -9,31 +9,27 @@ date: "2025-11-10"
 
 One-on-ones should reduce your management overhead, not add to it. They should catch small problems before they become crises. They should help your team grow.
 
-Instead, they've become just another meeting in your calendar.
+Instead, they've become just another meeting on your calendar.
 
-You're asking "how's everything going?" because you forgot what you talked about last time.
-
-You're making commitments you don't track.
-
-You're having the same conversation about career development every month with no actual progress.
+You ask "how's everything going?" because you forgot what you talked about last time. You make commitments you don't track. You have the same career-development conversation every month with no actual progress.
 
 ## What makes one-on-ones actually productive
 
-A productive 1:1 focuses on surfacing real concerns before they escalate, identifying patterns across conversations, and making concrete commitments that both of you actually follow through on.
+A productive 1:1 surfaces real concerns before they escalate, finds patterns across conversations, and produces commitments both sides follow through on.
 
-It's not a status update (that's what standups are for). It's not you doing all the talking. It's not checking boxes on generic development questions or rehashing things everyone already knows.
+It is not a status update — that is what standups are for. It is not you doing all the talking. It is not a generic development checklist.
 
-Instead, your direct report gets uninterrupted time to raise concerns. You identify patterns in what's blocking them across multiple conversations. Both of you make commitments and follow through. Your team member feels heard and supported. You understand where each person is heading and help them get there.
+Your direct report gets uninterrupted time to raise concerns. You spot what is blocking them across multiple conversations. Both of you commit and follow through.
 
-If your 1:1s are draining you, you're doing them wrong.
+If your 1:1s are draining you, you are doing them wrong.
 
 ## 5 strategies to run better one-on-ones without burning out
 
 ### 1. Stop starting every conversation from scratch
 
-Most 1:1s lose their first fifteen minutes to reconstruction. You're trying to remember what you talked about last time. Your direct report is doing the same thing. You're both pulling from vague memories instead of picking up where you left off.
+Most 1:1s lose the first fifteen minutes to reconstruction. You are trying to remember what you talked about last time. Your report is doing the same. Both of you pull from vague memories instead of picking up where you left off.
 
-This is why managers end up asking "so... how's everything going?" It's the default question when nobody actually remembers specifics from three weeks ago.
+That is why managers default to "so... how's everything going?" It is the question you ask when nobody actually remembers specifics from three weeks ago.
 
 Before each 1:1, spend five minutes reviewing your actual conversation history with this person. Not bullet points you wrote down—the actual conversations.
 
@@ -43,19 +39,19 @@ If you're using Anarlog AI Notetaker, open Contacts View in Finder and search th
 - "What did we commit to last time?"
 - "What career goals has she mentioned?"
 
-You get specific answers pulled from actual transcripts, not your faulty reconstruction. This preparation takes five minutes but transforms the conversation. You walk in knowing exactly where you left off: "Last time you mentioned feeling blocked on the API refactor because docs were incomplete. How did that resolve?"
+You get specific answers pulled from actual transcripts, not your faulty reconstruction. Five minutes of prep, and you walk in knowing where you left off: "Last time you mentioned feeling blocked on the API refactor because docs were incomplete. How did that resolve?"
 
-Your direct report immediately knows you're paying attention and the conversation moves forward.
+Your report knows you were paying attention. The conversation moves forward.
 
 ### 2. Be fully present—let AI handle the documentation
 
-The biggest drain on 1:1s isn't the conversation itself. It's trying to listen, engage, and document simultaneously.
+The drain on 1:1s is not the conversation. It is trying to listen, engage, and document at the same time.
 
-You're having a meaningful discussion about someone's career concerns while frantically typing notes, worried you'll forget the important parts. Your attention is split. Your direct report can tell.
+You are talking through someone's career concerns while frantically typing, worried you will forget the important parts. Your attention is split, and your report can tell.
 
-Use Anarlog to automatically capture the entire conversation. It's open source, stores everything as plain markdown files, and lets you choose your AI stack—critical for sensitive conversations about performance, compensation, or personal issues. No bot joins your call. No lock-in.
+Use Anarlog to capture the conversation. It is open source, stores everything as plain markdown files on your device, and lets you choose your AI stack — which matters for conversations about performance, compensation, or personal issues. No bot joins the call.
 
-After the meeting, Anarlog gives you a complete transcript. Hover over any part of your AI-generated summary to see the exact quote from the conversation. Your manual notes get enhanced with full context without you having to choose between being present and capturing information.
+After the meeting, you get a full transcript. Hover over any line of the AI summary to see the exact quote behind it. You stop choosing between being present and remembering what was said.
 
 ### 3. Use templates to structure your 1:1s consistently
 
@@ -72,17 +68,15 @@ With Anarlog's custom templates, you can define exactly how your one-on-one note
 - Commitments made (both manager and direct report)
 - Concerns or tensions that need addressing
 
-To create a custom template, define your sections and add system instructions. For instance: "For every commitment made, note who owns it and extract the specific deadline mentioned. Highlight any recurring concerns that appeared in previous conversations."
+To build a custom template, define your sections and add system instructions. For example: "For every commitment made, note who owns it and pull the deadline. Flag any concern that has come up in past conversations."
 
-Set this as your default template in Settings, and every 1:1 automatically gets summarized in this format. No more inconsistent notes. No more forgetting to cover important areas.
-
-Your direct reports also benefit. When they know the structure, they can prepare better. When notes are consistent, they can track their own progress over time.
+Set this as your default template in Settings. Every 1:1 gets summarized in the same format. Your reports benefit too — when they know the structure, they can prepare for it.
 
 ### 4. Document commitments immediately (both yours and theirs)
 
-Your direct report mentions a blocker. You say "I'll look into that." Then you forget. They bring it up again next time. You forgot again.
+Your report mentions a blocker. You say "I'll look into that". Then you forget. They bring it up again next time. You forgot again.
 
-Same thing happens in reverse. They say "I'll draft that proposal." Next 1:1, you don't ask about it. They didn't do it, but they didn't have to explain why. The accountability is missing on both sides.
+Same thing in reverse. They say "I'll draft that proposal". Next 1:1, you do not ask about it. They did not do it, and they never had to explain why.
 
 Right after each 1:1, capture what needs follow-up action. With Anarlog, ask AI Chat: "What commitments did I make?" and "What commitments did Alex make?"
 
@@ -93,15 +87,15 @@ You'll get specific items:
 - **Alex:** Draft team charter by next Tuesday
 - **Alex:** Send feedback on the API proposal
 
-Add these to your task system with specific language. Not vague items like "follow up on Alex's stuff" but concrete tasks: "Email design lead about feedback turnaround time - due Friday."
+Add these to your task system with specific language. Not "follow up on Alex's stuff" but "Email design lead about feedback turnaround time — due Friday".
 
-Share the action items with your direct report right after the meeting. Send them a quick message: "Here's what we both committed to - me: design feedback and HR policy by Friday. You: team charter and API review by Tuesday." Now you're both clear on what needs to happen before the next 1:1.
+Share the action items with your report right after the meeting. Something like: "Here's what we both committed to — me: design feedback and HR policy by Friday. You: team charter and API review by Tuesday". Now both of you know what needs to happen before the next 1:1.
 
 ### 5. Separate career conversations from tactical ones
 
 Most managers try to pack everything into one 1:1: status updates, immediate blockers, long-term development, career goals, feedback, team dynamics.
 
-The result: You spend thirty minutes on tactical issues and rush through "so, uh, how are you thinking about your career?" in the last five minutes. The answer is always generic: "Yeah, I want to grow, maybe move toward senior engineer eventually."
+The result: thirty minutes on tactical issues, then a rushed "so, uh, how are you thinking about your career?" in the last five minutes. The answer is always generic: "Yeah, I want to grow, maybe move toward senior engineer eventually".
 
 Nobody benefits from that conversation.
 
@@ -144,21 +138,19 @@ Here's what the actual workflow looks like when you're using Anarlog:
 - Identify recurring themes and patterns by scanning through summaries
 - Prepare for career conversations with specific examples and observations
 
-This system reduces prep time while improving quality. You're not scrambling before each meeting because context is always available. You're not forgetting commitments because they're systematically tracked and shared. You're not missing patterns because you can review conversation history in one place.
+Less prep, better meetings. You stop scrambling before each one because context is already there. You stop forgetting commitments because they are tracked and shared. You catch patterns because the history is in one place.
 
-Your mental energy goes to the actual conversation, not the overhead of managing the conversation.
+Your mental energy goes to the conversation, not the overhead around it.
 
 ## Stop treating one-on-ones like they're optional
 
-Management advice hasn't evolved, but the tools have.
+Management advice has not evolved. The tools have.
 
-You don't need to manually track everyone's development in spreadsheets. You don't need to remember every conversation across eight direct reports. You don't need to start each 1:1 from scratch, reconstructing context from memory.
+You do not need to track everyone's development in spreadsheets, remember every conversation across eight reports, or rebuild context from memory before every 1:1.
 
-Use AI to handle the overhead that's not actually management. Let Anarlog capture conversations automatically—it's open source with zero lock-in, storing everything as plain markdown files you fully own.
+Let AI handle the overhead. Anarlog captures conversations, stores them as plain markdown on your device, and is open source. No vendor lock-in.
 
-Search across all your 1:1s to identify patterns. Ask AI about recurring themes and commitments. Track what each person cares about over time without drowning in manual documentation.
-
-Your brain should be doing what it does best: connecting with people, identifying what they need, helping them grow. Not trying to be a human database of scattered conversations.
+Search across all your 1:1s for patterns. Ask AI about recurring themes and commitments. Track what each person cares about over time without becoming a human database.
 
 [Download Anarlog free](/) and run one-on-ones that actually develop your team without burning you out.
 

--- a/apps/web/content/articles/how-to-participate-in-meetings-effectively.mdx
+++ b/apps/web/content/articles/how-to-participate-in-meetings-effectively.mdx
@@ -8,15 +8,13 @@ category: "Guides"
 date: "2025-11-07"
 ---
 
-You've heard the advice. "Be an active listener." "Come prepared." "Ask thoughtful questions."
+You have heard the advice. "Be an active listener". "Come prepared". "Ask thoughtful questions".
 
-Solid advice, sure. But it doesn't help much when you're in your sixth meeting of the day, someone asks you a direct question, and you realize you have no idea what the last ten minutes were about because your brain was still processing the previous meeting.
+Solid advice. Useless when you are in your sixth meeting of the day, someone asks you a direct question, and you realize you have no idea what the last ten minutes were about because your brain is still chewing on the meeting before this one.
 
-Standard meeting participation advice assumes you're operating at peak cognitive capacity—rested, focused, with unlimited mental bandwidth to engage deeply and track everything simultaneously.
+Standard meeting advice assumes you are rested, focused, and operating at full cognitive capacity. You are not. You are context-switching between seven projects, pulled into this call with five minutes' notice, trying to look engaged while your brain begs for a break.
 
-In reality, you're context-switching between seven different projects, pulled into this meeting with five minutes' notice, trying to look engaged while your brain screams for a break.
-
-So let's talk about what actually works when you need to participate effectively but you're running on cognitive fumes.
+Let's talk about what actually works when you are running on fumes.
 
 ## The real problem with meeting participation
 
@@ -29,21 +27,21 @@ Effective participation requires doing multiple things at once:
 - Maintaining awareness of group dynamics
 - Documenting important points for later
 
-That's a lot of cognitive load. When you're trying to do all of it simultaneously, you end up doing none of it particularly well.
+That is a lot of cognitive load. Try to do all of it at once and you do none of it well.
 
-Research from Stanford shows that multitasking can reduce productivity by up to 40%. Yet meetings expect people to effectively "multitask" their attention: listening, thinking, responding, and documenting all at once.
+Research from Stanford shows multitasking can drop productivity by up to 40%. But meetings expect exactly that: listening, thinking, responding, and documenting all at once.
 
-The solution isn't to "focus harder." It's to build systems that reduce the cognitive overhead of participation so your brain can focus on what actually matters: thinking and contributing.
+The fix is not "focus harder". It is building systems that take the overhead off your brain so you can think and contribute.
 
 ## Meeting participation strategies that work
 
 ### 1. Pre-load context instead of reconstructing it live
 
-You walk into a meeting and spend the first ten minutes trying to remember what was discussed last time. Who said what. What was decided. What's still unresolved.
+You walk into a meeting and burn the first ten minutes trying to remember what was decided last time and what is still unresolved.
 
-While you're mentally reconstructing context, the conversation has already moved on. You're three steps behind, and by the time you catch up, you've missed the critical moment to contribute.
+While you are reconstructing context, the conversation has already moved on. By the time you catch up, you have missed the moment to contribute.
 
-Instead, prep before the meeting starts.
+Prep before the meeting starts instead.
 
 Open your notes from the last relevant conversation and recap:
 
@@ -55,86 +53,86 @@ If you're using [Anarlog AI Notetaker](/), use Search (cmd + k) to find every pa
 
 Then use AI Chat to ask targeted questions: "What were the main objections to the pricing model?" or "What did Sarah say about the technical constraints?" You get specific answers pulled from actual transcripts, not your faulty memory.
 
-This takes five minutes. Those five minutes mean you walk in prepared to contribute immediately instead of spending the first chunk of the meeting getting oriented.
+Five minutes of prep. You walk in ready to contribute instead of catching up.
 
 **Want to optimize your entire meeting workflow?** Check out our [meeting preparation checklist](/blog/meeting-preparation-checklist) for the pre-meeting work that sets up better participation.
 
 ### 2. Use strategic silence, not constant commentary
 
-Effective participation doesn't mean contributing often. The people who talk the most in meetings aren't necessarily the most effective participants. Often they're thinking out loud, working through their ideas in real-time at everyone else's expense.
+Contributing often is not the same as participating well. The people who talk the most are usually thinking out loud at everyone else's expense.
 
-The most effective participants speak strategically:
+The effective participants speak strategically:
 
-- **Ask the question everyone's thinking but no one wants to ask.** "Before we go further, can we confirm we all have budget approval for this?" This saves twenty minutes of discussion on something that might be blocked anyway.
-- **Redirect when the conversation drifts.** "This is interesting, but I want to make sure we answer the original question first." You don't need to be the meeting leader to do this.
-- **Surface the unspoken tension.** "I'm sensing some hesitation about this approach. Can we talk about that directly?" Naming the dynamic everyone feels but no one acknowledges moves conversations forward faster than pretending everything's fine.
-- **Bridge perspectives.** "It sounds like engineering is concerned about timeline while marketing needs this for the launch. Can we discuss what's actually negotiable?" This identifies the actual problem to solve.
+- **Ask the question everyone is thinking but nobody wants to ask.** "Before we go further, can we confirm we all have budget approval for this?" Saves twenty minutes on something that might be blocked anyway.
+- **Redirect when the conversation drifts.** "This is interesting, but can we answer the original question first?" You do not need to be the meeting leader to do this.
+- **Name the unspoken tension.** "I'm sensing some hesitation. Can we talk about that directly?" Naming the dynamic moves things forward faster than pretending it is not there.
+- **Bridge perspectives.** "Engineering is worried about timeline. Marketing needs this for the launch. What is actually negotiable?" This finds the real problem.
 
-The rest of the time, listen actively, track what's being said, and let others take the floor. Your silence is strategic, not disengagement.
+The rest of the time, listen and let others take the floor. Silence is a contribution, not disengagement.
 
 ### 3. Separate capture from processing
 
-The biggest cause of [meeting fatigue](/blog/how-to-reduce-meeting-fatigue) is trying to participate and document simultaneously.
+The biggest cause of [meeting fatigue](/blog/how-to-reduce-meeting-fatigue) is trying to participate and document at the same time.
 
-You're in the middle of making a point, and someone drops a critical piece of information. Do you stop mid-sentence to write it down and lose your train of thought? Keep talking and hope you remember later? Try to hold it in working memory while finishing your point?
+You are mid-point and someone drops a critical detail. Do you stop and write it down? Keep talking and hope to remember? Try to hold it in working memory while finishing your sentence?
 
-This is why people take terrible notes. They're not bad at note-taking; they're trying to do two incompatible tasks at once.
+This is why people take bad notes. They are not bad at note-taking. They are trying to do two incompatible things at once.
 
-During the meeting, focus entirely on participation. Use a tool like Anarlog that runs locally on your device, automatically capturing both what's said and what you're thinking. No bot joining the call, no data leaving your machine, just automatic documentation.
+During the meeting, focus on participation. Use a tool like Anarlog that runs locally and captures both what is said and what you typed. No bot in the call, nothing leaving your machine.
 
-If you prefer manual note-taking, jot down fragments, keywords, reactions. But don't try to create polished, comprehensive notes in real-time. You can use Anarlog to enhance your manual notes using the meeting transcript afterward.
+If you prefer manual notes, jot down fragments and reactions. Do not try to write polished comprehensive notes live. Anarlog can enhance your fragments with the transcript afterward.
 
-After the meeting, process what was captured. This is when you review the transcript, identify action items, connect dots, and organize information. Your AI-generated summary is already waiting. Hover over any part to see the exact quote from the conversation.
+After the meeting, process what was captured. Review the transcript, pull action items, organize. Hover over any line of the AI summary to see the exact quote behind it.
 
-Ask AI Chat "What are my action items from this meeting?" instead of hunting through notes. Search across meetings to track how topics have evolved over time.
+Ask AI Chat "What are my action items from this meeting?" instead of scrolling notes. Search across meetings to see how a topic has evolved.
 
-Your brain is fully engaged during the conversation, and organizing happens later when you have the mental space for it.
+Your brain is fully on the conversation. Organizing happens later, when you have space for it.
 
 ### 4. Manage your energy, not just your calendar
 
-You can't participate effectively if you're mentally exhausted. And you will be mentally exhausted if you're trying to engage deeply in eight back-to-back meetings.
+You can not participate well if you are mentally fried. And you will be fried after eight back-to-back meetings.
 
-The standard advice is "schedule breaks between meetings." Except you don't control half your calendar. Meetings get added, extended, moved with no regard for your carefully planned buffer time.
+The standard advice — "schedule breaks between meetings" — assumes you control your calendar. You don't. Meetings get added, extended, and moved with no regard for your buffer time.
 
-Instead of controlling your schedule, manage your participation energy strategically:
+So manage your participation energy instead of your schedule:
 
-- **Identify which meetings need your best thinking.** A status update needs your attention but not your deepest analytical thinking. A strategic planning session does.
-- **Frontload your energy to high-stakes meetings.** If you have a critical client call at 2 PM, don't schedule three cognitively demanding meetings before it.
-- **Use lighter participation modes when you're drained.** If you're running on fumes, you can still contribute by asking clarifying questions, taking on action items for later execution, or providing specific factual information.
-- **Actually take the micro-breaks you have.** Between meetings, resist the urge to immediately process what just happened or prep for what's next. Take sixty seconds to look away from your screen. Stand up. Your brain needs transition time.
+- **Identify which meetings need your best thinking.** A status update needs attention. A strategic planning session needs analysis. They are not the same.
+- **Frontload energy for high-stakes meetings.** If you have a critical client call at 2 PM, do not stack three cognitively heavy meetings before it.
+- **Use lighter modes when drained.** Ask clarifying questions, volunteer for action items, contribute factual information.
+- **Take the micro-breaks you have.** Between meetings, do not immediately process or prep. Sixty seconds away from the screen. Your brain needs transition time.
 
-Use Anarlog's automatic capture so you're not doing the mental gymnastics of trying to remember everything from each meeting.
+Use Anarlog's automatic capture so you are not also doing memory gymnastics on top of everything else.
 
 ### 5. Close the loop on your commitments immediately
 
-You say "I'll look into that" in a meeting. The meeting ends. You move to the next thing. Three days later someone asks about it, and you've completely forgotten.
+You say "I'll look into that" in a meeting. The meeting ends. You move on. Three days later someone asks about it, and you have completely forgotten.
 
-It's not that you didn't care. You relied on memory instead of systems.
+You did not stop caring. You relied on memory instead of a system.
 
 Right after the meeting:
 
-- **Review your action items immediately.** Don't wait until later when everything blurs together. With Anarlog, ask AI Chat "What are my action items?" and get them instantly from your meeting transcript.
-- **Add them to your task system with specific deadlines.** "Look into X" is not actionable. "Research X and send summary to team by Thursday 3 PM" is.
-- **Block time to actually do them.** An action item without calendar time is wishful thinking.
+- **Review your action items now.** Not later, when everything blurs together. With Anarlog, ask AI Chat "What are my action items?" and get them straight from the transcript.
+- **Add them with specific deadlines.** "Look into X" is not actionable. "Research X and send summary to team by Thursday 3 PM" is.
+- **Block time to do them.** An action item without calendar time is wishful thinking.
 
 Before the next meeting:
 
-- **Check what you committed to in the last one.** Search your past notes for action items with your name. With Anarlog's Search, find every instance where you said "I'll handle this" or "I'll follow up on that."
-- **Update the group proactively.** Don't wait to be asked. "Quick update on the database research I said I'd do—found three options, here's my recommendation."
+- **Check what you committed to last time.** Search past notes for action items with your name. Anarlog's Search finds every "I'll handle this" or "I'll follow up on that".
+- **Update the group before they ask.** "Quick update on the database research — found three options, here is my recommendation".
 
-When you consistently deliver on commitments, people take your contributions seriously. When you don't, your participation becomes background noise.
+Deliver on commitments and people take your contributions seriously. Don't, and your participation becomes background noise.
 
 ## Stop participating like it's 2015
 
-Meeting participation advice hasn't evolved, but the tools have.
+Meeting advice has not evolved. The tools have.
 
-You don't need to frantically take notes while trying to contribute. You don't need to reconstruct context from memory. You don't need to manually track every commitment across dozens of conversations.
+You do not need to frantically take notes while trying to contribute, reconstruct context from memory, or track every commitment across dozens of conversations by hand.
 
-Use AI to handle the cognitive overhead that's not actually thinking. Let Anarlog capture conversations automatically, locally on your device without any data leaving your machine. Search across all your past meetings to find context instantly. Ask AI specific questions about what was discussed instead of hunting through transcripts.
+Let AI handle the overhead. Anarlog captures conversations locally on your device. Search across past meetings for context. Ask AI questions instead of scrolling transcripts.
 
-Your brain should do what it does best: connecting ideas, spotting patterns, contributing unique insights. Not being a human tape recorder.
+Your brain should be connecting ideas and spotting patterns, not being a human tape recorder.
 
-Meetings haven't changed. Your system for participating in them can.
+Meetings have not changed. Your system for participating in them can.
 
 [Download Anarlog free](https://anarlog.so) and participate in meetings without the cognitive overhead.
 

--- a/apps/web/content/articles/how-to-reduce-meeting-fatigue.mdx
+++ b/apps/web/content/articles/how-to-reduce-meeting-fatigue.mdx
@@ -6,27 +6,27 @@ category: "Guides"
 date: "2025-10-31"
 ---
 
-You've read the articles. You know the drill. "Cut unnecessary meetings!" "Block focus time!" "Just say no!"
+You have read the articles. "Cut unnecessary meetings!" "Block focus time!" "Just say no!"
 
-Great advice. Truly. Except when your job literally is meetings.
+Good advice — except when your job literally is meetings.
 
-If you're in sales, customer success, consulting, recruiting, or any role where human conversation is the actual work—not a distraction from it—then the standard productivity advice feels backwards. It's like telling a marathon runner to just run less. Sure, that would help with fatigue, but you wouldn't finish the race.
+If you are in sales, customer success, consulting, or recruiting, conversation is the actual work. The standard productivity advice is backwards. It is like telling a marathon runner to run less. Sure, less running, less fatigue. You also don't finish the race.
 
-So let's talk about the meeting fatigue nobody wants to acknowledge: the kind that happens even when every single meeting on your calendar matters. You optimize your schedule, batch your calls, and still end each day feeling like your brain has been through a blender.
+This is the meeting fatigue nobody talks about: the kind that hits even when every meeting on your calendar matters. You optimize your schedule, batch your calls, and still end the day feeling like your brain went through a blender.
 
 ## What causes meeting fatigue? The science behind Zoom exhaustion
 
-[Microsoft Research ran studies](https://www.microsoft.com/en-us/worklab/work-trend-index/brain-research) using EEG monitoring and found something striking: back-to-back video meetings cause stress to build up over time, with beta wave activity (associated with stress and anxiety) increasing progressively throughout the day.
+[Microsoft Research used EEG monitoring](https://www.microsoft.com/en-us/worklab/work-trend-index/brain-research) and found that back-to-back video meetings build stress over time. Beta wave activity (linked to stress and anxiety) climbs progressively through the day.
 
-Even brief transitions between meetings—a short walk, some light stretching—don't clear this buildup. Your mental state stays stuck between calls.
+Brief transitions — a short walk, some stretching — do not clear it. Your mental state stays stuck between calls.
 
-The real issue isn't the meetings themselves. It's the cognitive load of trying to capture and retain information while simultaneously participating in the conversation. You're listening, responding thoughtfully, asking follow-up questions, and frantically typing notes you hope to decipher later. Your brain is juggling three jobs at once: processing, engaging, and documenting.
+The issue is not the meetings. It is the cognitive load of capturing and retaining information while participating in the conversation. You are listening, responding, asking follow-ups, and typing notes you hope to decipher later. Three jobs at once: processing, engaging, documenting.
 
-Then the meeting ends. You've got seven minutes before your next call. Do you polish your notes while everything's fresh? Actually process what you learned? Take a breath and reset? Or are you already in your next meeting?
+Then the meeting ends. Seven minutes before the next call. Polish notes while it is fresh? Process what you learned? Take a breath? Or jump straight into the next call?
 
-Most people end up in option D. By day's end, you've had eight substantive conversations with fragments of notes scattered across documents, half-remembered insights, and a vague sense that someone said something important in the 2 PM call but you can't quite recall what.
+Most people pick the next call. By the end of the day you have had eight substantive conversations, fragments of notes scattered across documents, half-remembered insights, and a vague sense someone said something important in the 2 PM call.
 
-The fatigue isn't from talking. It's from the constant effort of trying to be present and preserve information simultaneously.
+The fatigue is not from talking. It is from trying to be present and preserve information at the same time.
 
 ## 5 ways to reduce meeting fatigue without cutting meetings
 
@@ -36,29 +36,29 @@ If you can't reduce your meeting load, focus on reducing the cognitive overhead 
 
 ### 1. Use AI note-taking tools to stop multitasking during calls
 
-Your brain excels at thinking but struggles with storage. Holding meeting details in your head while participating in new conversations drains attention and energy.
+Your brain is good at thinking and bad at storage. Holding meeting details in your head while running into the next conversation drains both.
 
-Better systems eliminate the need for memory altogether. [AI meeting assistants](/blog/best-ai-meeting-assistant-for-taking-notes) like Anarlog run entirely on your device, transcribing conversations in real-time without you doing anything. No bot joins your calls. No data leaves your machine. Just automatic documentation of what was said.
+Better systems remove the need for memory altogether. [AI meeting assistants](/blog/best-ai-meeting-assistant-for-taking-notes) like Anarlog run on your device and transcribe conversations in real time. No bot in the call. No data leaving your machine.
 
-When the meeting ends, you don't need to do anything immediately. Take that two-minute break. Actually transition. The conversation is captured for later.
+When the meeting ends, you do not need to do anything. Take the two-minute break. Actually transition. The conversation is captured.
 
-If you're someone who feels productive taking manual notes during meetings, keep doing it. Anarlog still helps by enhancing your fragments with full transcript context. Hover over any part of the AI-generated summary to see the exact quote from the conversation—you get active note-taking without worrying you missed something important.
+If manual note-taking helps you stay engaged, keep doing it. Anarlog enhances your fragments with full transcript context. Hover over any line of the AI summary to see the exact quote behind it.
 
 ### 2. Use voice notes instead of typing when possible
 
-Speaking for an hour, then switching to typing mode, then back to speaking, then typing again for follow-ups burns mental energy with each switch.
+Speaking for an hour, then typing, then speaking, then typing again for follow-ups burns mental energy at every switch.
 
 Use voice notes instead:
 
-- **Before the meeting**: Record your prep thoughts—context you want to remember, questions to ask, background on attendees
-- **During the meeting**: Keep it running to capture the conversation
-- **After the meeting**: Capture your immediate reactions and insights before switching tasks
+- **Before**: Record your prep — context you want to remember, questions to ask, background on attendees
+- **During**: Keep it running to capture the conversation
+- **After**: Capture your immediate reactions before moving on
 
-Tools like Anarlog weave together your pre-meeting context, the conversation itself, and your post-meeting thoughts into one cohesive summary. You're not constantly shifting between communication modes, which means less cognitive friction as the day progresses.
+Tools like Anarlog merge pre-meeting context, the conversation, and your post-meeting thoughts into one summary. You are not switching modes all day.
 
 ### 3. Review meeting notes strategically using AI
 
-You've got maybe 10 minutes between meetings. Don't scroll through transcripts or organize scattered notes. Use AI to extract what you actually need.
+You have maybe 10 minutes between meetings. Don't scroll through transcripts or organize notes. Use AI to pull what you need.
 
 With Anarlog, each meeting already has a summary with action items. When you need to review, you can:
 
@@ -70,48 +70,48 @@ Spend your between-meeting time on thinking and follow-up, not reconstructing wh
 
 ### 4. Use meeting templates to reduce prep fatigue
 
-Templates prevent you from starting from scratch each time, wondering how to structure the conversation. Your brain focuses on the actual discussion, not the meta-work of designing it.
+Templates stop you from starting from scratch every time. Your brain focuses on the discussion, not the meta-work of designing it.
 
-Create standard templates for recurring meeting types. Customer discovery calls might follow: intro (5 min), pain points (15 min), solution fit (15 min), next steps (5 min). 1-on-1s: wins, blockers, growth, action items. Demos: context questions, walkthrough, Q&A, close.
+Build standard templates for recurring meetings. Customer discovery: intro (5 min), pain points (15 min), solution fit (15 min), next steps (5 min). 1-on-1s: wins, blockers, growth, action items. Demos: context questions, walkthrough, Q&A, close.
 
-Anarlog includes built-in templates for common meeting types, and you can create custom ones. Set a default template in Settings so every meeting gets summarized in that format, or select a template after finishing a recording for specific meetings.
+Anarlog ships with templates for common meeting types and lets you build your own. Set a default in Settings so every meeting gets summarized in that format, or pick a template after recording.
 
-To create a custom template, define your sections and add system instructions for the AI. If you do user interviews, your instruction could be: "For every bullet point, attach the user's actual quote as a reference." Every user interview summary then comes with supporting evidence automatically. For sales calls, output in JSON format with fields like pain points, budget, timeline, and decision makers—perfect for pushing data to a CRM.
+To build a custom template, define your sections and add system instructions. For user interviews: "For every bullet point, attach the user's actual quote as a reference". Every summary comes with evidence. For sales calls, output in JSON with fields like pain points, budget, timeline, and decision makers — push it straight to a CRM.
 
 ### 5. Stop reinventing the wheel in every single meeting
 
-You've given hundreds of demos and handled dozens of objections. All that data is captured. But you treat every conversation as if it's the first time.
+You have given hundreds of demos and handled dozens of objections. All of that is captured. But you treat every conversation like it is the first.
 
-With AI notetaking, create a system to learn from your patterns, identify what worked, and refine it with each subsequent conversation:
+Build a system that learns from your patterns:
 
-- Search past successful demos to see exactly how you explained complex features when prospects got excited
-- Ask AI about specific objections and how you've handled them before. Use what worked instead of improvising the same responses from scratch
-- Before any call, search the person's name to see your complete conversation history. What they cared about, what questions they asked, where you left off
-- Use the Contacts View in Finder to see all meetings with a company organized in one place. Spot patterns in what resonates with that organization
+- Search past demos to see exactly how you explained a feature the time a prospect got excited
+- Ask AI how you have handled a specific objection before. Use what worked.
+- Before a call, search the person's name to see the full history — what they cared about, what they asked, where you left off
+- Use Contacts View in Finder to see every meeting with a company in one place
 
-Each conversation gets easier because you're building on what worked instead of starting from scratch every time.
+Each conversation gets easier because you are building on what worked.
 
 ## Meeting fatigue vs burnout: what's the difference?
 
-Meeting fatigue is the daily exhaustion from too many conversations without adequate breaks or processing time. Burnout is a chronic state of physical and emotional exhaustion that doesn't improve with rest.
+Meeting fatigue is daily exhaustion from too many conversations without adequate breaks or processing time. Burnout is chronic — it does not improve with rest.
 
-Meeting fatigue can contribute to burnout, but they're different. Meeting fatigue typically improves with the strategies above, better meeting hygiene (breaks, scheduling), and rest.
+Meeting fatigue can contribute to burnout. They are not the same. Meeting fatigue improves with the strategies above plus better meeting hygiene and rest.
 
-Burnout requires deeper intervention: job changes, therapy, or significant life restructuring.
+Burnout needs deeper intervention: job changes, therapy, real life restructuring.
 
-If you're implementing all the strategies in this article and still feeling chronically exhausted, you might be dealing with burnout rather than just meeting fatigue. That's worth addressing with a professional.
+If you are doing everything in this article and still feel chronically exhausted, you are probably dealing with burnout, not meeting fatigue. Talk to a professional.
 
 ## Reducing meeting fatigue
 
-The advice to "have fewer meetings" isn't wrong. If you can cut unnecessary meetings, do it.
+"Have fewer meetings" is not wrong. If you can cut, cut.
 
-But if that's not possible, reduce the cognitive overhead around meetings. Stop trying to listen, engage, document, and remember everything at once.
+If you can't, reduce the cognitive overhead around the ones you keep. Stop trying to listen, engage, document, and remember everything at once.
 
-I built Anarlog because I was exhausted from the mental gymnastics: frantically typing notes, wondering if I captured things correctly, reconstructing conversations from fragments. It wasn't the talking that drained me—it was everything else.
+I built Anarlog because I was tired of the mental gymnastics: frantically typing, wondering if I caught the right thing, reconstructing conversations from fragments. The talking did not drain me. Everything else did.
 
-Your meetings don't need to change. Your system does. Let AI handle documentation and organization so your brain can focus on the actual conversation.
+Your meetings do not need to change. Your system does.
 
-Six months in, meetings still tire me out. But it's the good kind of tired—from doing meaningful work, not from trying to be a human tape recorder.
+Six months in, meetings still tire me out. But it is the good kind of tired — from doing the work, not from trying to be a human tape recorder.
 
 **Ready to stop the mental juggling?** [Download Anarlog for free](https://anarlog.so). It runs on your Mac, keeps everything local, and handles the exhausting parts automatically.
 

--- a/apps/web/content/articles/how-to-transcribe-zoom-calls.mdx
+++ b/apps/web/content/articles/how-to-transcribe-zoom-calls.mdx
@@ -6,9 +6,9 @@ category: "Guides"
 date: "2025-09-16"
 ---
 
-Transcribing Zoom calls manually is time-consuming and error-prone. You can automate this process using either Zoom's built-in transcription feature or third-party AI tools.
+Transcribing Zoom calls by hand is slow and error-prone. You can automate it with Zoom's built-in transcription or a third-party AI tool.
 
-This article covers both approaches and helps you decide which works for your workflow.
+This article covers both, and helps you pick.
 
 ## Method 1: Transcribing Zoom calls using Zoom's built-in transcription
 
@@ -47,18 +47,18 @@ If you're interested in Zoom's meeting summaries feature, see our [Zoom AI Compa
 
 ## Method 2: Using third-party tools to transcribe Zoom calls
 
-Many excellent options exist for Zoom transcription. See our comprehensive guide on the [best AI notetakers for Zoom](/blog/best-ai-notetaker-for-zoom) for a detailed comparison. Anarlog is a complete AI notetaking solution that goes beyond simple transcription.
+There are plenty of options for Zoom transcription. See our [best AI notetakers for Zoom](/blog/best-ai-notetaker-for-zoom) guide for a side-by-side. Anarlog goes past transcription into note-taking.
 
 ### What is Anarlog?
 
-Anarlog is an open-source AI notepad for meetings that gives you complete control over your data and AI stack. Everything is stored as plain markdown files with zero lock-in. This matters for:
+Anarlog is an open-source AI notepad for meetings. You control your data and your AI stack. Notes live as plain markdown files, no lock-in. This matters for:
 
 - **Privacy-sensitive conversations** -- Healthcare professionals, lawyers, counselors, and anyone handling confidential information
 - **Compliance-heavy industries** -- Organizations meeting HIPAA, GDPR, SOX, or CCPA requirements
 - **Offline functionality** -- Works without internet connectivity
 - **Universal compatibility** -- Works with all meeting platforms without requiring bots
 
-Anarlog transcribes your meeting in real-time and generates actionable summaries automatically, without bots joining your call.
+Anarlog transcribes in real time and generates summaries with action items, without a bot in the call.
 
 ### How to transcribe Zoom meetings with Anarlog
 
@@ -99,7 +99,7 @@ Anarlog transcribes your meeting in real-time and generates actionable summaries
 <Image src="/api/assets/blog/how-to-transcribe-zoom-calls/auto-6.webp" alt="Zoom native transcription review" />
 *Source*
 
-Zoom users often spend hours editing 45-60 minute transcripts due to poor accuracy and formatting issues. Anarlog's AI models deliver better transcription quality with minimal manual cleanup.
+Zoom users often spend hours editing 45-60 minute transcripts because of accuracy and formatting issues. Anarlog produces cleaner transcripts with less manual cleanup.
 
 #### 2. Privacy and control
 
@@ -119,7 +119,7 @@ Anarlog lets you ask questions about your meeting notes through AI chat—"What 
 
 #### 6. Flexibility
 
-Anarlog works with any meeting platform, offers custom templates, and gives you complete deployment flexibility—local-only processing, on-premises deployment, or private cloud options. Zoom locks you into their ecosystem.
+Anarlog works with any meeting platform, supports custom templates, and lets you deploy how you want — local only, on-prem, or private cloud. Zoom locks you into Zoom.
 
 Anarlog offers unlimited AI summaries and transcription free forever.
 
@@ -159,19 +159,19 @@ Third-party tools like Anarlog can capture and transcribe Zoom audio in real-tim
 
 ### 2. Where are Zoom transcripts stored?
 
-Zoom transcripts are stored in Zoom's cloud servers alongside your recorded meetings. You can access them through the Zoom web portal under "Recordings."
+Zoom transcripts are stored in Zoom's cloud servers alongside your recorded meetings. You can access them through the Zoom web portal under "Recordings".
 
 The transcripts are saved in VTT format, which you can download and convert to other formats like Word documents or PDFs. This cloud storage raises privacy concerns for sensitive meetings.
 
 ### 3. What's the best alternative to Zoom's transcription?
 
-For users who want complete control, Anarlog offers the best alternative with zero lock-in—plain markdown files, your choice of AI stack, and true file ownership.
+If you want full control, Anarlog gives you plain markdown files, your choice of AI stack, and no lock-in.
 
-For those comfortable with cloud processing, other popular alternatives include Otter AI, Fathom, and Tactiq. See our comprehensive guide on the [best AI notetakers for Zoom](/blog/best-ai-notetaker-for-zoom) for a detailed comparison.
+If you are fine with cloud processing, popular alternatives include Otter AI, Fathom, and Tactiq. See our [best AI notetakers for Zoom](/blog/best-ai-notetaker-for-zoom) for a side-by-side.
 
 ### 4. How accurate is Zoom's native transcription?
 
-Zoom's transcription has significant accuracy issues. [Users report](https://community.zoom.com/t5/Zoom-Meetings/Transcription-Highly-Inaccurate/m-p/130271) incorrect speaker identification, common words requiring editing even with clear speech, and frequent formatting errors.
+Zoom's transcription has accuracy issues. [Users report](https://community.zoom.com/t5/Zoom-Meetings/Transcription-Highly-Inaccurate/m-p/130271) wrong speaker labels, common words requiring edits even with clear speech, and frequent formatting errors.
 
 ### 5. Can I transcribe Zoom calls offline?
 

--- a/apps/web/content/articles/how-we-build-with-ai.mdx
+++ b/apps/web/content/articles/how-we-build-with-ai.mdx
@@ -7,13 +7,13 @@ category: "Engineering"
 date: "2025-12-01"
 ---
 
-For the past year, I've heard endless takes about how "engineers are dead" because of AI. But from where I'm sitting, building Anarlog day and night, the real bottleneck has shifted. It's the business generalists who are struggling.
+For the past year, I've heard a lot of takes about how "engineers are dead" because of AI. From where I'm sitting, building Anarlog day and night, the bottleneck has moved. It is the business generalists who are struggling.
 
 Our team has been running full-speed with AI in our development workflow. [Devin](https://devin.ai), [Cursor](https://cursor.com), [Zed](https://zed.dev), [Claude Code](https://www.claude.com/product/claude-code), [Warp](https://warp.dev), [GitButler](http://gitbutler.com) — we use all of them, sometimes at the same time. Our commits per hour exploded. Hiring more engineers stopped making sense. The velocity just isn't the bottleneck anymore.
 
 <Image src="/api/assets/blog/how-we-build-with-ai/tools.jpg" alt="AI tools used in Anarlog"/>
 
-Once you embrace AI deeply, the limiting factors become taste — design taste, product taste, code review taste. Someone who can't contribute meaningfully to those areas slows things down. Negative velocity is real.
+Once you go all in on AI, the limit is taste — design, product, code review. People who can't contribute there slow things down. Negative velocity is real.
 
 Engineers who lean into AI become unstoppable. They write more. Ship more. Break fewer things. Learn absurdly fast. Their growth has no ceiling. Only how quickly they can refine judgment matters.
 
@@ -27,7 +27,7 @@ Builders win. AI-augmented builders win harder.
 
 I want to document how we actually work at Anarlog — not the polished PR version, but the real workflows that help a tiny team ship like a much larger one.
 
-We don't add AI to our stack. We build with AI as the default. Anarlog sits at the center of that. Every conversation becomes captured locally. Every decision becomes context we can revisit. Every idea gets distilled and carried forward. AI creates output fast, but Anarlog gives it memory and direction.
+We don't add AI to our stack. AI is the default. Anarlog sits at the center of that. Every conversation gets captured locally. Every decision becomes context we can revisit later. AI produces output fast — Anarlog gives it memory and direction.
 
 This series shares that openly — the good parts, the messy parts, the stuff I wish someone told me a year ago.
 
@@ -50,6 +50,6 @@ This will be a living, honest series. No hype, just how we actually operate.
 
 ## A Small Personal Note
 
-I'm writing this because I want more teams — especially small ones — to feel this kind of momentum. AI didn't remove the need to think. It removed the need to drown. Now the real differentiator is clarity, taste, and courage.
+I'm writing this because I want more teams — especially small ones — to feel this kind of momentum. AI didn't remove the need to think. It removed the need to drown. The real differentiator now is taste and conviction.
 
 If that resonates with you, stick around. And if you want a tool that keeps your team's thinking sharp and your conversations durable, give Anarlog a try. It's how we work every single day.

--- a/apps/web/content/articles/hyprnote-is-now-char.mdx
+++ b/apps/web/content/articles/hyprnote-is-now-char.mdx
@@ -28,7 +28,7 @@ In December, we received a cease & desist from another company with a similarly 
 
 The cease & desist pushed us to act. But we were already there.
 
-Over the past year, something became clear: we hadn't built just another privacy tool. We'd built something people couldn't get anywhere else—complete control.
+Over the past year, something became clear: we hadn't built another privacy tool. We'd built something people couldn't get anywhere else — complete control.
 
 Control over which AI models process their data. Control over their notes as actual files on their machine, not entries in someone else's database. Control over whether their information ever touches the cloud.
 

--- a/apps/web/content/articles/is-ai-notetaking-legal.mdx
+++ b/apps/web/content/articles/is-ai-notetaking-legal.mdx
@@ -8,9 +8,9 @@ category: "Guides"
 date: "2025-08-26"
 ---
 
-AI notetaking is legal, but the devil's in the details. While you can absolutely use these tools, certain missteps can trigger privacy violations, consent law breaches, and compliance nightmares that cost millions.
+AI notetaking is legal. The catch is that a few wrong moves can trigger privacy violations, consent law breaches, and compliance fines that run into the millions.
 
-Most compliance issues stem from overlooking consent requirements and choosing tools without understanding their data practices. Get these fundamentals right, and you can stay productive while staying protected.
+Most of those issues come from skipping consent and picking tools without reading what they do with your data. Handle those two right and you're mostly fine.
 
 **TL;DR:**
 
@@ -26,31 +26,31 @@ Most compliance issues stem from overlooking consent requirements and choosing t
 
 ### 1. Consent requirements: you must comply with the strictest applicable state law
 
-Recording consent laws form the foundation of AI note-taking legality, and they're more complex than most people realize.
+Recording consent law is messier than most people assume.
 
 At the federal level, the Electronic Communications Privacy Act allows "[one-party consent](https://detectiveservices.com/2012/02/state-by-state-recording-laws/)", meaning you can legally record a conversation if you're a participant or if one participant consents with full knowledge. A majority of states require only one-party consent—any party to the conversation can record it without getting the consent of anyone else.
 
 However, 11-13 states require "[all-party consent](https://detectiveservices.com/2012/02/state-by-state-recording-laws/)", meaning everyone involved must agree to be recorded. These states include California, Connecticut, Delaware, Florida, Illinois, Maryland, Massachusetts, Michigan, Montana, Nevada, New Hampshire, Pennsylvania, and Washington.
 
-When participants are in different states, the strictest standard generally applies. This means obtaining consent from all parties is necessary to ensure compliance.
+When participants are in different states, the strictest standard usually applies. Get consent from everyone.
 
 ### 2. Data processing: understanding where your data goes and how it's used
 
-Many cloud-based AI note-taking tools like Otter AI don't just transcribe your meetings—they learn from them. This creates data processing issues most organizations never consider.
+Cloud tools like Otter AI don't just transcribe your meetings, they learn from them. Most organizations don't think about that until it's a problem.
 
-A [recent lawsuit against Otter](/blog/is-otter-ai-safe) alleges the service automatically joins meetings through calendar integrations "without obtaining the affirmative consent from any meeting participant." The recordings are then used to train Otter's AI systems without participants knowing their private conversations became training data.
+A [recent lawsuit against Otter](/blog/is-otter-ai-safe) alleges the service auto-joins meetings through calendar integrations "without obtaining the affirmative consent from any meeting participant". Those recordings then train Otter's AI without participants knowing.
 
-Cross-border data transfers add another layer of complexity. If your AI note-taking service processes data outside your home country, you may need to comply with additional regulations about international data transfers, especially under frameworks like GDPR.
+Cross-border transfers make this worse. If your tool processes audio outside your home country, GDPR and similar frameworks pull you into a separate compliance regime.
 
 ### 3. Third-party access: what your vendor really does with your data
 
-Most people using AI note-taking tools have never read their vendor's data processing agreements, and this oversight can be costly.
+Most people using AI note-takers have never read their vendor's data processing agreement. That oversight gets expensive.
 
-Businesses should purchase licensed AI applications and ensure meeting recordings and AI outputs are retained in their own AI cloud instance, used to train AI only for their own purposes, and encrypted during transmission and at rest.
+The baseline a business should demand: recordings and AI outputs stay in your own cloud instance, training is opt-in and scoped to you, encryption applies in transit and at rest.
 
-Many popular AI note-taking tools don't offer this level of control in their standard plans. They may store your data indefinitely on their servers, use your conversations to improve their AI models, share data with third-party partners for analysis, or lack proper encryption for data in transit and at rest.
+Most popular tools don't offer that on their standard plans. They store data indefinitely, train on your conversations, share with third-party partners, or skip encryption somewhere in the pipeline.
 
-This makes Business Associate Agreements (BAAs) crucial for organizations in regulated industries. Businesses should structure their relationship with AI providers through appropriate data processing agreements, which ensure compliance with cybersecurity and privacy laws and outline the parties' respective roles and liabilities.
+For regulated industries, Business Associate Agreements (BAAs) and data processing agreements are how you allocate liability and prove compliance.
 
 The vendor security assessment should cover:
 
@@ -64,19 +64,19 @@ The vendor security assessment should cover:
 
 ### 4. Privilege protection: when AI recording breaks confidentiality
 
-Attorney-client privilege can be waived if confidential information is shared with a third party. Since AI transcription services may store transcripts, privilege could be inadvertently waived if a third party outside the circle of privilege has access to that data storage.
+Attorney-client privilege breaks when confidential information is shared with a third party. If your AI transcription vendor stores transcripts and someone outside the privilege circle can reach that storage, privilege is gone.
 
-The implications extend beyond legal conversations. Healthcare providers risk violating doctor-patient confidentiality, financial advisors may breach client confidentiality requirements, and any organization could inadvertently disclose trade secrets or sensitive business information.
+This goes beyond legal work. Healthcare providers risk doctor-patient confidentiality, financial advisors breach client confidentiality, and any company can leak trade secrets through a transcript.
 
-AI-produced content could be seen as a neutral document and easily [discoverable by opposing parties during legal proceedings](https://www.huffpost.com/entry/ai-notetaker-meetings-privacy_l_683dda81e4b0cceca4075fc6), whereas human-generated notes may fall under attorney-client privilege or other confidentiality safeguards.
+AI-generated transcripts are also [discoverable in legal proceedings](https://www.huffpost.com/entry/ai-notetaker-meetings-privacy_l_683dda81e4b0cceca4075fc6) in ways that handwritten notes often aren't.
 
 ### 5. Compliance standards: navigating industry-specific regulations
 
-Different industries face different regulatory requirements, and AI note-taking can trigger compliance obligations you might not expect.
+Different industries trigger different obligations. AI note-taking pulls you into more of them than you might expect.
 
 #### HIPAA (Healthcare)
 
-Healthcare organizations face some of the strictest requirements. HIPAA's Security Rule mandates specific technical, administrative, and physical safeguards for electronic protected health information (ePHI), including end-to-end encryption, access controls, audit logging, and Business Associate Agreements with AI vendors.
+Healthcare gets the strictest treatment. HIPAA's Security Rule mandates technical, administrative, and physical safeguards for electronic protected health information (ePHI): end-to-end encryption, access controls, audit logging, and BAAs with every AI vendor in the chain.
 
 Any AI note-taking tool used in healthcare settings must:
 
@@ -86,13 +86,13 @@ Any AI note-taking tool used in healthcare settings must:
 - Allow for patient data deletion upon request
 - Meet HITRUST validation requirements
 
-HIPAA violations carry severe penalties, ranging from thousands to millions of dollars, plus potential criminal charges.
+HIPAA penalties run from thousands to millions of dollars, plus potential criminal charges.
 
 #### GDPR (Global/EU)
 
-The General Data Protection Regulation applies to any organization serving EU residents and requires explicit consent for processing personal data, data minimization principles, and the ability for individuals to access, correct, and delete their personal information.
+GDPR applies to any organization serving EU residents. It requires explicit consent for processing personal data, data minimization, and the right for individuals to access, correct, and delete their information.
 
-For AI note-taking, GDPR creates several specific challenges:
+For AI note-taking, that translates to a few specific problems:
 
 - Recording a person's voice itself constitutes personal data processing
 - Explicit consent is required from all EU participants
@@ -102,25 +102,25 @@ For AI note-taking, GDPR creates several specific challenges:
 
 #### CCPA/CPRA (California)
 
-California's privacy laws require businesses to provide notice at collection of personal information, including the categories collected and purposes of use. The California Privacy Rights Act expands protections for "sensitive personal information" including biometric data.
+California requires businesses to give notice at collection: what they're collecting and why. CPRA expands that to "sensitive personal information", which includes biometric data.
 
-Voice recordings can be considered biometric identifiers, so AI note-taking may trigger CCPA's sensitive data provisions, requiring additional consent and opt-out mechanisms.
+Voice recordings can count as biometric identifiers, so AI note-taking often trips CCPA's sensitive-data provisions. That means extra consent and opt-out mechanisms.
 
 #### SOX (financial services)
 
-Financial services firms using AI note-taking for client communications must ensure proper data governance and retention policies. Client conversations may need to be preserved for regulatory examination while remaining protected from unauthorized access.
+Financial firms using AI note-taking for client calls need data governance and retention that holds up to a regulator. Client conversations may need to be preserved for examination while still being locked down from unauthorized access.
 
 #### FERPA (education)
 
-Educational institutions must be particularly careful about AI note-taking in settings where student information might be discussed. Student records and information are protected under FERPA, and unauthorized disclosure can result in loss of federal funding.
+Schools have to be careful any time student information might come up in a recorded discussion. FERPA protects student records, and unauthorized disclosure can cost an institution its federal funding.
 
 #### SOC 2 (system and organization controls)
 
-SOC 2 is a security framework that evaluates how organizations handle customer data. For AI note-taking tools, SOC 2 Type II compliance demonstrates that the vendor has implemented proper security controls around data processing, access management, and system monitoring.
+SOC 2 evaluates how a vendor handles customer data. SOC 2 Type II is the version that matters: it shows the controls actually held up over time, not just on paper.
 
 ## AI note-taking legal compliance checklist
 
-Use this checklist to ensure your AI note-taking practices meet legal requirements and protect your organization from compliance risks.
+Run through this before recording anything sensitive.
 
 - ✅ Get consent from all meeting participants before recording (assume all-party consent required)
 - ✅ Verify where your data is stored and whether it's used for AI training
@@ -135,23 +135,21 @@ Use this checklist to ensure your AI note-taking practices meet legal requiremen
 
 ## Choosing the right AI note-taking solution
 
-Your choice of AI note-taking tool largely determines whether compliance is a complex ongoing challenge or a manageable one-time setup.
+Your tool choice decides whether compliance is an ongoing project or a one-time setup.
 
-With most tools, you don't get a say in how your data is handled. Your audio goes to their servers, gets processed by their AI, and lives in their database. Every regulation you need to comply with becomes your vendor's problem to solve and yours to verify.
+With most tools, you don't get a say. Audio goes to their servers, gets processed by their AI, and sits in their database. Every regulation becomes their problem to solve and yours to verify.
 
-Anarlog works differently. You decide how your data is processed — [local models on your device](/blog/local-ai-meeting-notes/) or your own cloud API keys. Everything saves as plain markdown files on your device, and IT teams can audit the open-source code. When you control the stack, you control the compliance surface.
-
-For organizations serious about both productivity and legal protection, that level of control makes both feasible.
+Anarlog works differently. You decide how your data is processed: [local models on your device](/blog/local-ai-meeting-notes/) or your own cloud API keys. Everything saves as plain markdown on your device, and IT can audit the open-source code. When you control the stack, you control the compliance surface.
 
 ## About Anarlog's AI notetaker
 
 ![Anarlog ai notetaker](/api/assets/blog/is-ai-notetaking-legal/legal-1.webp)
 
-Anarlog has an Apple Notes-like interface that feels instantly familiar, with AI running in the background.
+Anarlog has an Apple Notes-like interface, with AI running in the background.
 
-When you launch a meeting, it starts transcribing speech in real-time — no bots joining your call, no calendar permissions required. When the meeting ends, it presents a structured summary with key decisions, action items, and discussion themes.
+Start a meeting and it transcribes in real time. No bots, no calendar permissions. When the meeting ends, you get a structured summary with decisions, action items, and themes.
 
-The AI works hands-off if you want it to. You can also jot down key points yourself, and Anarlog will expand your notes with context from the transcript.
+You can let the AI do the whole thing, or jot your own points and have Anarlog fill in context from the transcript.
 
 **Key benefits:**
 

--- a/apps/web/content/articles/is-fireflies-ai-safe.mdx
+++ b/apps/web/content/articles/is-fireflies-ai-safe.mdx
@@ -18,9 +18,9 @@ We decided to find out.
 
 ![Fireflies](/api/assets/blog/is-fireflies-ai-safe/fireflies-1.webp)
 
-Fireflies AI is a cloud-based service that automatically joins your video calls as a bot participant. It records everything, transcribes the conversation, and uses AI to create summaries and insights. The bot integrates with popular platforms like Zoom, Google Meet, and Microsoft Teams.
+Fireflies AI is a cloud service that joins your video calls as a bot. It records, transcribes, and runs the conversation through AI for summaries. It plugs into Zoom, Google Meet, and Microsoft Teams.
 
-Everything gets processed on Fireflies' servers, not your device. Your conversations become their data. [Otter AI raises similar concerns](/blog/is-otter-ai-safe/) with its own cloud-based recording practices.
+Everything is processed on Fireflies' servers, not your device. Your conversations become their data. [Otter AI raises similar concerns](/blog/is-otter-ai-safe/).
 
 ## What does Fireflies actually do with your data?
 
@@ -50,25 +50,25 @@ I went through their privacy policy and terms of service. Here's what I found.
 
 **Access to your other accounts:**
 
-When you connect Google Calendar or other services, Fireflies can access and store "any content that you have provided to and stored in your Third-Party Account" - including your contact lists.
+When you connect Google Calendar or any other service, Fireflies can access and store "any content that you have provided to and stored in your Third-Party Account", including your contact lists.
 
 ### 2. The fine print that should worry you
 
-**They're not responsible if their AI messes up:** Their terms explicitly say that while they use AI to process your conversations, "Fireflies is not liable for any loss or harm resulting from the user's use of AI." If something goes wrong with how they handle your data, you're on your own.
+**They're not responsible if their AI messes up:** Their terms say "Fireflies is not liable for any loss or harm resulting from the user's use of AI". If something goes wrong, you're on your own.
 
-**Your data becomes theirs forever:** Fireflies keeps "all rights to aggregated and anonymous data derived from your use of the Service" with no expiration date. Even if they can't identify you personally, they own insights from your conversations permanently.
+**Your data becomes theirs forever:** Fireflies keeps "all rights to aggregated and anonymous data derived from your use of the Service" with no expiration. Even if they can't identify you personally, they own insights from your conversations permanently.
 
-**They share your data widely:** Your information gets shared with their business partners, service providers, any company that might buy Fireflies in the future, or government authorities if they think it's necessary.
+**They share your data widely:** Your information goes to their business partners, service providers, any company that might buy Fireflies, or government authorities if they think it's necessary.
 
-**You're legally responsible for everything:** Their terms say "You are responsible for compliance with all recording laws." If you accidentally record someone without consent, that's your legal problem, not theirs. This becomes especially problematic when users can't actually control when Fireflies records—you're still legally liable even if their bot shows up uninvited.
+**You're legally responsible for everything:** Their terms say "You are responsible for compliance with all recording laws". Accidentally record someone without consent and it's your problem, not theirs, even if their bot showed up uninvited.
 
 ### 3. Their liability? Basically nothing
 
-Even if Fireflies completely screws up and causes major damage, their maximum liability is capped at either what you paid them in the last six months or $100—whichever is less. Your confidential business meeting gets leaked and costs you a major client, and Fireflies owes you maybe $100.
+Even if Fireflies causes serious damage, their maximum liability is whatever you paid them in the last six months or $100, whichever is less. Your confidential meeting leaks, you lose a major client, Fireflies owes you maybe $100.
 
 ## Real privacy problems users are experiencing with Fireflies AI
 
-The privacy policy issues aren't just theoretical. Real users are reporting some concerning problems:
+The privacy policy issues aren't theoretical. Users keep reporting the same problems:
 
 ### 1. It won't go away
 
@@ -76,7 +76,7 @@ The privacy policy issues aren't just theoretical. Real users are reporting some
 
 Source: [Reddit](https://www.reddit.com/r/sales/comments/1gw2xpk/how_to_uninvite_fireflies_from_my_meetings/)
 
-Multiple people report that Fireflies keeps showing up in their meetings even after they deactivated their accounts, tried to uninstall it, asked their IT department for help, or explicitly requested it to stop recording. One user described it as "trying to remove a deer tick from your leg—messy and painful."
+People report Fireflies keeps showing up in meetings after they deactivated accounts, uninstalled the app, asked IT for help, or explicitly told it to stop recording. One user described it as "trying to remove a deer tick from your leg—messy and painful".
 
 ### 2. It shares transcripts with people who never signed up
 
@@ -84,7 +84,7 @@ Multiple people report that Fireflies keeps showing up in their meetings even af
 
 Source: [Reddit](https://www.reddit.com/r/SaaS/comments/1dznmxo/fireflies_is_a_nightmare/)
 
-Fireflies automatically sends meeting summaries to everyone on the calendar invite, including people who never consented to being recorded, external clients and partners, former employees who still have access to recurring meetings, and anyone who happened to be invited but didn't even attend.
+Fireflies sends meeting summaries to everyone on the calendar invite. That includes people who never consented to being recorded, external clients and partners, former employees still on recurring meetings, and people who didn't attend at all.
 
 ### 3. It installs itself without permission
 
@@ -92,7 +92,7 @@ Fireflies automatically sends meeting summaries to everyone on the calendar invi
 
 Source: [Reddit](https://www.reddit.com/r/SaaS/comments/1dznmxo/fireflies_is_a_nightmare/)
 
-Several users report that just by joining a meeting where someone else used Fireflies, the software somehow installed itself on their computers and started recording their future meetings without their knowledge.
+Users report that just by joining a meeting where someone else used Fireflies, the software installed itself on their computers and started recording their future meetings without their knowledge.
 
 ## Should I trust Fireflies with sensitive information?
 
@@ -124,13 +124,13 @@ Even then, everyone in the meeting needs to consent to being recorded, and you'r
 
 ## Is there a safer Fireflies alternative?
 
-If you need AI-powered meeting transcription but don't want to hand over your conversations to a cloud service, there's a better way. [Local AI meeting notetakers](/blog/local-ai-meeting-notes/) process everything on your device.
+If you need AI meeting transcription but don't want to hand your conversations to a cloud service, [local AI notetakers](/blog/local-ai-meeting-notes/) process everything on your device.
 
 ### Meet Anarlog: Zero lock-in AI note-taker
 
 ![Anarlog](/api/assets/blog/is-fireflies-ai-safe/fireflies-5.webp)
 
-Anarlog is an an open-source AI notepad for meetings that gives you complete control. While Fireflies locks you into their cloud, Anarlog stores everything as plain markdown files and lets you choose your AI stack. Zero lock-in, zero compromises. It's the only truly open-source AI notepad for meetings.
+Anarlog is an open-source AI notepad for meetings. Fireflies locks you into their cloud. Anarlog stores everything as plain markdown files and lets you pick your AI stack. Zero lock-in.
 
 Check out our [Fireflies AI Alternatives](/blog/fireflies-ai-alternatives) article for a detailed Anarlog vs Fireflies review.
 
@@ -171,10 +171,10 @@ Anarlog never collects your recordings, transcripts, notes, meeting participant 
 
 ## Is Fireflies AI Safe?
 
-Fireflies AI might seem convenient, but convenience comes at a steep privacy cost. Their extensive data collection, broad sharing permissions, minimal liability, and documented issues with user control make it risky for most business conversations.
+Fireflies AI is convenient, and the convenience is expensive. Heavy data collection, wide sharing permissions, near-zero liability, and a long track record of bots that won't leave make it a bad fit for most business conversations.
 
-If you need AI-powered meeting assistance, choose a solution with zero lock-in that gives you complete control. Anarlog proves you don't have to sacrifice ownership for functionality.
+If you need AI meeting assistance, pick a tool with zero lock-in. Anarlog shows you don't have to trade ownership for the feature set.
 
-Your conversations are valuable. Don't give them away for free.
+Your conversations are worth more than free transcription.
 
 &nbsp;

--- a/apps/web/content/articles/is-otter-ai-safe.mdx
+++ b/apps/web/content/articles/is-otter-ai-safe.mdx
@@ -6,11 +6,11 @@ category: "Comparisons"
 date: "2025-08-18"
 ---
 
-[A federal class-action lawsuit](https://www.npr.org/2025/08/15/g-s1-83087/otter-ai-transcription-class-action-lawsuit) filed in August 2025 has thrust popular AI transcription service Otter AI into the spotlight, with allegations that the company "deceptively and surreptitiously" records private conversations without proper consent.
+[A federal class-action lawsuit](https://www.npr.org/2025/08/15/g-s1-83087/otter-ai-transcription-class-action-lawsuit) filed in August 2025 alleges Otter AI "deceptively and surreptitiously" records private conversations without proper consent.
 
-The lawsuit, filed in the U.S. District Court for the Northern District of California, represents a growing pattern of privacy concerns surrounding the Mountain View-based company that has processed more than 1 billion meetings since 2016 for its 25 million users.
+The case was filed in the U.S. District Court for the Northern District of California. The Mountain View company has processed more than 1 billion meetings since 2016 for 25 million users.
 
-The case raises fundamental questions about consent, privacy, and data use in the age of AI-powered workplace tools—questions that extend far beyond a single company to the entire automated transcription industry.
+The questions it raises about consent, privacy, and data reuse don't stop at Otter. They apply to the entire automated transcription industry.
 
 ---
 
@@ -26,25 +26,25 @@ The case raises fundamental questions about consent, privacy, and data use in th
 <Image src="/api/assets/blog/is-otter-ai-safe/otter-1.webp" alt="Otter AI Lawsuit"/>
 Source: [NPR](https://www.npr.org/2025/08/15/g-s1-83087/otter-ai-transcription-class-action-lawsuit)
 
-The lawsuit centers on plaintiff Justin Brewer of San Jacinto, California, who alleges his privacy was "severely invaded" upon realizing Otter was secretly recording a confidential conversation.
+The lawsuit centers on plaintiff Justin Brewer of San Jacinto, California, who alleges his privacy was "severely invaded" when he realized Otter was secretly recording a confidential conversation.
 
-The complaint alleges that Otter Notebook, which provides real-time transcriptions of Zoom, Google Meet, and Microsoft Teams meetings, "by default does not ask meeting attendees for permission to record and fails to alert participants that recordings are shared with Otter to improve its artificial intelligence systems."
+The complaint says Otter Notebook, which transcribes Zoom, Google Meet, and Microsoft Teams meetings in real time, "by default does not ask meeting attendees for permission to record and fails to alert participants that recordings are shared with Otter to improve its artificial intelligence systems".
 
-The system can automatically join meetings. As detailed in the lawsuit:
+The system can auto-join meetings. From the filing:
 
 > "If the meeting host is an Otter accountholder who has integrated their relevant Google Meet, Zoom, or Microsoft Teams accounts with Otter, an Otter Notetaker may join the meeting without obtaining the affirmative consent from any meeting participant, including the host."
 
-The legal filing claims this practice violates both state and federal privacy and wiretap laws, with lawyers arguing that Otter uses these recordings to "derive financial gain" through AI model training.
+The plaintiffs argue this violates state and federal privacy and wiretap laws, and that Otter uses these recordings to "derive financial gain" through AI model training.
 
-The lawsuit also challenges Otter's "de-identification" process. It argues that "Otter's deidentification process does not remove confidential information or guarantee speaker anonymity" and that the company "provides no public explanation of its 'de-identifying' process."
+The lawsuit also challenges Otter's "de-identification" process, arguing it "does not remove confidential information or guarantee speaker anonymity" and that the company "provides no public explanation of its 'de-identifying' process".
 
 ## Other User Incidents Concerning Otter's Consent and Recording Issues
 
-Real users have reported their own experiences with Otter's privacy issues, providing concrete examples of the problems outlined in the lawsuit:
+The lawsuit isn't operating in a vacuum. Users keep posting variations of the same story.
 
 ### 1. The VC Meeting Data Leak
 
-Alex Bilzerian described a particularly damaging incident in a viral tweet:
+Alex Bilzerian described a damaging incident in a viral tweet.
 
 <Image src="/api/assets/blog/is-otter-ai-safe/otter-2.webp" alt="Otter AI Lawsuit 2"/>
 
@@ -58,7 +58,7 @@ Attorney Anessa Allen Santos [warned of organizational security risks in a Linke
 
 ### 3. Otter Spam Warning
 
-A Reddit user in r/projectmanagement [described how Otter automatically places links in meetings](https://www.reddit.com/r/projectmanagement/comments/1j0cfei/do_not_join_otterai_unless_you_want_your_whole) to share notes with others, causing confusion for those unfamiliar with the service:
+A Reddit user in r/projectmanagement [described how Otter drops links in meetings](https://www.reddit.com/r/projectmanagement/comments/1j0cfei/do_not_join_otterai_unless_you_want_your_whole) to share notes with everyone, confusing people who've never used it:
 
 <Image src="/api/assets/blog/is-otter-ai-safe/otter-4.webp" alt="Otter AI Lawsuit 4"/>
 
@@ -72,7 +72,7 @@ One Reddit user shared [how they lost a job opportunity](https://www.reddit.com/
 
 ### 5. Gartner Community Response
 
-IT professionals on [Gartner's peer community](https://www.gartner.com/peer-community/post/how-managing-risk-ai-transcription-bots-like-otter-ai-fireflies-ai) raised concerns about the tool. [Fireflies AI faces similar scrutiny](/blog/is-fireflies-ai-safe/) from users reporting comparable privacy issues.
+IT professionals on [Gartner's peer community](https://www.gartner.com/peer-community/post/how-managing-risk-ai-transcription-bots-like-otter-ai-fireflies-ai) flagged the tool. [Fireflies AI gets similar treatment](/blog/is-fireflies-ai-safe/) for the same reasons.
 
 <Image src="/api/assets/blog/is-otter-ai-safe/otter-6.webp" alt="Otter AI Lawsuit 6"/>
 
@@ -86,29 +86,29 @@ A Director of Engineering added:
 
 ## What Does Otter's Privacy Policy Explain About These Privacy Issues?
 
-Otter.ai's official privacy policy and privacy & security pages reveal practices that many users may not fully understand.
+Otter.ai's privacy policy and privacy & security pages describe practices most users haven't read.
 
-While the company emphasizes security and privacy protections, the detailed policies show extensive data collection, usage, and sharing that goes well beyond simple transcription.
+The company markets security and privacy hard. The actual policies describe data collection, usage, and sharing that go well beyond transcription.
 
 ### 1. Data Collection and AI Training
 
-[Otter's privacy policy](https://otter.ai/privacy-policy) openly states it uses customer data for AI training purposes:
+[Otter's privacy policy](https://otter.ai/privacy-policy) states they train on customer data:
 
 > "We train our proprietary artificial intelligence technology on de-identified audio recordings. We also train our technology on transcriptions to provide more accurate services, which may contain Personal Information."
 
 <Image src="/api/assets/blog/is-otter-ai-safe/otter-7.webp" alt="Otter AI Lawsuit 7"/>
 
-The policy also reveals manual review of recordings when users provide consent:
+The policy also says human reviewers listen to recordings when users opt in:
 
 > "We obtain explicit permission (e.g. when you rate the transcript quality and check the box to give Otter ai and its third-party service provider(s) permission to access the conversation for training and product improvement purposes) for manual review of specific audio recordings to further refine our model training data."
 
-The [privacy & security FAQ](https://otter.ai/privacy-security) claims that "audio recordings and transcripts are not manually reviewed by a human" as part of the automatic training process, yet the privacy policy clearly states that manual review occurs when users provide explicit permission. This creates ambiguity about when human access to recordings actually happens.
+The [privacy & security FAQ](https://otter.ai/privacy-security) says "audio recordings and transcripts are not manually reviewed by a human" during automatic training. The privacy policy says manual review does happen with explicit permission. The two pages don't line up cleanly.
 
 <Image src="/api/assets/blog/is-otter-ai-safe/otter-8.webp" alt="Otter AI Lawsuit 8"/>
 
 ### 2. Extensive Third-Party Data Sharing
 
-The breadth of third-party data sharing outlined in Otter's privacy policy is significant. The company shares personal information with multiple categories of external parties, including:
+The privacy policy lists a long roster of third parties Otter shares personal information with:
 
 - "Cloud service providers who we rely on for compute and data storage, including Amazon Web Services, based in the United States"
 - "Data labeling service providers who provide annotation services and use the data we share to create training and evaluation data for Otter's product features"
@@ -119,13 +119,13 @@ The breadth of third-party data sharing outlined in Otter's privacy policy is si
 
 ### 3. The De-identification Problem
 
-Otter claims to use "a proprietary method to de-identify user data before training our models so that an individual user cannot be identified," but provides no public explanation of how this process works.
+Otter says they use "a proprietary method to de-identify user data before training our models so that an individual user cannot be identified", but they don't publish how it works.
 
-The privacy policy also acknowledges that transcriptions used for training "may contain Personal Information," which raises questions about anonymization effectiveness.
+The same policy admits that training transcriptions "may contain Personal Information". That tension is the core of the lawsuit.
 
 ### 4. Automatic Data Collection
 
-The privacy policy reveals extensive automatic data collection beyond recordings and transcripts:
+Beyond recordings and transcripts, Otter collects:
 
 - **Usage Information:** "When you use the Services, you generate information pertaining to your use, including timestamps, such as access, record, share, edit and delete events, app use information, screenshots/screen captures taken during the meeting, interactions with our team, and transaction records"
 - **Device Information:** "We assign a unique user identifier ('UUID') to each mobile device that accesses the Services"
@@ -135,25 +135,21 @@ The privacy policy reveals extensive automatic data collection beyond recordings
 
 ## How Safe is Otter AI
 
-The privacy concerns surrounding Otter.ai reflect broader issues that affect anyone using AI-powered workplace tools.
+Otter's situation isn't unique. Anyone running cloud AI on workplace conversations is exposed to a version of this.
 
-Organizations in heavily regulated industries face potential violations when sensitive conversations are automatically recorded and processed by third-party services without proper consent mechanisms or data controls.
+In regulated industries, automatic recording by a third-party service without proper consent is a compliance violation waiting for a regulator. One employee installing Otter exposes the whole org, since it shares with multiple processors and rarely has enterprise-grade controls. For teams that need transcription without that risk, [local AI notetakers](/blog/local-ai-meeting-notes/) keep data on the device.
 
-Individual employee adoption of cloud-based AI tools can create organization-wide data exposure, especially when these tools share information with multiple external processors and lack enterprise-grade security controls. For teams that need transcription without these risks, [local AI meeting notetakers](/blog/local-ai-meeting-notes/) keep data on your device entirely.
+Auto-recording wrecks relationships. People notice when a bot they didn't agree to shows up on the call. They notice more when the transcript hits their inbox.
 
-Automatic recording features can damage business relationships, compromise confidential discussions, and create legal exposure when private conversations are captured without all participants' knowledge.
-
-The fundamental issue extends beyond any single company. As AI tools become more automated, the gap between user expectations and actual data practices widens, creating risks that users may not realize they're accepting.
+The deeper problem: as these tools get more automatic, what users expect drifts further from what the policies actually allow.
 
 ## Is There a Safer Otter AI Alternative?
 
-The privacy concerns around Otter AI highlight the need for transcription solutions that prioritize user privacy and data control.
+If you want AI transcription without the vendor lock-in, open-source is the obvious move.
 
-For organizations and individuals seeking AI-powered transcription without vendor lock-in, open-source alternatives offer a compelling option.
+**Anarlog** is the [best Otter AI alternative](/blog/otter-ai-alternatives). It's an open-source AI notepad for meetings. You control the data and the AI stack. Everything is stored as plain markdown files, not a proprietary database.
 
-**Anarlog** is the [best Otter AI alternative](/blog/otter-ai-alternatives) and an open-source AI notepad for meetings that gives you complete control over your data and AI stack. Everything is stored as plain markdown files—not in proprietary databases.
-
-This approach addresses the core issues raised in the Otter AI lawsuit and user complaints:
+This is the inverse of what the Otter lawsuit is fighting:
 
 - **Zero lock-in:** Plain markdown files, open source, portable format—your data works with any tool
 - **Complete control:** Choose your AI stack: managed cloud, bring your own keys, or run fully local
@@ -161,6 +157,6 @@ This approach addresses the core issues raised in the Otter AI lawsuit and user 
 - **Simplified compliance:** Reduces the compliance surface area by minimizing dependency on cloud vendors, making audits easier
 - **Complete transparency:** As an open-source solution, IT teams can audit the code and you can use the AI provider your security team approves
 
-Anarlog is free forever for local transcription, BYOK, and all core features. For enterprises navigating compliance frameworks like HIPAA, SOC 2, or GDPR, Anarlog's zero-lock-in architecture makes it easier to fulfill data subject rights, maintain audit trails, and enforce access controls.
+Anarlog is free forever for local transcription, BYOK, and all core features. For enterprises on HIPAA, SOC 2, or GDPR, the zero-lock-in architecture makes it easier to fulfill data subject rights, keep audit trails, and enforce access controls.
 
 [Download Anarlog for MacOS](https://anarlog.so) and experience meeting notes with zero lock-in.

--- a/apps/web/content/articles/krisp-alternatives.mdx
+++ b/apps/web/content/articles/krisp-alternatives.mdx
@@ -12,7 +12,7 @@ Krisp started as the noise cancellation app, the one that filtered out backgroun
 
 But Krisp in 2026 is a different product. It bundles noise cancellation, real-time transcription, AI summaries, accent conversion, CRM integrations, and call center tools into a single subscription. The Core plan runs $8/month on annual billing. Advanced is $15/month. Enterprise is custom-quoted. The old free tier with 60 minutes of daily noise cancellation is gone, replaced by a 7-day trial that requires a calendar connection during signup.
 
-That's a lot of product for people who only need one piece of it. Some just want noise cancellation without the meeting suite. Others want meeting notes but don't want to hand over calendar permissions. Some need their data to stay on their own machine. I looked at seven tools that cover different slices of what Krisp does. Not all of them replace every feature, but depending on what brought you to Krisp in the first place, one of them probably does the job better.
+That's a lot of product for people who only need one piece of it. Some just want noise cancellation without the meeting suite. Others want meeting notes but don't want to hand over calendar permissions. Some need their data to stay on their own machine. I looked at seven tools that cover different slices of Krisp. None replace every feature, but depending on what brought you to Krisp in the first place, one of them probably does that job better.
 
 ## Top Krisp Alternatives Compared
 
@@ -47,9 +47,9 @@ The honest limitations: it's macOS and Linux only (no Windows yet), there's no v
 
 [Otter](https://otter.ai/) is one of the longest-running names in AI transcription, and its defining feature is something most competitors still don't offer: a live, collaborative transcript you can edit and annotate while the meeting is happening. It's like Google Docs for your conversation. You see words appearing in real time, highlight key moments, and add comments, all before the call ends.
 
-Where it falls short is accuracy in noisy or multi-speaker environments. Accents trip it up more often than I'd like, and the AI summaries lean generic. "The team discussed project timelines" isn't useful when you were in the room. These are the exact problems Krisp's noise cancellation and accent conversion were built to solve, and Otter doesn't touch either of those. It's purely a transcription and notes tool.
+Where it falls short is accuracy in noisy or multi-speaker rooms. Accents trip it up more often than I'd like, and the AI summaries lean generic. "The team discussed project timelines" isn't useful when you were in the room. Those are exactly the problems Krisp's noise cancellation and accent conversion were built for, and Otter doesn't do either. It's just transcription and notes.
 
-There's also a privacy issue worth knowing about. In August 2025, [Otter was hit with a federal class action](https://anarlog.so/blog/is-otter-ai-safe/) lawsuit alleging it records conversations without proper consent from all participants, then uses those recordings to train its AI. NPR and The Register both covered it. The University of Massachusetts banned the tool entirely. Otter says users agree via a checkbox in the privacy policy, but the people on the other end of those meetings never checked any box.
+Also worth knowing: in August 2025, [Otter was hit with a federal class action](https://anarlog.so/blog/is-otter-ai-safe/) alleging it records conversations without consent from all participants, then trains its AI on those recordings. NPR and The Register covered it. UMass banned the tool entirely. Otter says users agree via a checkbox in the privacy policy. The people on the other end of those calls never checked any box.
 
 The free plan caps at around 300 minutes per month. Pro starts at $8.49/user/month. OtterPilot, its meeting bot, is visible to everyone on the call, which changes the dynamic for sensitive conversations.
 
@@ -75,7 +75,7 @@ Fathom recently launched "Ask Fathom" for account-wide search across every meeti
 
 It also does conversation analytics: talk-time ratios, question frequency, sentiment tracking. For sales managers reviewing team performance, that's the kind of data Krisp doesn't offer even on its Enterprise plan. Where Fireflies can't compete with Krisp is the audio layer: there's no noise cancellation, no accent conversion, and transcription accuracy drops noticeably with non-native English speakers.
 
-Fireflies also has a legal issue. It's facing a BIPA class action in Illinois federal court for allegedly collecting voiceprints from meeting participants without consent. The complaint points out that Fireflies records and identifies speakers even when those people never created an account or agreed to any terms. If you're in a regulated industry, this is worth flagging before you roll it out.
+Fireflies has its own legal problem: a BIPA class action in Illinois federal court for allegedly collecting voiceprints from meeting participants without consent. The complaint notes Fireflies records and identifies speakers even when those people never created an account or agreed to terms. In a regulated industry, flag this before rolling it out.
 
 The bot is visible to all participants. The free tier gives you 800 minutes of storage total (not monthly), which vanishes in a couple of weeks. Pro runs $18/user/month.
 
@@ -87,9 +87,9 @@ The bot is visible to all participants. The free tier gives you 800 minutes of s
 
 [Granola](https://www.granola.ai/) takes a fundamentally different approach: no bot joins your call. It captures audio directly from your device's speakers and microphone, transcribes locally, and then enhances whatever rough notes you took during the meeting into structured summaries. Your shorthand bullet points go in; organized decisions, action items, and key quotes come out. It's notepad-first, not transcript-first. For a lot of people, that distinction matters.
 
-The company just raised $125 million in March 2026 at a $1.5 billion valuation. But that same month, Granola encrypted its local database, breaking every agent workflow that read notes directly from the local cache. Guido Appenzeller, a partner at a16z, posted about it on X and it went viral: 'In a world where notes are managed by agents, the app now has zero value.' Granola's co-founder responded that MCP access was available, but developers wanted a proper API, not a proprietary protocol. A public API has since been announced. But the incident is a reminder that 'local-first' doesn't mean 'yours' if the vendor controls the format.
+The company just raised $125 million in March 2026 at a $1.5 billion valuation. The same month, Granola encrypted its local database, breaking every agent workflow that read notes from the local cache. Guido Appenzeller, a partner at a16z, posted about it on X and it went viral: "In a world where notes are managed by agents, the app now has zero value". Granola's co-founder responded that MCP access was available; developers wanted a proper API, not a proprietary protocol. A public API has since been announced. The incident is a reminder that "local-first" doesn't mean "yours" if the vendor controls the format.
 
-Moreover, Granola doesn't do speaker identification well in multi-person calls, doesn't save audio for playback, and offers no noise cancellation or accent conversion, so audio quality depends entirely on your conferencing app. The free plan covers only 25 meetings lifetime (not monthly). Business runs $14/user/month, which is cheaper than most competitors. Available on Mac, Windows, and iOS.
+Granola also doesn't handle speaker identification well in multi-person calls, doesn't save audio for playback, and has no noise cancellation or accent conversion, so audio quality depends entirely on your conferencing app. The free plan covers 25 meetings lifetime (not monthly). Business runs $14/user/month, cheaper than most competitors. Available on Mac, Windows, and iOS.
 
 **Right for:** anyone in sensitive, client-facing meetings where discretion matters more than feature count.
 
@@ -119,14 +119,14 @@ The catch is it's Mac-only, development has been slow, and it doesn't perform as
 
 ## So Which One Actually Replaces Krisp?
 
-Honestly, none of them replace all of it, and that's kind of the point. Krisp bundles noise cancellation, transcription, accent conversion, CRM sync, and enterprise compliance into one subscription. Most people use maybe two of those features and pay for all of them.
+Honestly, none of them replace all of it. That's the point. Krisp bundles noise cancellation, transcription, accent conversion, CRM sync, and enterprise compliance into one subscription. Most people use two of those features and pay for all of them.
 
 If noise cancellation is what brought you to Krisp and the rest is clutter, Utterly does that one job on Mac for $5/month or free.
 
-If meeting notes are the thing, Fathom is the strongest starting point for individuals. The Zoom integration is invisible, and the free tier is more generous than anything else in the category, though the 5-summary cap means heavy users will upgrade fast. Fireflies wins for sales teams who need CRM automation, but the BIPA lawsuit and bot visibility are real considerations. Otter is the pick if live collaborative transcription matters to you, though the privacy lawsuit and data training practices deserve scrutiny.
+If meeting notes are the thing, Fathom is the strongest starting point for individuals. The Zoom integration is invisible and the free tier is more generous than anything else in the category, though the 5-summary cap means heavy users will upgrade fast. Fireflies wins for sales teams who need CRM automation, but the BIPA lawsuit and bot visibility are real. Otter is the pick if live collaborative transcription matters to you, though the privacy lawsuit and training practices deserve scrutiny.
 
-Granola is the answer for client-facing calls where a bot would kill the conversation. It's well-funded and expanding fast, but the database encryption incident is a reminder that local-first doesn't mean yours if the vendor controls the format. tl;dv is the best option for distributed teams that need to share meeting clips across time zones, especially in multiple languages.
+Granola is the answer for client-facing calls where a bot would kill the conversation. It's well-funded and expanding fast, but the database encryption incident is a reminder that local-first doesn't mean yours if the vendor controls the format. tl;dv is the best option for distributed teams that need to share meeting clips across time zones.
 
-And if data ownership is what actually matters to you, like choosing your own AI provider, keeping files on your own machine, and never worrying about a vendor encrypting your database or training models on your conversations, Anarlog is the only tool here that gives you that. It's open-source. Your files are yours. Nobody else gets a vote.
+If data ownership is the actual issue, picking your own AI provider, keeping files on your machine, never worrying about a vendor encrypting your database or training on your conversations, Anarlog is the only tool here that does that. It's open-source. Your files are yours. Nobody else gets a vote.
 
 Anarlog is free for unlimited local transcription. [Download Anarlog for macOS](https://anarlog.so/download/apple-silicon) and try it on your next meeting.

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -8,11 +8,11 @@ category: "Comparisons"
 date: "2026-04-10"
 ---
 
-Every meeting notetaker calls itself "local" or "private" now. The word has become a marketing checkbox. But local means wildly different things depending on which tool you pick.
+Every meeting notetaker calls itself "local" or "private" now. The word is a marketing checkbox. Local means very different things depending on which tool you pick.
 
-Some tools transcribe on your device but send the transcript to a cloud LLM for summarization. Some store notes locally but make them accessible via a shareable link by default. Some process everything on-device but only work on one operating system, or only on recent hardware. And some are fully local until you look at the fine print and discover your data trains their models unless you opt out.
+Some transcribe on-device but send the transcript to a cloud LLM. Some store notes locally but make them accessible via a shareable link by default. Some process everything on-device but only on one OS, or only on recent hardware. Some are fully local until you read the fine print and find out your data trains their models unless you opt out.
 
-I tested five tools that take different positions on this spectrum. For each one, I dug into what "local" actually means in practice: what stays on your machine, what leaves, what the tradeoffs are, and what it costs.
+I tested five tools across that spectrum. For each one, I worked out what "local" actually means: what stays on your machine, what leaves, what the tradeoffs are, what it costs.
 
 ## How These Local AI Meeting Notetakers Compare
 
@@ -45,18 +45,18 @@ The AI stack is yours to choose: a managed cloud option, your own API keys from 
 - Storage: all data stored locally on your device. Your files, your folder structure, zero lock-in.
 - Open-source codebase. Your security team can audit exactly how data is handled.
 
-If you run Anarlog with local models, nothing leaves your machine. If you plug in an API key, only the transcript goes to that provider for summarization. For companies that have banned cloud-based meeting tools, Anarlog is one of the few options where "local-first" means exactly what it says.
+Run Anarlog with local models and nothing leaves your machine. Plug in an API key and only the transcript goes to that provider for summarization. For companies that banned cloud meeting tools, Anarlog is one of the few options where "local-first" means what it says.
 
 #### Where it falls short
 
 - macOS and Linux only. No Windows client yet.
 - No mobile app, no video recording.
-- No built-in CRM integrations. If you need notes pushed into Salesforce, you will need to build that yourself.
+- No built-in CRM integrations. If you need notes pushed into Salesforce, you'll need to build it.
 - No team dashboard or cross-meeting cloud search. Your notes live in your file system.
 
 #### Pricing
 
-Free for unlimited loacl transcription and AI.
+Free for unlimited local transcription and AI.
 
 ### 2. Meetily
 
@@ -64,7 +64,7 @@ Free for unlimited loacl transcription and AI.
 
 [Meetily](https://meetily.ai) is an open-source meeting assistant (MIT license) that runs transcription entirely on your device using Whisper or Parakeet models. 
 
-It captures system audio [without a bot](/blog/bot-free-ai-meeting-assistants/), works with Zoom, Teams, Meet, and anything else that produces audio on your machine. Parakeet is the default engine and runs significantly faster than Whisper with lower resource usage, with GPU acceleration built in for Apple Silicon, NVIDIA, and AMD hardware.
+It captures system audio [without a bot](/blog/bot-free-ai-meeting-assistants/) and works with Zoom, Teams, Meet, and anything else that produces audio. Parakeet is the default engine and runs faster than Whisper with lower resource usage, with GPU acceleration on Apple Silicon, NVIDIA, and AMD.
 
 Summaries are pluggable: use Ollama for fully local processing, or connect your own API key to Claude, Groq, or OpenRouter. The app is built in Rust with a Next.js frontend and ships as a single installer for macOS and Windows. Linux users can build from source.
 
@@ -75,7 +75,7 @@ Summaries are pluggable: use Ollama for fully local processing, or connect your 
 - Storage: local SQLite database. Audio files stored on your device.
 - GPU acceleration: Apple Silicon (Metal), NVIDIA (CUDA), AMD/Intel (Vulkan).
 
-The team is transparent that local model summarization does not match cloud quality yet, especially on longer meetings. They document the tradeoffs in their blog and are actively working on closing the gap.
+The team is upfront that local summarization doesn't match cloud quality yet, especially on long meetings. They document the gap on their blog and are working on it.
 
 #### Where it falls short
 
@@ -92,9 +92,9 @@ Community Edition is free forever. Pro is at $10/month, billed annually, include
 
 ![shadow.do review](/api/assets/blog/blog/Screenshot-2026-04-10-at-7.43.38-PM.png "anarlog-editor-width=80")
 
-[Shadow](https://shadow.do) captures both channels of a meeting: what is said and what is shown on screen. It runs on macOS, records system audio without a bot, and automatically takes timestamped screenshots of whatever is displayed during your call: slides, code, dashboards, design mockups. Those screenshots are embedded directly in your notes alongside the transcript.
+[Shadow](https://shadow.do) captures both channels of a meeting: what's said and what's shown on screen. It runs on macOS, records system audio without a bot, and takes timestamped screenshots of whatever is displayed during your call: slides, code, dashboards, design mockups. Those screenshots get embedded directly in your notes alongside the transcript.
 
-This matters the moment someone says "look at the numbers on slide four" and you need to know what those numbers were. Every other tool on this list captures audio only. Shadow also has autopilot mode that detects meetings and starts recording without you pressing anything, real-time speaker identification, and custom post-meeting AI "Skills" that run automatically.
+That matters the moment someone says "look at the numbers on slide four" and you need to know what those numbers were. Every other tool on this list captures audio only. Shadow also has an autopilot mode that detects meetings and starts recording without you pressing anything, real-time speaker identification, and custom post-meeting AI "Skills" that run automatically.
 
 #### How local is it actually
 
@@ -103,7 +103,7 @@ This matters the moment someone says "look at the numbers on slide four" and you
 - Summarization: cloud LLM APIs by default. Can be disabled, but you lose summaries, action items, and the "Ask Shadow" chatbot.
 - Export: .md files to a local folder. Works with Obsidian out of the box, webhooks for Zapier/Make/n8n.
 
-Shadow is local for capture but not fully local for intelligence. The AI features route through external APIs. You can turn them off and keep just the transcript and screenshots, but then you lose the analysis layer.
+Shadow is local for capture but not for intelligence. The AI features route through external APIs. Turn them off and you keep transcript and screenshots, but lose the analysis layer.
 
 #### Where it falls short
 
@@ -120,9 +120,9 @@ Free for unlimited transcription and 25 lifetime meetings for AI features. Plus,
 
 ![talat notetaker review](/api/assets/blog/blog/image-25.png "anarlog-editor-width=80")
 
-[Talat](https://talat.app) runs transcription and summarization entirely on your Mac's Neural Engine. It captures both sides of your call (system audio and microphone), transcribes in real time with speaker identification, and generates summaries using a local LLM (Qwen3-4B-4bit by default). The whole app is 20 MB. It detects when a conferencing app grabs your microphone and starts recording in the background.
+[Talat](https://talat.app) runs transcription and summarization on your Mac's Neural Engine. It captures both sides of your call (system audio and mic), transcribes in real time with speaker identification, and summarizes with a local LLM (Qwen3-4B-4bit by default). The whole app is 20 MB. It detects when a conferencing app grabs your mic and starts recording in the background.
 
-The focus is configurability. You choose your LLM provider: the built-in local model, OpenAI, Anthropic, OpenRouter, or Ollama. You can write custom summarization prompts, auto-export notes to Obsidian, fire webhooks when a meeting ends, and run an MCP server so AI coding tools can query your meeting history. No analytics, no telemetry, no data collection.
+The focus is configurability. Pick your LLM provider: the built-in local model, OpenAI, Anthropic, OpenRouter, or Ollama. Write custom summarization prompts, auto-export to Obsidian, fire webhooks on meeting end, and run an MCP server so AI coding tools can query your meeting history. No analytics, no telemetry, no data collection.
 
 #### How local is it actually
 
@@ -150,11 +150,11 @@ $49 one-time purchase (pre-release price). $99 at version 1.0. 10 hours of free 
 
 [Screenpipe](https://screenpi.pe) records your screen and audio 24/7, transcribes everything locally with Whisper, and indexes it in a searchable local database. 
 
-It is not a meeting tool. It is an open-source AI memory layer for your entire desktop that happens to be very good at meeting notes, because meeting notes are a side effect of it always running.
+It's not a meeting tool. It's an open-source AI memory layer for your entire desktop that happens to be very good at meeting notes, because meeting notes are a byproduct of it always running.
 
-After a call, you ask the AI: "Summarize my meeting from 2 to 3pm and list action items." Screenpipe searches your audio transcripts and screen content from that time window. 
+After a call, you ask the AI: "Summarize my meeting from 2 to 3pm and list action items". Screenpipe searches your audio transcripts and screen content from that window.
 
-It captures what audio-only tools miss: the URL someone dropped in the Zoom chat, the spreadsheet someone shared, the code someone walked through in a terminal. It also runs as an MCP server, so Cursor, Claude Code, and Cline can query your meeting history directly.
+It captures what audio-only tools miss: the URL someone dropped in Zoom chat, the spreadsheet someone shared, the code someone walked through in a terminal. It also runs as an MCP server, so Cursor, Claude Code, and Cline can query your meeting history directly.
 
 #### How local is it actually
 
@@ -177,7 +177,7 @@ $400 lifetime (one-time). All features, all future updates. $600 lifetime + 1 ye
 
 **Which Local AI Meeting Notetaker Is Right for You?**
 
-Local processing means accepting tradeoffs. Local models are not as accurate as cloud transcription on messy audio, speaker diarization is still maturing across the board, and most of these tools are macOS-only or macOS-first. The gap is closing fast, though, and for anyone handling sensitive conversations, the architectural guarantee that your audio never left your device is worth more than a privacy policy that can change with a terms-of-service update.
+Local processing has tradeoffs. Local models aren't as accurate as cloud transcription on messy audio, speaker diarization is still maturing, and most of these tools are macOS-only or macOS-first. The gap is closing fast. For anyone handling sensitive conversations, an architectural guarantee that audio never left your device beats a privacy policy that can change with a terms-of-service update.
 
 Anarlog is the strongest choice if you want complete control: open-source, your choice of AI provider, and data that lives on your device in a format you own. 
 
@@ -185,17 +185,17 @@ Meetily is the best open-source option if you need Windows support or want a fre
 
 Shadow is the only tool that captures what is on screen alongside what is said. 
 
-Talat is for people who loved Granola but could not accept cloud dependency, and it is the only one-time purchase purpose-built meeting tool here.
+Talat is for people who loved Granola but couldn't accept the cloud dependency, and it's the only one-time-purchase meeting tool here.
 
-Screenpipe is the power user's option: not just meeting notes but a searchable memory of your entire workday. 
+Screenpipe is the power user's option: not just meeting notes but a searchable memory of your entire workday.
 
-If you want to start with local AI meeting notes that give you full ownership, [try Anarlog](https://anarlog.so). It is free, open-source, and works offline with local models. Your first meeting's notes will land on your device, readable by any tool you already use.
+If you want local AI meeting notes that give you full ownership, [try Anarlog](https://anarlog.so). It's free, open-source, and works offline with local models. Your first meeting's notes will land on your device, readable by any tool you already use.
 
 ## Frequently Asked Questions
 
 ### 1. Is Granola a local AI notetaker?
 
-No. Granola captures system audio locally, which is why it gets grouped with local tools, but the similarity ends there. Your audio is sent to Deepgram for transcription, your transcript is processed through GPT-4o or Claude for summarization, and your notes are stored on AWS servers. There is no offline mode and no option to run local models. Granola is a cloud tool with a local audio capture step. 
+No. Granola captures system audio locally, which is why it gets grouped with local tools, but the similarity ends there. Your audio is sent to Deepgram for transcription, your transcript runs through GPT-4o or Claude for summarization, and your notes sit on AWS. There's no offline mode and no option for local models. Granola is a cloud tool with a local audio capture step.
 
 ### 2. Can I use these tools for in-person meetings?
 
@@ -203,7 +203,7 @@ Yes. Tools that capture microphone input (Anarlog, Meetily, Talat, Screenpipe) w
 
 ### 3. Do local meeting notetakers work offline?
 
-If both transcription and summarization use local models, yes. Anarlog with Ollama, Meetily with Parakeet + Ollama, Talat with its built-in LLM, and Screenpipe with local Whisper all work without an internet connection. Shadow's transcription works offline but the AI summary features need a connection.
+If transcription and summarization both run on local models, yes. Anarlog with Ollama, Meetily with Parakeet + Ollama, Talat with its built-in LLM, and Screenpipe with local Whisper all work without an internet connection. Shadow's transcription works offline; its AI summary features need a connection.
 
 ### 4. What hardware do I need to run local transcription?
 
@@ -211,8 +211,8 @@ Most tools work on any Mac from the last five years. Apple Silicon (M1 or later)
 
 ### 5. Is it legal to record meetings without telling participants?
 
-Recording laws vary by jurisdiction. In many US states and most of Europe, you need consent from all parties to record a conversation. The fact that these tools do not send a bot into the meeting makes them less visible, but that does not remove your legal obligation to inform participants. Always tell the people on your call that you are recording.
+Recording laws vary by jurisdiction. In many US states and most of Europe, you need consent from all parties. These tools don't send a bot into the meeting, which makes them less visible, but that doesn't remove your obligation to inform participants. Tell the people on your call you're recording.
 
 ### 6. Are local AI meeting notes as accurate as cloud-based tools?
 
-It depends on the model and your hardware. Cloud transcription services like Deepgram still have an edge on messy audio, heavy accents, and cross-talk. But local models like Parakeet and Whisper Large V3 have closed the gap significantly, especially on clear audio from a decent microphone. For most one-on-one and small group calls, the difference is negligible.
+Depends on the model and your hardware. Cloud services like Deepgram still have an edge on messy audio, heavy accents, and cross-talk. Local models like Parakeet and Whisper Large V3 have closed most of the gap, especially on clear audio from a decent mic. For most one-on-one and small group calls, the difference is negligible.

--- a/apps/web/content/articles/local-ai-privacy-tools.mdx
+++ b/apps/web/content/articles/local-ai-privacy-tools.mdx
@@ -8,21 +8,21 @@ date: "2025-07-28"
 
 ## Intro
 
-In the past decade, we've watched a new generation of software companies win not by collecting more data, but by collecting none. [DuckDuckGo](https://duckduckgo.com/) built a search engine without profiling users. [Brave](https://brave.com/) gave people a browser that blocked trackers by default. [Proton](https://proton.me) delivered email and cloud storage that not even they could read.
+A new generation of software companies has won by collecting no data at all. [DuckDuckGo](https://duckduckgo.com/) built a search engine without profiling users. [Brave](https://brave.com/) shipped a browser that blocks trackers by default. [Proton](https://proton.me) delivered email and cloud storage that not even they could read.
 
-Each of these tools rejected the tradeoffs that Big Tech made years ago—usability traded for privacy, performance traded for control. They proved that privacy isn't just a niche preference. It's a product category.
+They rejected the trades Big Tech made years ago: usability for privacy, performance for control. Privacy isn't a niche preference. It's a product category.
 
-Now, AI is testing that principle again.
+AI is testing that principle again.
 
 ## Privacy, revisited
 
-The AI boom has delivered impressive capabilities but also renewed surveillance. A meeting you record with an AI notetaker gets sent to the cloud. A contract you upload for AI review gets logged on someone else's server. Even just asking ChatGPT a question reveals more about you than most search queries ever did.
+The AI boom shipped real capabilities and renewed surveillance at the same time. The meeting you record with an AI notetaker goes to the cloud. The contract you upload for review gets logged on someone else's server. Asking ChatGPT a question reveals more about you than most search queries ever did.
 
-The current generation of AI tools is fundamentally cloud-first. To use them is to surrender control over what you share, where it goes, and who might see it later.
+This generation of AI is cloud-first. Using it means giving up control over what you share, where it goes, and who sees it later.
 
-Where are the privacy-first tools in AI?
+Where are the privacy-first tools for AI?
 
-Just as DuckDuckGo and Brave offered new choices for search and browsing, and Proton reimagined communications, we now need tools that bring the same principles into this new era.
+DuckDuckGo and Brave reset search and browsing. Proton reset email. AI needs the same.
 
 ## Why local AI works
 
@@ -32,7 +32,7 @@ Two things make this work:
 
 ### 1. Physical assurance
 
-When AI runs on your device, no data ever needs to leave it. Cloud-based models promise "we won't look." Local AI guarantees "we can't look." This shifts privacy from policy to physics.
+When AI runs on your device, no data needs to leave it. Cloud models promise "we won't look". Local AI guarantees "we can't look". That shifts privacy from policy to physics.
 
 ### 2. No training risk
 

--- a/apps/web/content/articles/mac-productivity-apps.mdx
+++ b/apps/web/content/articles/mac-productivity-apps.mdx
@@ -91,7 +91,7 @@ Free forever, fully local + BYOK, open source.
 
 - Local file access: Give Claude permission to specific folders and it'll read, edit, organize, and create files without you manually uploading anything
 - Multi-step task execution: Set it loose on a project and it'll work through multiple steps autonomously, checking in when it needs guidance
-- Built-in skills: Comes with pre-loaded expertise for creating presentations, spreadsheets, and documents with proper formatting
+- Built-in skills: Comes with pre-loaded skills for creating presentations, spreadsheets, and documents with proper formatting
 - Works with your connectors: Integrates with MCP servers you already have set up (like Google Drive, Slack)
 - Task queueing: Drop multiple requests and let Claude work through them in parallel—feels less like a conversation, more like delegating to a coworker
 
@@ -99,7 +99,7 @@ Free forever, fully local + BYOK, open source.
 
 - Handles tedious work you'd normally grind through for hours (organizing downloads, processing receipts, restructuring notes)
 - No bot joining your Zoom calls or needing calendar permissions
-- Works seamlessly with tools like Obsidian, Notion, VS Code since everything's just files
+- Works well with tools like Obsidian, Notion, VS Code since everything's just files
 - Can handle complex workflows like "find all my unpublished blog drafts that are almost done"
 
 #### Cons:
@@ -138,7 +138,7 @@ Available to paid subscribers, with pricing starting at $17/month for Pro users,
 - Can map any action to a global hotkey that works system-wide
 - Active development with constant updates and new features
 - Clean, modern interface that doesn't feel cluttered despite doing so much
-- Works seamlessly across macOS versions
+- Works smoothly across macOS versions
 
 #### Cons:
 
@@ -395,7 +395,7 @@ $10/year subscription (roughly $1/month). Reeder Classic remains available as se
 
 Here's what nobody tells you about productivity apps: at some point, you have to stop optimizing your workflow and actually do the work.
 
-I've spent years building this setup. Some of these apps have been with me so long I forget what it was like before them. Others are new enough that I'm still discovering features. But they all have one thing in common—they make me think less about how I'm working so I can focus on what I'm working on.
+I've spent years building this setup. Some of these apps have been with me so long I forget what it was like before them. Others are new enough that I'm still discovering features. But they all have one thing in common: they make me think less about how I'm working so I can focus on what I'm working on.
 
 That's the only metric that matters.
 

--- a/apps/web/content/articles/markdown-note-taking-apps.mdx
+++ b/apps/web/content/articles/markdown-note-taking-apps.mdx
@@ -90,7 +90,7 @@ Opening one note pulls you into three others you forgot existed but suddenly nee
 - Sync works with whatever you already use (iCloud, Dropbox, Google Drive) or pay for Obsidian Sync if you want something purpose-built
 - Plugin ecosystem means the app grows with your needs
 - [Meeting notes](/blog/obsidian-meeting-notes/) from Anarlog land directly in your vault since both use markdown
-- Active community with real depth - forums, Discord, YouTube channels dedicated to workflows
+- Active community with real depth: forums, Discord, YouTube channels dedicated to workflows
 
 #### Cons:
 
@@ -129,7 +129,7 @@ Every bullet point is a block that can be linked, referenced, and surfaced anywh
 #### Pros:
 
 - The daily journal approach cuts friction. You stop procrastinating on "where to put this" and just write
-- Bidirectional linking is more fluid here than elsewhere - connections emerge naturally rather than being manually managed
+- Bidirectional linking is more fluid here than elsewhere; connections emerge naturally rather than being manually managed
 - PDF annotation is class-leading and built in natively, not a plugin afterthought
 - Free forever for personal use, open source, data stays local
 - The longer you use it, the more useful the graph becomes
@@ -168,7 +168,7 @@ Free for personal use. Logseq Sync is in beta. No paid tiers beyond sync.
 
 #### Pros:
 
-- The sync flexibility is genuinely unmatched - no other free app lets you bring your own backend with E2EE
+- The sync flexibility is hard to beat: no other free app lets you bring your own backend with E2EE
 - Desktop app is solid and reliable, users regularly report six-plus years of daily use without issues
 - Completely free with no note limits, no device limits, no paywall surprises
 - Rich text editor means markdown is optional - lower barrier than most apps in this list
@@ -211,10 +211,10 @@ Where Obsidian gives you a blank canvas to build whatever system you want, Inkdr
 
 #### Pros:
 
-- The most polished cross-platform experience in this list - desktop and mobile feel consistent, sync is instant and reliable
+- The most polished cross-platform experience in this list: desktop and mobile feel consistent, sync is instant and reliable
 - Developer-specific features are native, not bolted on via plugins
 - Offline-first, so the app is always ready regardless of connectivity
-- UI is genuinely clean - users consistently praise how unobtrusive it feels
+- UI is genuinely clean; users consistently praise how unobtrusive it feels
 
 #### Cons:
 

--- a/apps/web/content/articles/meetily-review.mdx
+++ b/apps/web/content/articles/meetily-review.mdx
@@ -88,7 +88,7 @@ This matters more for Meetily than for most tools, so it is worth being specific
 
 **MIT license.** You can fork it, modify it, self-host it, or build on top of it with no restrictions. For teams with strict compliance requirements, this matters more than it sounds.
 
-**Genuinely free community tier.** It is not a trial and it is not crippled. The core functionality, record, transcribe, summarize, works without paying anything.
+**Genuinely free community tier.** It is not a trial and it is not crippled. The core functionality (record, transcribe, summarize) works without paying anything.
 
 ## **Meetily Limitations**
 
@@ -132,6 +132,6 @@ Meetily does what it says. Local transcription, local summaries, nothing leaving
 
 The gaps are real. No calendar, summarization struggles on long calls, no search across sessions, no integrations, and no mobile app.
 
-If you want a focused local recorder and especially if you are on Windows, Meetily is the best option in its category. If you are on Mac and want meetings integrated into your broader workflow, with calendar context, a note editor, and developer tooling, [Anarlog](https://anarlog.so) covers that ground instead.
+If you want a focused local recorder and especially if you are on Windows, Meetily is the best option in its category. If you are on Mac and want meetings integrated into your wider workflow, with calendar context, a note editor, and developer tooling, [Anarlog](https://anarlog.so) covers that ground instead.
 
 Deciding between the two? Read our [Anarlog vs Meetily](https://anarlog.so/blog/anarlog-vs-meetily/) comparison for a full head-to-head breakdown.

--- a/apps/web/content/articles/meeting-minutes-software.mdx
+++ b/apps/web/content/articles/meeting-minutes-software.mdx
@@ -7,7 +7,7 @@ category: "Comparisons"
 date: "2026-01-10"
 ---
 
-If you're worried about missing important details while taking minutes of the meeting, here are some tools you'll find useful. 
+If you're worried about missing details while taking minutes of the meeting, here are tools you'll find useful.
 
 ## Meeting minutes software comparison
 
@@ -36,7 +36,7 @@ You decide if your audio, transcripts, or notes ever leave your device. You pick
 
 #### How it works
 
-Anarlog captures system audio without joining meetings as a bot. During meetings, it transcribes conversations in real-time and combines any notes you've taken with transcripts to create a summary when the meeting ends.
+Anarlog captures system audio without joining meetings as a bot. It transcribes conversations in real time and combines any notes you've taken with transcripts to create a summary when the meeting ends.
 
 #### Key Features
 
@@ -107,9 +107,9 @@ Free plan includes 10 AI recordings per user per month. Paid plans start at $7/u
 
 ![](/api/assets/blog/articles/meeting-minutes-software/image-2.png)
 
-**[MeetGeek](https://meetgeek.ai/)** is designed for sales teams and enterprises that want conversation analytics and performance tracking beyond transcription.
+**[MeetGeek](https://meetgeek.ai/)** is built for sales teams and enterprises that want conversation analytics and performance tracking beyond transcription.
 
-It captures data-driven insights into communication patterns, not just meeting notes.
+It captures insights about communication patterns, not just meeting notes.
 
 #### Key features
 
@@ -142,7 +142,7 @@ Free plan includes 5 hours of transcription per month with 3 months of transcrip
 
 ![](/api/assets/blog/articles/meeting-minutes-software/image-3.png)
 
-**[Diligent](https://www.diligent.com/solutions/board-and-leadership-collaboration)** is built specifically for corporate boards, executive committees, and governance-focused organizations. It's designed for high-stakes board-level governance, not general meetings.
+**[Diligent](https://www.diligent.com/solutions/board-and-leadership-collaboration)** is built for corporate boards, executive committees, and governance-focused organizations. It's for high-stakes board-level work, not general meetings.
 
 #### Key features
 
@@ -154,11 +154,11 @@ Free plan includes 5 hours of transcription per month with 3 months of transcrip
 
 #### Pros
 
-- Industry-leading security with enterprise-grade encryption and compliance
-- Comprehensive governance features beyond basic meeting management
-- Trusted by Fortune 500 companies and major organizations globally
-- AI-powered analytics provide board-level insights on critical issues
-- Seamless mobile access from any device
+- Strong security with enterprise-grade encryption and compliance
+- Governance features beyond basic meeting management
+- Used by Fortune 500 companies
+- AI-powered analytics for board-level insights
+- Mobile access from any device
 
 #### Cons
 
@@ -175,7 +175,7 @@ Diligent offers custom pricing based on organization size and requirements. Cont
 
 ![](/api/assets/blog/articles/meeting-minutes-software/image-4.png)
 
-**[Fireflies.ai](http://fireflies.ai)** excels at helping you find specific information months later through advanced search functionality. While many tools transcribe meetings, Fireflies focuses on searchable archives and powerful search capabilities across all conversations.
+**[Fireflies.ai](http://fireflies.ai)** is built to help you find information months later through search. Many tools transcribe meetings; Fireflies focuses on searchable archives across all conversations.
 
 #### Key features
 
@@ -189,10 +189,10 @@ Diligent offers custom pricing based on organization size and requirements. Cont
 
 #### Pros
 
-- Excellent search functionality across entire meeting history
-- Sentiment analysis provides conversation insights
-- Strong integration ecosystem (7,000+ apps via Zapier)
-- Works well for both online and in-person meetings with mobile apps
+- Search works well across entire meeting history
+- Sentiment analysis for conversation insights
+- Large integration ecosystem (7,000+ apps via Zapier)
+- Works for online and in-person meetings via mobile apps
 
 #### Cons
 
@@ -209,7 +209,7 @@ Free plan includes 800 minutes of storage with 3 months of transcript retention 
 
 ![](/api/assets/blog/articles/meeting-minutes-software/image-5.png)
 
-**[Beenote](https://beenote.io/)** focuses on collaborative planning, real-time note-taking, and organized follow-up with a generous free tier. It's designed for teams that need structured meeting workflows without AI automation.
+**[Beenote](https://beenote.io/)** focuses on collaborative planning, real-time note-taking, and follow-up, with a generous free tier. It's for teams that need structured meeting workflows without AI automation.
 
 #### Key features
 
@@ -255,11 +255,11 @@ Beenote is free forever with basic features. Paid plans start at $552/year for 1
 
 #### Pros
 
-- Powerful for complex enterprise workflows with multiple stakeholders
-- Deep Outlook integration makes adoption easier in Microsoft-heavy organizations
-- Meeting series feature provides excellent continuity for recurring meetings
-- Advanced meeting facilitation tools (voting, pros/cons) improve decision quality
-- Proven track record with 30+ years in the market
+- Handles complex enterprise workflows with multiple stakeholders
+- Deep Outlook integration speeds adoption in Microsoft-heavy organizations
+- Meeting series feature gives continuity for recurring meetings
+- Built-in voting and pros/cons tools improve decision quality
+- 30+ years in the market
 
 #### Cons
 
@@ -276,7 +276,7 @@ MeetingBooster offers custom pricing based on organization size and needs. They 
 
 ![](/api/assets/blog/articles/meeting-minutes-software/image-7.png)
 
-**[Fathom](https://www.fathom.ai/)** automatically logs everything to Salesforce, HubSpot, and other platforms immediately after each call. While other tools require you to copy-paste summaries into your CRM, Fathom eliminates that step.
+**[Fathom](https://www.fathom.ai/)** logs everything to Salesforce, HubSpot, and other platforms right after each call. Other tools make you copy-paste summaries into your CRM; Fathom skips that step.
 
 #### Key features
 
@@ -289,10 +289,10 @@ MeetingBooster offers custom pricing based on organization size and needs. They 
 
 #### Pros
 
-- Completely free for unlimited meetings
-- Excellent CRM integration eliminates manual data entry
-- Simple, clean interface with minimal setup required
-- Fast AI processing—summaries available within minutes
+- Free for unlimited meetings
+- CRM integration removes manual data entry
+- Clean interface with minimal setup
+- Summaries available within minutes
 
 #### Cons
 
@@ -309,7 +309,7 @@ Free forever for individuals with unlimited meetings and transcription. Team pla
 
 ![](/api/assets/blog/articles/meeting-minutes-software/image-8.png)
 
-**[tl;dv](https://tldv.io/)** offers genuinely unlimited recordings on its free plan. Unlike other "free" options with restrictive limits, it's ideal for individuals and small teams on tight budgets.
+**[tl;dv](https://tldv.io/)** offers unlimited recordings on its free plan. Unlike other "free" options with restrictive limits, it works for individuals and small teams on tight budgets.
 
 #### Key features
 
@@ -322,10 +322,10 @@ Free forever for individuals with unlimited meetings and transcription. Team pla
 
 #### Pros
 
-- Truly unlimited recordings on free plan (no monthly hour caps)
-- Video clip feature makes it easy to share key moments
-- Simple, intuitive interface with minimal setup
-- Works well for both Zoom and Google Meet
+- Unlimited recordings on free plan (no monthly hour caps)
+- Video clips make it easy to share moments
+- Intuitive interface with minimal setup
+- Works for Zoom and Google Meet
 
 #### Cons
 
@@ -340,7 +340,7 @@ Free plan includes unlimited recordings and AI summaries. Pro plan starts at $18
 
 ## Key features that matter in meeting minutes software
 
-When evaluating meeting minutes software, focus on these five categories:
+When evaluating meeting minutes software, focus on five things.
 
 ### 1. Transcription accuracy
 
@@ -352,7 +352,7 @@ Accuracy matters if you're relying on automated transcription. Look for:
 - Custom vocabulary training for specialized terms
 - Multi-language support if needed
 
-Most AI meeting minutes software achieves 90-95% accuracy in ideal conditions, but accuracy drops significantly with background noise, accents, or multiple speakers talking simultaneously.
+Most AI meeting minutes software hits 90-95% accuracy in ideal conditions. Accuracy drops with background noise, accents, or multiple speakers talking at once.
 
 ### 2. Privacy & security
 
@@ -364,7 +364,7 @@ For sensitive conversations, privacy architecture matters more than compliance c
 - **Data retention policies** control how long recordings are stored
 - **Access controls** manage who can view sensitive meetings
 
-If your conversations involve confidential information, prioritize tools with local processing or strong encryption over convenient cloud-based options.
+If your conversations involve confidential information, pick tools with local processing or strong encryption over convenient cloud options.
 
 ### 3. Integrations
 
@@ -376,7 +376,7 @@ Meeting minutes software should connect with your existing workflow:
 - **Communication platforms** (Slack, Teams) for sharing summaries
 - **Document storage** (Google Drive, Dropbox) for archival
 
-The best integrations are bidirectional—not just pushing data out, but pulling context in to make summaries more relevant.
+The best integrations are bidirectional. They push data out and pull context in, so summaries stay relevant.
 
 ### 4. Collaboration features
 
@@ -388,7 +388,7 @@ Teams need to work together on meeting documentation:
 - **Approval workflows** for formal minutes requiring sign-off
 - **Version control** to track changes and revert if needed
 
-Remote teams particularly benefit from strong collaboration features that keep everyone aligned regardless of location.
+Remote teams benefit most from collaboration features that keep everyone aligned across time zones.
 
 ### 5. Search & retrieval
 
@@ -404,6 +404,6 @@ The difference between a searchable meeting archive and 100 unsearchable documen
 
 ## Our top recommendation
 
-If you value both functionality and control, Anarlog is worth a look. You get AI-powered features without giving up ownership of your data, and you can export everything as plain markdown with zero lock-in.
+If you want functionality without giving up control, try Anarlog. You get AI features without giving up ownership of your data, and everything exports as plain markdown.
 
-You can try the tool out for free. If it's not for you, export everything and walk away.
+Try it for free. If it's not for you, export everything and walk away.

--- a/apps/web/content/articles/meeting-preparation-checklist.mdx
+++ b/apps/web/content/articles/meeting-preparation-checklist.mdx
@@ -30,7 +30,7 @@ Walking into a meeting with specific references keeps conversations focused on m
 
 ### 2. Stakeholder research & profiling: know who you're talking to
 
-Effective meeting prep recognizes that every person brings different priorities, communication styles, and decision-making authority.
+Every person brings different priorities, communication styles, and decision-making authority. Effective prep accounts for that.
 
 Before the meeting, research each participant:
 
@@ -39,7 +39,7 @@ Before the meeting, research each participant:
 - **Decision-making authority** -- Can this person say yes, or do they need to escalate? Who influences their thinking?
 - **Recent context** -- What wins or setbacks have they experienced lately that might affect their perspective?
 
-This research helps you tailor your communication approach and anticipate conflicts before they surface. When you know that two participants have historically disagreed on resource allocation, or that the legal team has concerns about compliance implications, you can address these tensions in your preparation rather than getting blindsided mid-meeting.
+This research helps you tailor your approach and anticipate conflict. If two participants have disagreed on resource allocation before, or the legal team has compliance concerns, you can address those tensions in prep instead of getting blindsided mid-meeting.
 
 **Where to gather this intel 💡:** LinkedIn for professional background, your CRM for past interactions, and your meeting history.
 
@@ -59,9 +59,9 @@ Include:
 - **Pre-reading materials** -- Background documents, relevant data, context from previous meetings. Keep these concise; nobody reads 40-page reports.
 - **Preparation expectations** -- Be explicit. "Please review the budget scenarios and come prepared with your preference" tells people what to actually do.
 - **Decision framework** -- If you're making decisions, explain how. Consensus? Voting? Executive call? When people know the rules upfront, meetings run faster.
-- **Recording notice** -- If you're recording (and if you're using Anarlog), mention it in the invite. Transparency builds trust, especially in compliance-sensitive industries.
+- **Recording notice** -- If you're recording (including with Anarlog), mention it in the invite. Transparency matters in compliance-sensitive industries.
 
-**Pro tip 💡:** Create a single source of truth: a shared doc, a sales room, a project page, and link to it clearly in the calendar invite. Don't bury this in a massive email thread.
+**Pro tip 💡:** Create one source of truth (a shared doc, sales room, or project page) and link to it in the calendar invite. Don't bury it in a long email thread.
 
 ### 4. Participation strategy: design for diverse voices
 
@@ -73,9 +73,9 @@ The loudest voices dominate meetings by default. Without a deliberate participat
 
 **Structured Q&A segments:** Instead of "any questions?" which usually gets silence, try "I'm going to pause here for questions, please drop them in chat or unmute." Or assign specific Q&A windows: "After the budget overview, we'll have 10 minutes for questions about resource allocation."
 
-**Pre-assign speaking roles:** If you need input from specific people, tell them before the meeting. "Dev, I'd like you to speak to the technical feasibility. Priya, can you cover the customer impact?" People contribute better when they know they're expected to speak and have time to prepare.
+**Pre-assign speaking roles:** If you need input from specific people, tell them before the meeting. "Dev, I'd like you to speak to technical feasibility. Priya, can you cover customer impact?" People contribute better when they know they're expected to speak and have time to prepare.
 
-This ensures you actually hear the perspectives that matter before making decisions.
+Do this and you'll actually hear the perspectives that matter before making decisions.
 
 ### 5. Fallback plans: prepare for when discussions stall
 
@@ -97,22 +97,22 @@ When something goes sideways, you're steering the meeting back on track instead 
 
 ### 6. Meeting recording: capture everything without the overhead
 
-Traditional meeting documentation either misses crucial details or requires so much effort that nobody maintains it. Taking manual notes means you're distracted from the actual conversation. Inviting a bot to your call announces to everyone that their words are being sent to the cloud—not ideal for sensitive discussions.
+Traditional meeting documentation either misses details or takes so much effort that nobody keeps it up. Manual notes pull you out of the conversation. Inviting a bot announces to everyone that their words are being sent to the cloud, which doesn't work for sensitive discussions.
 
-Anarlog runs entirely on your device. No bot joins your call. No data leaves your machine. It just captures the conversation, both your microphone and system audio, so you have a complete record without the overhead.
+Anarlog runs on your device. No bot joins. No data leaves your machine. It captures both your microphone and system audio, so you get a full record without the overhead.
 
 <Image src="/api/assets/blog/meeting-preparation-checklist/prep-3.webp" alt="Anarlog"/>
 
 **What to consider when recording 💡:**
 
-- **Consent management:** In many jurisdictions and industries, you need explicit consent to record conversations. Mention recording in your meeting invite. For higher-stakes meetings, consider verbal confirmation at the start: "Just confirming we're recording this for our records, everyone comfortable with that?"
-- **For compliance-sensitive industries** (healthcare, legal, finance), zero-lock-in tools like Anarlog give you complete control. When discussing patient information, legal matters, or confidential business details, choosing your own AI stack and storing files as plain markdown helps you meet HIPAA, attorney-client privilege, and other regulatory requirements.
-- **Environment matters:** Find a quiet space. Use a decent microphone. Background noise and poor audio quality break transcription accuracy.
-- **Offline meetings:** If you're recording an in-person conversation, make sure your meeting assistant works when you need it most. Choose tools that don't rely on internet connectivity for transcription and note-taking. Anarlog runs entirely on your device using local AI models, so it works in basement conference rooms, on planes, or anywhere without WiFi.
+- **Consent management:** In many jurisdictions and industries, you need explicit consent to record. Mention recording in your invite. For higher-stakes meetings, get verbal confirmation at the start: "Just confirming we're recording this for our records, everyone comfortable with that?"
+- **Compliance-sensitive industries** (healthcare, legal, finance): zero-lock-in tools like Anarlog give you control. When discussing patient information, legal matters, or confidential business details, picking your own AI stack and storing files as plain markdown helps you meet HIPAA, attorney-client privilege, and other regulations.
+- **Environment matters:** Find a quiet space. Use a decent microphone. Background noise and poor audio quality wreck transcription accuracy.
+- **Offline meetings:** Pick tools that don't rely on the internet for transcription. Anarlog runs on your device using local AI models, so it works in basement conference rooms, on planes, or anywhere without WiFi.
 
 ### 7. Meeting templates: stop starting from scratch every time
 
-You run the same types of meetings repeatedly: customer calls, team standups, strategy reviews, performance check-ins. Templates reduce cognitive load by giving you a proven framework.
+You run the same meeting types over and over: customer calls, standups, strategy reviews, performance check-ins. Templates reduce cognitive load by giving you a known frame.
 
 **How to create meeting templates:**
 
@@ -124,29 +124,29 @@ Anarlog lets you create custom templates that automatically structure your AI-ge
 
 To create a custom template, define your sections (the structure you want) and add system instructions (rules for the AI to follow). For example:
 
-- **For user interviews** -- "For every bullet point you write, attach the user's actual quote as a reference next to it." Now every interview summary comes with supporting evidence automatically.
-- **For sales calls** -- "Generate the summary in JSON format with fields: painPoints, budget, timeline, decisionMakers." Perfect if you're pushing data to a CRM.
+- **For user interviews** -- "For every bullet point you write, attach the user's actual quote as a reference next to it." Every interview summary comes with supporting evidence.
+- **For sales calls** -- "Generate the summary in JSON format with fields: painPoints, budget, timeline, decisionMakers." Useful if you're pushing data to a CRM.
 - **For therapy or coaching sessions** -- "Focus on the client's own words and emotional themes. Minimize interpretation."
 
-The more specific your instructions, the better the AI tailors notes to your needs.
+The more specific your instructions, the closer the notes get to what you actually need.
 
 ---
 
-These seven steps transform chaotic meeting prep into a structured process.
+These seven steps turn chaotic meeting prep into a process you can repeat.
 
 ## Use Anarlog for productive meetings
 
-Meeting preparation is exhausting when you're doing it manually: searching through old emails, reconstructing context from memory, frantically taking notes while trying to stay present.
+Manual meeting prep is exhausting: searching old emails, reconstructing context from memory, frantically taking notes while trying to stay present.
 
-Anarlog eliminates that overhead.
+Anarlog removes that overhead.
 
 **Before the meeting:** Use Search (cmd + k) to instantly find relevant past conversations. Check Contacts View to see your complete history with each participant. Ask AI Chat questions like "What did we decide about the pricing model?" to pull specific context without digging through transcripts.
 
-**During the meeting:** Stop trying to be a human tape recorder. Anarlog captures everything automatically—both what's said and what you're thinking. Everything is stored as plain markdown files with zero lock-in. You choose your AI stack, making it the right choice for sensitive conversations in healthcare, legal, and finance. You can stay fully present in the conversation instead of splitting focus between listening and documenting.
+**During the meeting:** Stop trying to be a human tape recorder. Anarlog captures everything automatically: what's said and what you're thinking. Everything is stored as plain markdown files with zero lock-in. You pick your AI stack, which makes it workable for sensitive conversations in healthcare, legal, and finance. You stay present instead of splitting focus between listening and documenting.
 
-**After the meeting:** Don't immediately process anything. Take an actual break. When you're ready, your AI-generated summary is waiting with your custom template already applied. Hover over any part to see the exact quote from the transcript. Ask AI Chat "What are my action items?" instead of hunting through notes. Search across all meetings to track themes and patterns.
+**After the meeting:** Don't process anything right away. Take a break. When you're ready, the summary is waiting with your custom template applied. Hover over any part to see the exact quote from the transcript. Ask AI Chat "What are my action items?" instead of hunting through notes. Search across all meetings to track themes and patterns.
 
-You spend your mental energy on thinking, not on reconstructing what happened or organizing information.
+Spend your mental energy on thinking, not on reconstructing what happened.
 
 [Download Anarlog free](/) and have productive meetings with confidence
 

--- a/apps/web/content/articles/meeting-productivity-tools.mdx
+++ b/apps/web/content/articles/meeting-productivity-tools.mdx
@@ -9,9 +9,9 @@ category: "Comparisons"
 date: "2026-02-19"
 ---
 
-Meetings are a category of problems that no single tool can solve. You need the right time to meet, a way to stay engaged during the meeting, a place to capture what was discussed, somewhere to ideate visually, and a calendar that isn't completely dominated by other people's priorities.
+No single tool fixes meetings. You need a way to schedule, stay engaged, capture what was discussed, ideate visually, and a calendar that isn't dominated by other people's priorities.
 
-Most "best tools for meetings" articles hand you a list of 25 apps and call it a day. This one doesn't. We picked five tools and focused on being honest about what each one actually does well and where it falls short.
+Most "best tools for meetings" articles hand you 25 apps and call it a day. This one picks five and is honest about what each does well and where it falls short.
 
 Here's what we're covering:
 
@@ -29,13 +29,13 @@ Let's get into it.
 
 ![](/api/assets/blog/articles/meeting-productivity-tools/image-1-3.png)
 
-Most AI meeting tools make the same trade: convenience in exchange for your data living in someone else's database, locked into their format, processed by their AI. Anarlog doesn't make that trade.
+Most AI meeting tools make the same trade: convenience for your data living in someone else's database, locked into their format, processed by their AI. Anarlog doesn't make that trade.
 
-<u>[Anarlog](https://anarlog.so)</u> (formerly Anarlog) is an open-source AI notepad for meetings, built for people who want complete control over their files, their AI stack, and what happens to their data. 
+<u>[Anarlog](https://anarlog.so)</u> (formerly Anarlog) is an open-source AI notepad for meetings, built for people who want control over their files, AI stack, and data. 
 
-Every meeting is saved as a plain .md file on your device. You choose which AI processes it. Nothing is locked behind Anarlog's ecosystem.
+Every meeting is saved as a plain .md file on your device. You pick which AI processes it. Nothing is locked behind Anarlog's ecosystem.
 
-That design is deliberate. Engineers, developers, and privacy-conscious professionals in fields like law, healthcare, and finance don't want a SaaS tool deciding what happens to their meeting data.
+That design is deliberate. Engineers, developers, and privacy-conscious professionals in law, healthcare, and finance don't want a SaaS tool deciding what happens to their meeting data.
 
 #### Key Features
 
@@ -50,11 +50,11 @@ That design is deliberate. Engineers, developers, and privacy-conscious professi
 
 #### Pros
 
-- True data ownership - your files, on your device, not in someone's database
-- No lock-in of any kind: portable format, swappable AI providers, works with any editor
-- Works for any conversation - phone calls, in-person meetings, anything with audio, not just scheduled video calls
-- Fully local mode available for teams that can't send data to any external service
-- Open source builds trust with security teams; the code is there to inspect
+- Real data ownership - your files, on your device, not in someone's database
+- No lock-in: portable format, swappable AI providers, works with any editor
+- Works for any conversation - phone calls, in-person, anything with audio, not just scheduled video calls
+- Fully local mode for teams that can't send data to any external service
+- Open source - security teams can inspect the code before approving
 
 #### Cons
 
@@ -72,7 +72,7 @@ Free forever, fully local + BYOK, open source.
 
 You share a link, the other person picks a time, it lands on both calendars. That's the premise, and <u>[Calendly](https://calendly.com/)</u> executes it cleanly. 
 
-What makes it more than a booking page is how much complexity it absorbs underneath: multiple calendars, team routing, automated follow-ups, while the person booking sees nothing but a simple interface.
+It's more than a booking page because of how much complexity it absorbs underneath: multiple calendars, team routing, automated follow-ups. The person booking sees a simple interface.
 
 For groups where no one shares a calendar - cross-company sessions, client kickoffs - Doodle is cleaner. 
 
@@ -88,7 +88,7 @@ For groups where no one shares a calendar - cross-company sessions, client kicko
 
 - Once it's set up, scheduling just happens - the back-and-forth stops
 - Automatic timezone detection handles international meetings without anyone thinking about it
-- Free plan is genuinely usable for basic individual scheduling
+- Free plan is usable for basic individual scheduling
 
 #### Cons
 
@@ -115,7 +115,7 @@ Free plan with one event type. Standard is $12/user/month, Teams is $20/user/mon
 
 #### Pros
 
-- Video clips are genuinely useful - sharing a precise 90-second moment beats sending a full recording
+- Video clips are useful - sharing a 90-second moment beats sending a full recording
 - CRM sync means the data entry that normally gets skipped actually happens
 - Free plan is generous: unlimited recordings with one Notetaker seat
 
@@ -135,7 +135,7 @@ Free plan with unlimited recordings (one Notetaker seat). Starter is $19/user/mo
 
 If you've ever watched someone share their screen, open a Google Doc, and spend 30 minutes trying to explain something that needed to be drawn, you understand what <u>[Miro](https://miro.com/)</u> solves. 
 
-It's an infinite collaborative canvas, and the most capable digital replacement for a physical whiteboard that exists right now.
+It's an infinite collaborative canvas, and the closest digital replacement for a physical whiteboard right now.
 
 #### Key Features
 
@@ -147,9 +147,9 @@ It's an infinite collaborative canvas, and the most capable digital replacement 
 
 #### Pros
 
-- Nothing else comes close for visual collaboration - the infinite canvas genuinely changes how teams think together
-- Strong for both live sessions and async work, which most tools aren't
-- Easy to get started; most people figure it out without a tutorial
+- Nothing else comes close for visual collaboration - the infinite canvas changes how teams think together
+- Works for live sessions and async work, which most tools don't
+- Easy to start; most people figure it out without a tutorial
 
 #### Cons
 
@@ -167,7 +167,7 @@ Free plan with three editable boards and unlimited collaborators. Starter is $8/
 
 You can use every tool on this list correctly and still end up with a week that's wall-to-wall meetings and no time for actual work. That's where <u>[Reclaim](https://reclaim.ai/)</u> comes in. 
 
-It sits on top of your Google Calendar or Outlook as an intelligent layer - you tell it your priorities (focus time, lunch, recurring 1:1s), and it finds the best times, marks them appropriately, and reshuffles lower-priority blocks when something more important needs the slot. Your calendar ends up reflecting what you actually want your week to look like.
+It sits on top of Google Calendar or Outlook as a layer. You tell it your priorities (focus time, lunch, recurring 1:1s), and it finds the best times, marks them, and reshuffles lower-priority blocks when something more important needs the slot. Your calendar ends up reflecting what you actually want your week to look like.
 
 #### Key Features
 
@@ -179,9 +179,9 @@ It sits on top of your Google Calendar or Outlook as an intelligent layer - you 
 
 #### Pros
 
-- Once configured, your calendar reflects your priorities rather than just everyone else's requests
-- The priority system is smart - higher-priority items automatically overbook lower-priority ones
-- Free plan is genuinely useful, not just a trial
+- Once configured, your calendar reflects your priorities rather than everyone else's requests
+- Priority system is smart - higher-priority items automatically overbook lower-priority ones
+- Free plan is useful, not just a trial
 
 #### Cons
 
@@ -205,6 +205,6 @@ These five tools solve different parts of the same problem:
 
 **Protecting time for actual work**: Reclaim.ai
 
-None of these replace each other. And none of them replace the part where you actually pay attention and do the work. But if you're losing hours every week to scheduling friction, forgotten decisions, or a calendar you feel like you have no control over - starting with even one of these changes the situation meaningfully.
+None of these replace each other. And none replace the part where you pay attention and do the work. But if you're losing hours every week to scheduling friction, forgotten decisions, or a calendar you don't control, even one of these changes the picture.
 
-We're biased, but we'd start with Anarlog. Not because it's ours, but because if you're not capturing what's actually happening in your meetings - on your terms - every other optimization sits on a leaky foundation.
+We're biased, but we'd start with Anarlog. If you're not capturing what's happening in your meetings on your terms, every other optimization sits on a leaky foundation.

--- a/apps/web/content/articles/mistral-api-key.mdx
+++ b/apps/web/content/articles/mistral-api-key.mdx
@@ -19,7 +19,7 @@ You need:
 
 No credit card required for the free Experiment plan.
 
-One thing worth knowing upfront: on the free Experiment plan, your API requests may be used to train Mistral's models. If you're working with sensitive data, you'll want to upgrade to a paid plan, which comes with data isolation.
+One thing to know upfront: on the free Experiment plan, your API requests may be used to train Mistral's models. If you're working with sensitive data, upgrade to a paid plan, which comes with data isolation.
 
 ## **How to generate your Mistral API key (step by step)**
 
@@ -33,9 +33,9 @@ One thing worth knowing upfront: on the free Experiment plan, your API requests 
 
 On the free Experiment plan, every model is capped at 500,000 tokens per minute and 1,000,000,000 tokens per month. That's a billion tokens a month, which sounds like a lot until you're running something in a loop.
 
-The per-minute limit is the one you'll actually hit. 500k tokens per minute works out to roughly 375,000 words per minute, which is fast, but easy to saturate if you're processing batches or running concurrent requests. If a request gets rate limited, the API returns a 429 and you'll need to retry with backoff.
+The per-minute limit is the one you'll hit. 500k tokens per minute is roughly 375,000 words per minute. Fast, but easy to saturate if you're processing batches or running concurrent requests. If a request gets rate limited, the API returns a 429 and you retry with backoff.
 
-The monthly cap of 1B tokens is genuinely generous for individual use. At typical usage, most developers won't come close. If you're building something at scale or need guaranteed throughput, upgrading to the Scale plan removes these ceilings and adds data isolation.
+The monthly cap of 1B tokens is generous for individual use. Most developers won't come close. If you're building at scale or need guaranteed throughput, the Scale plan removes these ceilings and adds data isolation.
 
 ## **Mistral API pricing: how much does it cost**
 
@@ -47,17 +47,17 @@ Mistral charges per million tokens, counting both input (what you send) and outp
 | Mistral Small 3.2 | $0.10 / M tokens | $0.30 / M tokens |
 | Mistral Large 3 | $0.50 / M tokens | $1.50 / M tokens |
 
-To put those numbers in context: a million input tokens is roughly 750,000 words, or about 1,500 pages of text. At Mistral Small's rates, that costs ten cents. For most personal or small-team use, the monthly bill is negligible.
+For context: a million input tokens is roughly 750,000 words, or about 1,500 pages. At Mistral Small's rates, that's ten cents. For most personal or small-team use, the monthly bill is negligible.
 
-If you're running batch jobs that don't need an immediate response, Mistral offers a 50% discount on batch API requests. Worth using if latency isn't a concern.
+If you're running batch jobs that don't need an immediate response, Mistral offers a 50% discount on batch API requests. Worth using when latency doesn't matter.
 
 ## **Which Mistral model should you use**
 
 If you're not sure, use mistral-small-latest.
 
-It's fast, cheap, multimodal, multilingual, and Apache 2.0 licensed. The Apache 2.0 license matters if you're building something commercial. No usage restrictions, no license fees.
+It's fast, cheap, multimodal, multilingual, and Apache 2.0 licensed. The Apache 2.0 license matters if you're building something commercial: no usage restrictions, no license fees.
 
-Step up to mistral-large-latest if you need heavier reasoning: complex multi-step tasks, nuanced analysis, or anything where output quality is worth paying more for. It's five times the price of Small, so it's worth being deliberate about when you actually need it.
+Step up to mistral-large-latest if you need heavier reasoning: complex multi-step tasks, nuanced analysis, or anything where output quality is worth paying more for. It's five times the price of Small, so be deliberate about when you actually need it.
 
 ## **How to use your Mistral API key in your project**
 
@@ -92,14 +92,14 @@ api_key = os.getenv("MISTRAL_API_KEY")
 
 ![](/api/assets/blog/articles/mistral-api-key/image-1.png)
 
-Getting your own API key is a deliberate choice. It means you want control over what AI you're using and what happens to the data you send it. Anarlog works on the same principles. 
+Getting your own API key is a deliberate choice. It means you want control over which AI you're using and what happens to the data you send it. Anarlog works on the same principle. 
 
-It’s an open-source AI notepad for meetings that gives you complete control over your AI stack and your data. 
+It's an open-source AI notepad for meetings that gives you control over your AI stack and your data. 
 
 The workflow is simple: record, transcribe locally, summarize with your own Mistral key. You choose which model runs. You can swap to Anthropic, OpenAI, or a local Ollama model any time without losing your files or your history.
 
-Everything else stays local. The audio file, the transcript, the summary are all saved as plain markdown files on your device, not on Anarlog's servers. Anarlog doesn't have servers storing your conversations. There's nothing to breach, no vendor to trust with your data.
+Everything else stays local. The audio file, transcript, and summary are saved as plain markdown files on your device, not on Anarlog's servers. Anarlog doesn't have servers storing your conversations. There's nothing to breach and no vendor to trust with your data.
 
-Plus, all core features, local transcription, and BYOK stay completely free. You’re already paying for the API key, you shouldn’t have to pay twice. But if you want cloud services and don't want to manage keys at all, there is a $8/month plan you can check out. 
+All core features, local transcription, and BYOK are free. You're already paying for the API key; you shouldn't have to pay twice. If you want cloud services and don't want to manage keys at all, there's an $8/month plan. 
 
-To connect Mistral, open Anarlog's settings, go to API Keys, paste your key, and that's it. Try it out for free now - [Download Anarlog for macOS](https://anarlog.so/download/).
+To connect Mistral, open Anarlog's settings, go to API Keys, and paste your key. That's it. [Download Anarlog for macOS](https://anarlog.so/download/) to try it.

--- a/apps/web/content/articles/mistral-data-retention-policy.mdx
+++ b/apps/web/content/articles/mistral-data-retention-policy.mdx
@@ -8,51 +8,51 @@ category: "Guides"
 date: "2026-03-17"
 ---
 
-We've been evaluating data retention policies of major AI providers and Mistral is the only provider headquartered in the European Union. That is not a minor detail. It means Mistral is natively subject to GDPR, stores your data in the EU by default, and was built from the ground up under stricter privacy regulation than any of the US-based alternatives.
+We've been evaluating data retention policies of major AI providers, and Mistral is the only one headquartered in the European Union. That's not a minor detail. Mistral is natively subject to GDPR, stores your data in the EU by default, and was built under stricter privacy regulation than any US-based alternative.
 
-For teams evaluating AI providers on data governance grounds, that starting point matters.
+For teams evaluating AI providers on data governance, that starting point matters.
 
-Here is how the policy works in practice.
+Here's how the policy works in practice.
 
 ## What Mistral Stores by Default
 
-For API users, Mistral retains your inputs and outputs for 30 rolling days after the request is processed. This window exists for abuse monitoring. After 30 days, the data is deleted. It is not used to train Mistral's models unless you explicitly opt in.
+For API users, Mistral retains your inputs and outputs for 30 rolling days after the request is processed. This window exists for abuse monitoring. After 30 days, the data is deleted. It's not used to train Mistral's models unless you explicitly opt in.
 
 For free users of Le Chat, Mistral's consumer product, your conversations may be used for model improvement unless you opt out. You can do this by opening the Privacy menu in the Admin Console and disabling the toggle under Anonymous improvement data.
 
 Paid plans are handled differently. Users on Le Chat Team, Le Chat Enterprise, or any paid API plan have their data excluded from training by default. No opt-out required.
 
-Account metadata follows a separate schedule. Name and identity data is kept for 5 years after account termination. Email and phone number are retained for 1 year after account deletion. Technical data such as connection logs is kept for 1 rolling year.
+Account metadata follows a separate schedule. Name and identity data is kept for 5 years after account termination. Email and phone number are kept for 1 year after account deletion. Technical data like connection logs is kept for 1 rolling year.
 
 ## Where Your Data Is Stored
 
-By default, all data is hosted within the European Union. Mistral [explicitly states](https://legal.mistral.ai/terms/privacy-policy) that it prioritizes EU-based infrastructure providers and applies GDPR-standard safeguards when any non-EU provider is involved.
+By default, all data is hosted in the European Union. Mistral [explicitly states](https://legal.mistral.ai/terms/privacy-policy) that it prioritizes EU-based infrastructure providers and applies GDPR-standard safeguards when any non-EU provider is involved.
 
-There is a US API endpoint available if you need it. Using it will route your data to US infrastructure. If EU residency matters for your use case, stick with the default endpoint and confirm with your Mistral account contact that your deployment is EU-only.
+There's a US API endpoint if you need it, which routes your data to US infrastructure. If EU residency matters for your use case, stick with the default endpoint and confirm with your Mistral contact that your deployment is EU-only.
 
 ## Is Zero Data Retention Applicable?
 
-ZDR is available on the API. When activated, Mistral does not retain your inputs or outputs beyond what is needed to return the result. The 30-day abuse monitoring window does not apply.
+ZDR is available on the API. When activated, Mistral doesn't retain your inputs or outputs beyond what's needed to return the result. The 30-day abuse monitoring window doesn't apply.
 
-One important limitation: Zero Data Retention is not available on Le Chat. Because the consumer product relies on stored conversation history to function, ZDR cannot be applied there. If ZDR is a requirement, you need to use the API directly.
+One limitation: ZDR isn't available on Le Chat. The consumer product relies on stored conversation history to function. If ZDR is a requirement, use the API directly.
 
 ## Training Opt-Out in Plain Terms
 
-Free Le Chat users are opted in to training by default and can opt out via Privacy settings. Paid Le Chat and paid API users are opted out by default. ZDR API customers have no training risk because their data is never retained to begin with.
+Free Le Chat users are opted in to training by default and can opt out via Privacy settings. Paid Le Chat and paid API users are opted out by default. ZDR API customers have no training risk because their data is never retained.
 
-If you are a paid API customer, you do not need to take any action to keep your data out of training pipelines. It is already excluded.
+If you're a paid API customer, you don't need to do anything to keep your data out of training pipelines. It's already excluded.
 
 ## GDPR and Compliance
 
-As an EU company, Mistral operates under GDPR natively rather than as a compliance overlay. A Data Processing Addendum is available for all business customers. GDPR rights including access, correction, deletion, and portability can be exercised by contacting Mistral's privacy team directly.
+As an EU company, Mistral operates under GDPR natively, not as a compliance overlay. A Data Processing Addendum is available for all business customers. GDPR rights (access, correction, deletion, portability) can be exercised by contacting Mistral's privacy team directly.
 
-Mistral does not currently publish a HIPAA Business Associate Agreement. For US healthcare organizations that need HIPAA coverage, Mistral is not the right choice without confirming a BAA is available for your specific plan.
+Mistral doesn't currently publish a HIPAA Business Associate Agreement. For US healthcare organizations that need HIPAA coverage, don't pick Mistral without first confirming a BAA is available for your specific plan.
 
 ## How Mistral Compares With Other AI Providers
 
-The structural difference between Mistral and the US-based providers is data residency by default. With [OpenAI](/blog/chatgpt-data-retention-policy/), [Anthropic](/blog/anthropic-data-retention-policy/), or Google, you are opting into EU data residency as an enterprise feature. With Mistral, EU residency is the baseline and US routing is the opt-in.
+The structural difference between Mistral and US-based providers is data residency by default. With [OpenAI](/blog/chatgpt-data-retention-policy/), [Anthropic](/blog/anthropic-data-retention-policy/), or Google, EU residency is an enterprise opt-in. With Mistral, EU residency is the baseline and US routing is the opt-in.
 
-For organizations in the EU or those operating under GDPR, that reversal is meaningful. It shifts the burden of compliance from your team to Mistral's default configuration.
+For organizations in the EU or operating under GDPR, that reversal matters. It shifts the burden of compliance from your team to Mistral's default config.
 
 ## Use Mistral API to Take Meeting Notes Through Anarlog
 
@@ -60,6 +60,6 @@ For organizations in the EU or those operating under GDPR, that reversal is mean
 
 If you activate ZDR on your Mistral API account, that protection applies to requests made through Anarlog as well. Nothing is stored beyond the time needed to process the result.
 
-And if your data governance requirements change, or a different provider gets approved by your security team, you can switch inside Anarlog without changing how your notes are stored or structured. Your files stay on your device regardless.
+If your data governance requirements change, or a different provider gets approved by your security team, you can switch inside Anarlog without changing how your notes are stored or structured. Your files stay on your device regardless.
 
-[Download Anarlog for macOS](https://anarlog.so/download/apple-silicon) and use the AI provider your security team actually trusts.
+[Download Anarlog for macOS](https://anarlog.so/download/apple-silicon) and use the AI provider your security team trusts.

--- a/apps/web/content/articles/notetakers-for-developers.mdx
+++ b/apps/web/content/articles/notetakers-for-developers.mdx
@@ -8,11 +8,11 @@ category: "Comparisons"
 date: "2026-04-08"
 ---
 
-Most "best note-taking apps" articles are written for project managers and productivity influencers. They'll recommend Notion, show you a Kanban board screenshot, and call it a day. This isn't that article.
+Most "best note-taking apps" articles are written for project managers and productivity influencers. They recommend Notion, show you a Kanban board screenshot, and call it a day. This isn't that article.
 
-If you install tools through Homebrew, keep your dotfiles in a Git repo, and care whether your notes are stored as plain markdown or a proprietary blob, you have different requirements. You want local files you can grep. You want version control that isn't "page history (30 days)." You want a tool that doesn't require an account just to write a thought down.
+If you install tools through Homebrew, keep your dotfiles in a Git repo, and care whether your notes are stored as plain markdown or a proprietary blob, you have different requirements. You want local files you can grep. You want version control that isn't "page history (30 days)". You want a tool that doesn't require an account to write a thought down.
 
-I tested and researched these five tools across developer forums, Hacker News threads, Reddit discussions, and my own workflow. Each one covers a distinct use case. Here's what I found.
+I tested these tools across developer forums, Hacker News threads, Reddit discussions, and my own workflow. Each one covers a distinct use case. Here's what I found.
 
 ## How These Note-Taking Apps for Developers Compare
 
@@ -30,7 +30,7 @@ I tested and researched these five tools across developer forums, Hacker News th
 
 ### 1. Anarlog[a]
 
-[Anarlog](https://anarlog.so) is an open-source AI meeting note-taker that captures system audio directly from your computer, with no bot joining the call and no calendar permissions required. You jot notes in a built-in notepad while it transcribes in the background, then the AI merges both into a structured summary. Everything is stored on your device, and you can bring your own LLM: Ollama, LM Studio, OpenAI, Anthropic, etc.
+[Anarlog](https://anarlog.so) is an open-source AI meeting note-taker that captures system audio from your computer. No bot joins the call. No calendar permissions required. You jot notes in a built-in notepad while it transcribes in the background, and the AI merges both into a structured summary. Everything is stored on your device, and you can bring your own LLM: Ollama, LM Studio, OpenAI, Anthropic, etc.
 
 #### Why devs love it
 
@@ -40,7 +40,7 @@ I tested and researched these five tools across developer forums, Hacker News th
 - Export to Markdown, PDF (with a formatted cover page), JSON, VTT, and Org mode. You can point the storage directory at an Obsidian vault.
 - Record-only mode lets you capture audio now and transcribe it later. Meeting countdown auto-starts recording for calendar events.
 
-#### What’s the catch
+#### What's the catch
 
 - macOS only right now. Windows and Linux builds are planned for Q2 2026.
 - No mobile app. If you need to record a call from your phone, Anarlog can't help yet.
@@ -62,14 +62,14 @@ Free with no limits if you bring your own API key or run local models. For a dev
 - Your notes are just .md files on disk. Claude Code, VS Code, and grep all work on them directly. No API, no MCP, no export step.
 - The plugin ecosystem is enormous: Kanban boards, spaced repetition, Mermaid diagrams, Dataview queries, Git integration, and Vim keybindings.
 - Backlinks and graph view build a map of how your ideas connect over time. You don't organize upfront. You write, link with [[brackets]], and the structure emerges.
-- Canvas mode lets you spatially arrange notes and images on an infinite board for brainstorming architecture or planning sprints.
-- The app is fast. Startup is near-instant even with thousands of notes, which is more than most Electron apps can say.
+- Canvas mode lets you arrange notes and images on an infinite board for brainstorming architecture or planning sprints.
+- The app is fast. Startup is near-instant even with thousands of notes, which most Electron apps can't claim.
 
-#### What’s the catch
+#### What's the catch
 
 - Syncing across devices costs extra. Obsidian Sync starts at $4/month. Many devs use iCloud or Dropbox as a free workaround, but conflict resolution isn't as clean.
 - No real-time collaboration. You can share a vault via Sync, but it's not designed for two people editing the same note simultaneously.
-- The learning curve is real. New users often spend their first week configuring plugins instead of writing notes. The community calls this "plugin paralysis."
+- The learning curve is real. New users often spend their first week configuring plugins instead of writing notes. The community calls this "plugin paralysis".
 
 #### Cost
 
@@ -79,7 +79,7 @@ The core app is free forever, no account required. Obsidian Sync runs $5–10/mo
 
 ![how to use VS Code for notetaking](/api/assets/blog/articles/notetakers-for-developers/image-2.png "anarlog-editor-width=80")
 
-This isn't a product. It's a setup. You create a folder of .md files, open it in VS Code, and version-control it with Git.And if your team needs those markdown files published as shared docs, [GitBook](https://www.gitbook.com) syncs directly with your Git repo and renders them as a polished documentation site. Edit in VS Code, push to GitHub, GitBook handles the rest.
+This isn't a product. It's a setup. You create a folder of .md files, open it in VS Code, and version-control it with Git. If your team needs those markdown files published as shared docs, [GitBook](https://www.gitbook.com) syncs directly with your Git repo and renders them as a documentation site. Edit in VS Code, push to GitHub, GitBook handles the rest.
 
 #### Why devs love it
 
@@ -88,7 +88,7 @@ This isn't a product. It's a setup. You create a folder of .md files, open it in
 - Markdown All in One (5M+ installs) adds TOC generation, list continuation, and formatting shortcuts. markdownlint keeps your files consistent.
 - Side-by-side preview with Cmd+K V. IntelliSense autocompletes file links and headings. Drag-and-drop images just work.
 
-#### What’s the catch
+#### What's the catch
 
 - No mobile access. Your notes live on your laptop, period. Unless you set up something like GitHub Codespaces, you're stuck.
 - No backlinks, no graph view, no knowledge graph. Notes don't know about each other unless you manually link them in markdown.
@@ -96,7 +96,7 @@ This isn't a product. It's a setup. You create a folder of .md files, open it in
 
 #### Cost
 
-Free. VS Code is free. Git is free. A private GitHub repo is free. The only cost is the setup time and the discipline to commit regularly. Several devs automate the commit step with shell scripts or the GitDoc extension, which turns it into a fire-and-forget system.
+Free. VS Code is free, Git is free, a private GitHub repo is free. The only cost is setup time and the discipline to commit regularly. Several devs automate commits with shell scripts or the GitDoc extension, which turns it into a fire-and-forget system.
 
 ### 4. Joplin
 
@@ -111,11 +111,11 @@ Free. VS Code is free. Git is free. A private GitHub repo is free. The only cost
 - The terminal app (joplin) lets you manage notes entirely from the command line. It's the only mainstream note app that ships a TUI.
 - Web clipper for Chrome and Firefox. Evernote import tool that actually works. Markdown with notebook and tag organization.
 
-#### What’s the catch
+#### What's the catch
 
-- The desktop app is Electron and feels like it. It's functional, not fast. Opening a large notebook takes a noticeable beat compared to Obsidian or Apple Notes.
+- The desktop app is Electron and feels like it. Functional, not fast. Opening a large notebook takes a beat compared to Obsidian or Apple Notes.
 - No real-time collaboration. Joplin is a single-player tool. Sharing a note means exporting it.
-- The UI is honest but dated. If you care about visual polish, Joplin will feel utilitarian. The community calls it "function over form."
+- The UI is honest but dated. If you care about visual polish, Joplin will feel utilitarian. The community calls it "function over form".
 
 #### Cost
 
@@ -125,7 +125,7 @@ The app is free and open-source with no feature gates. Joplin Cloud is $5/month 
 
 ![logseq for notetaking](/api/assets/blog/articles/notetakers-for-developers/image-4.png "anarlog-editor-width=80")
 
-[Logseq](https://logseq.com) is an open-source, block-based outliner where every bullet point is a first-class object that can be linked, queried, and embedded anywhere in your knowledge graph. It stores notes as local Markdown or Org-mode files and uses daily journal pages as the main entry point. With 32,000+ GitHub stars and an AGPL license, it's one of the most actively developed PKM tools in the open-source ecosystem.
+[Logseq](https://logseq.com) is an open-source, block-based outliner where every bullet is a first-class object you can link, query, and embed anywhere in your graph. It stores notes as local Markdown or Org-mode files and uses daily journal pages as the entry point. With 32,000+ GitHub stars and an AGPL license, it's one of the most actively developed PKM tools in open source.
 
 #### Why devs love it
 
@@ -134,7 +134,7 @@ The app is free and open-source with no feature gates. Joplin Cloud is $5/month 
 - Built-in flashcards with spaced repetition. Add #card to any bullet and Logseq schedules reviews automatically. Useful for learning new frameworks or prepping for interviews.
 - PDF annotation with Zotero integration. Highlight a passage, and it links directly to your notes. Researchers and devs who read papers will recognize the value immediately.
 
-#### What’s the catch
+#### What's the catch
 
 - Mobile apps are the weak point. The iOS app has a history of crashes and slow loading. It works for quick capture, but extended editing on a phone is frustrating.
 - Sync has been Logseq's biggest friction point. The official Logseq Sync is still in beta. Without it, you're wiring up iCloud, Dropbox, or Git, all of which can cause conflicts if you're not careful.
@@ -157,7 +157,7 @@ Completely free with no feature limits for local use. Logseq Sync is $5/month (b
 - The editor is fast and modern: slash commands, nested collections, drag-and-drop, code blocks, embeds, and a clean reading experience that doesn't feel like a wiki from 2010.
 - REST API + webhooks + 20+ integrations including Slack, Zapier, and SSO via Google, Microsoft, or OIDC. If your team already has an identity provider, Outline slots right in.
 
-#### What’s not there yet
+#### What's not there yet
 
 - No mobile app. Outline works through a responsive web interface, which is functional but not the same as a native app for quick capture on the go.
 - Self-hosting requires Docker, Postgres, Redis, and an external auth provider (OIDC/OAuth). There's no built-in username/password login. If your team doesn't already run an identity provider, the setup is more involved.

--- a/apps/web/content/articles/obsidian-meeting-notes.mdx
+++ b/apps/web/content/articles/obsidian-meeting-notes.mdx
@@ -19,7 +19,7 @@ By the end of this guide you'll have:
 - A meeting note template that auto-fills the date and drops your cursor where you start typing
 - A person note for each colleague that automatically shows every meeting they appeared in
 - Action items you can find across your entire vault in one search
-- A way to get full meeting transcripts and AI summaries into your vault without any copy-pasting — and without your data leaving your machine
+- A way to get full meeting transcripts and AI summaries into your vault without any copy-pasting, and without your data leaving your machine
 
 ## Sources and credit
 
@@ -129,7 +129,7 @@ tags:
 
 Look at what just happened:
 
-- [[Sarah Chen]] appears in multiple places. Her person note now shows this meeting in backlinks — with the surrounding context of what she said, what she decided, and what she owes.
+- [[Sarah Chen]] appears in multiple places. Her person note now shows this meeting in backlinks, with the surrounding context of what she said, what she decided, and what she owes.
 - [[PCI audit]] links to a topic note. If that note doesn't exist yet, that's fine. When the PCI audit becomes important enough to have its own page, every meeting that mentioned it is already connected.
 - The action items use - [ ] task syntax. Obsidian's search can find these directly, and you can narrow it to a specific person.
 
@@ -137,7 +137,7 @@ Look at what just happened:
 
 ![Person note with backlinks panel showing linked meeting notes](/api/assets/blog/articles/obsidian-meeting-notes/image-3-1.png "anarlog-editor-width=80")
 
-Open `Sarah Chen.md` in `People/`. Click the backlinks icon in the right sidebar. Every meeting where you wrote `[[Sarah Chen]]` shows up with surrounding context. You can see what was discussed, what she decided, what she owes — all without maintaining anything.
+Open `Sarah Chen.md` in `People/`. Click the backlinks icon in the right sidebar. Every meeting where you wrote `[[Sarah Chen]]` shows up with surrounding context. You can see what was discussed, what she decided, what she owes, all without maintaining anything.
 
 This is the approach from the [Managing notes for meetings thread](https://forum.obsidian.md/t/managing-notes-for-meetings-and-one-on-ones-effectively/32049) that resonated with the most people. No plugins. No queries. Just links and backlinks doing the work.
 
@@ -150,7 +150,7 @@ filters:
  - 'type = "meeting"'
 ```
 
-Embed this Base in Sarah's person note and it renders a table of every meeting note that links to her, filterable and sortable. This uses Obsidian's built-in Bases feature — no community plugins needed.
+Embed this Base in Sarah's person note and it renders a table of every meeting note that links to her, filterable and sortable. This uses Obsidian's built-in Bases feature, no community plugins needed.
 
 ### Step 6: Create meeting notes fast from your daily note
 
@@ -209,7 +209,7 @@ All March meetings:
 [date:/2026-03/]
 ```
 
-Uses regex on the date property to find all notes with a March 2026 date. Works for any month — change the pattern to match what you need.
+Uses regex on the date property to find all notes with a March 2026 date. Works for any month: change the pattern to match what you need.
 
 Everyone at a specific company:
 
@@ -225,7 +225,7 @@ Searches the `company` property across person notes. Useful when you're preparin
 
 Everything up to this point relies on what you managed to type. In a 30-minute meeting, that's maybe 15% of what was said. The decision that was made at minute 22. The exact phrasing someone used when they pushed back on a deadline. The side comment that turns out to be the most important thing said all week. It's gone unless you happened to write it down.
 
-You need transcription. And if you're the kind of person who chose Obsidian — you chose it because your files live on your machine, in a format you control, with no lock-in — you need transcription that works the same way.
+You need transcription. And if you're the kind of person who chose Obsidian (you chose it because your files live on your machine, in a format you control, with no lock-in) you need transcription that works the same way.
 
 Most meeting transcription tools don't. They store your data on their servers. They require monthly subscriptions. They join your call as a bot. They lock your transcripts in a proprietary format you can't move.
 

--- a/apps/web/content/articles/open-source-meeting-transcription-software.mdx
+++ b/apps/web/content/articles/open-source-meeting-transcription-software.mdx
@@ -32,7 +32,7 @@ We'll compare Anarlog, Meetily, and Amical—the only three open-source meeting 
 
 ### 1. Anarlog
 
-[Anarlog](/) is an open-source AI notepad for meetings that gives you complete control over your data and AI stack. Everything is stored as plain markdown files.
+[Anarlog](/) is an open-source AI notepad for meetings that gives you full control over your data and AI stack. Everything is stored as plain markdown files.
 
 The interface works like Apple Notes. You open it and start typing. No list of past meetings to navigate, no calendar integration. Just a blank canvas ready to use.
 
@@ -44,7 +44,7 @@ While you're writing, Anarlog listens to both your microphone and system audio. 
 
 #### **Top Features**
 
-- Multiple deployment options: keep everything on your device, deploy on your own servers, or use the managed cloud service
+- Several deployment options: keep everything on your device, deploy on your own servers, or use the managed cloud service
 - Real-time transcription with no bots or calendar permissions required
 - Works with Zoom, Teams, Google Meet, and in-person meetings without any setup
 - Your choice of AI: managed cloud, bring your own API keys (OpenAI, Anthropic, Mistral, and others), or run local models via Ollama or LM Studio
@@ -89,7 +89,7 @@ Free forever for local transcription, BYOK, and all core features. Enterprise of
 - **Dual audio capture** records both microphone and system audio simultaneously with intelligent ducking and clipping prevention.
 - **GPU acceleration support** automatically detects and uses hardware acceleration: Metal/CoreML on macOS, CUDA for NVIDIA, Vulkan for AMD/Intel.
 - **Semantic search via ChromaDB** enables searching by concepts and related discussions, not just exact keywords.
-- **Universal meeting platform support** works with Zoom, Teams, Google Meet, Webex, and any platform without requiring bots.
+- **Wide meeting platform support** works with Zoom, Teams, Google Meet, Webex, and any platform without requiring bots.
 - **SQLite local storage** keeps all data locally in a lightweight database that's easy to back up and migrate.
 - **REST API access** exposes endpoints for integrating with other tools and workflows.
 
@@ -155,7 +155,7 @@ Completely free with no paid tiers.
 
 ## Which open-source transcription tool should you choose?
 
-For most developers and privacy-conscious professionals, **Anarlog** stands out. It delivers zero lock-in with complete control over your data and AI stack. Plain markdown files work with any tool, you choose your AI provider, and the manual note integration gives you control over what the AI focuses on.
+For most developers and privacy-conscious professionals, **Anarlog** stands out. It delivers zero lock-in with full control over your data and AI stack. Plain markdown files work with any tool, you choose your AI provider, and the manual note integration gives you control over what the AI focuses on.
 
 The code is open source under the MIT license, so you can verify exactly how your data is processed. Need enterprise deployment? Self-host it on your own infrastructure. Want to modify the summarization logic? Fork it and make it yours.
 
@@ -185,7 +185,7 @@ With larger Whisper models, accuracy typically reaches 90-95% for clear English 
 
 ### 5. What about HIPAA, GDPR, and compliance?
 
-Because processing happens locally by default, these tools simplify compliance significantly. Your data doesn't leave your device, so you're not transmitting protected information to third-party processors. This makes HIPAA, GDPR, SOC 2, and other frameworks much easier to satisfy.
+Because processing happens locally by default, these tools simplify compliance. Your data doesn't leave your device, so you're not transmitting protected information to third-party processors. This makes HIPAA, GDPR, SOC 2, and other frameworks easier to satisfy.
 
 Organizations needing formal compliance documentation can use Anarlog or Meetily's enterprise plans, which include dedicated support.
 

--- a/apps/web/content/articles/openrouter-data-retention-policy.mdx
+++ b/apps/web/content/articles/openrouter-data-retention-policy.mdx
@@ -24,7 +24,7 @@ Your actual conversation content is not retained by OpenRouter unless you specif
 
 OpenRouter offers a 1% discount on usage costs in exchange for enabling prompt logging. If you turn this on, OpenRouter stores your prompts and completions.
 
-There is a significant term attached to this. [OpenRouter's privacy policy](https://openrouter.ai/privacy) states that enabling prompt logging grants OpenRouter an irrevocable right to commercial use of those inputs and outputs. That language is broader than most providers use. It means logged data could be used for purposes beyond just displaying your history in the dashboard.
+There is a notable term attached to this. [OpenRouter's privacy policy](https://openrouter.ai/privacy) states that enabling prompt logging grants OpenRouter an irrevocable right to commercial use of those inputs and outputs. That language is broader than most providers use. It means logged data could be used for purposes beyond just displaying your history in the dashboard.
 
 If you are evaluating OpenRouter for any use case involving confidential information, sensitive conversations, or regulated data, do not enable prompt logging. The 1% discount is not worth the data rights you are granting.
 
@@ -54,7 +54,7 @@ EU routing is not enabled by default and requires an enterprise account configur
 
 OpenRouter does not publish a HIPAA Business Associate Agreement. If your use case involves protected health information, OpenRouter is not the right routing layer without a BAA in place. The same applies to other regulated data categories.
 
-For compliance-sensitive deployments, the multi-provider nature of OpenRouter adds complexity. You are not just evaluating OpenRouter's compliance posture but also the compliance posture of every provider your requests might be routed to. Unless you lock routing to a specific provider with known compliance certifications, the compliance surface is difficult to bound.
+For compliance-sensitive deployments, the multi-provider nature of OpenRouter adds complexity. You are not just evaluating OpenRouter's compliance posture but also the compliance posture of every provider your requests might be routed to. Unless you lock routing to a specific provider with known compliance certifications, the compliance surface is hard to bound.
 
 ## **When OpenRouter Works for Sensitive Work and When It Does Not**
 
@@ -62,7 +62,7 @@ OpenRouter's value is flexibility and cost optimization across providers. For no
 
 For sensitive work, the two-layer data question requires more active management. You need to be specific about which provider your requests go to, verify that provider's data policy, confirm that OpenRouter ZDR is enabled, and ensure prompt logging is off. That is manageable, but it requires deliberate configuration rather than relying on defaults.
 
-The defaults at OpenRouter are reasonably privacy-conscious. Prompts are not logged out of the box. But the flexibility that makes OpenRouter useful also makes its data handling harder to audit than a direct provider relationship.
+The defaults at OpenRouter are reasonably privacy-conscious. Prompts are not logged out of the box. But the same flexibility that makes OpenRouter useful also makes its data handling harder to audit than a direct provider relationship.
 
 ## Use OpenRouter to Take AI Notes Through Anarlog
 

--- a/apps/web/content/articles/organize-meeting-notes.mdx
+++ b/apps/web/content/articles/organize-meeting-notes.mdx
@@ -17,7 +17,7 @@ Most people capture meeting notes fine. Finding them three weeks later is the pr
 
 Before building any system on top, most people underuse what their note-taking app already gives them. Conversational search. Summaries that pull out decisions and action items. Templates for recurring meetings. Anarlog, Otter, Granola, Fireflies - all of them have this to some degree.
 
-Start there. Search is good enough now that a lot of organizational overhead simply isn't necessary anymore. Most things you'd want to find are one query away.
+Start there. Search is good enough now that most organizational overhead isn't necessary. Most things you'd want to find are one query away.
 
 ### **If You're Using Anarlog, You're Already at an Advantage**
 

--- a/apps/web/content/articles/otter-ai-alternatives.mdx
+++ b/apps/web/content/articles/otter-ai-alternatives.mdx
@@ -6,11 +6,11 @@ category: "Comparisons"
 date: "2025-08-11"
 ---
 
-While [Otter.ai](/blog/otter-ai-review/) has established itself as a popular meeting transcription tool, teams that prioritize data privacy and security often find it unsuitable for their needs.
+[Otter.ai](/blog/otter-ai-review/) is a popular meeting transcription tool, but teams that prioritize data privacy and security often find it unsuitable.
 
-If you need better accuracy, offline capabilities, or want to keep sensitive conversations off cloud servers, several alternatives are worth evaluating.
+If you need better accuracy, offline capabilities, or want to keep sensitive conversations off cloud servers, several alternatives are worth a look.
 
-This guide reviews 14 Otter AI alternatives, from zero-lock-in open-source solutions to enterprise platforms with advanced analytics.
+This guide reviews 14 Otter AI alternatives, from zero-lock-in open-source tools to enterprise platforms with analytics.
 
 ## Quick comparison: top Otter AI alternatives
 
@@ -39,9 +39,9 @@ The most common pain points we found include:
 
 ### 1. Privacy and data control concerns
 
-[Otter.ai's privacy policy](https://otter.ai/privacy-policy) indicates they transfer data across international borders to partners and service providers, subjecting conversations to different privacy laws and regulatory frameworks depending on where those partners operate.
+[Otter.ai's privacy policy](https://otter.ai/privacy-policy) says they transfer data across international borders to partners and service providers. That means your conversations fall under different privacy laws depending on where those partners operate.
 
-This creates compliance complexity: organizations must ensure adherence to privacy regulations across multiple countries rather than maintaining local control.
+Compliance gets messy fast. You're tracking privacy rules across multiple countries instead of keeping things local.
 
 Otter also shares data with third-party vendors and uses customer conversations for AI model training, even when de-identified.
 
@@ -51,7 +51,7 @@ Also read about [Otter AI's recent class-action lawsuit and privacy concerns](/b
 
 ### 2. Bot dependence and intrusiveness
 
-Otter.ai requires meeting bots to join Zoom, Teams, or Google Meet calls to record and transcribe. Many users find this intrusive—especially in client-facing meetings where an unfamiliar "bot participant" suddenly appears.
+Otter.ai sends a bot into Zoom, Teams, or Google Meet to record and transcribe. Users find this intrusive, especially in client-facing meetings where an unfamiliar "bot participant" shows up uninvited.
 
 Bot-based assistants also create compliance hurdles in finance and healthcare, where explicit participant consent is mandatory.
 
@@ -66,25 +66,25 @@ Source: [G2](https://www.g2.com/products/otter-ai/reviews/otter-ai-review-986071
 
 ### 4. Language support gaps
 
-[International teams](https://cybernews.com/ai-tools/otter-ai-review/) report significant limitations with Otter AI's support for only English, Spanish, and French, compared to competitors offering 40+ languages. Global organizations with diverse linguistic needs find this restrictive.
+[International teams](https://cybernews.com/ai-tools/otter-ai-review/) hit a wall with Otter AI's three-language support (English, Spanish, French) when competitors offer 40+. Global organizations find this too narrow.
 
 ### 5. Internet dependency
 
-Teams working in locations with poor connectivity or needing offline capabilities find Otter AI's requirement for stable internet connection for live transcription limiting.
+Otter AI needs a stable internet connection for live transcription. Teams in locations with poor connectivity or anyone needing offline capabilities are out of luck.
 
 <Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-3.webp" alt="does otter ai work offline"/>
 Source: [G2](https://www.g2.com/products/otter-ai/reviews/otter-ai-review-10454595)
 
 ### 6. Cost escalation for teams
 
-Advanced features are locked behind higher-tier subscriptions. Organizations with heavy usage requirements report costs escalating quickly.
+Advanced features are locked behind higher-tier subscriptions. Heavy users report costs escalating fast.
 
 <Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-4.webp" alt="otter ai cost"/>
 Source: [G2](https://www.g2.com/products/otter-ai/reviews/otter-ai-review-10454595)
 
 ### 7. Accuracy and speaker identification issues
 
-Speaker identification accuracy issues become problematic in multi-speaker environments where precise attribution is critical for follow-up actions and accountability.
+Speaker identification breaks down in multi-speaker meetings, where accurate attribution drives follow-ups and accountability.
 
 <Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-5.webp" alt="otter ai accuracy issues"/>
 Source: [G2](https://www.g2.com/products/otter-ai/reviews/otter-ai-review-10454595)
@@ -97,15 +97,15 @@ Source: [G2](https://www.g2.com/products/otter-ai/reviews/otter-ai-review-104545
 
 #### How it compares to Otter AI:
 
-[Anarlog](/) is an open-source AI notepad for meetings built for high-agency people who demand complete control over their data and AI stack.
+[Anarlog](/) is an open-source AI notepad for meetings, built for people who want full control over their data and AI stack.
 
-The interface resembles Apple Notes, and everything is stored as plain markdown files on your device—not in proprietary databases. No bots joining your calls, no vendor lock-in.
+The interface resembles Apple Notes. Everything is stored as plain markdown files on your device, not in a proprietary database. No bots joining your calls, no vendor lock-in.
 
-Launch a meeting and the AI assistant transcribes speech in real-time. When the meeting ends, it presents a structured summary with key decisions, action items, and discussion themes automatically extracted.
+Start a meeting and the AI transcribes in real-time. When it ends, you get a structured summary with decisions, action items, and discussion themes pulled out automatically.
 
-You choose your AI stack: use the managed cloud service, bring your own API keys (OpenAI, Deepgram, Anthropic), or run local models via Ollama. Otter AI locks you into their cloud with no way to switch.
+You pick your AI stack: managed cloud, your own API keys (OpenAI, Deepgram, Anthropic), or local models via Ollama. Otter AI locks you into its cloud with no way to switch.
 
-You trade Otter's real-time collaboration features for zero lock-in, true file ownership, and complete control over your workflow. Your notes work with any tool—Obsidian, Notion, VS Code—because they're just markdown files.
+You give up Otter's real-time collaboration features in exchange for zero lock-in and full file ownership. Your notes work with any tool — Obsidian, Notion, VS Code — because they're just markdown files.
 
 #### Key advantages over Otter AI:
 
@@ -128,9 +128,9 @@ You trade Otter's real-time collaboration features for zero lock-in, true file o
 
 #### How it compares to Otter AI:
 
-[Fireflies](https://fireflies.ai/) addresses Otter.ai's language limitations. Otter AI supports only 3 languages, making it unsuitable for global organizations. Fireflies offers 69+ languages while also providing the advanced conversation intelligence that Otter AI lacks.
+[Fireflies](https://fireflies.ai/) covers Otter.ai's language gap. Otter supports 3 languages; Fireflies handles 69+, plus deeper conversation intelligence Otter lacks.
 
-Both tools use meeting bots, which may concern people preferring less intrusive AI assistants.
+Both tools use meeting bots, which may put off people who want a less intrusive AI assistant.
 
 #### Key advantages over Otter AI:
 
@@ -152,9 +152,9 @@ Both tools use meeting bots, which may concern people preferring less intrusive 
 
 #### How it compares to Otter AI:
 
-[Rev](https://www.rev.com/) solves Otter AI's accuracy limitations. While Otter relies solely on AI transcription with 85% accuracy, Rev offers both AI (96%+) and human transcription (99% accuracy) options.
+[Rev](https://www.rev.com/) closes Otter's accuracy gap. Otter sticks to AI transcription at 85% accuracy. Rev offers AI (96%+) or human transcription (99%).
 
-This matters for legal, healthcare, and journalism professionals who cannot tolerate transcription errors from Otter's AI-only approach.
+This matters for legal, healthcare, and journalism work where errors aren't acceptable.
 
 #### Key advantages over Otter AI:
 
@@ -176,13 +176,13 @@ This matters for legal, healthcare, and journalism professionals who cannot tole
 
 #### How it compares to Otter AI:
 
-[Tactiq](https://tactiq.io/) works directly in your browser rather than as a separate app.
+[Tactiq](https://tactiq.io/) runs directly in your browser instead of as a separate app.
 
-This browser-first design eliminates the need to download additional software like Otter AI requires, but creates dependency on Chrome that limits flexibility.
+That removes the need to install software, but ties you to Chrome.
 
-The privacy philosophy differs significantly—Tactiq transcribes without storing audio files, addressing privacy concerns some users have with Otter's comprehensive recording approach.
+Tactiq also transcribes without storing audio files, which sidesteps privacy concerns Otter's full-recording model creates.
 
-This privacy-focused design means sacrificing Otter's ability to playback meetings or share recordings with absent team members.
+The trade-off: no playback, no sharing recordings with team members who missed the meeting.
 
 #### Key advantages over Otter AI:
 
@@ -205,9 +205,9 @@ This privacy-focused design means sacrificing Otter's ability to playback meetin
 
 #### How it compares to Otter AI:
 
-[Fathom](https://www.fathom.ai/) directly challenges Otter AI's freemium limitations. While Otter AI restricts free users to 300 minutes monthly and basic features, Fathom provides unlimited recording, transcription, and AI summaries at no cost.
+[Fathom](https://www.fathom.ai/) takes a swing at Otter's freemium limits. Otter caps free users at 300 minutes a month with basic features. Fathom gives you unlimited recording, transcription, and AI summaries for free.
 
-In its "Teams Edition," Fathom offers conversation intelligence features typically found in expensive tools like Gong. Otter AI remains focused on basic meeting documentation.
+The "Teams Edition" includes conversation intelligence features usually found in pricier tools like Gong. Otter stays focused on basic meeting documentation.
 
 #### Key advantages over Otter AI:
 
@@ -229,11 +229,11 @@ In its "Teams Edition," Fathom offers conversation intelligence features typical
 
 #### How it compares to Otter AI:
 
-[Notta](https://www.notta.ai/) solves Otter's language support limitation.
+[Notta](https://www.notta.ai/) covers Otter's language gap.
 
-Otter's three-language restriction makes it unsuitable for international organizations, while Notta supports 58 languages with real-time translation capabilities.
+Otter's three-language limit rules it out for international teams. Notta supports 58 languages and adds real-time translation.
 
-The trade-off involves ecosystem maturity—Otter AI offers more established integrations and collaborative features, while Notta focuses on superior multilingual accuracy.
+The trade-off is ecosystem maturity. Otter has more established integrations and collaborative features. Notta is built for multilingual accuracy.
 
 #### Key advantages over Otter AI:
 
@@ -255,11 +255,11 @@ The trade-off involves ecosystem maturity—Otter AI offers more established int
 
 #### How it compares to Otter AI:
 
-[MeetGeek](https://meetgeek.ai/) goes beyond Otter's basic transcription and summary by automatically understanding meeting context.
+[MeetGeek](https://meetgeek.ai/) goes past Otter's basic transcription by reading meeting context automatically.
 
-Otter AI treats every meeting the same way. MeetGeek intelligently detects whether you're in a sales call, HR interview, or team standup, then applies appropriate templates and workflows.
+Otter treats every meeting the same. MeetGeek detects whether you're in a sales call, HR interview, or team standup, then applies the right template and workflow.
 
-This contextual intelligence means less manual post-meeting work compared to Otter's generic output, though it requires more initial setup and learning to fully utilize advanced automation features.
+Less manual post-meeting work, but more setup and a steeper learning curve for the automation features.
 
 #### Key advantages over Otter AI:
 
@@ -281,11 +281,11 @@ This contextual intelligence means less manual post-meeting work compared to Ott
 
 #### How it compares to Otter AI:
 
-[Dialpad](https://www.dialpad.com/) positions transcription as part of a complete business communications platform. Otter AI focuses solely on meeting documentation.
+[Dialpad](https://www.dialpad.com/) bundles transcription into a full business communications platform. Otter sticks to meeting documentation.
 
-Dialpad users get unified voice, video, messaging, and contact center capabilities alongside transcription, but pay significantly more than Otter's meeting-focused pricing.
+Dialpad gives you unified voice, video, messaging, and contact center alongside transcription, at a much higher price than Otter.
 
-For organizations already using multiple communication tools, Dialpad consolidates functionality that Otter AI cannot provide, though it may be overkill for teams only needing meeting transcription.
+If you're already running multiple communication tools, Dialpad consolidates them. If you just need meeting transcription, it's overkill.
 
 #### Key advantages over Otter AI:
 
@@ -307,9 +307,9 @@ For organizations already using multiple communication tools, Dialpad consolidat
 
 #### How it compares to Otter AI:
 
-[Avoma](https://www.avoma.com/) transforms meeting transcripts into revenue intelligence. Otter.ai stops at basic documentation.
+[Avoma](https://www.avoma.com/) turns meeting transcripts into revenue intelligence. Otter.ai stops at basic documentation.
 
-Otter AI provides generic summaries. Avoma automatically identifies objections, tracks deal progression, and generates sales coaching insights. This makes Avoma invaluable for revenue teams frustrated with Otter's inability to connect meeting content to business outcomes, though the specialized focus and higher pricing make it less suitable for general meeting documentation needs.
+Otter gives you generic summaries. Avoma flags objections, tracks deal progression, and generates sales coaching insights. Useful for revenue teams who need meeting content tied to business outcomes. The specialized focus and higher pricing make it a bad fit for general meeting documentation.
 
 #### Key advantages over Otter AI:
 
@@ -331,11 +331,11 @@ Otter AI provides generic summaries. Avoma automatically identifies objections, 
 
 #### How it compares to Otter AI:
 
-[Grain](https://grain.com/) prioritizes video content creation over text transcription, making it ideal for teams who need to share meeting clips rather than read summaries.
+[Grain](https://grain.com/) puts video clips ahead of text transcription. Good for teams that share clips instead of reading summaries.
 
-Otter AI focuses on searchable text and collaborative editing. Grain excels at creating shareable video highlights with timestamps for visual learners and content creators.
+Otter focuses on searchable text and collaborative editing. Grain is built for shareable video highlights with timestamps.
 
-This video-first approach trades some of Otter's text analysis capabilities for superior visual meeting documentation and clip sharing.
+You trade some text analysis depth for better video documentation and clip sharing.
 
 #### Key advantages over Otter AI:
 
@@ -357,9 +357,9 @@ This video-first approach trades some of Otter's text analysis capabilities for 
 
 #### How it compares to Otter AI:
 
-Otter AI focuses primarily on transcription and basic note-taking. [Sembly AI](https://www.sembly.ai/) positions itself as a comprehensive meeting intelligence platform.
+Otter sticks to transcription and basic note-taking. [Sembly AI](https://www.sembly.ai/) is a meeting intelligence platform.
 
-Sembly analyzes deeper, creating structured insights, action items, and complex artifacts like project plans and requirements documents. Otter AI excels at accurate transcription but lacks Sembly's advanced document generation.
+Sembly digs deeper: structured insights, action items, and complex artifacts like project plans and requirements docs. Otter is better at clean transcription but doesn't generate documents like Sembly does.
 
 #### Key advantages over Otter AI:
 
@@ -384,9 +384,9 @@ Sembly analyzes deeper, creating structured insights, action items, and complex 
 
 #### How it compares to Otter AI:
 
-[Descript](https://www.descript.com/) combines transcription with comprehensive audio and video editing tools. Otter focuses purely on meeting documentation. Descript works better for podcast creators, video producers, and content teams who need to edit their recordings, not just transcribe them.
+[Descript](https://www.descript.com/) pairs transcription with full audio and video editing. Otter sticks to meeting documentation. Descript fits podcast creators, video producers, and content teams who need to edit recordings, not just transcribe them.
 
-This expanded functionality comes with complexity and higher pricing that exceeds what most teams need for simple meeting notes—an area where Otter AI's focused approach provides better value.
+That extra functionality brings complexity and higher pricing than most teams need for simple meeting notes. Otter's focused approach is the better deal there.
 
 #### Key advantages over Otter AI:
 
@@ -408,13 +408,13 @@ This expanded functionality comes with complexity and higher pricing that exceed
 
 #### How it compares to Otter AI:
 
-[Jamie AI](https://www.meetjamie.ai/) addresses privacy and compliance concerns that European organizations have with US-based tools like Otter AI.
+[Jamie AI](https://www.meetjamie.ai/) handles the privacy and compliance concerns European organizations raise with US-based tools like Otter.
 
-Otter processes data in the cloud and uses meeting bots that can feel intrusive. Jamie operates without bots and stores all data within EU servers in Frankfurt with strict GDPR compliance.
+Otter processes data in the cloud and uses meeting bots that can feel intrusive. Jamie skips the bots and stores all data on EU servers in Frankfurt under strict GDPR compliance.
 
-Jamie works both online and offline, making it ideal for in-person meetings or areas with poor connectivity. Otter AI requires stable internet.
+Jamie works online or offline, which fits in-person meetings and areas with poor connectivity. Otter needs stable internet.
 
-The key trade-off is real-time collaboration—Otter AI offers live editing and team features, while Jamie focuses on post-meeting processing and individual productivity.
+The trade-off is real-time collaboration. Otter has live editing and team features. Jamie is built for post-meeting processing and individual productivity.
 
 #### Key advantages over Otter AI:
 
@@ -436,11 +436,11 @@ The key trade-off is real-time collaboration—Otter AI offers live editing and 
 
 #### How it compares to Otter AI:
 
-Otter only offers video recording on Enterprise plans. [tl;dv](https://tldv.io/) provides unlimited video recordings, transcriptions, and automated notes for free.
+Otter only offers video recording on Enterprise plans. [tl;dv](https://tldv.io/) gives you unlimited video recordings, transcriptions, and automated notes for free.
 
-tl;dv excels at creating video clips directly from transcripts and timestamped highlights. Otter AI requires users to upgrade to expensive enterprise tiers for basic video functionality.
+tl;dv is built for video clips pulled directly from transcripts and timestamped highlights. Otter forces you onto an expensive enterprise tier for basic video.
 
-Otter offers better transcript editing capabilities and mobile functionality that tl;dv currently lacks.
+Otter still wins on transcript editing and mobile functionality, where tl;dv is weaker.
 
 #### Key advantages over Otter AI:
 
@@ -459,14 +459,14 @@ Otter offers better transcript editing capabilities and mobile functionality tha
 
 ## Why Anarlog stands out
 
-While each alternative has strengths, **Anarlog** offers a unique value proposition: **zero lock-in and complete control**.
+Every alternative here has strengths. **Anarlog** is the only one built around **zero lock-in and full control**.
 
 ✅ **Zero lock-in** - Plain markdown files, open source, portable format that works with any tool
-✅ **Complete control** - Choose your AI stack: managed cloud, bring your own keys, or run fully local
+✅ **Full control** - Choose your AI stack: managed cloud, bring your own keys, or run fully local
 ✅ **True ownership** - Your files live on your device, not in someone's database
-✅ **Simple but powerful** - Complete control without complexity
+✅ **Simple but powerful** - Full control without complexity
 ✅ **Cost-effective** - No recurring fees for basic functionality
 
-Whether you're an engineer who wants files over apps, a privacy-conscious professional in regulated industries, or someone whose company has banned cloud tools like Otter—Anarlog gives you ownership at the foundational level.
+If you're an engineer who prefers files over apps, a privacy-conscious professional in a regulated industry, or someone whose company has banned cloud tools like Otter, Anarlog gives you ownership at the foundation.
 
-**Ready to take control?** [Download Anarlog](https://anarlog.so) and experience meeting notes with zero lock-in.
+**Ready to take control?** [Download Anarlog](https://anarlog.so) and try meeting notes with zero lock-in.

--- a/apps/web/content/articles/otter-ai-review.mdx
+++ b/apps/web/content/articles/otter-ai-review.mdx
@@ -8,9 +8,9 @@ ready_for_review: true
 date: "2026-02-11"
 ---
 
-After using Otter AI across 200+ meetings, including sensitive client calls and chaotic team standups, I've learned what the marketing materials won't tell you.
+After using Otter AI across 200+ meetings, including sensitive client calls and chaotic team standups, I've seen what the marketing won't tell you.
 
-Otter AI offers a free tier with significant limitations. Safety is complicated—there's a 2025 lawsuit and privacy concerns worth understanding. This review covers pricing (including hidden costs), features that actually work, transcription accuracy, privacy issues, and alternatives I've tested.
+The free tier is heavily capped. Safety is complicated — there's a 2025 lawsuit and real privacy concerns worth understanding. This review covers pricing (including hidden costs), features that actually work, transcription accuracy, privacy, and alternatives I've tested.
 
 ## How does Otter AI work?
 
@@ -19,9 +19,9 @@ Otter AI offers a free tier with significant limitations. Safety is complicated�
 3. It records everything and sends audio to Otter AI's cloud servers
 4. You get a transcript, summary, and action items 2 hours later
 
-I find bots intrusive. In practice, people become more guarded, speak less candidly, and conversation flows suffer.
+Bots are intrusive. People get guarded, speak less candidly, and conversation suffers.
 
-Beyond the social awkwardness is technical dependency. Otter AI's bot requires stable internet connectivity and proper permissions. I've seen it fail to join meetings due to calendar sync issues, get kicked out by overzealous hosts, or simply not work with certain enterprise meeting configurations. When the bot doesn't join, you have no transcript and no backup recording happening locally. This is why I prefer bot-free meeting assistants.
+Beyond the social cost is the technical dependency. Otter's bot needs stable internet and the right permissions. I've watched it fail to join over calendar sync issues, get kicked out by hosts, or refuse to work with certain enterprise meeting configurations. When the bot doesn't join, you have no transcript and no local backup. That's why I prefer bot-free meeting assistants.
 
 ## What platforms does Otter AI support?
 
@@ -33,13 +33,13 @@ Otter AI works with:
 - Mobile apps for iOS/Android (requires internet)
 - Browser extensions
 
-Otter AI requires constant internet connectivity. During a venue walkthrough with spotty WiFi, it captured 12 minutes of a 45-minute conversation. There's no offline mode.
+Otter needs constant internet. During a venue walkthrough with spotty WiFi, it captured 12 minutes out of 45. No offline mode.
 
 ## What languages does Otter support?
 
-Otter AI transcribes only 3 languages: English, Spanish, and French.
+Otter transcribes only 3 languages: English, Spanish, French.
 
-For international teams, this becomes a dealbreaker. A weekly check-in with German partners means no Otter AI. A client call with Japanese stakeholders gets no transcription.
+For international teams, that's a dealbreaker. A weekly check-in with German partners? No Otter. A client call with Japanese stakeholders? No transcription.
 
 ## Otter meeting assistant features & how I would grade them
 
@@ -64,19 +64,19 @@ For international teams, this becomes a dealbreaker. A weekly check-in with Germ
 
 ### 1. Real-time transcription (Grade: B-)
 
-Live transcription appears within 2-3 seconds of speech, which helps when following fast-paced discussions. Accuracy drops to 60-70% with background noise. Technical terms are consistently wrong ("Kubernetes" becomes "communitas"). It fails completely with heavy accents.
+Live transcription appears within 2-3 seconds of speech, which helps in fast-paced discussions. Accuracy drops to 60-70% with background noise. Technical terms come out wrong consistently ("Kubernetes" becomes "communitas"). Heavy accents break it entirely.
 
 ### 2. Meeting summary (Grade: B+)
 
-Otter.ai generates automated summaries broken into chapters with timestamps. Email summaries arrive within 2 hours (usually 45 minutes in my experience). The chapter breakdown makes long meetings navigable. Action item extraction catches about 70-80% of commitments.
+Otter generates automated summaries broken into chapters with timestamps. Email summaries land within 2 hours, usually 45 minutes in my experience. Chapter breakdowns make long meetings navigable. Action item extraction catches about 70-80% of commitments.
 
-The frustration: summaries for technical discussions turn generic. "The team discussed system architecture" instead of actual details. Nuanced decisions in complex strategy calls get missed, and there's no way to customize summary format or depth.
+The frustration: technical discussions get generic summaries. "The team discussed system architecture" instead of actual details. Strategy calls lose nuance, and there's no way to customize summary format or depth.
 
 ### 3. Slide and screen capture (Grade: A-)
 
-The automatic screenshot feature worked surprisingly well. During product demos, it captured 90% of slides without manual input. Visual context embedded in transcripts saved me hours when reviewing what was actually shown versus what was said.
+The automatic screenshot feature worked better than I expected. During product demos, it captured 90% of slides without manual input. Visual context inside the transcript saved me hours when reviewing what was actually shown versus what was said.
 
-One caution: it captures everything on screen, including private Slack messages or emails if you forget to pause screen sharing. I almost leaked internal metrics to a client once.
+One warning: it captures everything on screen, including private Slack messages or emails if you forget to pause screen sharing. I almost leaked internal metrics to a client once.
 
 ### 4. Otter Chat / AI assistant (Grade: C+)
 
@@ -84,11 +84,11 @@ The AI assistant handles basic questions like "What were the main action items?"
 
 ### 5. Speaker identification (Grade: D)
 
-Speaker identification is Otter.ai's weakest feature. In a 10-person team meeting, it misidentified speakers 30% of the time and confused two people with similar voices throughout, requiring 15 minutes of manual correction afterward. Even in simple two-person calls, it occasionally attributed my words to the other person. For meeting minutes you'll actually share, plan on extensive editing.
+Speaker identification is Otter's weakest feature. In a 10-person team meeting, it misidentified speakers 30% of the time and confused two people with similar voices, requiring 15 minutes of manual cleanup. Even in two-person calls, it sometimes attributed my words to the other person. For meeting minutes you'll actually share, plan on heavy editing.
 
 ### 6. Otter channels & workspaces (Grade: B)
 
-Team collaboration features worked adequately for organizing meetings by project. I created separate channels for client work (private), internal strategy (public to team), and all-hands meetings (public). The permissions system is straightforward, though not as flexible as some Otter.ai alternatives.
+Team collaboration is adequate for organizing meetings by project. I set up separate channels for client work (private), internal strategy (public to team), and all-hands (public). Permissions are straightforward, though less flexible than some Otter alternatives.
 
 ### 7. Third-party integrations (Grade: B-)
 
@@ -98,21 +98,21 @@ Alternatives like Fireflies offer deeper CRM integration and workflow automation
 
 ### 8. Calendar integration (Grade: A)
 
-Otter.ai nails calendar integration. It detected 98% of scheduled meetings, joined automatically without manual intervention, and updated meeting details if the calendar changed. Truly set-it-and-forget-it functionality.
+Otter nails calendar integration. It detected 98% of scheduled meetings, joined automatically, and updated meeting details when the calendar changed. Set-it-and-forget-it.
 
-One minor issue: it occasionally joined recurring meetings I'd removed from the series.
+One minor issue: it sometimes joined recurring meetings I'd removed from the series.
 
 ### 9. Mobile app recording (Grade: B-)
 
-Recording in-person meetings from phone works, and transcripts sync across devices. It requires an internet connection (can record offline but won't transcribe until online), causes significant battery drain during long recordings, and the UI feels cramped for editing transcripts. You'll want to review and edit on a desktop.
+Recording in-person meetings from phone works, and transcripts sync across devices. It needs internet (can record offline but won't transcribe until online), drains battery hard on long recordings, and the UI is cramped for editing transcripts. Review and edit on desktop.
 
 ### 10. Search & playback (Grade: B+)
 
-Keyword search across hundreds of meetings is fast. Clicking any word in the transcript jumps audio to that moment. Variable playback speed (1.5x-2x) saved tons of review time. Advanced search operators are limited. You can't search "phrase in quotes AND keyword," and there's no way to filter by meeting duration, participant count, or date range easily.
+Keyword search across hundreds of meetings is fast. Clicking any word in the transcript jumps audio to that moment. Variable playback speed (1.5x-2x) saved tons of review time. Advanced search operators are limited. You can't search "phrase in quotes AND keyword", and you can't easily filter by meeting duration, participant count, or date range.
 
 ### 11. File upload & transcription (Grade: C+)
 
-Upload pre-recorded audio or video files for transcription. The problem: the free plan gets 3 lifetime uploads (then done forever), the Pro plan gets 10 uploads per month, and unlimited is locked to the Business tier. Having "lifetime limits" on a free tier is absurd. Ten per month on a $17/month plan feels stingy. This should be unlimited on Pro.
+Upload pre-recorded audio or video files for transcription. The problem: free plan gets 3 lifetime uploads (forever), Pro gets 10 per month, and unlimited is locked to Business. "Lifetime limits" on a free tier is absurd. Ten per month on a $17/month plan is stingy. Should be unlimited on Pro.
 
 ### 12. Export options (Grade: B)
 
@@ -122,31 +122,31 @@ Missing: direct export to Google Docs, customization options (remove speakers, k
 
 ### 13. Vocabulary customization (Grade: B)
 
-Add custom words for better transcription accuracy with company names, product names, and technical terms. After adding "Kubernetes", "PostgreSQL", and "Supabase", accuracy improved 10-15% for jargon-heavy meetings.
+Add custom words for better transcription on company names, product names, and technical terms. After adding "Kubernetes", "PostgreSQL", and "Supabase", accuracy improved 10-15% for jargon-heavy meetings.
 
-However, I had to manually add every term (no bulk upload), and it sometimes ignored custom vocabulary anyway.
+I had to add every term manually (no bulk upload), and it sometimes ignored custom vocabulary anyway.
 
 ### 14. Live collaboration & comments (Grade: C+)
 
-Team members can comment on transcripts at specific timestamps and @mention others for follow-up. It works for basic collaboration, but comments don't integrate with task management tools, there's no way to mark comments as resolved, and notifications become overwhelming with active teams.
+Team members can comment on transcripts at specific timestamps and @mention others. Basic collaboration works, but comments don't integrate with task management tools, there's no way to resolve them, and notifications get overwhelming on active teams.
 
 ### 15. Admin controls & analytics (Grade: B) (Business/Enterprise only)
 
-See who's using minutes to prevent overages, manage user permissions, and view usage reports by department. This catches power users and helps deactivate former employees' access.
+See who's using minutes to prevent overages, manage permissions, and view usage reports by department. Catches power users and helps deactivate former employees.
 
-Analytics are superficial though (just usage, not meeting quality metrics), and you can't set per-user or per-team minute limits.
+Analytics stay shallow (usage only, no meeting quality metrics), and you can't set per-user or per-team minute limits.
 
 ## Is Otter AI safe?
 
-Otter AI's security became a major concern following a federal class-action lawsuit filed in August 2025 and multiple user incidents. The case, filed in the U.S. District Court for the Northern District of California, alleges that Otter "deceptively and surreptitiously" records private conversations without proper consent.
+Otter's security became a serious concern after a federal class-action lawsuit filed in August 2025 and multiple user incidents. The case, filed in the U.S. District Court for the Northern District of California, alleges Otter "deceptively and surreptitiously" records private conversations without proper consent.
 
 ### Legal and privacy concerns
 
 ![](/api/assets/blog/articles/otter-ai-review/image-1.png)
 
-The lawsuit centers on allegations that Otter's bot automatically joins meetings without obtaining consent from participants. If a meeting host has integrated their calendar with Otter, the system may join meetings without alerting attendees that conversations are being recorded and shared with Otter for AI training.
+The lawsuit centers on Otter's bot automatically joining meetings without participant consent. If a meeting host has integrated their calendar with Otter, the system may join meetings without alerting attendees that conversations are being recorded and shared with Otter for AI training.
 
-Real-world incidents have highlighted these privacy issues:
+Real incidents have surfaced these privacy issues:
 
 - Corporate data leaks where sensitive VC meetings were inadvertently shared with external parties
 - Job interview recordings captured without candidate knowledge
@@ -154,19 +154,19 @@ Real-world incidents have highlighted these privacy issues:
 
 ### Data collection and usage
 
-Otter's privacy policy reveals extensive data collection practices beyond simple transcription. The company admits to using customer data for AI training:
+Otter's privacy policy goes well beyond simple transcription. The company admits to using customer data for AI training:
 
 *"We train our proprietary artificial intelligence technology on de-identified audio recordings. We also train our technology on transcriptions to provide more accurate services, which may contain Personal Information." - Otter AI*
 
-The service shares personal information with multiple third-party processors, including cloud service providers, data labeling services, and AI backend providers. This creates potential exposure points that many users may not realize they're accepting.
+The service shares personal information with third-party processors, including cloud service providers, data labeling services, and AI backend providers. That's exposure most users don't realize they're accepting.
 
 ### Enterprise security considerations
 
 ![](/api/assets/blog/articles/otter-ai-review/image-2.png)
 
-Organizations in regulated industries face particular risks. Individual employee adoption of Otter can create company-wide data exposure. The service collects extensive metadata including usage patterns, device information, and location data, which may conflict with enterprise security policies.
+Regulated industries face particular risk. One employee adopting Otter can create company-wide data exposure. The service collects metadata including usage patterns, device information, and location data, which often conflicts with enterprise security policies.
 
-Some IT security professionals have compared Otter's behavior to malware-like characteristics. Otter automatically sends workspace invitations to colleagues on users' behalf and shares meeting transcripts with external participants without explicit authorization. This can spread throughout organizations before users realize what's happening.
+Some IT security professionals have likened Otter's behavior to malware. Otter automatically sends workspace invitations to colleagues on users' behalf and shares meeting transcripts with external participants without explicit authorization. It spreads through organizations before users realize what's happening.
 
 For a detailed analysis of these security concerns and documented incidents, see <u>[Is Otter AI Safe: What You Need to Know](https://anarlog.so/blog/is-otter-ai-safe/)</u>.
 
@@ -186,9 +186,9 @@ Otter AI offers several pricing tiers:
 - AI Chat (20 queries/month)
 - Integration with Zoom, Teams, Meet, Slack
 
-After three weeks of daily meetings, I hit the 300-minute limit. I had to choose which meetings to transcribe for the rest of the month. The 30-minute per-conversation cap is particularly painful. Long strategy sessions required restarting the recording, breaking the transcript into chunks.
+After three weeks of daily meetings, I hit the 300-minute limit. I had to pick which meetings to transcribe for the rest of the month. The 30-minute per-conversation cap is the worst part. Long strategy sessions forced me to restart recording, breaking transcripts into chunks.
 
-Otter AI's free tier works only if you average 1-2 meetings per week. For daily meeting participants, you'll need to upgrade within a month.
+Otter's free tier only works if you average 1-2 meetings per week. Daily meeting participants will need to upgrade within a month.
 
 ### Otter AI Pro plan
 
@@ -236,11 +236,11 @@ For a 10-person team:
 
 ### How costs add up
 
-The pricing structure creates multiple pressure points. Heavy users quickly exhaust even the Business tier's 6,000-minute limit (100 hours/month). Teams face escalating per-user costs.
+The pricing structure has multiple pressure points. Heavy users blow past even the Business tier's 6,000-minute limit (100 hours/month). Per-user costs escalate fast.
 
-The annual discount of 51% pressures users into longer commitments before they fully understand the service's privacy implications or workflow integration challenges.
+The 51% annual discount pushes users into long commitments before they understand the privacy implications or workflow integration challenges.
 
-Enterprise pricing remains opaque with custom quotes. Organizations needing HIPAA compliance or advanced security features face potentially much higher rates than the published tiers suggest.
+Enterprise pricing stays opaque with custom quotes. Organizations needing HIPAA compliance or advanced security may face much higher rates than the published tiers suggest.
 
 ## What users think about Otter AI?
 
@@ -303,9 +303,9 @@ See <u>[detailed reviews of all Otter AI competitors](https://anarlog.so/blog/ot
 
 ### What is the best Otter alternative?
 
-Anarlog is the best Otter AI alternative if you want zero lock-in and complete control. It's an open-source AI notepad that stores everything as plain markdown files and lets you choose your AI: bring your own keys or run local models. Zero vendor lock-in, zero compromises.
+Anarlog is the best Otter AI alternative if you want zero lock-in and full control. It's an open-source AI notepad that stores everything as plain markdown files and lets you pick your AI: bring your own keys or run local models. No vendor lock-in.
 
-You get all the core AI note-taking features—transcription, summaries, search—without sacrificing control.
+You get the core AI note-taking features — transcription, summaries, search — without giving up control.
 
 ## Frequently asked questions
 
@@ -315,7 +315,7 @@ Otter.ai offers a free plan with 300 monthly minutes (5 hours) and a 30-minute l
 
 ### 2. Does Otter.ai sell my data?
 
-Otter.ai doesn't explicitly "sell" data, but their privacy policy states they use customer conversations to train AI models and share data with third-party processors. For complete control over your data, consider open-source alternatives like Anarlog.
+Otter doesn't explicitly "sell" data, but their privacy policy states they use customer conversations to train AI models and share data with third-party processors. For full control, consider open-source alternatives like Anarlog.
 
 ### 3. What are Otter.ai free plan features?
 
@@ -323,7 +323,7 @@ The free plan includes 300 monthly minutes, 30-minute conversation limit, 3 life
 
 ### 4. Can Otter.ai transcribe in languages other than English?
 
-Otter.ai supports only 3 languages: English, Spanish, and French. This is a major limitation compared to competitors.
+Otter supports only 3 languages: English, Spanish, French. That's a major gap compared to competitors.
 
 ### 5. What are the best alternatives to Otter.ai?
 
@@ -331,4 +331,4 @@ Anarlog (best for zero lock-in with complete control over data and AI), Fireflie
 
 ### 6. Is Otter.ai worth it for teams?
 
-Otter.ai works for basic English-language meeting documentation if you're comfortable with cloud processing. For a 10-person team, costs run $200-400/month. However, it offers only 3 languages, has significant privacy concerns, requires constant internet, and transcription accuracy needs editing.
+Otter works for basic English-language meeting documentation if you're comfortable with cloud processing. For a 10-person team, costs run $200-400/month. The downsides: only 3 languages, real privacy concerns, constant internet required, and transcription accuracy that needs editing.

--- a/apps/web/content/articles/plaud-ai-alternatives.mdx
+++ b/apps/web/content/articles/plaud-ai-alternatives.mdx
@@ -9,11 +9,11 @@ category: "Comparisons"
 date: "2025-10-27"
 ---
 
-Plaud's credit card-sized recorder looked promising until you saw the subscription costs pile up. Or maybe you're tired of managing yet another piece of hardware. Perhaps you just want your meeting data to stay on your device instead of floating around in someone else's cloud.
+Plaud's credit card-sized recorder looks promising until you add up the subscription costs. Or you're tired of managing another piece of hardware. Or you want your meeting data on your device instead of in someone else's cloud.
 
-Whatever brought you here, you're looking for something different. This guide covers six alternatives that take different approaches to voice recording and AI transcription.
+Whatever brought you here, you want something different. This guide covers six alternatives that take different approaches to voice recording and AI transcription.
 
-We'll focus on what actually matters: how they work, what they cost, and whether they'll solve your specific problem better than Plaud.
+We'll focus on what matters: how they work, what they cost, and whether they'll solve your specific problem better than Plaud.
 
 ## Quick Plaud AI review
 
@@ -23,9 +23,9 @@ The lineup includes Plaud Note (a credit card-sized recorder at 0.12" thin), Pla
 
 All devices use dual-mode recording, switching between phone call capture via vibration conduction and ambient recording for in-person conversations.
 
-The catch? After your 300 free minutes per month, you're paying $99.99/year for 1,200 minutes or $239.99/year for unlimited. Plus, there's the upfront hardware cost ($159-$179) and the fact that you need cloud processing for the AI features that make it useful.
+The catch? After your 300 free minutes per month, you're paying $99.99/year for 1,200 minutes or $239.99/year for unlimited. Add the upfront hardware cost ($159-$179) and cloud processing for the AI features that make it useful.
 
-It works, but it's not for everyone. Let's look at what else is out there.
+It works, but it's not for everyone. Here's what else is out there.
 
 ## Comparison table: Plaud vs alternatives
 
@@ -47,21 +47,21 @@ Continue reading for detailed reviews of each of these tools.
 
 ### 1. Anarlog
 
-[Anarlog](/) is an open-source AI notepad for meetings that gives you complete control over your data, AI stack, and workflow. Everything is stored as plain Markdown files on your device and not in proprietary databases or cloud servers.
+[Anarlog](/) is an open-source AI notepad for meetings that gives you full control over your data, AI stack, and workflow. Everything is stored as plain Markdown files on your device, not in a proprietary database or cloud server.
 
-You can inspect the code, customize functionality, and choose which AI processes your data. Zero lock-in, zero compromises.
+Inspect the code, customize functionality, and pick which AI processes your data. Zero lock-in.
 
 ![Anarlog](/api/assets/blog/plaud-ai-alternatives/anarlog.webp)
 
 #### How it works
 
-Anarlog sits quietly on your computer and captures audio directly from your system without bots joining your calls. While you're in a meeting, it generates a live transcript as you take your own notes alongside it.
+Anarlog sits on your computer and captures audio directly from your system without bots joining your calls. During a meeting, it generates a live transcript while you take your own notes alongside it.
 
-When the meeting ends, it combines your notes with the transcript and uses AI to produce a structured summary. 
+When the meeting ends, it combines your notes with the transcript and uses AI to produce a structured summary.
 
-You choose which AI processes that data — our managed service, your own API keys (OpenAI, Anthropic, etc.), or a fully local model running on your machine via Ollama or LM Studio.
+You pick which AI processes that data — our managed service, your own API keys (OpenAI, Anthropic, etc.), or a fully local model running on your machine via Ollama or LM Studio.
 
-Everything gets saved as plain markdown files on your device. Nothing goes to Anarlog's servers. You can open those files in Obsidian, VS Code, Notion, or any text editor; they're just files you own.
+Everything saves as plain markdown files on your device. Nothing goes to Anarlog's servers. Open those files in Obsidian, VS Code, Notion, or any text editor — they're just files you own.
 
 #### Key features
 
@@ -92,7 +92,7 @@ Everything gets saved as plain markdown files on your device. Nothing goes to An
 
 #### Pricing
 
-Anarlog is free forever for local transcription, BYOK, and all core features. No artificial caps, no trial that expires. Most people never need to pay—the free plan handles meeting notes completely.
+Anarlog is free forever for local transcription, BYOK, and all core features. No artificial caps, no trial that expires. Most people never need to pay — the free plan covers meeting notes completely.
 
 Enterprise pricing applies when you need on-prem deployment, SSO, consent management, or admin controls for compliance-sensitive environments. [Contact sales](https://char.com) for custom quotes.
 
@@ -104,13 +104,13 @@ Enterprise pricing applies when you need on-prem deployment, SSO, consent manage
 
 #### How it works
 
-iFLYTEK takes a self-contained approach. The device packs eight microphones (two directional, six omnidirectional) that capture audio from up to 15 meters away, along with an octa-core processor that handles real-time transcription directly on the device. No phone or internet required during recording.
+iFLYTEK takes a self-contained approach. The device packs eight microphones (two directional, six omnidirectional) that capture audio from up to 15 meters away, plus an octa-core processor that runs real-time transcription on the device. No phone or internet required during recording.
 
-The 3.5-inch touchscreen lets you see transcriptions appear as you record, switch between four recording modes (intelligent, conference, interview, speech), and mark important moments with bookmarks.
+The 3.5-inch touchscreen shows transcriptions as you record, lets you switch between four recording modes (intelligent, conference, interview, speech), and mark important moments with bookmarks.
 
-Unlike Plaud's sync-and-process model, iFLYTEK transcribes as you record using on-device AI. The transcription happens locally for privacy, though you can connect to WiFi or insert a 4G SIM card for cloud syncing.
+Unlike Plaud's sync-and-process model, iFLYTEK transcribes as you record using on-device AI. Transcription happens locally for privacy, though you can connect to WiFi or insert a 4G SIM card for cloud syncing.
 
-Files export to PDF, Word, or TXT, and you can transfer them via USB or access through their web portal at cloud.iflytekrecord.com.
+Files export to PDF, Word, or TXT. Transfer via USB or access through their web portal at cloud.iflytekrecord.com.
 
 #### Key features
 
@@ -142,11 +142,11 @@ Files export to PDF, Word, or TXT, and you can transfer them via USB or access t
 
 #### Pricing
 
-iFLYTEK's pricing reflects its position as a professional-grade tool rather than a consumer gadget. The Smart Recorder Pro currently lists at $329.99 (reduced from $369.99), while the standard Smart Recorder runs $199.99.
+iFLYTEK is priced as a professional tool, not a consumer gadget. The Smart Recorder Pro lists at $329.99 (reduced from $369.99). The standard Smart Recorder runs $199.99.
 
-There's no monthly subscription or transcription minute limits. You buy the hardware once, get 5GB of cloud storage valid for three years, and transcribe as much as you want offline.
+No monthly subscription or transcription minute limits. Buy the hardware once, get 5GB of cloud storage valid for three years, and transcribe as much as you want offline.
 
-After three years, the cloud storage expires, but they haven't announced what happens next—presumably a renewal fee or you just keep using local storage.
+After three years, cloud storage expires. They haven't announced what happens next, so expect a renewal fee or fall back to local storage.
 
 ### 3. Mobvoi TicNote
 
@@ -156,13 +156,13 @@ After three years, the cloud storage expires, but they haven't announced what ha
 
 #### How it works
 
-TicNote takes Plaud's magnetic attachment approach but adds an AI agent layer that changes things.
+TicNote borrows Plaud's magnetic attachment approach and stacks an AI agent layer on top.
 
-The hardware captures audio through three MEMS microphones with dual modes (phone calls via vibration conduction, ambient recording for meetings), then uploads to the cloud where Shadow, powered by GPT-4o, GPT-4o-mini, and DeepSeek-R1, handles transcription in 120+ languages.
+The hardware captures audio through three MEMS microphones with dual modes (phone calls via vibration conduction, ambient recording for meetings), then uploads to the cloud where Shadow — powered by GPT-4o, GPT-4o-mini, and DeepSeek-R1 — handles transcription in 120+ languages.
 
-The key difference is Shadow's project-centric approach. Instead of treating each recording separately, you organize files into projects. Shadow builds contextual knowledge across everything in a project, so when you ask it questions or request research, it pulls from your entire conversation history within that project.
+The difference is Shadow's project-centric approach. Instead of treating each recording separately, you organize files into projects. Shadow builds contextual knowledge across everything in a project, so when you ask questions or request research, it pulls from your entire conversation history within that project.
 
-The more you use it, the smarter Shadow gets at connecting dots and surfacing insights you didn't explicitly ask for.
+The more you use it, the better Shadow gets at connecting dots and surfacing insights you didn't ask for.
 
 #### Key features
 
@@ -196,15 +196,15 @@ The more you use it, the smarter Shadow gets at connecting dots and surfacing in
 
 #### Pricing
 
-TicNote costs $159.99 for hardware—matching Plaud's entry point.
+TicNote costs $159.99 for hardware, matching Plaud's entry point.
 
 The free tier gives 300 transcription minutes monthly (same as Plaud) but includes AI agent features Plaud doesn't offer.
 
-Pro runs $79/year for 2,000 minutes versus Plaud's $99/year for 1,200 minutes, making it better value if you need the extra capacity.
+Pro runs $79/year for 2,000 minutes versus Plaud's $99/year for 1,200 minutes — better value if you need the extra capacity.
 
 Business tier ($239/year) delivers 6,000 minutes with unlimited audio imports and AI Speech Enhancement.
 
-The real differentiator is Shadow's contextual intelligence. If you organize work into projects and want an AI that connects dots across conversations, TicNote's pricing makes sense. If you just need straightforward transcription, you're paying extra for features you won't use.
+The real differentiator is Shadow's contextual intelligence. If you organize work into projects and want an AI that connects dots across conversations, TicNote's pricing makes sense. If you just need straightforward transcription, you're paying for features you won't use.
 
 &nbsp;
 
@@ -216,11 +216,11 @@ Notta Memo is a Japanese AI company's entry into hardware. An ultra-lightweight 
 
 #### How it works
 
-The device weighs just 28 grams with four MEMS microphones plus one bone conduction mic for phone calls. Toggle between live mode (ambient recording) and call mode (phone recording via vibration detection), then recordings automatically sync via Bluetooth or WiFi to Notta's cloud platform.
+The device weighs 28 grams with four MEMS microphones plus one bone conduction mic for phone calls. Toggle between live mode (ambient recording) and call mode (phone recording via vibration detection). Recordings sync via Bluetooth or WiFi to Notta's cloud platform automatically.
 
-The differentiator is the mature software ecosystem behind it. Your recordings flow across web interface, iOS app, Android app, Chrome extension, and the device itself with AI context maintained throughout.
+The differentiator is the mature software ecosystem behind it. Recordings flow across web interface, iOS app, Android app, Chrome extension, and the device itself with AI context maintained throughout.
 
-Start recording on hardware, edit on mobile, analyze on web, share via browser extension. The platform handles transcription in 58 languages, then generates summaries, mind maps, and integrates with 30+ templates.
+Start recording on hardware, edit on mobile, analyze on web, share via browser extension. The platform handles transcription in 58 languages, generates summaries and mind maps, and integrates with 30+ templates.
 
 #### Key features
 
@@ -255,11 +255,11 @@ Start recording on hardware, edit on mobile, analyze on web, share via browser e
 
 #### Pricing
 
-Notta Memo costs $149 for the hardware. This gets you the device plus a "Starter Plan" with 300 minutes monthly transcription, same as Plaud's free tier.
+Notta Memo costs $149 for the hardware. That gets you the device plus a "Starter Plan" with 300 minutes monthly transcription, same as Plaud's free tier.
 
-Notta's software pricing sits between basic and premium. Pro plan runs $13.49/month, giving unlimited transcription minutes with a 200 uploaded file monthly cap. Business plan starts at $27.99/user/month with unlimited transcription and uploaded files.
+Notta's software pricing sits between basic and premium. Pro runs $13.49/month for unlimited transcription minutes, capped at 200 uploaded files monthly. Business starts at $27.99/user/month with unlimited transcription and uploaded files.
 
-Compare this to Plaud's $99.99/year Pro (1,200 minutes/month) or $239.99/year Unlimited. If you need truly unlimited transcription, Notta's annual Pro delivers better value than Plaud's $99 plan that still caps you at 1,200 minutes monthly. But if 1,200 minutes covers your needs, Plaud's Pro is slightly cheaper.
+Compare with Plaud's $99.99/year Pro (1,200 minutes/month) or $239.99/year Unlimited. If you need truly unlimited transcription, Notta's annual Pro beats Plaud's $99 plan, which still caps at 1,200 minutes monthly. If 1,200 minutes covers your needs, Plaud's Pro is slightly cheaper.
 
 ### 5. Deepscribe
 
@@ -269,9 +269,9 @@ Deepscribe is an enterprise-grade AI medical scribe built specifically for healt
 
 #### How it works
 
-Physicians use an iOS app during patient visits, and the AI—trained on data from over 2 million patient encounters—listens to natural doctor-patient conversations, extracts medically relevant information, and automatically populates discrete EHR fields with complete, billable documentation.
+Physicians use an iOS app during patient visits. The AI — trained on data from over 2 million patient encounters — listens to natural doctor-patient conversations, extracts medically relevant information, and populates discrete EHR fields with complete, billable documentation.
 
-It integrates deeply with major EHR systems (Epic, athenaOne, eClinicalWorks, DrChrono) and includes AI pre-charting that pulls forward patient history, labs, imaging, medications, and diagnoses for context. The AI learns individual physician styles and continuously adapts to their documentation preferences.
+It integrates with major EHR systems (Epic, athenaOne, eClinicalWorks, DrChrono) and includes AI pre-charting that pulls forward patient history, labs, imaging, medications, and diagnoses for context. The AI learns individual physician styles and adapts to their documentation preferences over time.
 
 #### Key features
 
@@ -305,9 +305,9 @@ It integrates deeply with major EHR systems (Epic, athenaOne, eClinicalWorks, Dr
 
 #### Pricing
 
-Deepscribe doesn't list prices publicly—you have to request a demo for custom quotes. Based on third-party sources and industry reports, pricing runs approximately $400-500 per provider per month for EHR-integrated plans, with some estimates suggesting $8,000+ annually per clinician. Non-integrated plans may start around $250-400/month.
+Deepscribe doesn't list prices publicly. You request a demo for custom quotes. Based on third-party sources and industry reports, pricing runs about $400-500 per provider per month for EHR-integrated plans, with some estimates suggesting $8,000+ annually per clinician. Non-integrated plans may start around $250-400/month.
 
-Compare this to Plaud's $159 hardware + $99-239/year software, and you're looking at 20-40x higher annual cost for Deepscribe. That comparison misses the point entirely: Deepscribe generates billable clinical documentation that meets regulatory standards and integrates with practice management systems. Plaud gives you meeting transcripts. These solve completely different problems for completely different users.
+Compared with Plaud's $159 hardware + $99-239/year software, that's 20-40x higher annual cost. The comparison misses the point: Deepscribe generates billable clinical documentation that meets regulatory standards and integrates with practice management systems. Plaud gives you meeting transcripts. Different problems, different users.
 
 ### 6. Avoma
 
@@ -317,13 +317,13 @@ Avoma is a cloud-based AI meeting assistant built specifically for revenue teams
 
 #### How it works
 
-Avoma operates as a bot-based meeting assistant that joins your Zoom, Teams, or Google Meet calls to record and transcribe conversations in real-time across 75+ languages.
+Avoma is a bot-based meeting assistant that joins your Zoom, Teams, or Google Meet calls to record and transcribe conversations in real-time across 75+ languages.
 
-During meetings, you can live-bookmark key moments by clicking categories like "Pain Points" or "Next Steps", and Avoma automatically organizes these under time-stamped sections.
+During meetings, you can live-bookmark moments by clicking categories like "Pain Points" or "Next Steps". Avoma organizes these under time-stamped sections automatically.
 
-After the call, AI generates human-like notes using custom templates (MEDDIC, SPICED, SPIN, etc.) and automatically extracts topics like Business Need, Objections, and Pricing Discussions into smart chapters.
+After the call, AI generates human-like notes using custom templates (MEDDIC, SPICED, SPIN, etc.) and extracts topics like Business Need, Objections, and Pricing Discussions into smart chapters.
 
-The platform then pushes this data directly to your CRM, updating custom fields, logging activities, and syncing action items without manual data entry.
+The platform pushes this data directly to your CRM, updating custom fields, logging activities, and syncing action items without manual data entry.
 
 #### Key features
 
@@ -355,11 +355,11 @@ The platform then pushes this data directly to your CRM, updating custom fields,
 
 #### Pricing
 
-Avoma's pricing looks straightforward until you realize the good features cost extra. The base Organization plan starts at $29/user/month (billed annually) and includes unlimited transcription, AI notes, CRM automation, and scheduling. This handles core meeting needs without artificial limits.
+Avoma's pricing looks straightforward until you realize the good features cost extra. The base Organization plan starts at $29/user/month (billed annually) with unlimited transcription, AI notes, CRM automation, and scheduling. That covers core meeting needs without artificial limits.
 
-But to unlock conversation intelligence features like call scoring, coaching insights, and keyword tracking, add another $29/user/month. Want revenue intelligence with deal risk alerts and pipeline tracking? That's another $29/user/month. Need advanced lead routing? Add $19/user/month for the Scheduler add-on.
+To unlock conversation intelligence (call scoring, coaching insights, keyword tracking), add another $29/user/month. Revenue intelligence with deal risk alerts and pipeline tracking? Another $29/user/month. Advanced lead routing? Add $19/user/month for the Scheduler add-on.
 
-For teams that actually need the full revenue intelligence stack, Avoma delivers legitimate ROI by replacing multiple tools. But if you're just looking for meeting transcription, this is expensive overkill.
+If your team needs the full revenue intelligence stack, Avoma delivers ROI by replacing multiple tools. If you just want meeting transcription, it's expensive overkill.
 
 ## Which Plaud alternative should you choose?
 

--- a/apps/web/content/articles/publishing-stack.mdx
+++ b/apps/web/content/articles/publishing-stack.mdx
@@ -49,7 +49,7 @@ Our stack uses GitHub drag-and-drop for inline screenshots, Supabase buckets for
 
 ## 5. Custom MDX components
 
-Content becomes code when you use MDX, and every document becomes a canvas. We built a small but powerful set of components: `<Figure />`, `<Aside />`, `<Callout />`, `<CodeBlock />`, `<Tabs />`, `<Video />`, `<ComparisonTable />`, `<Grid />`.
+Content becomes code when you use MDX, and every document becomes a canvas. We built a small set of components: `<Figure />`, `<Aside />`, `<Callout />`, `<CodeBlock />`, `<Tabs />`, `<Video />`, `<ComparisonTable />`, `<Grid />`.
 
 These work across blog, docs, guides, landing pages, internal playbooks, and product updates. The UI of our content is dictated by design, not by a CMS. And because it's MDX, these components can become intelligent later: interactive, stateful, contextual, personalized, AI-enhanced. CMS platforms can't do that without becoming full application frameworks.
 

--- a/apps/web/content/articles/read-ai-alternatives.mdx
+++ b/apps/web/content/articles/read-ai-alternatives.mdx
@@ -10,11 +10,11 @@ date: "2026-04-01"
 
 Most users came to Read AI for meeting notes and ended up paying for email summaries, a Slack integration, and an AI assistant they never asked for. And then there's the bot: Read AI joins every call as a visible participant, spreads through organizations via OAuth, and records people who never consented. 
 
-A security architect at Crayon called it *"a case study in viral Shadow IT"* in [a widely shared post](https://agderinthe.cloud/2026/01/19/read-ai-the-meeting-assistant-you-didnt-invite/) after it propagated through a client's Microsoft 365 tenant. IT teams across [Microsoft's own forums](https://learn.microsoft.com/en-us/answers/questions/4419430/read-ai) have been asking how to block it. Read AI recently shipped a botless integration for Google Meet, but on Zoom and Teams the bot remains the default.
+A security architect at Crayon called it *"a case study in viral Shadow IT"* in [a post](https://agderinthe.cloud/2026/01/19/read-ai-the-meeting-assistant-you-didnt-invite/) after it propagated through a client's Microsoft 365 tenant. IT teams across [Microsoft's own forums](https://learn.microsoft.com/en-us/answers/questions/4419430/read-ai) have been asking how to block it. Read AI recently shipped a botless integration for Google Meet, but on Zoom and Teams the bot remains the default.
 
 So if you're in the market for Read AI alternatives, I've covered six tools in this article that are worth a look. 
 
-The first four are bot-free meeting tools for people whose primary use was transcription and summaries. The last two, Microsoft Copilot and Slack AI, are platform-level alternatives that cover the broader feature set: email, messaging, and cross-channel search. Nobody replaces the full bundle in one product. But most people don't need the full bundle.
+The first four are bot-free meeting tools for people whose primary use was transcription and summaries. The last two, Microsoft Copilot and Slack AI, are platform-level alternatives that cover the broader feature set: email, messaging, and cross-channel search. Nobody replaces the full bundle in one product, and most people don't need the full bundle.
 
 ## **How These Read AI Alternatives Compare**
 
@@ -52,7 +52,7 @@ Where Anarlog gives you raw ownership and flexibility, [Jamie](https://meetjamie
 
 The feature set is the closest match to Read AI among bot-free tools: HubSpot and Salesforce integrations, 100+ languages with automatic detection, in-person meeting support, and an "Ask Jamie" semantic search that lets you query across all your recorded meetings.
 
-The privacy credentials are built around European compliance: EU-hosted infrastructure, GDPR compliant, ISO 27001 certified. Audio gets deleted after transcription and customer data is never used for model training. 
+Privacy is built around European compliance: EU-hosted infrastructure, GDPR compliant, ISO 27001 certified. Audio gets deleted after transcription and customer data is never used for model training. 
 
 For companies in Europe where Read AI's US-based data handling was the dealbreaker, Jamie was designed for that exact use case. The tradeoff against Anarlog is that Jamie is closed-source and stores data on their servers (EU servers, but still theirs).
 
@@ -66,7 +66,7 @@ Anarlog and Jamie are desktop apps. [Tactiq](https://tactiq.com/) lives entirely
 
 You install it, join a call in your browser, and it transcribes in real time with [over a million users and a 4.8-star rating](https://chromewebstore.google.com/detail/tactiq-chatgpt-meeting-su/fggkaccpbmombhnjkjokndojfgagejfb) on the Chrome Web Store. No bot joins the meeting. The transcript shows up live as people speak, so you can highlight and tag moments during the call rather than reviewing everything after.
 
-The workflow automations are where Tactiq earns its keep. One-click summaries, action item extraction, follow-up email drafting, and reusable prompt templates that push to Slack, Notion, HubSpot, Pipedrive, and Linear. Security is stronger than you'd expect from a browser extension: SOC 2 Type II, GDPR, ISO 27001, HIPAA. No audio is recorded or stored.
+The workflow automations are where Tactiq earns its keep. One-click summaries, action item extraction, follow-up email drafting, and reusable prompt templates that push to Slack, Notion, HubSpot, Pipedrive, and Linear. Security is better than you'd expect from a browser extension: SOC 2 Type II, GDPR, ISO 27001, HIPAA. No audio is recorded or stored.
 
 [Pro starts at $8/month](https://tactiq.io/buy) (annual) with unlimited transcripts, which makes it the cheapest option on this list by a wide margin. Free gives 10 transcripts and 5 AI credits per month. 
 
@@ -88,11 +88,11 @@ Speaker identification is weak in multi-person calls and there's no audio playba
 
 ![Copilot vs read ai](/api/assets/blog/Copilot%20pros%20and%20cons "anarlog-editor-width=80")
 
-[Microsoft 365 Copilot](https://www.microsoft.com/en-us/microsoft-365/copilot/pricing) is the closest full-scope alternative to Read AI. It operates across Microsoft's entire suite, which means if your organization already runs M365, most of what Read AI does is available without adding another vendor's bot to your meetings.
+[Microsoft 365 Copilot](https://www.microsoft.com/en-us/microsoft-365/copilot/pricing) is the closest full-scope alternative to Read AI. It works across Microsoft's entire suite, so if your organization already runs M365, most of what Read AI does is available without adding another vendor's bot to your meetings.
 
 Wave 3 shipped in March 2026 with model choice (Claude alongside OpenAI), Copilot Cowork for multi-step tasks, and deeper integration into Teams meetings including a [Facilitator AI agent](https://summarizemeeting.com/en/app-reviews/microsoft-teams) that manages agendas, captures notes, and tracks time. Meeting transcription in Teams doesn't require a bot joining from outside your org. It's native. That alone eliminates the shadow IT problem that drives people away from Read AI.
 
-The cost is significant. Copilot Business is $21/user/month as an add-on to your existing M365 subscription ($12.50-22/user/month), bringing the total to $33-43/user/month. Enterprise plans go higher. 
+The cost adds up. Copilot Business is $21/user/month as an add-on to your existing M365 subscription ($12.50-22/user/month), bringing the total to $33-43/user/month. Enterprise plans go higher. 
 
 If your organization doesn't already run Microsoft 365, this isn't a realistic option. But if you do, it covers meetings, email, messaging, and search in one licensing line item, with no third-party bots and no separate vendor handling your data.
 
@@ -112,7 +112,7 @@ Slack AI doesn't replace Read AI's engagement scoring, speaker coaching, or meet
 
 ## Which Read AI Alternative Is Right for You?
 
-Read AI bundles five things into one subscription: meeting notes, email summaries, messaging summaries, cross-channel search, and engagement analytics. Most people use one, maybe two of those. The question isn't which tool replaces all of Read AI. It's which parts you actually need.
+Read AI bundles five things into one subscription: meeting notes, email summaries, messaging summaries, cross-channel search, and engagement analytics. Most people use one, maybe two of those. The question isn't which tool replaces all of Read AI, it's which parts you actually need.
 
 If you came to Read AI for meeting notes and the bot was the problem, Anarlog gives you complete ownership: open-source, local files, your AI provider, nothing touching your org's OAuth. Jamie packages the bot-free experience with CRM integrations and EU compliance at a higher price point. Tactiq is the budget pick at $8/month if your meetings happen in the browser. Granola works for client-facing calls where the notepad workflow fits, though the database encryption incident and lifetime meeting cap on free are worth weighing.
 

--- a/apps/web/content/articles/sales-ai-note-takers.mdx
+++ b/apps/web/content/articles/sales-ai-note-takers.mdx
@@ -1,7 +1,7 @@
 ---
 meta_title: "Best AI Notetakers for Sales Teams in 2026"
 display_title: "Which AI Tools Automate Sales Meeting Notes?"
-meta_description: "We tested 20+ AI meeting tools to find the 5 best options for sales teams. Compare features, pricing, and real-world value to find your perfect match."
+meta_description: "We tested 20+ AI meeting tools to find the 5 best options for sales teams. Compare features, pricing, and real-world value to find your match."
 author: "Harshika"
 category: "Comparisons"
 date: "2025-10-20"
@@ -46,7 +46,7 @@ Growing sales teams (25-100 reps) who want an affordable all-in-one alternative 
 - **Scheduler & Lead Router Add-on** offers group and round-robin scheduling, advanced lead routing rules, inbound form qualification, and SDR-to-AE handoff automation
 - **"Ask Avoma" AI Copilot** gets you answers from individual meetings, across all conversations, or at the deal/account level
 - **Smart Playlists** automatically curate call recordings based on rules for easy coaching and review
-- **Integration ecosystem** includes native integrations with CRMs, dialers (RingCentral, Aircall, Kixie), Slack, MS Teams, Zapier, and more
+- **Integrations** include native connections to CRMs, dialers (RingCentral, Aircall, Kixie), Slack, MS Teams, Zapier, and more
 
 #### Pros
 
@@ -148,7 +148,7 @@ Individual sales reps or small teams (2-10 people) who want a user-friendly tool
 - CRM field sync and Deal View only available on the most expensive Business plan ($28/user/month)
 - Coaching metrics and AI scorecards also locked behind the Business plan, limiting its value for sales managers on lower tiers
 - Team collaboration features require at least the Team plan ($18/user/month minimum 2 users)
-- Less robust conversation intelligence compared to Avoma or Gong. No talk pattern analysis, sentiment tracking, or advanced topic intelligence
+- Less conversation intelligence than Avoma or Gong. No talk pattern analysis, sentiment tracking, or advanced topic intelligence
 
 #### Pricing
 
@@ -182,8 +182,8 @@ Sales teams that handle multilingual calls, sales managers who need coaching ins
 
 #### Pros
 
-- Industry-leading multilingual capabilities with translation and summarization in 30+ languages, perfect for global sales teams
-- Enterprise-grade security (SOC 2, GDPR, ISO 27001) with option for privately hosted AI
+- Strong multilingual capabilities with translation and summarization in 30+ languages, suited to global sales teams
+- Enterprise security (SOC 2, GDPR, ISO 27001) with the option for privately hosted AI
 - Unlimited uploads on Pro plan for analyzing pre-recorded calls
 - Pro plan at $29/month offers unlimited AI notes, making it competitive for individual reps
 
@@ -197,7 +197,7 @@ Sales teams that handle multilingual calls, sales managers who need coaching ins
 
 #### Pricing
 
-tl;dv's free plan is useful with 10 AI meeting notes per month (vs. Fathom's 5), unlimited recordings, and full transcription.
+tl;dv's free plan gives 10 AI meeting notes per month (vs. Fathom's 5), unlimited recordings, and full transcription.
 
 Pro at $29/month unlocks unlimited everything and works well for individual reps or small teams.
 
@@ -207,7 +207,7 @@ Also check: [I Tested tl;dv So You Don't Have To [2026 Review]](/blog/tldv-revie
 
 ### 5. Sybill
 
-[Sybill](https://www.sybill.ai/?) is an AI sales assistant purpose-built for account executives, functioning as a sales coordinator, personal assistant, and research analyst combined. Unlike basic notetakers, Sybill learns from every call, email, Slack message, and CRM update to automate sales busywork across the entire deal lifecycle.
+[Sybill](https://www.sybill.ai/?) is an AI sales assistant built for account executives, working as a sales coordinator, personal assistant, and research analyst combined. Unlike basic notetakers, Sybill learns from every call, email, Slack message, and CRM update to automate sales busywork across the entire deal lifecycle.
 
 <Image src="/api/assets/blog/sales-ai-note-takers/sales-5.webp" alt="review of Sybill for sales teams"/>
 
@@ -244,7 +244,7 @@ Account executives managing complex B2B deals who need deal-level intelligence a
 
 #### Pricing
 
-Sybill's pricing reflects its positioning as a deal-focused AI assistant rather than a simple notetaker. Essentials at $29/month offers basic transcription and summaries but strips out the deal intelligence features that make Sybill special.
+Sybill's pricing reflects its positioning as a deal-focused AI assistant rather than a simple notetaker. Essentials at $29/month offers basic transcription and summaries but strips out the deal intelligence features that make Sybill worth using.
 
 The real value starts at Business ($99/month), which unlocks 100% CRM autofill (up to 10 fields), custom AI follow-up emails, Deal Workspace, and behavioral AI. If you need unlimited CRM field mapping or advanced integrations, Enterprise requires custom pricing.
 

--- a/apps/web/content/articles/see-zoom-meeting-history.mdx
+++ b/apps/web/content/articles/see-zoom-meeting-history.mdx
@@ -17,7 +17,7 @@ Zoom offers a few ways to view your meeting history, depending on whether you ho
 
 <Image src="/api/assets/blog/see-zoom-meeting-history/zoom-1.png" alt="Zoom dashboard" />
 
-If you're the meeting host, accessing your history is straightforward:
+If you're the meeting host, here's how to access your history:
 
 1. Sign in to the [Zoom web portal](https://zoom.us/)
 2. Click **Meetings** in the navigation menu, then select **Previous**
@@ -27,7 +27,7 @@ Your account admin and owner can also see this information. If a meeting ID has 
 
 ### For meetings you joined
 
-You can only see meetings you've joined through the Zoom desktop app, with significant limitations:
+You can only see meetings you've joined through the Zoom desktop app, with notable limits:
 
 1. Open the Zoom desktop app
 2. Click **Join**
@@ -123,7 +123,7 @@ Key features for Zoom users:
 - **Privacy-first** -- Makes HIPAA, GDPR, SOC 2 compliance simple by eliminating cloud dependencies
 - **Flexible AI options** -- Go fully local, connect to OpenAI/Mistral/Ollama, or use custom endpoints
 
-For organizations in healthcare, legal, finance, or any compliance-sensitive industry, this approach matters. You can have AI-powered meeting intelligence while meeting regulatory requirements. For everyone else, you get meeting history that actually works the way your brain works—by content and context.
+For organizations in healthcare, legal, finance, or any compliance-sensitive industry, this approach matters. You get AI-powered meeting intelligence while meeting regulatory requirements. For everyone else, you get meeting history that works the way your brain works: by content and context.
 
 [Download Anarlog](https://anarlog.so) and start building meeting history that's actually useful.
 

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -82,7 +82,7 @@ It covers the full record → transcribe → summarize pipeline without leaving 
 
 #### Pricing
 
-Free and open source (MIT) for the Community Edition. Pro is $120/year ($10/month billed annually) and runs on a separate codebase with enhanced accuracy and additional features. Enterprise pricing is custom.
+Free and open source (MIT) for the Community Edition. Pro is $120/year ($10/month billed annually) and runs on a separate codebase with better accuracy and extra features. Enterprise pricing is custom.
 
 ### 3. Scriberr
 
@@ -142,7 +142,7 @@ Free and open-source (MIT).
 
 [Whishper](https://github.com/pluja/whishper) is another Docker-deployed web UI for Whisper with drag-and-drop upload and subtitle generation (SRT, VTT). 
 
-It's built for teams that need a transcription service without any setup complexity. Automatic language detection across 90+ languages. 
+It's built for teams that need a transcription service with minimal setup. Automatic language detection across 90+ languages. 
 
 No summarization, no post-processing — you get the transcript and take it elsewhere.
 
@@ -199,4 +199,4 @@ It depends on what you're optimizing for.
 - If you just need fast, reliable file transcription on your desktop, Vibe is the simplest path.
 - If you're building a custom pipeline and need word-level timestamps with speaker diarization, WhisperX gives you the research-grade engine to wire into your own stack.
 
-For most users who want privacy-first meeting notes that just work, start with [Anarlog](https://anarlog.so/download/apple-silicon). Free for fully local use, no account required.
+For most users who want privacy-first meeting notes that work out of the box, start with [Anarlog](https://anarlog.so/download/apple-silicon). Free for fully local use, no account required.

--- a/apps/web/content/articles/slack-is-the-best-ide.mdx
+++ b/apps/web/content/articles/slack-is-the-best-ide.mdx
@@ -13,7 +13,7 @@ Async beats everything when you're jumping between roles this often.
 
 ## My stack
 
-I use Devin, Claude Code, GitButler, Zed, and Warp. These are all good tools. But my center of gravity isn't any of them. It's Slack.
+I use Devin, Claude Code, GitButler, Zed, and Warp. All good tools. But my center of gravity isn't any of them. It's Slack.
 
 I have a channel called "product-with-devin." Bugs, feedback, and ideas get dumped there. Devin picks up tasks async. The whole team can see what's happening. Nothing gets lost in DMs or local files.
 
@@ -29,7 +29,7 @@ For UI taste and micro-interactions, I use Zed. This is where I get hands-on wit
 
 ## Why Slack works as an IDE
 
-An IDE is supposed to be where you do your work. For most people, that's a code editor. For me, it's where context lives and where async work compounds.
+An IDE is where you do your work. For most people, that's a code editor. For me, it's where context lives and async work compounds.
 
 Slack is where problems surface. Tasks get picked up there, and the whole team can see what's in flight and what's blocked.
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -8,11 +8,11 @@ category: "Comparisons"
 date: "2026-04-02"
 ---
 
-Tactiq is one of the lighter, smarter approaches to meeting transcription. It runs as a Chrome extension, captures live captions from Google Meet, Zoom, or Teams without sending a bot into the call, and generates AI summaries from the text. Over a million people use it weekly, and for a browser-based tool, it handles the basics well.
+Tactiq is one of the lighter approaches to meeting transcription. It runs as a Chrome extension, captures live captions from Google Meet, Zoom, or Teams without sending a bot into the call, and generates AI summaries from the text. Over a million people use it weekly, and for a browser-based tool, it handles the basics well.
 
-But the Chrome dependency is also its ceiling. You have to join meetings through the browser, not the Zoom desktop app or Teams client. 
+But the Chrome dependency is also its ceiling. You have to join meetings through the browser, not the Zoom desktop app or Teams client.
 
-I spent weeks testing alternatives that remove that ceiling in different ways. Here are seven tools worth a look.
+I spent weeks testing alternatives that remove that ceiling in different ways. Here are seven worth a look.
 
 ## List of the Best Tactiq Alternatives
 
@@ -33,11 +33,11 @@ I spent weeks testing alternatives that remove that ceiling in different ways. H
 
 ![anarlog vs tactiq](/api/assets/blog/blog/anarlog-summary.png "anarlog-editor-width=80")
 
-[Anarlog](https://anarlog.so) is an open-source AI notepad for meetings, built for people who want to own their data. 
+[Anarlog](https://anarlog.so) is an open-source AI notepad for meetings, built for people who want to own their data.
 
-Where Tactiq captures text inside Chrome, Anarlog is a desktop app that records system audio from any meeting platform: Zoom, Teams, phone calls, even in-person conversations. 
+Where Tactiq captures text inside Chrome, Anarlog is a desktop app that records system audio from any meeting platform: Zoom, Teams, phone calls, even in-person conversations.
 
-It transcribes in real time while you take notes in a built-in editor, then combines both into a structured summary after the call. No bot joins your meeting and no calendar permissions are required.
+It transcribes in real time while you take notes in a built-in editor, then combines both into a structured summary after the call. No bot joins your meeting. No calendar permissions required.
 
 #### What works
 
@@ -74,7 +74,7 @@ Free forever with on-device transcription and BYOK. (Managed cloud, sync, integr
 
 - A federal class-action lawsuit filed in August 2025 accuses Otter of "deceptively and surreptitiously" recording private conversations and using them to train its AI without consent from all meeting participants. The suit alleges the bot records everyone in a call, including people who never signed up for the service.
 - The bot ("Otter.ai") joins meetings as a visible participant. Clients notice.
-- AI transcription only works in English, French, and Spanish. Significant gap for international teams.
+- AI transcription only works in English, French, and Spanish. A real gap for international teams.
 - Free tier burns through fast: 300 minutes per month with a 30-minute cap per conversation.
 
 #### Pricing
@@ -110,11 +110,11 @@ Business plan at ~$14/month; requires a Google account to sign up.
 
 ![Fathom vs tactiq](/api/assets/blog/blog/image-14.png "anarlog-editor-width=80")
 
-[Fathom](https://fathom.ai) has disrupted the pricing model of this entire category by offering unlimited free transcription for individual users. No credit card, no time limits, no catch. 
+[Fathom](https://fathom.ai) broke the pricing model of this category by offering unlimited free transcription for individuals. No credit card, no time limits, no catch.
 
-It sends a bot into your Zoom, Meet, or Teams call, records everything, and produces AI summaries that are often ready before the meeting ends. 
+It sends a bot into your Zoom, Meet, or Teams call, records everything, and produces AI summaries that are often ready before the meeting ends.
 
-The interface is clean and uncluttered, and the highlight clip feature lets you share short video moments with teammates who missed the call.
+The interface is clean. The highlight clip feature lets you share short video moments with teammates who missed the call.
 
 #### What works
 
@@ -125,7 +125,7 @@ The interface is clean and uncluttered, and the highlight clip feature lets you 
 
 #### What doesn't
 
-- The free tier is individual only. Team features start at $32/user/month (Standard) or $39/user/month (Pro), which is significantly more than Fireflies or Otter at scale.
+- The free tier is individual only. Team features start at $32/user/month (Standard) or $39/user/month (Pro), well above Fireflies or Otter at scale.
 - Bot is visible to all meeting participants. For external or client-facing calls, this matters.
 - No offline mode, no local storage. Everything lives in Fathom's cloud.
 - Limited value outside of meeting transcription. No conversation analytics, no sentiment tracking.
@@ -138,14 +138,14 @@ Free (unlimited individual); Team Standard $32/user/month, Team Pro $39/user/mon
 
 ![Fireflies vs tactiq](/api/assets/blog/blog/image-15.png "anarlog-editor-width=80")
 
-[Fireflies](https://fireflies.ai) is built for revenue teams. Where other tools stop at transcription, Fireflies layers on conversation analytics: talk-to-listen ratios, sentiment analysis, topic tracking, and custom vocabulary for industry-specific terminology. 
+[Fireflies](https://fireflies.ai) is built for revenue teams. Where other tools stop at transcription, Fireflies layers on conversation analytics: talk-to-listen ratios, sentiment analysis, topic tracking, and custom vocabulary for industry-specific terminology.
 
-The CRM integrations are the deepest I have tested. After connecting HubSpot, every client call automatically logged notes, action items, and summaries to the correct contact record without any manual work.
+The CRM integrations are the deepest I tested. After connecting HubSpot, every client call automatically logged notes, action items, and summaries to the correct contact record with no manual work.
 
 #### What works
 
 - Native auto-sync with Salesforce, HubSpot, Pipedrive, and Zoho.
-- Conversation analytics (sentiment, talk ratio, topic detection) are genuinely useful for sales coaching and pipeline reviews.
+- Conversation analytics (sentiment, talk ratio, topic detection) are useful for sales coaching and pipeline reviews.
 - Most generous free tier among bot-based tools: 800 minutes per month of storage.
 - Works across Zoom, Meet, Teams, and Webex. Broader platform coverage than most competitors.
 
@@ -164,14 +164,14 @@ Free (800 min/mo storage); Pro $10/user/month; Business $19/user/month.
 
 ![tl;dv vs tactiq](/api/assets/blog/blog/image-16.png "anarlog-editor-width=80")
 
-[tl;dv](https://tldv.io) takes a different angle than the other tools on this list. The core idea is that most people do not need a full transcript or even a summary. They need the one moment that matters, packaged in a way they can send to someone who was not on the call. 
+[tl;dv](https://tldv.io) takes a different angle than the other tools here. The idea is that most people don't need a full transcript or summary. They need the one moment that matters, packaged in a way they can send to someone who wasn't on the call.
 
-tl;dv records your meeting, transcribes it, and lets you create timestamped video clips shareable via Slack, Notion, or a direct link. It is built for async-first teams more than for documentation.
+tl;dv records your meeting, transcribes it, and lets you create timestamped video clips shareable via Slack, Notion, or a direct link. It's built for async-first teams more than for documentation.
 
 #### What works
 
 - Unlimited free recordings and transcriptions with no time cap. One of the most generous free tiers available.
-- Timestamped video clips are the fastest way to share a specific meeting moment with someone who was not there.
+- Timestamped video clips are the fastest way to share a meeting moment with someone who wasn't there.
 - AI-powered search finds specific moments across all recordings, not just keywords in transcripts.
 - Integrates with Slack, Notion, HubSpot, and project management tools for clip distribution.
 
@@ -190,14 +190,14 @@ Free (unlimited recordings and transcriptions); Pro $29/user/month.
 
 ![Notta vs tactiq](/api/assets/blog/blog/image-18.png "anarlog-editor-width=80")
 
-[Notta's](https://notta.ai) strongest card is language coverage. It supports 58 languages for transcription and real-time translation for over 50, which is more than any other tool on this list. Tactiq claims 60+ languages for captions, but accuracy drops noticeably with accents and non-native speakers in practice. 
+[Notta's](https://notta.ai) strongest card is language coverage. It supports 58 languages for transcription and real-time translation for over 50, more than any other tool here. Tactiq claims 60+ languages for captions, but accuracy drops noticeably with accents and non-native speakers in practice.
 
 #### What works
 
-- 58 languages for transcription with real-time translation for 50+. Best-in-class for international and multilingual teams.
-- Actually records audio and video, so you can replay meetings, verify exact wording, and export files. Essential for compliance-sensitive industries.
-- Exports to DOCX, PDF, SRT, and other formats. Good data portability compared to tools that lock notes in proprietary views.
-- Works on desktop, mobile, and browser. The broadest device coverage on this list.
+- 58 languages for transcription with real-time translation for 50+. Best on this list for international and multilingual teams.
+- Records audio and video, so you can replay meetings, verify exact wording, and export files. Useful for compliance-sensitive industries.
+- Exports to DOCX, PDF, SRT, and other formats. Better portability than tools that lock notes into proprietary views.
+- Works on desktop, mobile, and browser. The broadest device coverage here.
 
 #### What doesn't
 
@@ -211,18 +211,18 @@ Free (limited); Pro $13.49/user/month; Business $27.99/user/month.
 
 ## Which Tactiq Alternative Is Right for You?
 
-**Anarlog** is the pick if data ownership is non-negotiable: plain markdown files, your choice of AI, fully offline capable. 
+**Anarlog** is the pick if data ownership is non-negotiable: plain markdown files, your choice of AI, fully offline capable.
 
-**Otter.ai** has the most mature search and knowledge base, but the ongoing consent lawsuit and visible bot make it a harder sell for client-facing work. 
+**Otter.ai** has the most mature search and knowledge base, but the ongoing consent lawsuit and visible bot make it a harder sell for client-facing work.
 
-**Granola** produces excellent notes without a bot, though the recent database encryption incident should give pause to anyone who builds agent workflows around direct file access. 
+**Granola** produces strong notes without a bot, though the recent database encryption incident should give pause to anyone building agent workflows around direct file access.
 
-**Fathom** is unbeatable for individuals on a budget: unlimited, free, fast. The team pricing is where it gets expensive. 
+**Fathom** is unbeatable for individuals on a budget: unlimited, free, fast. Team pricing is where it gets expensive.
 
-**Fireflies.ai** earns its place for sales teams through CRM depth and analytics, but the BIPA lawsuits are a real consideration for organizations with Illinois-based participants. 
+**Fireflies.ai** earns its place for sales teams through CRM depth and analytics, but the BIPA lawsuits are a real consideration for organizations with Illinois-based participants.
 
-**tl;dv** works best when you need to share moments, not documents, with teammates who were not on the call. And 
+**tl;dv** works best when you need to share moments, not documents, with teammates who weren't on the call.
 
 **Notta** is the strongest option for multilingual teams that need transcription and translation accuracy across dozens of languages.
 
-If you want prefer the local-first approach, [download Anarlog](https://anarlog.so/download/apple-silicon) and try it on your next meeting.
+If you prefer the local-first approach, [download Anarlog](https://anarlog.so/download/apple-silicon) and try it on your next meeting.

--- a/apps/web/content/articles/tldv-alternatives.mdx
+++ b/apps/web/content/articles/tldv-alternatives.mdx
@@ -6,9 +6,9 @@ category: "Comparisons"
 date: "2026-02-27"
 ---
 
-tl;dv does a lot well but at $29/month, you're paying for sales coaching and multi-meeting intelligence you may never use. Add a visible bot in every call and no HIPAA compliance, and the cracks start to show for a lot of teams. (We covered this in detail in our [tl;dv review](/blog/tldv-review).)
+tl;dv does a lot well, but at $29/month you're paying for sales coaching and multi-meeting intelligence you may never use. Add a visible bot in every call and no HIPAA compliance, and the cracks start to show for a lot of teams. (We covered this in detail in our [tl;dv review](/blog/tldv-review).)
 
-So, if you're in the market for a tl;dv alternative, I have compiled the best options in this article.
+If you're shopping for a tl;dv alternative, here are the best options.
 
 ## Top tl;dv Competitors for Specific Use Cases
 
@@ -26,9 +26,9 @@ So, if you're in the market for a tl;dv alternative, I have compiled the best op
 
 ### 1. Anarlog
 
-[Anarlog](/) is an open-source AI notepad for meetings that stores everything as plain markdown files on your device. No proprietary database, no cloud dependency.
+[Anarlog](/) is an open-source AI notepad for meetings that stores everything as plain markdown files on your device. No proprietary database. No cloud dependency.
 
-It looks like Apple Notes with AI superpowers, capturing audio from any meeting platform without joining as a bot.
+It looks like Apple Notes with AI built in, capturing audio from any meeting platform without joining as a bot.
 
 #### How it compares to tl;dv
 
@@ -36,7 +36,7 @@ tl;dv sends your audio to their servers, then to Anthropic for processing. You g
 
 Anarlog skips the video entirely and gives you text-based meeting intelligence with complete data ownership.
 
-tl;dv Pro is $29/month. Anarlog is free forever for local transcription and BYOK. If you left tl;dv over pricing or privacy, the gap here is still meaningful.
+tl;dv Pro is $29/month. Anarlog is free forever for local transcription and BYOK. If you left tl;dv over pricing or privacy, the gap is real.
 
 #### Top Features
 
@@ -68,13 +68,13 @@ Free forever for local transcription, BYOK, and all core features. Managed cloud
 
 ### 2. Fathom
 
-[Fathom](https://fathom.video/) is built for sales and customer-facing teams who need meeting notes to automatically flow into their CRM without any manual input.
+[Fathom](https://fathom.video/) is built for sales and customer-facing teams who need meeting notes to flow into their CRM without manual input.
 
 #### How it compares to tl;dv
 
-The overlap with tl;dv is real: both record video, both let you clip and share moments, both generate AI summaries. Where they diverge is depth. tl;dv built toward multi-meeting intelligence, coaching playbooks, and trend tracking across calls. Fathom went deeper on CRM automation and sales workflow.
+The overlap is real: both record video, both let you clip and share moments, both generate AI summaries. Where they diverge is depth. tl;dv built toward multi-meeting intelligence, coaching playbooks, and trend tracking across calls. Fathom went deeper on CRM automation and sales workflow.
 
-If you used tl;dv mainly for clipping moments and sharing them with your team, Fathom is a fair switch. If you relied on the cross-meeting analytics or sales coaching features, Fathom doesn't cover that.
+If you used tl;dv mainly for clipping moments and sharing them with your team, Fathom is a fair switch. If you relied on cross-meeting analytics or sales coaching, Fathom doesn't cover that.
 
 #### Top Features
 
@@ -107,11 +107,11 @@ Also check: [Fathom AI alternatives](/blog/fathom-ai-alternatives)
 
 ### 3. Grain
 
-If you're leaving tl;dv but actually used the video clip features, [Grain](https://grain.com/) does that part better and cheaper. It's built around the same idea—record meetings, create shareable video highlights—but starts at $15/month instead of $29.
+If you're leaving tl;dv but actually used the video clip features, [Grain](https://grain.com/) does that part better and cheaper. Same idea — record meetings, create shareable video highlights — but it starts at $15/month instead of $29.
 
 #### How it compares to tl;dv
 
-Grain's clip creation and highlight reels are more polished than tl;dv's. The interface for browsing and sharing moments is cleaner. What you lose is tl;dv's multi-meeting analytics and sales coaching. If you used those, Grain isn't the right move. If you mostly made clips and shared them with your team, it is.
+Grain's clip creation and highlight reels are more polished than tl;dv's. The interface for browsing and sharing moments is cleaner. What you lose is tl;dv's multi-meeting analytics and sales coaching. If you used those, Grain isn't the right move. If you mostly made clips and shared them, it is.
 
 #### Top Features
 
@@ -146,7 +146,7 @@ Free with 5 recordings. Starter at $19/month. Business at $39/month.
 
 #### How it compares to tl;dv
 
-The conversation intelligence that tl;dv locks behind Pro and Business tiers, Fireflies includes at a lower price point. Where Fireflies falls short: no video clip creation, and the sales coaching playbooks aren't as developed. Where it wins: 69 languages (tl;dv has 30), unlimited free transcription, and a larger integration ecosystem.
+The conversation intelligence that tl;dv locks behind Pro and Business, Fireflies includes at a lower price. Where Fireflies falls short: no video clip creation, and sales coaching playbooks aren't as developed. Where it wins: 69 languages (tl;dv has 30), unlimited free transcription, and a larger integration ecosystem.
 
 #### Top Features
 
@@ -182,7 +182,7 @@ Also check: [Fireflies AI alternatives](/blog/fireflies-ai-alternatives)
 
 #### How it compares to tl;dv
 
-Unlike tl;dv's bot-based approach, Tactiq works invisibly in your browser and shows the transcript live during the meeting. tl;dv doesn't offer that real-time view. The trade-off: Chrome only, no video recording, and limited to three meeting platforms.
+Tactiq works invisibly in your browser and shows the transcript live during the meeting. tl;dv doesn't offer that real-time view. The trade-off: Chrome only, no video recording, and limited to three meeting platforms.
 
 #### Top Features
 
@@ -196,7 +196,7 @@ Unlike tl;dv's bot-based approach, Tactiq works invisibly in your browser and sh
 
 - No meeting bot disruption
 - See transcripts while the meeting is happening
-- Fast setup—works immediately after installing the extension
+- Fast setup — works immediately after installing the extension
 - Custom prompts for specific meeting outputs
 
 #### Cons
@@ -216,9 +216,9 @@ Free with 10 meetings/month and 5 AI credits. Pro at $12/month.
 
 #### How it compares to tl;dv
 
-MeetGeek has analytics, but it's more about meeting health than revenue coaching. If you used tl;dv primarily for its cross-meeting AI reports or sales coaching, MeetGeek isn't a straight swap.
+MeetGeek has analytics, but it's more about meeting health than revenue coaching. If you used tl;dv primarily for cross-meeting AI reports or sales coaching, MeetGeek isn't a straight swap.
 
-If you used it for solid transcription, summaries, and workflow integrations across a broader team, MeetGeek is a strong and cheaper alternative. MeetGeek also offers HIPAA compliance, which tl;dv doesn't.
+If you used it for transcription, summaries, and workflow integrations across a broader team, MeetGeek is a cheaper alternative. MeetGeek also offers HIPAA compliance, which tl;dv doesn't.
 
 #### Top Features
 
@@ -233,8 +233,8 @@ If you used it for solid transcription, summaries, and workflow integrations acr
 
 - Automatic categorization saves setup time
 - HIPAA compliance for healthcare and legal teams
-- Good multilingual support for international teams
-- Strong analytics and coaching insights
+- Multilingual support for international teams
+- Analytics and coaching insights
 
 #### Cons
 
@@ -249,13 +249,13 @@ Free with 3 hours/month. Pro at $19/month. Business at $29/month.
 
 ### 7. Supernormal
 
-[Supernormal](https://www.supernormal.com/) is AI for agencies. It pulls context from your meetings, emails, and docs to complete actual client work, such as creating slide decks, project briefs, research reports, follow-up emails, and mood boards.
+[Supernormal](https://www.supernormal.com/) is AI for agencies. It pulls context from your meetings, emails, and docs to complete actual client work: slide decks, project briefs, research reports, follow-up emails, mood boards.
 
 #### How it compares to tl;dv
 
-Supernormal starts from meeting capture and goes further into actually completing the work that comes out of those meetings.
+Supernormal starts from meeting capture and goes further into completing the work that comes out of those meetings.
 
-If you used tl;dv mainly as a notetaker with CRM sync or sales coaching, Supernormal isn't the right swap. But if you left tl;dv wishing it would just do the post-meeting work for you, especially in an agency context where every client call produces deliverables, Supernormal is worth a serious look.
+If you used tl;dv mainly as a notetaker with CRM sync or sales coaching, Supernormal isn't the right swap. If you left tl;dv wishing it would just do the post-meeting work for you, especially in an agency where every client call produces deliverables, Supernormal is worth a serious look.
 
 #### Top Features
 
@@ -287,8 +287,8 @@ Free plan available. Pro at $10/month.
 
 ## Our top recommendation
 
-Anarlog is worth trying if you value both functionality and control.
+Anarlog is worth trying if you want both functionality and control.
 
-You get AI-powered features without giving up ownership of your data. You get enterprise-grade functionality without vendor lock-in. You get ease of use without sacrificing flexibility.
+You get AI features without giving up data ownership. You get enterprise-grade functionality without vendor lock-in.
 
-You can [try the tool out for free](https://anarlog.so). If it's not for you, you can walk away and your notes stay yours.
+You can [try it for free](https://anarlog.so). If it's not for you, walk away — your notes stay yours.

--- a/apps/web/content/articles/tldv-review.mdx
+++ b/apps/web/content/articles/tldv-review.mdx
@@ -7,29 +7,29 @@ category: "Comparisons"
 date: "2025-10-17"
 ---
 
-If you're considering tl;dv to handle your meeting notes and summaries automatically, you'll find a detailed breakdown here.
+If you're considering tl;dv to handle meeting notes and summaries automatically, here's a detailed breakdown.
 
-I've tested the platform, analyzed dozens of user reviews, and compared it against [top alternatives](/blog/tldv-alternatives/).
+I tested the platform, read dozens of user reviews, and compared it against [top alternatives](/blog/tldv-alternatives/).
 
 ## What is tl;dv and how does it work?
 
-[tl;dv](https://tldv.io) (yes, lowercase, it stands for "too long; didn't view") is a cloud-based AI note-taker designed primarily for virtual meetings on Zoom, Google Meet, and Microsoft Teams. A bot joins your meeting, records everything, transcribes the conversation in real-time, and generates AI summaries once the call ends.
+[tl;dv](https://tldv.io) (yes, lowercase — it stands for "too long; didn't view") is a cloud-based AI note-taker built primarily for virtual meetings on Zoom, Google Meet, and Microsoft Teams. A bot joins your meeting, records everything, transcribes in real time, and generates AI summaries after the call.
 
-The platform has attracted over 2 million users worldwide, including teams at Fortune 500 companies like Cloudflare, Forbes, and Salesforce. It's particularly popular among sales and customer success teams who need to track conversations, coach reps, and push insights into their CRMs.
+The platform has over 2 million users, including teams at Cloudflare, Forbes, and Salesforce. It's popular with sales and customer success teams who track conversations, coach reps, and push insights into their CRMs.
 
-tl;dv is entirely cloud-based and bot-dependent. Your data goes to their servers for processing, then to Anthropic (their AI partner) for generating summaries and insights. This architecture shapes both its strengths and limitations.
+tl;dv is entirely cloud-based and bot-dependent. Your data goes to their servers, then to Anthropic (their AI partner) for summaries and insights. That architecture shapes both its strengths and its limits.
 
 ## tl;dv's top features and my verdict on them
 
 ### 1. Real-time transcription
 
-tl;dv delivers live transcription as people speak during meetings. The claimed accuracy is 96% for clear English audio, and you can watch the transcript appear in real-time.
+tl;dv delivers live transcription as people speak. Claimed accuracy is 96% for clear English audio, and you can watch the transcript appear in real time.
 
-After the meeting, you get a full searchable transcript with timestamps. The transcription supports 30+ languages including Spanish, Portuguese, German, Japanese, and Korean.
+After the meeting, you get a full searchable transcript with timestamps. Transcription supports 30+ languages including Spanish, Portuguese, German, Japanese, and Korean.
 
-**Verdict:** Works well for native English speakers with good audio quality. But struggles significantly with accents—[particularly Indian English and mixed vernacular conversations](https://www.g2.com/products/tl-dv/reviews/tl-dv-review-11077932)—and completely falls apart with technical jargon.
+**Verdict:** Works well for native English speakers with good audio. Struggles with accents — [particularly Indian English and mixed vernacular conversations](https://www.g2.com/products/tl-dv/reviews/tl-dv-review-11077932) — and falls apart on technical jargon.
 
-The biggest problem is the lack of custom vocabulary options. Teams in biotech, fintech, or specialized fields spend considerable time manually correcting transcripts after every meeting.
+The biggest problem is the lack of custom vocabulary. Teams in biotech, fintech, or specialized fields spend real time manually correcting transcripts after every meeting.
 
 <Image src="/api/assets/blog/tldv-review/tldv-1.webp" alt="tl;dv real-time transcription interface" />
 Source: [G2](https://www.g2.com/products/tl-dv/reviews/tl-dv-review-11538783)
@@ -38,7 +38,7 @@ Source: [G2](https://www.g2.com/products/tl-dv/reviews/tl-dv-review-11538783)
 
 The platform automatically identifies who's speaking and labels them in the transcript. You can rename speakers afterward to keep things organized.
 
-**Verdict:** Works great for one-on-one calls or structured meetings where people take turns. Falls apart when multiple people talk quickly, interrupt, or overlap. Manual cleanup is necessary for fast-paced team discussions.
+**Verdict:** Works for one-on-one calls or structured meetings where people take turns. Falls apart when multiple people talk quickly, interrupt, or overlap. Manual cleanup is necessary for fast-paced team discussions.
 
 ### 3. AI summaries with custom templates
 
@@ -46,7 +46,7 @@ After each meeting, tl;dv generates an AI summary that includes key discussion p
 
 You can customize these summaries using templates. Built-in frameworks include MEDDIC and BANT for sales teams, or you can create your own format using custom prompts.
 
-**Verdict:** Saves time for getting the gist quickly, but misses nuances and context regularly. Users report having to prompt the AI multiple times to capture all action items correctly. Consider it a smart first draft that needs review rather than a finished product you can trust blindly.
+**Verdict:** Fast for getting the gist, but misses nuance and context regularly. Users report prompting the AI multiple times to capture all action items correctly. Treat it as a first draft that needs review, not a finished product.
 
 <Image src="/api/assets/blog/tldv-review/tldv-2.webp" alt="tl;dv AI-generated meeting summary example" />
 Source: [G2](https://www.g2.com/products/tl-dv/reviews/tl-dv-review-11529251)
@@ -55,15 +55,15 @@ Source: [G2](https://www.g2.com/products/tl-dv/reviews/tl-dv-review-11529251)
 
 You can highlight any part of the transcript and instantly generate a short video clip of that exact moment. You can combine multiple clips into "Reels" to share highlights with stakeholders without forcing them to watch full recordings.
 
-**Verdict:** This is one of tl;dv's standout features. Being able to grab exact customer feedback or important decisions and share them instantly proves useful in practice. Users consistently praise this capability, and it works well with no complaints.
+**Verdict:** This is one of tl;dv's standout features. Grabbing exact customer feedback or a key decision and sharing it instantly is useful in practice. Users consistently praise it, and it works well.
 
 ### 5. Multi-meeting conversational intelligence
 
 You can ask questions across multiple meetings, track topics automatically with keyword alerts, analyze sentiment, get automated weekly reports of trends, and evaluate sales performance with coaching scorecards.
 
-**Verdict:** Powerful for sales managers, CS leaders, and product people who need insights from many customer conversations. Much less valuable if you only need occasional meeting notes.
+**Verdict:** Useful for sales managers, CS leaders, and product people who need insights from many customer conversations. Much less so if you only need occasional meeting notes.
 
-However, users note the analytics lack depth. You get qualitative insights but limited quantitative metrics. Tools like Avoma offer more detailed statistical analysis if you need it.
+Users note the analytics lack depth. You get qualitative insights but limited quantitative metrics. Tools like Avoma offer more statistical analysis if you need it.
 
 <Image src="/api/assets/blog/tldv-review/tldv-3.webp" alt="tl;dv multi-meeting conversational intelligence dashboard" />
 Source: [G2](https://www.g2.com/products/tl-dv/reviews/tl-dv-review-11621640)
@@ -72,13 +72,13 @@ Source: [G2](https://www.g2.com/products/tl-dv/reviews/tl-dv-review-11621640)
 
 For sales teams, tl;dv offers coaching features that evaluate how well reps follow your methodology. You can compare actual responses against ideal rebuttals, track which reps need coaching, and identify performance patterns. The platform includes frameworks like BANT and MEDDIC built-in.
 
-**Verdict:** Well-designed for sales teams that want to scale coaching across reps. This differentiates tl;dv if you're managing a sales org. Less relevant for other use cases.
+**Verdict:** Built for sales teams that want to scale coaching across reps. A real differentiator if you're managing a sales org. Less relevant for other use cases.
 
 ### 7. Integrations
 
-tl;dv integrates with major CRMs like Salesforce and HubSpot. You can map your AI summary template to CRM fields, and the system will automatically update records after calls. The platform claims integration with 6,000+ tools via Zapier.
+tl;dv integrates with major CRMs like Salesforce and HubSpot. You can map your AI summary template to CRM fields, and the system updates records automatically after calls. The platform claims integration with 6,000+ tools via Zapier.
 
-**Verdict:** The 6,000+ number is misleading—most require Zapier, adding another tool to your stack. Even the native integrations have problems. Multiple users reported broken or limited HubSpot and Slack integrations, with some giving harsh reviews entirely due to integration failures and poor support.
+**Verdict:** The 6,000+ number is misleading — most require Zapier, adding another tool to your stack. Even the native integrations have problems. Multiple users reported broken or limited HubSpot and Slack integrations, with some leaving harsh reviews entirely over integration failures and poor support.
 
 <Image src="/api/assets/blog/tldv-review/tldv-4.webp" alt="tl;dv CRM and tool integrations" />
 Source: [G2](https://www.g2.com/products/tl-dv/reviews/tl-dv-review-11405083)
@@ -87,50 +87,50 @@ Source: [G2](https://www.g2.com/products/tl-dv/reviews/tl-dv-review-11405083)
 
 You can comment on specific meeting moments, tag teammates, share clips and highlights, and auto-share summaries to team channels. The platform also lets you take manual notes with timestamps during or after calls.
 
-**Verdict:** Async collaboration works well. You can't collaborate in real-time during a meeting, but post-meeting sharing and commenting function properly. Useful for distributed teams that need to circulate insights after calls.
+**Verdict:** Async collaboration works well. You can't collaborate in real time during a meeting, but post-meeting sharing and commenting work properly. Useful for distributed teams that need to circulate insights after calls.
 
 ### 9. Search and discovery
 
-Keyword search across all your transcripts makes it easy to find past discussions. You can search by speaker, topic, or specific phrases, then jump directly to relevant moments. Filtering by domain, date, and meeting status narrows results.
+Keyword search across all your transcripts lets you find past discussions, search by speaker, topic, or phrase, and jump to relevant moments. Filtering by domain, date, and meeting status narrows results.
 
-**Verdict:** The search functionality is hit or miss. While it works for straightforward keyword matches, it sometimes returns meetings that don't actually contain the searched keywords.
+**Verdict:** Search is hit or miss. It works for straightforward keyword matches, but sometimes returns meetings that don't actually contain the searched keywords.
 
 ### 10. Download and export
 
-On the Pro plan, you get unlimited downloads of meetings as .mp4 video files. You can download full recordings or just clips, then upload them to other platforms or save them to internal storage.
+On the Pro plan, you get unlimited downloads of meetings as .mp4 video files. You can download full recordings or just clips, then upload them elsewhere or save them to internal storage.
 
-**Verdict:** Works as advertised. Being able to grab recordings offline or move them to your own storage is useful. The catch is it requires the Pro plan. Free users face a 3+ day wait to access older videos.
+**Verdict:** Works as advertised. Grabbing recordings offline or moving them to your own storage is useful. The catch: it requires the Pro plan. Free users face a 3+ day wait to access older videos.
 
 ## Where tl;dv falls short
 
-Despite an impressive feature set, tl;dv has some notable gaps:
+The feature set is broad, but the gaps are notable:
 
 ### 1. No custom vocabulary
 
-You cannot add custom terms, product names, or industry jargon to improve transcription accuracy. For teams in biotech, fintech, legal, or healthcare, this means constant manual corrections of technical terms that the AI misunderstands.
+You can't add custom terms, product names, or industry jargon to improve transcription accuracy. For teams in biotech, fintech, legal, or healthcare, this means constant manual corrections of technical terms the AI misreads.
 
 ### 2. No offline capability
 
-tl;dv is entirely cloud-dependent. No internet means no recording, no transcription, no access to past meetings. If you travel frequently or work in areas with spotty connectivity, this becomes a real problem.
+tl;dv is entirely cloud-dependent. No internet means no recording, no transcription, no access to past meetings. If you travel often or work in areas with spotty connectivity, this becomes a real problem.
 
 ### 3. Virtual meetings only
 
-The platform only works with Zoom, Google Meet, and Microsoft Teams. In-person meetings, phone calls, and conversations on other platforms like Discord or Slack cannot be captured.
+It only works with Zoom, Google Meet, and Microsoft Teams. In-person meetings, phone calls, and conversations on Discord or Slack can't be captured.
 
-### 4. No seamless manual note-taking experience
+### 4. No real notepad experience
 
-While you can add timestamped notes, there's no true notepad experience where you can actively type alongside live transcription in a unified interface. It functions more as an annotation tool than an integrated note-taking workspace.
+You can add timestamped notes, but there's no real notepad where you type alongside live transcription in one interface. It's an annotation tool, not a note-taking workspace.
 
 ## tl;dv pros and cons
 
 **Pros**
 
-- Excellent clip creation feature for sharing specific moments
-- Multi-meeting insights valuable for sales and CS teams
-- Good sales coaching features with playbook tracking
-- Strong CRM integration for automating post-call admin work
+- Clip creation is excellent for sharing specific moments
+- Multi-meeting insights useful for sales and CS teams
+- Sales coaching features with playbook tracking
+- CRM integration automates post-call admin work
 - Custom summary templates let you control output format
-- Competitive pricing compared to expensive tools like Gong
+- Cheaper than Gong
 
 **Cons**
 
@@ -147,25 +147,25 @@ While you can add timestamped notes, there's no true notepad experience where yo
 
 ## How much does tl;dv cost?
 
-tl;dv operates on a freemium model with four tiers: Free Forever ($0), Pro ($29/seat/month), Business ($98/seat/month), and custom Enterprise pricing.
+tl;dv runs on a freemium model with four tiers: Free Forever ($0), Pro ($29/seat/month), Business ($98/seat/month), and custom Enterprise pricing.
 
 <Image src="/api/assets/blog/tldv-review/tldv-5.webp" alt="tl;dv pricing breakdown" />
 
-The free plan offers unlimited meetings, basic AI summaries, and transcription without a credit card. You're capped at 20 AI multi-meeting reports, which heavily restricts conversational intelligence features. You'll outgrow this quickly for anything beyond basic transcription.
+The free plan offers unlimited meetings, basic AI summaries, and transcription with no credit card. You're capped at 20 AI multi-meeting reports, which heavily restricts conversational intelligence features. You'll outgrow it quickly for anything beyond basic transcription.
 
-Pro at $29/month is expensive compared to the competition. Fireflies offers similar multi-meeting insights at $18/month. Otter charges $16.99/month. MeetGeek and Avoma both start at $19/month with comparable analytics. Read AI comes in at $19.75/month and offers unified search across meetings and emails.
+Pro at $29/month is expensive compared to the competition. Fireflies offers similar multi-meeting insights at $18/month. Otter charges $16.99/month. MeetGeek and Avoma both start at $19/month with comparable analytics. Read AI comes in at $19.75/month with unified search across meetings and emails.
 
-If you're just looking for meeting highlights and basic video clips, you're overpaying.
+If you only need meeting highlights and basic video clips, you're overpaying.
 
-The value proposition only makes sense if you specifically need tl;dv's sales coaching features, locked behind the Business plan at $98/month. That's a $69/month jump from Pro.
+The value only makes sense if you specifically need tl;dv's sales coaching features, locked behind Business at $98/month. That's a $69/month jump from Pro.
 
-Enterprise offers custom pricing for organizations needing privately hosted AI, advanced security, and dedicated support.
+Enterprise has custom pricing for orgs needing privately hosted AI, advanced security, and dedicated support.
 
 ## Final verdict: is tl;dv worth it?
 
-tl;dv is a capable meeting assistant with genuinely useful features, particularly for sales and customer success teams. The clip creation works well, multi-meeting intelligence delivers value when analyzing dozens of conversations, and the sales coaching tools are sophisticated.
+tl;dv is a capable meeting assistant with useful features, particularly for sales and customer success teams. The clip creation works, multi-meeting intelligence pays off when you're analyzing dozens of conversations, and the sales coaching tools are sophisticated.
 
-But tl;dv is priced at a premium without offering premium features until you hit the expensive Business tier.
+But tl;dv charges premium prices without delivering premium features until you hit the expensive Business tier.
 
 **Choose tl;dv if you:**
 
@@ -185,33 +185,33 @@ But tl;dv is priced at a premium without offering premium features until you hit
 
 ## How Anarlog compares with tl;dv
 
-Anarlog doesn't record meeting video, so it's not a one-to-one tl;dv alternative. But if you're looking for an AI meeting assistant that captures meeting audio to deliver real-time transcription and instant AI summaries, it's worth considering.
+Anarlog doesn't record meeting video, so it's not a one-to-one tl;dv alternative. But if you want an AI meeting assistant that captures meeting audio to deliver real-time transcription and instant AI summaries, it's worth considering.
 
 **Core advantages over tl;dv:**
 
-- **Local-first privacy.** Everything processes on your device using on-device AI models. Your conversations never touch the cloud unless you explicitly connect an external LLM provider of your choice.
-- **Bot-free recording.** Captures system audio and microphone directly. No visible bot in your meetings, no client discomfort, no disruption.
-- **Universal platform support.** Works with any meeting software—Zoom, Meet, Teams, Discord, Slack—and captures in-person conversations.
-- **Offline capability.** Record, transcribe, and summarize meetings anywhere without internet. Perfect for travel, secure environments, or unreliable connectivity.
-- **No vendor lock-in.** Choose your own AI providers—OpenAI, Anthropic, Gemini, Ollama, or custom endpoints.
-- **Open source.** Inspect the code, audit security, and customize for your organization's needs.
+- **Local-first privacy.** Everything processes on your device with on-device AI models. Your conversations never touch the cloud unless you explicitly connect an external LLM provider of your choice.
+- **Bot-free recording.** Captures system audio and microphone directly. No visible bot, no client discomfort, no disruption.
+- **Universal platform support.** Works with any meeting software — Zoom, Meet, Teams, Discord, Slack — and captures in-person conversations.
+- **Offline capability.** Record, transcribe, and summarize meetings without internet. Useful for travel, secure environments, or unreliable connectivity.
+- **No vendor lock-in.** Choose your own AI providers — OpenAI, Anthropic, Gemini, Ollama, or custom endpoints.
+- **Open source.** Inspect the code, audit security, and customize for your org.
 - **Better pricing.** Free forever for local transcription, BYOK, and all core features. Managed cloud is $25/month versus tl;dv's $29/month.
 
 <Image src="/api/assets/blog/tldv-review/tldv-6.webp" alt="Anarlog vs tl;dv comparison" />
 
 **Anarlog's note-taking and summary features:**
 
-- **Familiar notepad interface.** Feels like Apple Notes with powerful AI running locally in the background. A true notepad experience rather than an annotation tool.
-- **Custom templates for any meeting type.** Tailored formats for therapy sessions, legal consultations, sales calls, team standups, or casual conversations.
+- **Familiar notepad interface.** Feels like Apple Notes with AI running locally in the background. A real notepad, not an annotation tool.
+- **Custom templates for any meeting type.** Formats for therapy sessions, legal consultations, sales calls, team standups, or casual conversations.
 - **Real-time transcription.** Live captions appear as people speak, without sending data to the cloud.
 - **AI chat for instant answers.** Ask "What did Sarah say about the budget?" or "List all action items from this week" and get immediate responses.
-- **Control over AI involvement.** Choose how much AI restructures your notes—from minimal touch-ups to complete reformatting.
+- **Control over AI involvement.** Choose how much AI restructures your notes — from minimal touch-ups to full reformatting.
 - **Source verification.** Hover over any AI-generated summary point to see the exact transcript quote.
-- **Multiple export formats.** Markdown, PDF, or Rich Text to fit your workflow.
+- **Multiple export formats.** Markdown, PDF, or Rich Text.
 
 **Bottom line:** If you're a sales team needing video recording and coaching features, tl;dv makes more sense.
 
-If privacy matters, you need bot-free recording, or you want offline capability, Anarlog delivers better value at a fraction of the cost while keeping your data completely under your control.
+If privacy matters, you need bot-free recording, or you want offline capability, Anarlog delivers better value at a fraction of the cost while keeping your data fully under your control.
 
-Download Anarlog for macOS or explore our full comparison of AI meeting summary tools to see how other alternatives stack up.
+Download Anarlog for macOS or read our comparison of AI meeting summary tools to see how the alternatives stack up.
 

--- a/apps/web/content/articles/transcription-software-mac.mdx
+++ b/apps/web/content/articles/transcription-software-mac.mdx
@@ -7,9 +7,9 @@ category: "Comparisons"
 date: "2025-10-07"
 ---
 
-Finding transcription software that works well on Mac isn't as simple as it should be. Many popular tools are Windows-first ports, web apps that drain your battery, or subscription services that send your audio to the cloud.
+Finding transcription software that works well on Mac isn't as simple as it should be. Most popular tools are Windows-first ports, web apps that drain your battery, or subscription services that ship your audio to the cloud.
 
-This guide covers transcription software built for macOS, whether you need real-time meeting transcription, batch file processing, or podcast editing with built-in transcription.
+This guide covers transcription software built for macOS — whether you need real-time meeting transcription, batch file processing, or podcast editing with built-in transcription.
 
 ## Best transcription software for Mac: quick comparison
 
@@ -39,7 +39,7 @@ We tested each tool on M1, M2, and Intel Macs to assess:
 
 [Anarlog](/) is an open-source AI notepad for meetings built for Mac. Everything is stored as plain markdown files on your device. You choose your AI: bring your own keys or run local models. Zero lock-in.
 
-It works as both a real-time meeting assistant and a file transcription tool. Connect it to any meeting platform (Zoom, Teams, Meet, or in-person conversations), and it transcribes while you focus on the conversation.
+It works as both a real-time meeting assistant and a file transcription tool. Connect it to any meeting platform (Zoom, Teams, Meet, or in-person conversations) and it transcribes while you focus on the conversation.
 
 #### What makes it stand out on Mac
 
@@ -66,15 +66,15 @@ It works as both a real-time meeting assistant and a file transcription tool. Co
 
 ### 2. MacWhisper: best for simple file transcription
 
-[MacWhisper](https://goodsnooze.gumroad.com/l/macwhisper) wraps OpenAI's Whisper technology in a simple drag-and-drop interface built specifically for Mac. If you just need to transcribe audio files without the complexity of a full meeting assistant, MacWhisper delivers.
+[MacWhisper](https://goodsnooze.gumroad.com/l/macwhisper) wraps OpenAI's Whisper in a drag-and-drop interface built for Mac. If you just need to transcribe audio files without a full meeting assistant, MacWhisper delivers.
 
-The app processes everything locally on your Mac. Drop in an audio file, select a model size based on accuracy versus speed needs, and get your transcript with synced audio playback.
+The app processes everything locally. Drop in an audio file, pick a model size based on accuracy vs. speed, and get your transcript with synced audio playback.
 
 #### Performance on Mac
 
 Performance depends on your hardware. Apple Silicon Macs handle transcription smoothly, processing files at roughly 15x real-time speed. A 27-minute video with three speakers transcribes in about 2 minutes on an M2 Max.
 
-Intel Macs work but run significantly slower, especially with larger models that require more than 8GB RAM.
+Intel Macs work but run much slower, especially with larger models that need more than 8GB RAM.
 
 #### MacWhisper 12 update (2025)
 
@@ -100,13 +100,13 @@ The latest version adds automatic speaker recognition, making it the first Mac a
 
 ### 3. Descript: best for podcast and video editing
 
-[Descript](https://www.descript.com) isn't just transcription software. It's an audio/video editor that uses transcription as its core editing interface. Edit your podcast or video by editing the text transcript.
+[Descript](https://www.descript.com) isn't just transcription software. It's an audio/video editor that uses transcription as the core editing interface. Edit your podcast or video by editing the text transcript.
 
-Delete a sentence from the transcript, and it removes that audio from your recording. This text-based approach eliminates timeline scrubbing.
+Delete a sentence from the transcript and it removes that audio from your recording. No timeline scrubbing.
 
 #### Mac-specific considerations
 
-Descript runs as a native Mac app with decent Apple Silicon support, though it's more resource-intensive than simpler transcription tools. Expect it to use significant CPU and RAM during editing sessions.
+Descript runs as a native Mac app with decent Apple Silicon support, though it's more resource-intensive than simpler transcription tools. Expect heavy CPU and RAM use during editing sessions.
 
 #### What's free
 
@@ -126,7 +126,7 @@ Descript runs as a native Mac app with decent Apple Silicon support, though it's
 
 ### 4. Otter.ai: best for automated meeting transcription
 
-[Otter.ai](https://otter.ai) is one of the most popular meeting transcription tools. Its bot (OtterPilot) automatically joins your Zoom, Teams, and Google Meet calls based on your calendar, records everything, and shares notes afterward.
+[Otter.ai](https://otter.ai) is one of the most popular meeting transcription tools. Its bot (OtterPilot) joins your Zoom, Teams, and Google Meet calls based on your calendar, records everything, and shares notes afterward.
 
 The trade-off is clear: you gain convenience by sending all conversations to Otter's cloud servers for processing.
 
@@ -153,11 +153,11 @@ Otter works primarily through their web app and browser extensions. The Mac app 
 
 ### 5. Notta: best for multi-language transcription
 
-[Notta](https://www.notta.ai) supports 58 languages for transcription and 42 for translation, making it the strongest choice for multilingual teams. Like Otter, it uses a meeting bot to automatically join and transcribe calls.
+[Notta](https://www.notta.ai) supports 58 languages for transcription and 42 for translation, making it the strongest choice for multilingual teams. Like Otter, it uses a meeting bot to join and transcribe calls.
 
 #### Mac experience
 
-Notta offers a Mac app alongside their web interface. The app is functional but not particularly Mac-native in feel. Processing happens in the cloud.
+Notta offers a Mac app alongside the web interface. It's functional but doesn't feel especially Mac-native. Processing happens in the cloud.
 
 #### What's free
 
@@ -175,7 +175,7 @@ Notta offers a Mac app alongside their web interface. The app is functional but 
 
 ### 6. Rev: best for human transcription accuracy
 
-[Rev](https://www.rev.com) offers something unique: the option to have humans transcribe your audio for 99% accuracy. Their AI transcription is also available at lower cost, but the human option sets them apart.
+[Rev](https://www.rev.com) offers something unique: humans transcribing your audio for 99% accuracy. AI transcription is also available at lower cost, but the human option is what sets them apart.
 
 #### Pricing model
 
@@ -193,13 +193,13 @@ Rev is primarily web-based. Upload files through their website, and download tra
 
 ### 7. Sonix: best for subtitles and translation
 
-[Sonix](https://sonix.ai) focuses on transcription plus automated subtitles and translation. It supports 53+ languages for transcription and can translate into 54+ languages.
+[Sonix](https://sonix.ai) focuses on transcription plus automated subtitles and translation. It supports 53+ languages for transcription and translates into 54+.
 
-The platform is popular with video producers who need subtitles in multiple languages without hiring translators for each version.
+It's popular with video producers who need subtitles in multiple languages without hiring translators for each version.
 
 #### Mac experience
 
-Sonix is entirely web-based. All editing happens in their browser-based editor, which works fine on Mac but isn't a native experience.
+Sonix is entirely web-based. All editing happens in their browser editor, which works fine on Mac but isn't a native experience.
 
 #### Pricing
 
@@ -243,9 +243,9 @@ The biggest decision when choosing Mac transcription software is where your audi
 
 ## Which transcription software should you choose?
 
-**Anarlog** works best if you handle sensitive conversations, want unlimited local transcription, and prefer open-source transparency. The Mac-native experience and Apple Silicon optimization make it feel like it belongs on your Mac.
+**Anarlog** works best if you handle sensitive conversations, want unlimited local transcription, and prefer open-source transparency. The Mac-native build and Apple Silicon optimization make it feel like it belongs on your Mac.
 
-**MacWhisper** suits you if you need simple file transcription without meeting assistant features. The one-time payment model beats subscription fatigue.
+**MacWhisper** suits you if you need simple file transcription without meeting features. The one-time payment beats subscription fatigue.
 
 **Descript** is right for editing podcasts or videos through text. The transcription serves the editing workflow.
 
@@ -259,9 +259,9 @@ The biggest decision when choosing Mac transcription software is where your audi
 
 ## Our recommendation
 
-For most Mac users who care about privacy and want a tool that actually feels like a Mac app, **Anarlog** offers the best combination of unlimited local transcription, real-time meeting support, and native macOS experience.
+For most Mac users who care about privacy and want a tool that actually feels like a Mac app, **Anarlog** is the best combination of unlimited local transcription, real-time meeting support, and native macOS experience.
 
-If you just need occasional file transcription without meeting features, **MacWhisper** is solid with its one-time payment.
+If you just need occasional file transcription, **MacWhisper** is solid with its one-time payment.
 
-For teams who prioritize automation over privacy, **Otter** or **Notta** provide the meeting bot experience, though all conversations go to the cloud.
+If you prioritize automation over privacy, **Otter** or **Notta** give you the meeting-bot experience, though all conversations go to the cloud.
 

--- a/apps/web/content/articles/using-ide-for-writing.mdx
+++ b/apps/web/content/articles/using-ide-for-writing.mdx
@@ -8,23 +8,23 @@ category: "Engineering"
 date: "2025-11-24"
 ---
 
-There's this quiet assumption in a lot of teams that "writing" should happen somewhere else. Some separate workspace. Some browser tab. Some editor UI designed to hide the machinery. Maybe that works for some people.
+There's a quiet assumption in a lot of teams that "writing" should happen somewhere else. A separate workspace. A browser tab. An editor UI designed to hide the machinery. Maybe that works for some people.
 
-We never adopted that model. We spend most of our waking hours inside an IDE. Zed, Cursor, VS Code, Neovim—pick your flavor. That's where we think, debug, rewrite, delete, and try again. So it always felt strange to open a WYSIWYG editor and suddenly pretend the way we work should change just because the output is letters instead of code.
+We never adopted that model. We spend most of our waking hours inside an IDE. Zed, Cursor, VS Code, Neovim — pick your flavor. That's where we think, debug, rewrite, delete, and try again. It always felt strange to open a WYSIWYG editor and pretend the way we work should change just because the output is letters instead of code.
 
 This isn't just a workflow preference. It changes how you approach writing itself.
 
 ## Writing is part of building
 
-At Anarlog everyone writes and everyone codes. There's no sharp line between the two. Writing lives next to version control, next to the app logic, next to everything else we ship. When you treat writing as something that belongs in the same universe as code, a lot of decisions get simpler.
+At Anarlog everyone writes and everyone codes. There's no sharp line between the two. Writing lives next to version control, next to the app logic, next to everything else we ship. When writing belongs in the same universe as code, a lot of decisions get simpler.
 
-Context switching disappears. I don't have to think, "Okay, now I'm leaving my environment to go write a blog post." I'm already here. I just open a new `.mdx` file and start typing. Cursor or Zed already knows my shortcuts, my theme, my keybindings, my muscle memory. It feels natural.
+Context switching disappears. I don't have to think, "Okay, now I'm leaving my environment to go write a blog post." I'm already here. I open a new `.mdx` file and start typing. Cursor or Zed already knows my shortcuts, my theme, my keybindings, my muscle memory.
 
 ## WYSIWYG tools hide the wrong things
 
-WYSIWYG editors always promise ease. Click here, bold there, drag an image, done. But once you try to do anything slightly unusual, they fall apart. You start fighting the abstraction.
+WYSIWYG editors promise ease. Click here, bold there, drag an image, done. But once you try anything slightly unusual, they fall apart. You start fighting the abstraction.
 
-You want to add a custom callout, embed a component, adjust image borders, write MDX, leave inline comments for teammates, control spacing, or make the layout match the rest of the site. Suddenly you're clicking around a UI that was never meant for people who actually care what's happening under the hood. You end up debugging the editor itself.
+You want to add a custom callout, embed a component, adjust image borders, write MDX, leave inline comments for teammates, control spacing, or make the layout match the rest of the site. Suddenly you're clicking around a UI that was never meant for people who care what's happening under the hood. You end up debugging the editor itself.
 
 MDX lets you write what you mean and see what you wrote. Nothing forces your hand.
 

--- a/apps/web/content/articles/what-makes-reliable-ai-note-taker.mdx
+++ b/apps/web/content/articles/what-makes-reliable-ai-note-taker.mdx
@@ -11,7 +11,7 @@ date: "2025-10-25"
 
 When we started building Anarlog, we knew what we were up against. Otter, Fireflies, Granola—the space was already crowded with well-funded players offering impressive features.
 
-We could have tried to out-feature them. More integrations. Shinier interfaces. Flashier AI capabilities. Instead, we made reliability our north star.
+We could have tried to out-feature them. More integrations. Shinier interfaces. Flashier AI capabilities. Instead, we made reliability the priority.
 
 IT teams were banning existing tools. Users worried about data privacy. Most options didn't work without internet. The market needed an AI notetaker that worked anywhere, reliably, offline.
 
@@ -63,7 +63,7 @@ Check out [bot-free AI notetakers](/blog/bot-free-ai-meeting-assistants) that so
 
 Usage-based pricing scales your costs with your usage. Per-minute charges work until they don't.
 
-SaaS pricing has increased dramatically across the industry. Tools affordable at 10 meetings per month become expensive at 50. Features move from basic tiers to enterprise plans. Free tiers get restricted.
+SaaS pricing has gone up across the industry. Tools affordable at 10 meetings per month become expensive at 50. Features move from basic tiers to enterprise plans. Free tiers get restricted.
 
 Usage caps create the same problem. You get 100 minutes per month, then you're blocked. Or unlimited meetings but limited AI features. The tool works until you cross a threshold.
 

--- a/apps/web/content/articles/why-our-cms-is-github.mdx
+++ b/apps/web/content/articles/why-our-cms-is-github.mdx
@@ -44,7 +44,7 @@ You're never stuck asking "How do I do this in the CMS?" Instead you ask "How do
 
 Most CMS systems age poorly. Content models become rigid. Plugins break. WYSIWYG editors drift. Migrations become risky. Versioning becomes chaotic.
 
-GitHub doesn't have these problems. As your team grows, its primitives become more valuable: branch-based workflows, code owners for reviewing specific areas, protected branches, required checks, automation bots, and auditability. GitHub solved these problems at global scale. Why rebuild them in a CMS?
+GitHub doesn't have these problems. As your team grows, its primitives become more useful: branch-based workflows, code owners for reviewing specific areas, protected branches, required checks, automation bots, and auditability. GitHub solved these problems at global scale. Why rebuild them in a CMS?
 
 ## Images, assets, and everything else
 

--- a/apps/web/content/articles/zoom-ai-companion-review.mdx
+++ b/apps/web/content/articles/zoom-ai-companion-review.mdx
@@ -8,9 +8,9 @@ category: "Comparisons"
 date: "2025-09-19"
 ---
 
-The AI meeting assistant market has exploded with promises of effortless note-taking and perfect meeting summaries. Zoom, the platform where millions spend their workday, launched AI Companion to compete directly with specialized tools.
+The AI meeting assistant market is full of promises about effortless note-taking and perfect meeting summaries. Zoom, the platform where millions spend their workday, launched AI Companion to compete directly with specialized tools.
 
-After analyzing hundreds of real user reviews, community discussions, and hands-on testing, the picture is far more complex than Zoom's marketing suggests.
+After analyzing hundreds of real user reviews, community discussions, and hands-on testing, the picture is messier than Zoom's marketing suggests.
 
 ## What Is Zoom AI Companion? The Complete Feature Breakdown
 
@@ -19,7 +19,7 @@ After analyzing hundreds of real user reviews, community discussions, and hands-
 ### What are Zoom AI Companion's Meeting Features?
 
 - **Meeting Summaries** generate post-meeting overviews with key points and action items using your audio transcript, screen-shared content (via OCR), and chat messages. These summaries require cloud processing through third-party AI models from companies like Anthropic and OpenAI.
-- **Smart Recording** breaks cloud recordings into chapters, highlights important sections, and extracts next steps. This only works with cloud recordings, raising immediate privacy concerns for sensitive meetings.
+- **Smart Recording** breaks cloud recordings into chapters, marks important sections, and extracts next steps. This only works with cloud recordings, which raises privacy concerns for sensitive meetings.
 - **In-Meeting Questions** let you ask the AI what you missed without interrupting the conversation. Users report that the feature often provides inaccurate or irrelevant responses.
 - **Voice Recorder** creates meeting summaries for in-person meetings, but requires manual setup and doesn't offer real-time transcription like specialized tools.
 - **Agentic Capabilities** proactively suggest which meetings to skip, automatically detect and track action items across the platform, and provide meeting preparation assistance.
@@ -29,7 +29,7 @@ Beyond meetings, AI Companion extends to **Chat Compose** for drafting Team Chat
 
 Some features, like real-time voice translation and photorealistic AI avatars, are on the product roadmap.
 
-The breadth is impressive, but this wide scope comes at the cost of depth and reliability in core use cases.
+The breadth is wide, but it comes at the cost of depth and reliability in core use cases.
 
 ## Is Zoom AI Companion Free?
 
@@ -55,7 +55,7 @@ Zoom uses a "federated approach" to AI, dynamically routing your data to differe
 
 ### 3. Compliance Implications
 
-Zoom AI Companion's cloud processing creates serious problems for compliance-sensitive organizations. Major institutions are actively blocking these features or creating separate HIPAA-compliant instances without AI capabilities.
+Zoom AI Companion's cloud processing creates problems for compliance-sensitive organizations. Major institutions are blocking these features or running separate HIPAA-compliant instances without AI capabilities.
 
 UC Irvine explicitly states that "Zoom AI Companion is not available for any users under the UCI-HIPAA Zoom instance" and warns it "should never be used in any meeting involving discussion of sensitive or protected information." For healthcare providers, legal firms, and financial services companies, this makes AI Companion unusable for their most important meetings.
 
@@ -71,9 +71,9 @@ We analyzed hundreds of user reviews across Zoom's community forums, Reddit, G2,
 
  Source: [Zoom](https://community.zoom.com/t5/Zoom-AI-Companion/Why-is-the-AI-Meeting-Summary-So-Inaccurate/m-p/162719)
 
-Meeting summaries frequently misinterpret context and change the meaning of what was actually discussed. The AI often elevates minor side comments to major discussion points while completely missing critical decisions that determine project outcomes.
+Meeting summaries often misinterpret context and change the meaning of what was actually discussed. The AI often elevates minor side comments to major discussion points while missing decisions that determine project outcomes.
 
-In technical discussions or meetings with industry-specific terminology, the system struggles significantly with complex subject matter. Summaries shared with stakeholders who weren't present can contain fundamentally incorrect information about what was decided.
+In technical discussions or meetings with industry-specific terminology, the system struggles with complex subject matter. Summaries shared with stakeholders who weren't present can contain fundamentally incorrect information about what was decided.
 
 ### 2. Reliability Remains Inconsistent
 
@@ -81,7 +81,7 @@ In technical discussions or meetings with industry-specific terminology, the sys
 
  Source: [Zoom](https://community.zoom.com/t5/Zoom-AI-Companion/Inconsistent-performance-of-AI-Companion-Features/m-p/233318)
 
-Even when AI Companion functions properly, users cannot depend on consistent performance. Important meetings sometimes generate no summary at all, with no error message or explanation.
+Even when AI Companion works, users cannot depend on consistent performance. Important meetings sometimes generate no summary at all, with no error message or explanation.
 
 Teams must assign multiple people to save transcripts manually because data is regularly lost if meetings close before manual intervention. This unpredictability makes the tool unreliable for business-critical meetings.
 
@@ -91,13 +91,13 @@ Teams must assign multiple people to save transcripts manually because data is r
 
  Source: [G2](https://www.g2.com/products/zoom-ai-companion/reviews/zoom-ai-companion-review-3955518)
 
-Zoom AI Companion requires constant internet connectivity and cloud processing. This creates significant limitations for users in areas with unreliable internet, secure environments that restrict external connections, or traveling professionals who need meeting intelligence regardless of connectivity status.
+Zoom AI Companion requires constant internet connectivity and cloud processing. This creates limits for users in areas with unreliable internet, secure environments that restrict external connections, or traveling professionals who need meeting intelligence regardless of connectivity.
 
 ### 4. No Real-Time Transcription
 
 ![zoom ai transcription](/api/assets/blog/zoom-ai-companion-review/zoom-alt-5.webp)
 
-Unlike dedicated meeting assistants, AI Companion lacks live transcription during meetings. Users cannot catch important names, technical terms, or key decisions as they happen. The post-meeting summary approach leaves room for error in fast-moving or complex discussions where context matters most.
+Unlike dedicated meeting assistants, AI Companion lacks live transcription during meetings. Users cannot catch names, technical terms, or decisions as they happen. The post-meeting summary approach leaves room for error in fast-moving or complex discussions where context matters most.
 
 Read more about [how to transcribe Zoom calls automatically](/blog/how-to-transcribe-zoom-calls).
 
@@ -107,7 +107,7 @@ Read more about [how to transcribe Zoom calls automatically](/blog/how-to-transc
 
  Source: [G2](https://www.g2.com/products/zoom-ai-companion/reviews/zoom-ai-companion-review-10924080)
 
-While Zoom supports transcription in multiple languages, AI Companion's summarization quality degrades significantly with non-English content. Teams conducting mixed-language conversations or working in international environments report substantially reduced accuracy and utility.
+While Zoom supports transcription in multiple languages, AI Companion's summarization quality drops with non-English content. Teams running mixed-language conversations or working in international environments report reduced accuracy and utility.
 
 ### 6. Inconsistent Action Item Extraction
 
@@ -115,7 +115,7 @@ While Zoom supports transcription in multiple languages, AI Companion's summariz
 
  Source: [Zoom](https://community.zoom.com/t5/Zoom-AI-Companion/Why-is-the-AI-Meeting-Summary-So-Inaccurate/m-p/178437/highlight/true#M1207)
 
-Action item identification frequently misses genuine tasks while flagging irrelevant comments as actionable items. The AI sometimes creates entirely fictional action items that could lead to confusion or wasted effort if team members attempt to follow through on non-existent assignments.
+Action item identification often misses real tasks while flagging irrelevant comments as actionable items. The AI sometimes creates entirely fictional action items that could lead to confusion or wasted effort if team members attempt to follow through on non-existent assignments.
 
 ### 7. No Custom Vocabulary Training
 
@@ -137,7 +137,7 @@ Want to see how other AI notetakers stack up on pricing? Check out our [detailed
 
 ## Looking for a Better Zoom AI Companion Alternative? Meet Anarlog
 
-Anarlog is an open-source AI notepad for meetings that gives you complete control over your data and AI stack. Here's why it's a superior alternative for most users seeking reliable AI meeting assistance.
+Anarlog is an open-source AI notepad for meetings that gives you full control over your data and AI stack. Here's why it's a better fit for most users who want reliable AI meeting assistance.
 
 ### 1. Complete Data Control
 
@@ -145,7 +145,7 @@ Anarlog is an open-source AI notepad for meetings that gives you complete contro
 
 Unlike Zoom's cloud processing, Anarlog stores everything as plain markdown files on your device and lets you choose your AI: bring your own keys or run local models. Zero lock-in means your files work with any tool, and you can switch AI providers anytime.
 
-### 2. Superior Accuracy and Reliability
+### 2. Better Accuracy and Reliability
 
 Anarlog offers flexible AI model options—you can use the custom HyperLLM-V1 model for faster local processing, connect to your preferred cloud providers like OpenAI or Anthropic, or run other local models through Ollama.
 
@@ -167,7 +167,7 @@ Anarlog provides live transcription during meetings and can generate instant sum
 
 For organizations needing on-premise deployment, private cloud options, or hybrid setups, [Char](https://char.com) offers a managed enterprise plan with deployment flexibility, SSO integration, and smart consent management. You get complete control without vendor lock-in or cloud processing risks.
 
-### 6. Exceptional Value
+### 6. Strong Value
 
 Unlike Zoom's paid-plan requirement, Anarlog is free forever for local transcription, BYOK, and all core features—including calendar integration, meeting search, and basic AI chat.
 
@@ -190,6 +190,6 @@ Unlike Zoom's paid-plan requirement, Anarlog is free forever for local transcrip
 - You require on-premise deployment or hybrid cloud setups for compliance
 - You want real-time transcription instead of waiting for post-meeting summaries
 
-[Download Anarlog for macOS](https://anarlog.so) to experience meeting intelligence that costs nothing and compromises nothing (Windows and Linux versions coming in Q2 2026).
+[Download Anarlog for macOS](https://anarlog.so) to try meeting intelligence that costs nothing and compromises nothing (Windows and Linux versions coming in Q2 2026).
 
 &nbsp;


### PR DESCRIPTION
## Summary

- Surgical prose audit across all 72 blog posts in `apps/web/content/articles/`.
- Aggressive AI-tell removal in SEO/listicle posts: vocabulary (boasts, comprehensive, robust, seamless, leverage, underscore, pivotal, showcase, garner, etc.), promotional fluff, copula avoidance ("serves as," "functions as"), significance inflation, and em-dash reveals.
- Conservative pass on founder essays (char-is-now-anarlog, hyprnote-is-now-char, dont-use-a-cms, filesystem-is-coretex, why-our-cms-is-github, publishing-stack, etc.) — preserved voice; only fixed obvious tells.
- Logical-punctuation fixes (`."` → `".`, `,"` → `",`) and curly-quote → straight-quote conversion where found.
- 1141 deletions, 1121 insertions — net trim, mostly in place.

## Out of scope

- Frontmatter (meta_title, meta_description, dates) untouched.
- Links, URLs, product names, numbers, code blocks, and heading case preserved.
- No new sections or claims introduced.

## Test plan

- [ ] Spot-check 3-5 posts in dev (`pnpm -F @hypr/web dev`) for rendering regressions.
- [ ] Confirm dprint format is clean (`pnpm exec dprint check`).
- [ ] Skim founder essays to confirm voice intact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are MDX copy edits only (no logic/frontmatter/link changes), with main risk limited to accidental markdown/typography rendering regressions.
> 
> **Overview**
> **Site content-only PR:** performs a broad prose pass across many `apps/web/content/articles/*.mdx` posts to remove “AI-tell” wording, reduce promotional/fluffy phrasing, and tighten/shorten sentences while keeping the same claims and structure.
> 
> Includes minor style/typography normalization (e.g., punctuation/quote tweaks and dash usage) with no functional code changes, no new sections, and no updates to metadata or URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8439a3c3b2c8bf4f1ead927691d0f67ea6abfeba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->