### PR TITLE
chore(web): remove Windows/Linux from download dropdown

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -298,32 +298,6 @@ function DownloadButton() {
             />
             <span>Apple Intel</span>
           </a>
-          <div
-            aria-disabled="true"
-            className="flex items-center gap-3 rounded-xl px-3 py-3 text-[#756b5d]"
-          >
-            <img
-              src="https://upload.wikimedia.org/wikipedia/commons/5/5f/Windows_logo_-_2012.svg"
-              alt=""
-              className="size-5"
-              aria-hidden="true"
-            />
-            <span className="flex-1">Windows</span>
-            <span className="text-xs">Coming soon</span>
-          </div>
-          <div
-            aria-disabled="true"
-            className="flex items-center gap-3 rounded-xl px-3 py-3 text-[#756b5d]"
-          >
-            <img
-              src="https://upload.wikimedia.org/wikipedia/commons/3/35/Tux.svg"
-              alt=""
-              className="size-5"
-              aria-hidden="true"
-            />
-            <span className="flex-1">Linux</span>
-            <span className="text-xs">Coming soon</span>
-          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
Hide coming-soon Windows and Linux entries from the landing download dropdown.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that hides non-functional download options; no backend, auth, or data-handling logic is affected.
> 
> **Overview**
> Removes the disabled *Coming soon* `Windows` and `Linux` items from the landing page download dropdown in `apps/web/src/routes/index.tsx`, leaving only the Mac download options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae1adc901d15b406240a10dfc226dab5a6604c03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->