### PR TITLE
content: restore blog articles filtered against anarlog positioning

### DIFF
--- a/apps/web/content/articles/ai-meeting-summary-tools.mdx
+++ b/apps/web/content/articles/ai-meeting-summary-tools.mdx
@@ -1,0 +1,441 @@
+---
+meta_title: "AI Meeting Summary Tools: Top 9 Options"
+display_title: "Best AI Meeting Summary Tools in 2026"
+meta_description: "Find the best AI meeting summary tool for your team. Compare 9 top solutions, including free options, bot-free tools, and enterprise platforms."
+author:
+  - "John Jeong"
+coverImage: "/api/assets/blog/ai-meeting-summary-tools/cover.png"
+featured: false
+category: "Comparisons"
+date: "2025-10-06"
+---
+
+Most "AI meeting summary" tools are not really summary tools. They are transcription tools with a summary layer bolted on.
+
+That difference matters. A real summary should tell you what changed in the meeting in under a minute. A bad one just makes you reread the transcript in a cleaner layout.
+
+This list is about tools that actually compress information: decisions, action items, disagreements, and the parts worth carrying forward.
+
+## AI meeting summary tools comparison: quick overview
+
+Here's a quick comparison of the best AI meeting summary tools to help you decide:
+
+
+| Tool      | Best For                                     | Starting Price                            |
+| --------- | -------------------------------------------- | ----------------------------------------- |
+| Char      | Zero lock-in, complete control               | Free forever (local + BYOK). Cloud: $25/mo |
+| Read AI   | Unified search across meetings & emails      | Free (Pro: $19.75/mo)                     |
+| Fathom    | Small teams wanting free unlimited recording | Free (Premium: $19/mo)                    |
+| Jamie AI  | Bot-free professional meetings               | €24/mo (~$26)                             |
+| Fellow    | Security-focused enterprises                 | Free (Enterprise: $25/mo)                 |
+| Fireflies | Conversation analytics & insights            | Free (Pro: $18/mo)                        |
+| Otter AI  | Established mainstream solution              | Free (Pro: $16.99/mo)                     |
+| Avoma     | Revenue teams & sales operations             | $19/mo                                    |
+| MeetGeek  | Automated workflows & team analytics         | Free (Pro: $19/mo)                        |
+
+
+## What makes great AI meeting summary tools?
+
+A good summary does not just restate the conversation. It helps you reconstruct the meeting quickly.
+
+You should be able to scan it in 30 seconds and know what was decided, what is still open, and who owns the next step.
+
+What matters for summary generation:
+
+- **Structured output.** Summaries should organize information into sections you can scan quickly without drowning in transcript details.
+- **Customization for different meeting types.** Sales calls need different structures than customer interviews or team standups. Templates should adapt to your use case.
+- **Speed.** You need summaries within seconds of the meeting ending, not 10 minutes later when you're already in the next call.
+- **Data control and privacy.** Some organizations can't send conversations to the cloud. Understand where your data goes and who processes it before you commit.
+- **Useful AI.** The summary should distill key points, not merely reiterate the transcript in bullet points.
+
+That is the standard we used for the tools below.
+
+## Best AI Meeting Summary Tools in 2026: Detailed Reviews
+
+### 1. Char: AI Notepad for Meetings with Zero Lock-in
+
+Char is an open-source AI notepad for meetings that gives you complete control over your data and AI stack. Everything is stored as plain markdown files—not in proprietary databases. You choose your AI: managed cloud, BYOK, or run local models.
+
+**Full disclosure:** I'm a co-founder of Char, so I'll keep this as objective as possible.
+
+![ai meeting summary platforms with customizable templates](/api/assets/blog/ai-meeting-summary-tools/summary-1.webp)
+
+#### How Char's summary generation works
+
+Char sits quietly on your computer and captures audio directly from your system — no bots joining your calls, no calendar integrations needed. While you're in a meeting, it generates a live transcript as you take your own notes alongside it.
+
+When the meeting ends, it combines your notes with the transcript and uses AI to produce a structured summary. You choose which AI processes that data — their managed service, your own API keys (OpenAI, Anthropic, etc.), or a fully local model running on your machine via Ollama or LM Studio.
+
+#### Summary features
+
+![How Char works](/api/assets/blog/ai-meeting-summary-tools/summary-2.webp)
+
+- **Instant summary generation** delivers summaries within seconds of the meeting ending. No waiting around. The moment you stop recording, Char processes everything locally and delivers your summary.
+- **Customizable templates** let you create summary formats for any meeting type, including sales calls, therapy sessions, legal consultations, and team standups. Your summaries adapt to your workflow, not the other way around.
+- **Custom vocabulary support** lets you add industry-specific terms, company names, or technical jargon to improve transcription and summary accuracy for your specific context.
+- **AI Chat for follow-up questions** lets you ask specific questions about your meetings. "What did Sarah say about the budget?" or "List all action items from yesterday's calls."
+- **Source verification** lets you hover over any AI-generated summary point to see the exact transcript quote it came from. No hallucinations, no guessing.
+- **Conversational search** finds information across all your meeting history using natural language queries.
+- **Control over AI involvement** lets you choose how much the AI restructures your notes, from minimal touch-ups to complete reformatting.
+- **Multiple export formats** let you export summaries as Markdown, PDF, or Rich Text to fit into your existing documentation workflow.
+
+#### Strengths
+
+- **Maximum privacy** means summaries generated on-device with zero cloud exposure
+- **Unlimited AI summaries for free** with no usage caps on core summary generation
+- **No vendor lock-in** lets you choose your preferred AI models and providers
+- **Works completely offline**, perfect for air-gapped environments or unreliable connectivity
+- **Bot-free operation** means no disruption to meeting flow
+- **Open source** with full code transparency for security audits and customization
+
+#### Considerations
+
+- **macOS only currently** (Windows and Linux versions coming in Q2 2026)
+- **Basic speaker identification** currently distinguishes only between microphone and system audio channels
+
+#### Pricing
+
+Char's core features, including unlimited AI summaries and transcription, are **free forever**.
+
+Free forever for local transcription, BYOK, and all core features. **Managed cloud ($25/month)** for the easiest setup.
+
+**Enterprise** is available for on-premises deployment, SSO integration, consent management, or custom branding. Contact sales for a quote.
+
+### 2. Read AI: the unified meeting intelligence platform
+
+Read AI is a cloud-based AI meeting assistant that goes beyond individual meetings to provide unified search across meetings, emails, and messages. Think of it as an intelligence layer connecting all your communication platforms.
+
+![read ai summaries review](/api/assets/blog/ai-meeting-summary-tools/summary-3.webp)
+
+#### How Read AI's summary generation works
+
+Read AI joins your meetings as a visible bot that records and transcribes conversations. After the meeting, it generates AI summaries with key points, decisions, and action items while also analyzing engagement metrics like who's participating and who's disengaged.
+
+The platform's Search Copilot feature lets you query across all your meetings using natural language. Ask questions about any discussion and get answers with citations showing the source.
+
+#### Summary features
+
+- **Pre-Read summaries** show you a summary of the past meeting before recurring meetings start, including key questions that mattered to participants and action items with named owners.
+- **Multi-meeting insights** provide summaries that span across multiple related meetings, helping you track ongoing discussions and decisions over time.
+- **Automated meeting reports** include key discussion points, decisions made, and action items, delivered straight to your inbox within minutes of the meeting ending.
+- **Ask Read AI** lets you chat with your meeting summaries to extract specific information without rewatching recordings or rereading transcripts.
+- **Email thread summaries** go beyond meetings, summarizing long email chains with one-sentence overviews and detailed bullet points.
+- **Audience reactions tracking** includes engagement data showing who was paying attention or zoned out during the call.
+
+#### Strengths
+
+- **Unified search** lets you query across meetings, emails, and messages in one place
+- **Engagement analytics** track meeting participation, speaker time, and sentiment
+- **20+ language support** for transcribing and summarizing conversations in multiple languages
+- **Free tier available** with 5 free meetings per month without credit card required
+- **Extensive integrations** on the premium tier connect to Notion, Salesforce, HubSpot, Jira, and more
+
+#### Considerations
+
+- **Bot visibility** means it joins as a participant which can affect conversation dynamics
+- **Cloud-only processing** with no on-premises option for organizations with data sovereignty requirements
+- **Platform lock-in** means you can't bring your own AI models or switch providers
+
+#### Pricing
+
+**Free plan** offers 5 meetings per month with basic features. Paid plans start at **$19.75/user/month**.
+
+### 3. Fathom: the free AI meeting summary tool
+
+Fathom is a cloud-based AI meeting assistant that automatically generates concise meeting summaries and highlights key moments, with a generous free plan that offers unlimited recordings.
+
+![fathom ai summaries review](/api/assets/blog/ai-meeting-summary-tools/summary-4.webp)
+
+#### How Fathom's summary generation works
+
+Fathom joins your meetings as a bot participant, records the conversation, and generates AI summaries within seconds after the call ends. The summaries are structured with clear sections for decisions, action items, and key discussion points.
+
+You can highlight important moments during meetings with a single click, and these highlights get automatically timestamped and integrated into your post-meeting summary.
+
+#### Summary features
+
+- **Custom AI summary templates** give Team Edition users access to 17 pre-built templates for different meeting types, such as sales calls (SANDLER, SPICED, MEDDPICC, BANT), customer success, Q&A, demos, and more. You can also customize templates to fit your specific workflow.
+- **Instant summary generation** delivers summaries within 30 seconds after meetings end, making it one of the fastest tools for post-call processing.
+- **Ask Fathom** lets you query your meeting history with natural language questions. "What were the top three reasons Michael wouldn't move forward?" or "Show me all objections from last week's calls."
+- **Timestamped action items** are automatically detected and timestamped, so you can jump directly to the exact moment they were discussed.
+- **Highlight feature** lets you click to bookmark important moments during meetings, and Fathom weaves these into your final summary for easy reference.
+- **CRM auto-sync** automatically updates summaries to Salesforce and HubSpot, eliminating manual post-call data entry.
+
+#### Strengths
+
+- **Lightning-fast summaries** with 30-second generation time versus 5+ minutes for competitors
+- **90-95% transcription accuracy** with good audio quality and supports 28+ languages
+- **One-click formatted copy-paste** means summaries maintain formatting when pasted into other tools
+
+#### Considerations
+
+- **Bot presence required** for most use cases, appears as an additional participant
+- **Limited AI summaries on free plan** with only 5 AI-generated summaries per month, then reverts to basic chronological summaries
+- **No offline capability** requires an active internet connection for transcription and AI processing
+- **No mobile app** means the desktop-only experience limits flexibility
+
+#### Pricing
+
+**Free plan** includes unlimited recordings, transcriptions, and 5 AI summaries per month. Paid plans range from **$19-$39/user/month**.
+
+### 4. Jamie AI: the bot-free meeting assistant
+
+Jamie AI is a desktop application that transcribes meetings without joining as a bot, making it ideal for sensitive conversations where visible recording assistants aren't welcome.
+
+![Jamie ai meeting summaries review](/api/assets/blog/ai-meeting-summary-tools/summary-5.webp)
+
+#### How Jamie AI's summary generation works
+
+Jamie captures audio directly from your computer, both microphone input and system audio, without appearing as a meeting participant. After the meeting, it generates structured summaries organized by topics discussed, making them easy to scan and share.
+
+The platform works across all meeting platforms (Zoom, Teams, Meet) and even offline for in-person meetings, processing everything locally on your device before generating cloud-based summaries.
+
+#### Summary features
+
+- **Topic-sorted summaries** automatically detect topics discussed during meetings and organize summaries by theme, creating human-like structure that improves readability and comprehension.
+- **Multi-language support** generates summaries in 15+ languages, including English, French, German, Spanish, Japanese, and more.
+- **Ask Jamie Chat** is an AI chatbot that answers questions about past meetings, drafts follow-up emails, and provides instant insights without scrolling through transcripts.
+- **Screen capture integration** automatically saves graphs, slides, and visual content shared during meetings, embedding them into summaries for complete context.
+- **Customizable summary formats** let you create templates tailored to your workflow, for sales calls, customer interviews, team standups, or executive briefings.
+- **Executive Assistant Sidebar** lets you access information from past meetings, draft emails, and brainstorm ideas directly within the same interface.
+
+#### Strengths
+
+- **Bot-free operation** means no visible participant joining your calls, preserving natural meeting dynamics
+- **Offline transcription** works without internet connection for in-person meetings
+- **Universal platform compatibility** functions seamlessly across all video conferencing platforms
+- **EU data hosting** (Frankfurt, Germany) with GDPR compliance
+- **High transcription accuracy** handles technical discussions and multiple accents reliably
+
+#### Considerations
+
+- **No real-time transcription** means you don't see live transcripts during meetings
+- **No video recording** keeps it audio-only for enhanced privacy, but limits visual context
+- **No mobile app yet** means it's a desktop-only experience
+- **Cloud processing for summaries** means that while transcription happens locally, AI summaries require cloud processing
+
+#### Pricing
+
+**Free plan** includes basic meeting notes with limited AI features.
+
+Paid plans start at **€24/user/month** (approximately $26 USD) for unlimited AI summaries, advanced search, and Executive Assistant features.
+
+### 5. Fellow: the privacy-focused AI meeting assistant
+
+Fellow is a cloud-based meeting workflow platform that emphasizes security and granular privacy controls, making it popular with organizations that need rigorous data protection.
+
+![Fellow AI meeting summaries review](/api/assets/blog/ai-meeting-summary-tools/summary-6.webp)
+
+#### How Fellow's summary generation works
+
+Fellow joins meetings as a bot to record and transcribe conversations. It generates AI summaries that cover key takeaways, action items, and decisions, then links everything directly to your meeting notes and calendar events.
+
+The platform stands out with its focus on internal meetings with recording permissions that give managers fine-grained control over what gets captured.
+
+#### Summary features
+
+- **Structured AI summaries** organize information into clear chapters covering discussion topics, with automatic extraction of action items and decisions from the conversation.
+- **Ask Fellow (Ask Copilot)** is an AI chatbot that answers questions about your meeting history. "What did we decide on X topic?" or "What should I follow up on from last week's calls?"
+- **Meeting clips** let you create and share short video snippets highlighting key moments, making it easy to distribute specific insights without sharing entire recordings.
+- **Custom recording channels** organize summaries by team, department, or project with customizable access controls determining who can view each channel.
+- **Sales AI recap templates** provide pre-built summary formats specifically designed for sales calls that standardize how your team documents customer conversations.
+- **Transcript redaction** lets you remove sensitive information from summaries and transcripts before sharing.
+- **Multi-meeting analytics** track summary patterns across departments to understand meeting frequency, duration, and participant engagement.
+
+#### Strengths
+
+- **Enterprise-grade security** with SOC 2 Type II, GDPR, and HIPAA/BAA compliance and military-grade encryption
+- **Granular recording permissions** give organization-level control over who can record, what meetings get recorded, and who accesses recordings
+- **50+ integrations** connect to Asana, Jira, Linear, Salesforce, HubSpot, Slack, and project management tools
+- **No AI training on your data** as Fellow explicitly doesn't use your meeting content to train models
+
+#### Considerations
+
+- **Bot visibility** means it joins meetings as a participant which can feel intrusive for internal conversations
+- **Cloud-only** with no on-premises deployment for organizations with data sovereignty needs
+- **Internal meeting focus** makes it less robust than dedicated sales tools for customer-facing conversation intelligence
+- **Free plan limits** cap at 10 AI recordings per user monthly
+
+#### Pricing
+
+**Free plan** includes 10 AI notes/recordings per user per month with basic features.
+
+**Team plan** starts at **$7/user/month** (3 user minimum) with higher limits and additional integrations.
+
+&nbsp;
+
+### 6. Fireflies: the conversation intelligence platform
+
+Fireflies.ai positions itself as more than just a transcription tool. It's a conversation intelligence solution focused on analytics, searchability, and deep insights across all your meetings.
+
+![fireflies ai meeting summaries review](/api/assets/blog/ai-meeting-summary-tools/summary-7.webp)
+
+#### How Fireflies' summary generation works
+
+Fireflies joins your meetings as a bot participant called "Fred" that records and transcribes conversations. After the meeting, it automatically generates AI summaries and can push them to designated channels like Slack or your CRM.
+
+The platform emphasizes analytics, tracking speaker talk time, sentiment, and conversation themes to give you insights beyond basic summaries.
+
+#### Summary features
+
+- **AskFred AI assistant** lets you chat with your meeting transcripts and query past conversations. Ask questions like "What pricing concerns came up this month?" and get answers pulled from multiple meetings.
+- **Smart search across meetings** finds specific information across your entire meeting history using keywords or semantic search that understands context, not just exact matches.
+- **Auto-generated action items** identify tasks and next steps from conversations, automatically extracting who's responsible and what needs to be done.
+- **Conversation analytics** include speaker analytics showing talk time distribution, monologue alerts, sentiment analysis, and key topic tracking.
+- **Custom summary templates** let you create templates for different meeting types, such as sales calls, customer feedback, and team meetings, to standardize how information gets captured.
+- **Multi-meeting insights** track trends across conversations to identify recurring themes, common objections, or frequently requested features.
+
+#### Strengths
+
+- **Unlimited transcription on free plan** as even the free tier offers unlimited meeting transcription
+- **69+ language support** handles multilingual meetings with automatic language detection
+- **Extensive integrations** with 58+ platform connections including major CRMs and productivity tools
+- **Mobile app support** lets you record and transcribe in-person conversations on the go
+
+#### Considerations
+
+- **Bot presence can feel intrusive** since Fred appears as an additional participant that announces itself
+- **Storage limitations on lower tiers** mean the free plan only keeps 800 minutes of storage per seat
+- **May spam participants** by automatically sending meeting notes to all attendees unless configured otherwise
+- **Cloud-only processing** with no on-premises option for data sovereignty requirements
+
+#### Pricing
+
+**Free plan** includes unlimited transcription with 800 minutes of storage and limited AI summaries. Paid plans start at **$18/user/month**.
+
+### 7. Otter AI: AI summary tool with real-time collaboration
+
+Otter AI is probably the most well-known AI meeting assistant, offering cloud-based meeting intelligence with real-time collaboration features and established cross-platform support.
+
+![Otter ai meeting summaries review](/api/assets/blog/ai-meeting-summary-tools/summary-8.webp)
+
+#### How Otter AI's summary generation works
+
+Otter joins your meetings as a visible bot participant called "OtterPilot" that records audio and generates real-time transcripts. After meetings, it creates automated summaries with key topics, action items, and highlights, delivered to participants via email within 2 hours.
+
+The summaries are organized into chapters with timestamps, making it easy to jump to specific discussion points.
+
+#### Summary features
+
+- **Automated meeting summaries** generate summaries broken down by chapters with timestamps, key topics discussed, action items, and highlights after each meeting.
+- **Slide and screen capture** automatically screenshots presentations and screen shares during meetings, embedding them into summaries for visual context.
+- **OtterPilot AI Chat** is an AI assistant that answers questions about meeting content using @otter mentions. It can extract information, generate email drafts, or create meeting minutes based on conversations.
+- **Email summaries** deliver automatic email notifications to all meeting participants within 2 hours, including key discussion points and action items.
+- **Otter Channels** organize summaries into team collaboration spaces where multiple conversations can be shared with specific groups, either public or private.
+- **Custom vocabulary** lets you add industry terms, company names, and technical jargon to improve summary accuracy for your specific context.
+
+#### Strengths
+
+- **Established platform** with consistent performance, regular feature updates, and 25+ million users
+- **Reliable speaker identification** learns voice patterns over time and improves with usage
+- **Real-time collaboration** lets multiple users view, edit, and comment on summaries simultaneously
+- **Mobile app functionality** handles both virtual meetings and in-person conversation capture
+
+#### Considerations
+
+- **Limited language support** with only English, Spanish, and French
+- **Privacy concerns** due to an ongoing class-action lawsuit regarding data handling practices and unauthorized recording
+- **Free plan restrictions** limit you to 300 monthly minutes (5 hours), which gets consumed quickly
+- **Bot presence in meetings** can feel intrusive for sensitive client conversations
+- **Data used for AI training** as Otter admits to using customer data for training proprietary AI technology
+
+#### Pricing
+
+**Free plan** includes 300 monthly minutes (30-minute conversation limit) with basic features. Paid plans start at **$16.99/user/month**.
+
+### 8. Avoma: the revenue team meeting assistant
+
+Avoma is an AI-powered meeting platform specifically built for sales and customer success teams. It combines meeting intelligence with revenue operations, automatically extracting insights that matter for deal progression.
+
+![avoma ai summaries review](/api/assets/blog/ai-meeting-summary-tools/summary-9.webp)
+
+#### How Avoma's summary generation works
+
+Avoma joins meetings as a bot, records conversations, and generates AI summaries organized by smart categories like "Business Need", "Pain Points", "Next Steps", and "Competitors". The platform automatically detects sales methodologies (MEDDIC, SPICED, NEAT, BANT) and structures summaries accordingly.
+
+After meetings, summaries sync directly to your CRM with automatic field updates. No manual data entry required.
+
+#### Summary features
+
+- **Smart categorization** automatically organizes information into business-relevant categories, including pain points, business needs, budget discussions, decision criteria, competitive mentions, and next steps.
+- **Sales methodology tracking** provides built-in templates for MEDDIC, SPICED, NEAT, BANT, and custom frameworks. Avoma detects methodology-specific information and updates CRM fields automatically.
+- **AI-generated follow-up emails** produce one-click email drafts that recap meetings and outline next steps, maintaining deal momentum without manual effort.
+- **Smart chapters** break conversations into topic-based chapters, allowing you to jump directly to specific discussions like pricing, objections, or feature requests without guessing timestamps.
+- **Custom summary templates** let you create templates for different meeting types, such as discovery calls, demos, QBRs, and check-ins.
+- **AI Scorecards** provide automatic call scoring based on custom criteria like talk-listen ratio, question quality, or objection handling for coaching and performance tracking.
+- **Competitive intelligence** tracks competitor mentions across conversations, correlates with win/loss data, and adjusts positioning strategies based on customer feedback.
+
+#### Strengths
+
+- **Revenue-focused summaries** specifically designed for sales conversations with deal-relevant insights
+- **Automatic CRM updates** sync summaries to Salesforce, HubSpot, and other CRMs without manual data entry
+- **30+ language support** handles multilingual teams and global customer conversations
+- **Complete meeting lifecycle** covers scheduling, recording, transcription, summarization, and follow-up automation
+- **Team coaching tools** including call scoring, talk pattern analysis, and engagement metrics improve team performance
+
+#### Considerations
+
+- **Sales-focused positioning** means features optimized for revenue teams may feel excessive for non-sales use cases
+- **Learning curve** is steeper than basic transcription tools due to the extensive feature set
+- **Bot-based recording** adds a visible participant that announces itself in meetings
+- **Higher price point** starting at $19/user/month makes it pricier than general-purpose alternatives
+
+#### Pricing
+
+**14-day free trial** available with full access to test all features. Paid plans start at **$19/user/month**.
+
+### 9. MeetGeek: the automated meeting workflow platform
+
+MeetGeek is a cloud-based conversation intelligence platform that goes beyond basic summaries with sophisticated automation, meeting type detection, and team-level analytics.
+
+![Meetgeek ai summaries review](/api/assets/blog/ai-meeting-summary-tools/summary-10.webp)
+
+#### How MeetGeek's summary generation works
+
+MeetGeek automatically joins your scheduled meetings through calendar integrations, records conversations, and generates AI summaries that adapt based on meeting type.
+
+The platform automatically detects whether you're in a sales call, team meeting, interview, or customer feedback session and applies the appropriate summary template.
+
+Summaries are delivered immediately after meetings with key topics, decisions, and action items clearly organized.
+
+#### Summary features
+
+- **Automatic meeting type detection** recognizes your call type, such as sales, team meeting, onboarding, interview, or hiring, and automatically applies the perfect summary template with context-aware insights.
+- **Customizable summary templates** let you create your own summary formats or modify existing ones to match your team's workflow. Control the length, structure, formatting, and level of detail in every summary.
+- **AI-labeled highlights** include automatically tagged key moments, including concerns, decisions, action points, objections, and feature requests, rephrased in natural language for easy scanning.
+- **Topic-based organization** breaks down meetings by discussed topics, making it simple to navigate long conversations and find specific discussion points.
+- **Automated workflow triggers** let you set rules to auto-share summaries with specific teams based on meeting type, and push insights to document repositories, CRMs, and task management tools.
+- **Multi-meeting analytics** track summary patterns across conversations to identify recurring themes, monitor sentiment trends, and improve team communication over time.
+- **MeetGeek Chat** lets you ask questions about your meeting history and get answers with precise context from past summaries and transcripts.
+
+#### Strengths
+
+- **50+ language support** transcribes and summarizes meetings in multiple languages with automatic detection
+- **Smart automation** with intelligent meeting type detection that eliminates manual template selection
+- **Team collaboration features** include shared meeting libraries organized by type, team, and custom tags
+- **Conversation analytics** provide performance scores, sentiment analysis, and coaching insights for continuous improvement
+- **Mobile apps** let you record and summarize in-person meetings on iOS and Android, even offline
+
+#### Considerations
+
+- **Bot-based only** with a visible participant that announces itself and can affect sensitive conversations
+- **Aggressive storage limits** mean the free plan keeps transcripts only 3 months
+- **100-hour monthly limit on Business tier** means high-volume teams need Enterprise or pay overages
+- **Limited free transcription** with only 5 hours per month on the free plan
+- **Cloud-only processing** with no on-premises deployment except private data storage on Enterprise
+
+#### Pricing
+
+**Free plan** includes 5 hours of transcription per month with 3 months of transcript storage and 1 month of audio storage. Paid plans start at **$19/user/month**.
+
+## My take
+
+This category is getting crowded, but most products still make the same assumption: your meeting data should live in their cloud and your summary format should adapt to them.
+
+If that trade-off works for you, there are decent options here.
+
+If it does not, Char is the one that breaks the pattern. The notes stay on your device, the AI stack stays flexible, and the summary layer is something you control instead of rent.
+
+[Download Char for macOS](/download) if you want meeting summaries without handing over the whole system.
+
+&nbsp;

--- a/apps/web/content/articles/anthropic-data-retention-policy.mdx
+++ b/apps/web/content/articles/anthropic-data-retention-policy.mdx
@@ -84,10 +84,10 @@ This isn't about your personal data directly. But it's relevant context for how 
 | **Can switch AI providers**  | No                                 | Yes — OpenAI, Mistral, local models |
 
 
-[Char](https://char.com/) is an open-source AI notepad for meetings that lets you bring your own Anthropic API key. When you connect it, your meeting data goes through the API i.e. 7-day retention, never used for training, rather than through the consumer Claude.ai product where training opt-ins and longer retention windows apply.
+[Char](https://anarlog.so/) is an open-source AI notepad for meetings that lets you bring your own Anthropic API key. When you connect it, your meeting data goes through the API i.e. 7-day retention, never used for training, rather than through the consumer Claude.ai product where training opt-ins and longer retention windows apply.
 
 And if Anthropic's policy trajectory gives you pause, you're not locked in. Char supports OpenAI, Mistral, Google Gemini, and local models via Ollama. Your notes stay on your device regardless of which AI processes them. Switching providers doesn't mean starting over.
 
 That's what actual control looks like. It's not just a privacy toggle that defaults to whatever Anthropic decides next quarter.
 
-[Download Char for macOS](https://char.com/download/apple-silicon) and use the AI provider your security team actually trusts.
+[Download Char for macOS](https://anarlog.so/download/apple-silicon) and use the AI provider your security team actually trusts.

--- a/apps/web/content/articles/anthropic-data-retention-policy.mdx
+++ b/apps/web/content/articles/anthropic-data-retention-policy.mdx
@@ -1,0 +1,93 @@
+---
+meta_title: "Anthropic Claude Data Retention Policy 2026"
+meta_description: "Anthropic was supposed to be the privacy-first AI company. Then September 2025 happened. A full breakdown of what Claude keeps and how to control it."
+author:
+  - "Harshika"
+featured: false
+category: "Guides"
+date: "2026-03-30"
+---
+
+Anthropic built its reputation as the privacy-conscious alternative to OpenAI. Constitutional AI, safety-first research, no training on customer data. For a while, that reputation was earned.
+
+Then in August 2025, Anthropic quietly announced a policy change: consumer users would need to actively opt out if they didn't want their Claude conversations used to train future models. The deadline was September 28. If you missed it, your data was in.
+
+If you're evaluating AI providers right now, this is the context you need.
+
+## What Does Claude Store by Default?
+
+For consumer accounts, that are Claude Free, Pro, and Max, conversations are saved to your account until you delete them. Once deleted, they're removed from your chat history immediately but remain on Anthropic's back-end systems for up to 30 days before being permanently deleted.
+
+That's the standard case. A few exceptions matter:
+
+Policy violations. If a conversation is flagged for violating Anthropic's usage policy, the inputs and outputs are kept for 2 years. Trust and safety classification scores from that conversation are retained for 7 years.
+
+Feedback you submit. Thumbs up/down ratings and bug reports are kept for 5 years.
+
+Incognito mode. Conversations in Claude's incognito mode are never used for model training, regardless of your other settings.
+
+## The September 2025 Training Policy Change
+
+Anthropic's previous stance was clean: consumer chats would not be used for training. That was the explicit promise. In August 2025, that changed. [According to Anthropic's own announcement](https://www.anthropic.com/news/updates-to-our-consumer-terms), they introduced an opt-in toggle,  "You can help improve Claude", and gave users until September 28 to make their choice.
+
+If you opted in, Anthropic could retain your conversations in de-identified form for up to 5 years and use them for model training. If you opted out, nothing changed. There's still a 30-day retention, no training use.
+
+The reaction was immediate. Security researchers and privacy advocates flagged it as a "privacy pivot." The opt-in training setting extends data retention from 30 days to 5 years, a 60x increase in how long your conversations can sit in Anthropic's training pipeline.
+
+## How to Check and Change Your Settings
+
+To see where your account stands: Claude.ai → Settings → Privacy → "Improve Claude for everyone."
+
+If the toggle is on, your new conversations are eligible for training and retained for up to 5 years. Turning it off returns you to the 30-day retention standard.
+
+Turning it off does not retroactively remove data already used for training. Like [OpenAI](/blog/chatgpt-data-retention-policy/), Anthropic doesn't unlearn from data once it's been incorporated.
+
+## How Is the Anthropic API Different for Privacy-Conscious Users?
+
+The consumer product and the API have meaningfully different data policies, and the API is notably stronger.
+
+As of September 14, 2025, Anthropic reduced API log retention from 30 days to 7 days. API inputs and outputs are automatically deleted after 7 days. They are never used for model training.
+
+If your organization needs longer retention for auditing purposes, you can opt in to the 30-day window via your Data Processing Addendum. But the default is 7 days, which is stricter than most providers.
+
+For enterprise API customers who qualify, Anthropic also offers a Zero Data Retention agreement. Under ZDR, inputs and outputs are not stored at all beyond what's needed to screen for abuse. One caveat: Anthropic still retains User Safety classifier results even under ZDR, to enforce their usage policy.
+
+## Claude for Work, Enterprise, Edu, and Gov
+
+Commercial customers were explicitly excluded from the September 2025 consumer policy changes. If you're using Claude for Work, Claude Enterprise, Claude for Education, or Claude Gov, your data is not used for model training — that's covered under Anthropic's commercial terms and is not subject to opt-in or opt-out toggles.
+
+Deleted conversations are purged within 30 days unless legally required otherwise.
+
+## What About HIPAA and GDPR?
+
+HIPAA: Anthropic offers HIPAA-eligible services for qualifying healthcare customers, including a Business Associate Agreement. Under the BAA, certain features including web search are disabled. Standard consumer Claude is not HIPAA-compliant and should not be used with Protected Health Information.
+
+GDPR: Anthropic supports GDPR compliance for commercial customers through a Data Processing Addendum. For EU-based consumer users, standard GDPR rights apply including access, deletion, portability, and can be exercised through Anthropic's Privacy Center. Consumer accounts don't automatically come with a DPA.
+
+## Claude's Reddit Lawsuit Worth Knowing About
+
+In June 2025, [Reddit filed a lawsuit against Anthropic](https://ppc.land/reddit-files-lawsuit-against-anthropic-over-unauthorized-claude-ai-training/) alleging that Anthropic scraped more than 100,000 Reddit posts and comments without authorization to train Claude. Reddit presented evidence that Claude reproduced deleted Reddit posts with near-perfect accuracy.
+
+This isn't about your personal data directly. But it's relevant context for how Anthropic has approached training data acquisition, and it matters when evaluating whether a company's stated privacy values match their actual behavior.
+
+## How Claude.ai Compares to Using Claude Through Char
+
+
+|                              |                                    |                                     |
+| ---------------------------- | ---------------------------------- | ----------------------------------- |
+|                              | **Claude.ai (Consumer)**           | **Anthropic API via Char**          |
+| **Where notes are stored**   | Anthropic's servers                | Your device (plain markdown)        |
+| **Retention after deletion** | Up to 30 days on backend           | 7 days (API), then deleted          |
+| **Used for training**        | Yes — unless opted out (Sept 2025) | Never                               |
+| **If opted into training**   | Up to 5 years, de-identified       | Not applicable                      |
+| **HIPAA BAA available**      | No (consumer)                      | Yes (enterprise API)                |
+| **Can switch AI providers**  | No                                 | Yes — OpenAI, Mistral, local models |
+
+
+[Char](https://char.com/) is an open-source AI notepad for meetings that lets you bring your own Anthropic API key. When you connect it, your meeting data goes through the API i.e. 7-day retention, never used for training, rather than through the consumer Claude.ai product where training opt-ins and longer retention windows apply.
+
+And if Anthropic's policy trajectory gives you pause, you're not locked in. Char supports OpenAI, Mistral, Google Gemini, and local models via Ollama. Your notes stay on your device regardless of which AI processes them. Switching providers doesn't mean starting over.
+
+That's what actual control looks like. It's not just a privacy toggle that defaults to whatever Anthropic decides next quarter.
+
+[Download Char for macOS](https://char.com/download/apple-silicon) and use the AI provider your security team actually trusts.

--- a/apps/web/content/articles/azure-open-ai-data-retention-policy.mdx
+++ b/apps/web/content/articles/azure-open-ai-data-retention-policy.mdx
@@ -1,0 +1,63 @@
+---
+meta_title: "Azure OpenAI Data Retention Policy: What You Need to Know"
+meta_description: "Azure OpenAI runs the same GPT models as OpenAI.com, but with a fundamentally different data policy. Here's what changes when you go enterprise."
+author:
+  - "John Jeong"
+featured: false
+category: "Guides"
+date: "2026-03-19"
+---
+
+Azure OpenAI runs the same underlying models as the consumer ChatGPT product. GPT-4o, GPT-4 Turbo, o1, and others are all available through both. But the data policy is not the same.
+
+When you access OpenAI's models through Microsoft Azure, your data stays within your Azure tenant, Microsoft does not use it to train any models, and you gain access to enterprise compliance frameworks that the consumer product does not offer. The models are identical. The data handling is not.
+
+Here is what that means in practice.
+
+## What Azure OpenAI Stores by Default
+
+Your prompts and completions are retained for up to 30 days for abuse monitoring. This data is stored within your Azure region and is not accessible to other customers, to OpenAI, or to other Microsoft teams. It is isolated to your subscription.
+
+[Microsoft is explicit](https://learn.microsoft.com/en-us/legal/cognitive-services/openai/data-privacy) that customer prompts and completions are not used to train its models, OpenAI's models, or any third-party models. This is the default behavior, not an opt-out you need to configure.
+
+## Who at Microsoft Can Actually See Your Data?
+
+Microsoft employs automated systems for abuse monitoring. Human reviewers can access flagged content, but only content that has been specifically flagged by the automated system, and only through Secure Access Workstations with Just-In-Time approval from team managers. It is not open-access review.
+
+This is a materially different setup from [Google Gemini's human review policy](https://char.com/blog/google-gemini-data-retention-policy/#human-review-in-plain-terms), where reviewers can access conversations more broadly for quality evaluation.
+
+## Modified Abuse Monitoring and Zero Data Retention
+
+Standard abuse monitoring retains your data for 30 days. If that does not meet your requirements, there are two paths forward.
+
+Modified abuse monitoring removes human review from your subscription while keeping automated checks in place. If your application is approved, Microsoft will not store prompts and completions from your subscription for human review purposes.
+
+Full Zero Data Retention goes further. Under ZDR, no prompts or completions are stored at all beyond the in-memory processing needed to return a result. Both options require approval and are available to customers on an Enterprise Agreement (EA) or Microsoft Customer Agreement (MCA). They are not self-service portal settings.
+
+To apply, submit a request through the Azure OpenAI Limited Access program. Approval timelines vary depending on your use case and compliance requirements.
+
+## Is Azure OpenAI HIPAA and GDPR Compliant?
+
+Azure OpenAI is covered under Microsoft's HIPAA Business Associate Agreement. The BAA is incorporated through the Microsoft Data Protection Addendum, which applies to enterprise customers with qualifying licensing such as Enterprise Agreements, Microsoft 365, or CSP arrangements.
+
+For GDPR, Microsoft offers an EU Data Zone option that processes and stores your data entirely within the European Union. A Data Processing Addendum is available as part of Microsoft's standard enterprise agreements.
+
+## How Azure OpenAI Differs from OpenAI's API
+
+Both Azure OpenAI and [OpenAI's direct API](https://char.com/blog/chatgpt-data-retention-policy/#the-openai-api-has-meaningfully-better-data-controls) offer enterprise-grade data controls including ZDR. The practical differences come down to infrastructure and compliance coverage.
+
+Azure OpenAI sits inside your existing Azure environment, which means it integrates with your Azure Active Directory, your private virtual networks, your logging infrastructure, and your existing Microsoft compliance agreements. If your organization is already on Azure, adding Azure OpenAI does not introduce a new vendor relationship.
+
+## What This Means for Your Evaluation
+
+Consumer [ChatGPT trains on your conversations by default](/blog/chatgpt-data-retention-policy/) and requires an opt-out. Azure OpenAI never trains on your conversations and requires an explicit request to even enable training data sharing. Consumer ChatGPT offers no HIPAA BAA. Azure OpenAI is covered under an existing Microsoft BAA.
+
+The models are the same. The compliance posture is not.
+
+## Using Azure OpenAI Through Char
+
+[Char](https://char.com) supports custom API endpoints, which means you can connect your Azure OpenAI deployment directly. Your meeting data goes through your Azure subscription under your enterprise data policy.
+
+If your organization has a Modified Abuse Monitoring or ZDR agreement in place, those protections apply to requests routed through Char as well. Your notes are stored on your device regardless of which provider processes them.
+
+[Download Char for macOS](https://char.com/download/apple-silicon) and use the AI provider your security team actually trusts.

--- a/apps/web/content/articles/azure-open-ai-data-retention-policy.mdx
+++ b/apps/web/content/articles/azure-open-ai-data-retention-policy.mdx
@@ -24,7 +24,7 @@ Your prompts and completions are retained for up to 30 days for abuse monitoring
 
 Microsoft employs automated systems for abuse monitoring. Human reviewers can access flagged content, but only content that has been specifically flagged by the automated system, and only through Secure Access Workstations with Just-In-Time approval from team managers. It is not open-access review.
 
-This is a materially different setup from [Google Gemini's human review policy](https://char.com/blog/google-gemini-data-retention-policy/#human-review-in-plain-terms), where reviewers can access conversations more broadly for quality evaluation.
+This is a materially different setup from [Google Gemini's human review policy](https://anarlog.so/blog/google-gemini-data-retention-policy/#human-review-in-plain-terms), where reviewers can access conversations more broadly for quality evaluation.
 
 ## Modified Abuse Monitoring and Zero Data Retention
 
@@ -44,7 +44,7 @@ For GDPR, Microsoft offers an EU Data Zone option that processes and stores your
 
 ## How Azure OpenAI Differs from OpenAI's API
 
-Both Azure OpenAI and [OpenAI's direct API](https://char.com/blog/chatgpt-data-retention-policy/#the-openai-api-has-meaningfully-better-data-controls) offer enterprise-grade data controls including ZDR. The practical differences come down to infrastructure and compliance coverage.
+Both Azure OpenAI and [OpenAI's direct API](https://anarlog.so/blog/chatgpt-data-retention-policy/#the-openai-api-has-meaningfully-better-data-controls) offer enterprise-grade data controls including ZDR. The practical differences come down to infrastructure and compliance coverage.
 
 Azure OpenAI sits inside your existing Azure environment, which means it integrates with your Azure Active Directory, your private virtual networks, your logging infrastructure, and your existing Microsoft compliance agreements. If your organization is already on Azure, adding Azure OpenAI does not introduce a new vendor relationship.
 
@@ -56,8 +56,8 @@ The models are the same. The compliance posture is not.
 
 ## Using Azure OpenAI Through Char
 
-[Char](https://char.com) supports custom API endpoints, which means you can connect your Azure OpenAI deployment directly. Your meeting data goes through your Azure subscription under your enterprise data policy.
+[Char](https://anarlog.so) supports custom API endpoints, which means you can connect your Azure OpenAI deployment directly. Your meeting data goes through your Azure subscription under your enterprise data policy.
 
 If your organization has a Modified Abuse Monitoring or ZDR agreement in place, those protections apply to requests routed through Char as well. Your notes are stored on your device regardless of which provider processes them.
 
-[Download Char for macOS](https://char.com/download/apple-silicon) and use the AI provider your security team actually trusts.
+[Download Char for macOS](https://anarlog.so/download/apple-silicon) and use the AI provider your security team actually trusts.

--- a/apps/web/content/articles/best-ai-meeting-assistant-for-taking-notes.mdx
+++ b/apps/web/content/articles/best-ai-meeting-assistant-for-taking-notes.mdx
@@ -1,0 +1,336 @@
+---
+meta_title: "7 Best AI Meeting Assistants for Taking Notes in 2026"
+meta_description: "Discover the best AI meeting assistants for automated note-taking in 2026. Compare privacy, features & pricing to choose the right tool for your needs."
+author: "Harshika"
+coverImage: "/api/assets/blog/best-ai-meeting-assistant-for-taking-notes/cover.png"
+category: "Comparisons"
+date: "2025-08-04"
+---
+
+Most AI meeting assistants can transcribe. Far fewer produce notes you would actually trust the next day.
+
+That is the difference this guide is built around. A transcript is easy to generate. A useful note is harder. It needs structure, clear decisions, real action items, and enough context that you do not have to reconstruct the meeting from scratch.
+
+## What Are AI Meeting Assistants?
+
+At a practical level, they are tools that listen to meetings, turn speech into text, and then try to turn that text into something useful.
+
+The gap between products shows up in the second step. Some tools stop at transcription. Better ones help you leave the meeting with working notes instead of raw material.
+
+Core capabilities include:
+
+- **Real-time transcription** with speaker identification
+- **Automated note-taking** that extracts key points and decisions
+- **Action item extraction** that identifies tasks and deadlines
+- **Intelligent summarization** that distills hours of discussion into digestible insights
+- **Searchable archives** that make historical meeting data instantly accessible
+
+## Why This Article Focuses on AI Note-Taking Capabilities
+
+The easy part of this category is recording audio. The hard part is helping a team remember what changed.
+
+That is why this list focuses on note-taking quality, not just transcription quality.
+
+We evaluated each tool based on its ability to:
+
+- Generate structured, scannable meeting summaries
+- Automatically identify and format action items
+- Extract decisions and key discussion points
+- Create notes that teams actually use for follow-up
+- Integrate insights into existing productivity workflows
+
+The best tools leave you with notes you can act on, not a long transcript you plan to clean up later.
+
+_If you're specifically looking for budget-friendly options, check out our comprehensive guide to the best free AI notetakers that offer forever-free plans._
+
+## Our Top Picks for Best AI Note-taking apps for meetings
+
+| Tool         | Best For                                          | Meeting Platforms Supported                                                                                                    |
+| ------------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Char     | Zero lock-in, complete control over data and AI   | Universal compatibility - works with all platforms without joining as bot, supports offline/in-person                          |
+| Granola      | Active note-takers who want AI enhancement        | Zoom, Google Meet, Teams, Slack, WebEx, Skype, WhatsApp calls - captures device audio                                          |
+| Otter.ai     | Transcription accuracy and real-time features     | Zoom, Google Meet, Microsoft Teams + phone systems (Dialpad, JustCall, RingCentral, Zoom Phone)                                |
+| Fireflies.ai | Team analytics and conversation intelligence      | Zoom, Microsoft Teams, Google Meet, WebEx, GoToMeeting, UberConference, Skype, Lifesize + phone dialers (Aircall, RingCentral) |
+| Krisp        | Audio quality enhancement with noise cancellation | Universal compatibility (Zoom, Google Meet, Teams) - works at device audio level                                               |
+| Jamie AI     | Bot-free meeting experience                       | Universal compatibility - works with all platforms without joining as bot, supports offline/in-person                          |
+| Avoma        | Sales teams and revenue intelligence              | Zoom, Google Meet, Microsoft Teams, GoToMeeting, BlueJeans                                                                     |
+
+## Best AI Meeting Assistants for Taking Notes in 2026: In-depth Review
+
+### 1. Char: Best for Zero Lock-in and Complete Control
+
+[Char](/) is an open-source AI notepad for meetings built for high-agency people who demand complete control over their data and AI stack.
+
+Everything is stored as plain markdown files—not in proprietary databases. You choose your AI: managed cloud, bring your own keys, or run local models.
+
+<Image src="/api/assets/blog/best-ai-meeting-assistant-for-taking-notes/hyprnote-app-mock.jpg" alt="Char app mockup"/>
+
+#### About Char's AI notetaker:
+
+Char has an Apple Notes-like interface with powerful AI running locally in the background. When you launch a meeting, the AI assistant transcribes speech in real-time without any bots joining your call. After the meeting ends, it presents a structured summary with key decisions, action items, and discussion themes automatically extracted.
+
+The AI can work completely hands-off, generating organized notes without input. You can also collaborate by jotting down key points, and the AI will expand your rough notes with context you might have missed while actively participating.
+
+**Other notable features:**
+
+- Customizable templates for therapy sessions, legal meetings, job interviews, coffee chats, and more
+- Flexible AI model options—use local models or connect to OpenAI, Google Gemini, or OpenRouter
+- Conversational search functionality to query meeting history naturally
+- Chat functionality to ask questions about your meeting history and get instant answers (Pro plan)
+
+#### Pros:
+
+- Free forever for local transcription, BYOK, and all core features
+- Zero vendor lock-in—plain markdown files, switch AI providers anytime
+- No internet dependency for core transcription and summarization
+- Compatible with any video conferencing tool and in-person meetings
+
+#### Cons:
+
+- Currently macOS only (Windows and Linux versions coming in Q2 2026)
+- No video recording, only transcripts and summaries
+- No mobile app available
+
+#### Pricing:
+
+Char is free forever for local transcription, BYOK, and all core features. The managed cloud service is $25/month for the easiest setup. An Enterprise plan provides on-premises deployment, SSO, custom branding, and admin controls.
+
+<CtaCard/>
+
+### 2. Granola AI: Best for Active Note-Takers Who Want AI Enhancement
+
+[Granola](https://granola.ai) is an AI-powered notepad for people who prefer taking their own notes but want intelligent assistance to make them comprehensive.
+
+<Image src="/api/assets/blog/best-ai-meeting-assistant-for-taking-notes/granola.webp" alt="Granola app"/>
+
+#### About Granola's note-taking capabilities:
+
+Granola captures audio directly from your device like Char, offering a familiar notepad interface, custom templates, and intelligent note enhancement. However, it sends data to the cloud for AI processing, which can create privacy concerns for organizations with strict compliance requirements.
+
+**Other notable features:**
+
+- Post-meeting task assistance including drafting follow-up emails, extracting action items, and answering specific questions about discussions
+- Chat functionality to query your meeting history and get instant answers
+- Custom templates for different meeting types
+- Intelligent note enhancement that expands rough notes with context
+- Quick note generation with structured summaries almost immediately after meetings
+
+#### Pros:
+
+- Familiar notepad interface similar to Apple Notes
+- Works across all video conferencing platforms by capturing device audio
+- Quick note generation ready almost immediately after meetings
+- Chat functionality available in the free plan
+- Bot-free meeting experience with no disruptions
+
+Check out other [bot-free meeting assistants](/blog/bot-free-ai-meeting-assistants).
+
+#### Cons:
+
+- Requires active note-taking during meetings to be most effective
+- Search functionality issues reported by users
+- No video recording, only transcripts and summaries
+- No permanent free tier after the 25-meeting trial
+
+#### Pricing:
+
+Granola offers a free trial with up to 25 meetings. After the trial, paid plans start at $18 per month.
+
+Also check: [Best Granola AI Alternatives](/blog/granola-ai-alternatives)
+
+### 3. Otter: Best for teams that want "set it and forget it" automation
+
+[Otter](https://otter.ai/) is a cloud-based AI meeting assistant that automatically joins your video calls to record, transcribe, and summarize conversations.
+
+<Image src="/api/assets/blog/best-ai-meeting-assistant-for-taking-notes/otter.webp" alt="Otter app"/>
+
+#### About Otter.ai's note-taking capabilities:
+
+Unlike Char and Granola's bot-free approach, Otter.ai sends an AI assistant (OtterPilot) that automatically joins your Zoom, Google Meet, and Microsoft Teams meetings to capture everything. When meetings end, Otter condenses hour-long discussions into 30-second summaries and automatically emails participants with structured notes.
+
+Other notable features include:
+
+- Otter AI Chat for asking questions about meeting content and generating contextual emails or project updates
+- Screenshot capture when screens are shared during calls
+- Mobile apps for recording in-person meetings and lectures
+- File import capability for transcribing pre-recorded audio and video
+- OtterPilot for Sales with specialized CRM integration for sales teams
+
+Privacy-conscious users should be aware of documented concerns with Otter. The platform automatically sends meeting recaps to all attendees and invites them to sign up, causing account proliferation. [One enterprise](https://www.nudgesecurity.com/post/how-to-remove-otter-ai-from-your-organization-with-nudge-security) discovered 800 new account signups within 90 days without IT approval, creating compliance issues.
+
+#### Pros:
+
+- Real-time transcription allows following along live during meetings
+- Comprehensive mobile apps for iOS and Android for in-person meeting recording
+- Extensive integration ecosystem with CRM and productivity tools
+- Supports importing and transcribing pre-recorded audio and video
+- Strong speaker identification that improves over time
+
+#### Cons:
+
+- Significant privacy concerns with automatic meeting joining and cloud data processing
+- Limited monthly transcription minutes even on paid plans
+- Only supports English language transcription (UK and USA variants)
+- No video recording—audio transcription and screenshots only
+
+#### Pricing:
+
+Otter.ai offers a free plan with 300 monthly transcription minutes and 30 minutes per conversation. Paid plans start at $16.99 per user per month.
+
+Also check: [Top Otter AI's Alternatives](/blog/otter-ai-alternatives)
+
+### 4. Fireflies: Best for Conversation Analytics and Team Insights
+
+[Fireflies](https://fireflies.ai) is a comprehensive AI meeting assistant that offers deep conversation analytics and team collaboration features beyond basic transcription. With over 16 million users and a recent $1 billion valuation, it positions itself as an enterprise-grade solution.
+
+<Image src="/api/assets/blog/best-ai-meeting-assistant-for-taking-notes/fireflies.webp" alt="Fireflies"/>
+
+#### About Fireflies.ai's note-taking capabilities:
+
+Its AI assistant "Fred" automatically joins your meetings and creates detailed transcripts, then generates structured summaries with action items and decisions automatically extracted. Fireflies excels in conversation analytics by tracking speaker talk time, monitoring sentiment, identifying key topics, and providing team performance insights.
+
+**Other notable features:**
+
+- Ask Fred AI assistant for querying meeting content and generating follow-up emails
+- Soundbites feature for creating shareable audio clips from key moments
+- 200+ specialized AI apps for sales, HR, product management, and other departments
+- Advanced search and filtering across meeting transcripts
+- Team collaboration with comments, bookmarks, and private channels
+
+#### Pros:
+
+- Provides team insights that help optimize meeting effectiveness
+- Excellent for building searchable knowledge bases from discussions
+- Strong reliability with consistent performance across platforms
+- Enterprise-grade security with SOC 2 Type II, GDPR, and HIPAA compliance (Enterprise plans only)
+
+#### Cons:
+
+- Can feel overwhelming for users who just need basic notes
+- Meeting bot presence may feel intrusive and occasionally [joins meetings late](https://geekflare.com/software/fireflies-review/)
+- Free plan limitations require upgrading for advanced AI features
+- Privacy concerns as all data is processed and stored in the cloud
+
+#### Pricing:
+
+Fireflies offers a free forever plan with unlimited transcription and basic AI summaries. Paid plans range from $10–$19 per user per month. Enterprise pricing is custom and includes HIPAA compliance, SSO, private storage, and dedicated support.
+
+Also check: [Top Fireflies AI Alternatives](/blog/fireflies-ai-alternatives)
+
+### 5. Krisp: Best for Audio Quality Plus AI Note-Taking
+
+[Krisp](https://krisp.ai/) is primarily an AI-powered noise cancellation tool that has expanded into meeting note-taking, making it unique among AI assistants.
+
+<Image src="/api/assets/blog/best-ai-meeting-assistant-for-taking-notes/krisp.webp" alt="Krisp"/>
+
+#### About Krisp's note-taking capabilities:
+
+Krisp approaches note-taking as an add-on to its noise cancellation technology. The AI works silently in the background, processing your device's audio without sending bots to meetings. When you toggle the Note Taker feature on, Krisp transcribes conversations in real-time and generates summaries with action items when meetings end.
+
+**Other notable features:**
+
+- Local device processing without cloud dependency for core features
+- AI chat functionality within meeting notes for interactive follow-ups
+- Accent localization technology that adapts speech for better understanding
+- Mobile app with offline recording capabilities for in-person meetings
+- Integration with productivity tools and CRMs
+
+#### Pros:
+
+- Processes audio locally on device for better privacy than cloud-based solutions
+- Universal compatibility with any conferencing platform
+- Excellent for remote workers in noisy environments
+- Free plan includes core transcription and summarization
+
+#### Cons:
+
+- Note-taking features are less advanced than dedicated meeting assistants
+- Limited conversation analytics and team collaboration features
+- Storage limitations on paid plans
+- [App stability issues](https://apps.apple.com/us/app/krisp-ai-meeting-note-taker/id6740535865?see-all=reviews) with crashes and recording interruptions
+
+#### Pricing:
+
+Krisp offers a free plan with basic noise cancellation and AI note-taking. Paid plans start at $16 per user per month, with business and enterprise plans available at custom pricing.
+
+### 6. Jamie AI: Granola's Bot-free Meeting Assistant Alternative
+
+[Jamie AI](https://www.meetjamie.ai/) is a bot-free meeting assistant built with European privacy standards and GDPR compliance, offering a more privacy-focused alternative to cloud-based solutions.
+
+<Image src="/api/assets/blog/best-ai-meeting-assistant-for-taking-notes/jamie.webp" alt="Jamie"/>
+
+#### About Jamie AI's note-taking capabilities:
+
+Jamie AI captures audio directly from your device without sending bots to meetings. The AI processes conversations after meetings end using GPT-4, Claude 3.5, and its proprietary Jamie-M model to generate detailed summaries with topic detection that organizes notes into clear chapters. Unlike other cloud assistants, Jamie deletes audio files immediately after processing, and all data is hosted in Germany under GDPR protection.
+
+**Notable features:**
+
+- Executive Assistant sidebar for querying meeting history and brainstorming with AI
+- Offline functionality for in-person meetings without internet
+- Automatic speaker recognition that learns participants over time
+- Meeting reminders to ensure you never forget to start recording
+- 20+ language support with semantic search
+
+#### Pros:
+
+- AI assistant provides instant access to past meeting insights
+- Universal platform compatibility without plugins or extensions
+- Free plan includes all premium features with generous usage limits
+- Excellent accessibility features for users with disabilities
+
+#### Cons:
+
+- No real-time transcription (summaries generated 5–10 minutes after calls end)
+- No mobile app, limiting on-the-go recording
+- No video recording due to privacy-first design
+- Setup can be challenging for Mac users
+- Smaller integration ecosystem than established competitors
+
+#### Pricing:
+
+Jamie AI offers a generous free plan with all premium features and reasonable usage limits. Paid plans provide extended meeting length support, higher usage quotas, and enterprise features. Contact their team for specific pricing and custom arrangements.
+
+### 7. Avoma: Best for Sales Teams and Revenue Intelligence
+
+[Avoma](https://www.avoma.com/) is an AI meeting assistant for sales and customer success teams, offering deal intelligence, competitor tracking, and sales methodology scoring that goes beyond basic note-taking.
+
+<Image src="/api/assets/blog/best-ai-meeting-assistant-for-taking-notes/avoma.webp" alt="Avoma"/>
+
+#### About Avoma's AI note-taking capabilities:
+
+Avoma's AI automatically records, transcribes, and analyzes meetings while organizing discussions into "Smart Chapters" that break down conversations by topic. These chapters identify key themes like business needs, pain points, and competitor mentions with timestamps, allowing you to jump directly to specific segments.
+
+**Other notable features:**
+
+- Custom note templates for different meeting types with automatic CRM field updates for MEDDIC and SPICED methodologies
+- Collaborative note editor for multiple team members to work in real-time, drop comments, tag members, and mark action items
+- Advanced conversation analytics including filler word tracking, talk-to-listen ratios, and competitive intelligence
+- AI Copilot that provides answers about meetings and generates follow-up emails
+- Searchable knowledge base with global transcription search across all meetings
+
+#### Pros:
+
+- Comprehensive platform including scheduling, lead routing, and conversation intelligence
+- Free viewer seats allow unlimited team members to access meeting insights without paying
+
+#### Cons:
+
+- Steep learning curve due to extensive features
+- Advanced features primarily designed for sales teams
+- Limited support for non-English speaking users
+
+#### Pricing:
+
+Avoma's AI Meeting Assistant starts at $19 per user per month (billed annually) with a 14-day free trial.
+
+## Choose an AI Meeting Assistant With the Right Trade-off
+
+Most of the tools on this list can save time. That part is no longer rare.
+
+The harder decision is whether you want convenience inside someone else's system or notes you actually control.
+
+If you want the second option, Char is the outlier here. Your meetings become files. You choose the AI layer. You can run local, use your own keys, or use the managed cloud without rebuilding your workflow around a proprietary format.
+
+[**Download Char for macOS**](/download) if that is the kind of setup you want to keep long term.
+
+<CtaCard/>

--- a/apps/web/content/articles/best-ai-notetaker-for-in-person-meetings.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-in-person-meetings.mdx
@@ -1,0 +1,270 @@
+---
+meta_title: "7 Best AI Notetakers for In-person Meetings"
+meta_description: "Compare the top AI notetakers for in-person meetings. Find tools with mobile apps, offline recording, speaker ID, and real-time transcription features"
+author:
+  - "Harshika"
+coverImage: "/api/assets/blog/best-ai-notetaker-for-in-person-meetings/cover.png"
+featured: false
+category: "Comparisons"
+date: "2025-09-03"
+---
+
+In-person meetings are where a lot of AI notetakers fall apart.
+
+Most of these products were designed around video calls, calendar links, separate audio channels, and stable internet. Real conversations happen in conference rooms, cafes, hallways, cars, and client offices. The constraints are different.
+
+We looked for tools that could survive that mess.
+
+
+| Tool         | Best For                                                                       | Skip If                                                            |
+| ------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| Char         | Zero lock-in, complete control over data and AI stack                          | You need a mobile recording (iOS app coming soon)                  |
+| Jamie AI     | International teams needing multilingual support with European data compliance | You need mobile recording or real-time transcription               |
+| Fireflies AI | Teams needing comprehensive conversation analytics with mobile flexibility     | You prioritize data privacy or need real-time mobile transcription |
+| MeetGeek     | Teams requiring comprehensive analytics and workflow automation                | You need real-time mobile transcription or have budget constraints |
+| Otter AI     | Teams needing real-time transcription with strong collaboration features       | You handle sensitive information or have privacy concerns          |
+| Granola AI   | Mac/iOS users who prefer manual note-taking with AI enhancement                | You need automatic speaker identification or Android support       |
+| Read AI      | Teams seeking detailed meeting analytics and communication coaching            | You need Android support or extensive free usage                   |
+
+
+## What Makes In-Person AI Notetakers Work?
+
+The hard parts are different in person, so the criteria have to be different too.
+
+We focused on five things that matter most when there is no meeting bot, no clean audio channel split, and no guarantee of connectivity:
+
+### 1. Mobile App Support
+
+Can you record meetings directly from your phone or tablet? In-person meetings happen everywhere—coffee shops, client offices, conference rooms—and you can't always bring a laptop.
+
+### 2. Offline/Local Recording
+
+Does the tool work without internet connectivity? Many meeting locations have poor wifi, and some organizations restrict internet access during sensitive discussions.
+
+### 3. Speaker Identification
+
+How well does it distinguish between different voices? Unlike video calls where each person has a separate audio channel, in-person meetings require tools to identify speakers from a single audio source.
+
+### 4. Real-time Transcription
+
+Can you see live text during the meeting, or do you wait for processing afterward? This affects whether you can follow along in real-time or need to take backup notes.
+
+### 5. Multi-language Support
+
+How many languages can it handle accurately? International teams and diverse workplaces need tools that work across different languages and accents.
+
+## In-Person AI Notetakers: Detailed Comparison
+
+### 1. Char
+
+[Char](/) is an open-source AI notepad for meetings built for high-agency people who demand complete control over their data and AI stack. Everything is stored as plain markdown files—not in proprietary databases. You choose your AI: managed cloud, bring your own keys, or run local models.
+
+The interface feels like Apple Notes but with AI superpowers. Start a meeting, and it transcribes in real-time. When you hang up, you get structured summaries with decisions and action items automatically extracted.
+
+Zero lock-in—your files work with any tool (Obsidian, Notion, VS Code) and you can switch AI providers anytime.
+
+![Char for in person meetings](/api/assets/blog/best-ai-notetaker-for-in-person-meetings/inperson-1.webp)
+
+#### Pros:
+
+- Your choice of AI stack: managed cloud, bring your own API keys, or run local models
+- Real-time transcription with no bots or calendar permissions required
+- Everything saved as plain markdown files — works with Obsidian, Notion, VS Code, or any text editor
+- 45+ language support including English, Spanish, French, German, Japanese, and more
+- Customizable templates for different meeting types
+- Forever-free plan with local transcription, BYOK, and all core features
+
+#### Cons:
+
+- Currently limited to Mac, with no mobile app available yet
+- Requires manual speaker tagging for group discussions when using local processing
+
+#### Other Notable Features
+
+Includes customizable templates for different meeting types, and offers conversational search across meeting history. 
+
+#### Pricing
+
+Free forever for local transcription, BYOK, and all core features. Managed cloud service is $25/month for the easiest setup.
+
+Char also offers an Enterprise plan for organizations that need on-premise deployment, SSO integration, or smart consent management for compliance requirements. [Contact sales for a quote](/founders).
+
+### 2. Jamie AI
+
+[Jamie](https://www.meetjamie.ai) records audio locally on Windows or Mac computers, then uploads recordings to German servers for AI processing. The system automatically deletes audio files after generating transcripts and summaries, emphasizing privacy through data minimization rather than local processing.
+
+![jamie ai for in person meetings](/api/assets/blog/best-ai-notetaker-for-in-person-meetings/inperson-2.webp)
+
+#### Pros:
+
+- Speaker recognition improves over time by learning voices
+- Supports over 20 languages with automatic language detection
+- Complies with GDPR requirements through European data hosting
+- Works without requiring the internet during actual recording sessions
+
+#### Cons:
+
+- Limited to desktop computers with no mobile application currently available
+- Requires 5-10 minutes for summary generation after recording ends
+- Needs external microphones for optimal audio quality in group settings
+- No real-time transcription during meetings
+
+#### Other Notable Features
+
+Includes an executive assistant sidebar for querying past meetings, offers custom templates for different meeting types, and provides semantic search across conversation history. Users can draft follow-up emails directly from meeting content.
+
+#### Pricing
+
+Free plan with 10 meetings/month. Paid plans start at €24/month (~$25) with higher tiers available.
+
+### 3. Fireflies AI
+
+Fireflies uses a bot system for online meetings but shifts to mobile-first recording for in-person conversations. The platform emphasizes team analytics and workflow automation alongside transcription.
+
+![Fireflies ai for in person meetings](/api/assets/blog/best-ai-notetaker-for-in-person-meetings/inperson-3.webp)
+
+#### Pros:
+
+- Dedicated mobile applications enable portable recording on phones and tablets
+- Identifies different speakers with reasonable accuracy in recordings
+- Supports over 60 languages for transcription services
+- Provides detailed conversation analytics including speaker talk time and sentiment
+- Allows file uploads in multiple audio and video formats
+
+#### Cons:
+
+- Requires internet connectivity for AI processing and summary generation
+- No real-time transcription available on mobile devices
+- Users report occasional app stability issues and aggressive upselling tactics
+- Privacy concerns regarding cloud-based data processing and storage
+
+#### Other Notable Features
+
+Offers Smart Search for reviewing lengthy meetings quickly, creates shareable audio clips called Soundbites, and includes an AI assistant for querying meeting content. Integrates with over 60 workplace applications.
+
+#### Pricing
+
+Free plan includes unlimited transcription with 800 minutes of storage. Paid plans start at $18/user/month.
+
+### 4. MeetGeek
+
+With MeetGeek, you can record in-person meetings using their app, then send them for transcription and summarization. The platform syncs the content directly into your existing tools like Slack, HubSpot, or project management apps, reducing manual post-meeting work.
+
+![meetgeek for in person meetings](/api/assets/blog/best-ai-notetaker-for-in-person-meetings/inperson-4.webp)
+
+#### Pros:
+
+- Mobile applications available for iOS and Android devices
+- Automatic speaker identification and labeling in recordings
+- Supports over 50 languages for transcription accuracy
+- Offers meeting templates that can be selected before recording begins
+- Allows audio and video file uploads from mobile devices
+
+#### Cons:
+
+- No real-time transcription—processing occurs 5-7 minutes after recording ends
+- Free plan limits users to 300 minutes of monthly transcription time
+- Some users report transcription accuracy issues with poor audio quality
+- Limited offline capabilities requiring internet for processing
+
+#### Other Notable Features
+
+Provides advanced meeting analytics including talk-time distribution and sentiment analysis, automates workflow integrations with thousands of applications, and includes AI chat functionality for querying meeting content.
+
+#### Pricing
+
+Basic plan offers 300 free minutes monthly. Pro costs $19 monthly, Business $39 monthly.
+
+### 5. Otter AI
+
+Otter specializes in live transcription as meetings occur. However, the platform faces significant privacy concerns, including ongoing federal litigation.
+
+![Otter ai for in person meetings](/api/assets/blog/best-ai-notetaker-for-in-person-meetings/inperson-5.webp)
+
+#### Pros:
+
+- Mobile applications enable recording and transcription on smartphones and tablets
+- Provides live transcription visible during recording sessions
+- Learns speaker voices over time to improve identification accuracy
+- Strong collaboration features, including commenting and highlighting
+
+#### Cons:
+
+- Requires an active internet connection for real-time transcription functionality
+- Only supports English, Spanish, and French for transcription services
+- Free plan restricts usage to 300 minutes monthly with 30-minute session limits
+- Faces privacy concerns regarding unauthorized recording and spam
+
+#### Other Notable Features
+
+Includes custom vocabulary for industry-specific terminology, automated summary generation, extensive third-party integrations, and team workspace functionality for collaboration.
+
+#### Pricing
+
+Free plan provides 300 monthly minutes with conversation limits. Paid plans start at $16.99/user/month.
+
+### 6. Granola AI
+
+Granola encourages users to take notes manually during meetings, then uses AI to enhance and structure those notes afterward. The platform records locally but processes content in the cloud for intelligent analysis.
+
+![granola ai for in person meetings](/api/assets/blog/best-ai-notetaker-for-in-person-meetings/inperson-6.webp)
+
+#### Pros:
+
+- Mobile application available for iOS devices, enabling portable recording
+- Hybrid approach combining manual notes with automated transcription
+- Single-tap recording activation from device lock screens
+
+#### Cons:
+
+- Limited speaker identification resulting in generic labels like "Speaker 1" and "Speaker 2"
+- Mac and iOS only—no Android or web-based versions available
+- An internet connection is required for AI processing after recording sessions
+- System audio limitations affect speaker differentiation during group recordings
+
+#### Other Notable Features
+
+Offers customizable meeting templates, integrates with Google Calendar and Slack, includes chat functionality for querying past meetings, and emphasizes user control over note-taking processes.
+
+#### Pricing
+
+Free trial with up to 25 meetings to test the full feature set. Paid plans start at $18 per month.
+
+### 7. Read AI
+
+Read AI focuses on analyzing meeting dynamics and participant engagement alongside transcription. The platform recently introduced mobile capabilities for in-person meeting recording and analysis.
+
+![read ai for in person meetings](/api/assets/blog/best-ai-notetaker-for-in-person-meetings/inperson-7.webp)
+
+#### Pros:
+
+- iPhone application enables mobile recording with real-time transcription and summarization
+- Automatic speaker detection and identification in recorded conversations
+- Smart notifications that differentiate between in-person and virtual meeting contexts
+- Real-time transcript generation is visible during recording sessions
+- Cross-platform synchronization displays mobile recordings alongside virtual meetings
+
+#### Cons:
+
+- Currently limited to iPhone only
+- Requires internet connectivity for real-time transcription and AI processing
+- No offline processing capabilities for transcription or summarization
+- Limited information available about speaker identification accuracy in group settings
+
+#### Other Notable Features
+
+Provides detailed meeting analytics, including participant engagement metrics and speaking patterns, offers personalized coaching recommendations for communication improvement, and integrates with email, CRM systems, and collaboration platforms. Includes file upload capabilities for processing pre-recorded audio and video content.
+
+#### Pricing
+
+Free plan includes 5 monthly meeting reports. Paid plans start at $19.75/user/month.
+
+## Where I'd start for in-person meetings
+
+If you mostly care about mobile capture, a few cloud products here will do the job.
+
+If you care about ownership, offline use, and not building your workflow around a vendor's app, Char is the better long-term setup. It treats the meeting as yours, not as something that has to pass through a platform first.
+
+[Download Char for macOS](/download) if that is the direction you want to optimize for.
+
+&nbsp;

--- a/apps/web/content/articles/best-ai-notetaker-for-microsoft-teams.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-microsoft-teams.mdx
@@ -1,0 +1,315 @@
+---
+meta_title: "7 Best AI Notetakers for Microsoft Teams in 2026"
+meta_description: "Looking for the best AI notetaker for Microsoft Teams? Compare the top 7 solutions, including native and third-party options."
+author:
+  - "John Jeong"
+coverImage: "/api/assets/blog/best-ai-notetaker-for-microsoft-teams/cover.png"
+featured: false
+category: "Comparisons"
+date: "2025-09-09"
+---
+
+Microsoft Teams is one of the harder environments for AI notes because the answer depends on what kind of buyer you are.
+
+If your company is already standardized on Microsoft and wants the least resistance possible, the native options matter. If you want better portability, more control, or something that works beyond Teams, the third-party tools get more interesting.
+
+## TL;DR
+
+Here's a quick comparison of the [best AI notetakers](/blog/best-ai-meeting-assistant-for-taking-notes) for Microsoft Teams.
+
+![ai notetaker comparison for microsoft teams](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-1.webp)
+
+Keep reading for the detailed trade-offs. The category splits pretty cleanly between native Microsoft convenience and more flexible third-party tools.
+
+**💡 Our selection criteria:**
+
+We evaluated Microsoft's native options and third-party tools based on:
+
+- **Microsoft Teams compatibility** - Must work seamlessly with Teams meetings
+- **AI quality** - Accurate transcription and intelligent summarization capabilities
+- **Privacy and security** - Different deployment options for various compliance needs
+- **Ease of use** - Simple setup and intuitive interface
+- **Pricing value** - Cost-effectiveness for different team sizes and budgets
+- **User feedback** - Real-world reviews and adoption rates
+
+## Native AI Notetaker Solutions for Microsoft Teams
+
+Microsoft doesn't offer a free way to get AI-powered meeting notes, summaries, or intelligent transcription analysis from Teams. Teams users with Microsoft 365 Business or Enterprise get meeting transcription with speaker identification, but no AI summaries or intelligent note-taking.
+
+### 1. Microsoft 365 Copilot: The Premium AI Assistant
+
+![Microsoft 365 Copilot](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-2.webp)
+
+[Microsoft 365 Copilot](https://support.microsoft.com/en-us/office/use-copilot-in-microsoft-teams-meetings-0bf9dd3c-96f7-44e2-8bb8-790bedf066b1) is an AI assistant that works across Word, Excel, PowerPoint, Outlook, and Teams, powered by large language models. For Teams specifically, it transforms how you handle meeting preparation, participation, and follow-up.
+
+**Important Note:** Microsoft 365 Copilot is different from the [free Copilot](https://copilot.microsoft.com) available in browsers and Bing. Copilot does not record meetings itself—you need to provide it with a meeting transcription to generate a summary and AI notes.
+
+#### Microsoft 365 Copilot's Teams Integration Features
+
+- Cross-app integration across Word, Excel, PowerPoint, Outlook, and Teams
+- Real-time meeting intelligence with context understanding and topic organization
+- Intelligent summarization including decisions, action items, and participant insights
+- Post-meeting Q&A capability for specific questions about meeting content
+- Facilitator feature for virtual meeting moderation and mid-meeting recaps
+- Cross-reference capabilities connecting meetings with past discussions and documents
+
+#### Pros
+
+- Native integration eliminates compatibility issues
+- Enterprise-grade security with Microsoft's compliance framework
+- Cross-platform consistency across all Microsoft 365 apps
+- Contextual intelligence beyond basic transcription
+- No meeting bots required—cleaner meeting experience
+- Continuous AI improvements from Microsoft's ongoing development
+
+#### Cons
+
+- Premium pricing at $30/user/month (as of 2026)
+- Requires existing Microsoft 365 subscription
+- Limited customization compared to specialized tools
+- Some advanced features still in preview
+- Performance can vary with audio quality and meeting complexity
+
+#### Pricing
+
+Microsoft 365 Copilot costs $30 per user per month, in addition to your existing Microsoft 365 Business Premium or Enterprise subscription.
+
+### 2. Teams Premium: Enhanced Meeting Features
+
+![Teams Premium](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-3.webp)
+
+[Teams Premium](https://www.microsoft.com/en-us/microsoft-teams/premium) offers enhanced meeting features between basic Teams and full Copilot functionality.
+
+#### Key Features
+
+- Intelligent meeting recap with key talking points and decisions
+- Live translation for 40+ languages with real-time transcription
+- Advanced meeting options including custom backgrounds and security controls
+- Basic AI insights for action item extraction and organization
+
+#### Pros
+
+- More affordable than the full Copilot solution
+- Immediate availability without preview limitations
+- Good transcription accuracy in optimal conditions
+- International team support with live translation
+- Enhanced security features for sensitive meetings
+
+#### Cons
+
+- Limited AI capabilities compared to Copilot
+- Still requires an additional subscription beyond basic Teams
+- Less sophisticated summarization
+- No cross-app integration
+- Basic action item detection
+
+#### Pricing
+
+Teams Premium is priced at $10 per user per month.
+
+## Best Third-Party AI Notetakers for Microsoft Teams
+
+While Microsoft's native solutions work well for many organizations, third-party tools often provide specialized features, better privacy controls, or more competitive pricing.
+
+### 1. Char: The Zero Lock-in AI Notepad
+
+Char is an open-source AI notepad for meetings built for high-agency people who demand complete control over their data and AI stack. Everything is stored as plain markdown files—not in proprietary databases.
+
+**Full Disclosure:** I'm the co-founder of Char, so I'll try to be as objective as possible in this review.
+
+**How It Works with Microsoft Teams:** Char doesn't join your Teams meetings as a bot. Instead, it captures both your microphone input and your computer's system audio, so it hears both sides of the conversation. It transcribes your call in real-time. After the meeting ends, you get structured summaries with decisions and action items automatically extracted. No bots to invite, no meeting links to manage.
+
+![best ai notetaker for microsoft teams](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-4.webp)
+
+#### Key Features
+
+- Works with Zoom, Teams, Google Meet, and in-person meetings without any setup
+- Your choice of AI: managed cloud, bring your own API keys (OpenAI, Anthropic, Mistral, and others), or run local models via Ollama or LM Studio
+- AI chat to query your transcripts and search across your entire meeting history
+- Custom templates for different meeting types
+- Import existing recordings or transcripts
+- 45+ language support including English, Spanish, French, German, Japanese, and more
+- Floating panel and keyboard shortcuts for quick recording controls
+- Smart consent management for enterprises with options from simple pop-ups to verbal consent recognition
+
+**Pros**
+
+- Your choice of AI stack: managed cloud, bring your own keys, or run local models
+- Free forever for local transcription, BYOK, and all core features
+- Can work completely offline, suitable for air-gapped environments
+- Open source codebase allows for inspection, customization, and community contributions
+- Plain markdown files work with Obsidian, Notion, VS Code, or any text editor
+
+**Cons**
+
+- macOS only currently (Windows and Linux versions coming in Q2 2026)
+- No video recording by design
+
+#### Pricing
+
+Char is [free forever](/blog/free-ai-notetakers) for local transcription, BYOK, and all core features. The managed cloud service is $25/month for the easiest setup. Enterprise applies when your organization needs on-premises deployment, SSO integration, or consent management for compliance requirements. [Contact sales for a quote](/founders).
+
+### 2. Otter AI: The Established Cloud-Based Solution
+
+[Otter AI](https://otter.ai) is one of the most well-known names in AI transcription, offering cloud-based meeting intelligence that works across Microsoft Teams, [Zoom](/blog/best-ai-notetaker-for-zoom/), and Google Meet.
+
+**How It Works with Microsoft Teams:** Otter joins your Teams meetings as a participant. It records the audio, generates real-time transcripts, and creates meeting summaries automatically. Setup involves account creation, calendar connection, and bot invitation. The bot can be invited manually or set to auto-join meetings based on your calendar integration. Recent privacy concerns indicate that Otter sometimes joins meetings without proper consent. Also check: [Is Otter AI Safe?](/blog/is-otter-ai-safe)
+
+![Otter ai for microsoft teams](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-6.webp)
+
+#### Key Features
+
+- OtterPilot AI Chat for asking questions about meeting content during or after calls
+- Slide capture automatically screenshots presentations and embeds them in transcripts
+- Custom vocabulary for industry terms, names, and company-specific language
+- Team workspaces with comment threads and assignable action items
+- CRM integrations with Salesforce and HubSpot (Business/Enterprise plans)
+- OtterPilot for Sales extracts insights and pushes notes to CRM (Enterprise only)
+
+#### Pros
+
+- Mature platform with years of development and proven reliability
+- Strong speaker identification that improves with usage
+- Established integration ecosystem especially valuable for sales teams
+- Mobile app handles both virtual and [in-person meetings](/blog/is-otter-ai-safe) effectively
+
+#### Cons
+
+- Bot-based approach means meetings show an extra participant
+- Monthly minute limitations, even on paid plans
+- Privacy concerns, as all audio and transcripts are processed in Otter's cloud
+- Limited language support with only English, French, and Spanish
+- Complex permission management that teams struggle with
+- Higher pricing for teams—Business plan costs scale quickly for larger organizations
+- No offline capability requires a stable internet connection
+
+#### Pricing
+
+Free plan: 300 minutes monthly with 30-minute conversation limits. Paid plans start at $16.99/user/month for 1,200 minutes and advanced features.
+
+### 3. Tactiq: The Browser Extension Approach
+
+[Tactiq](https://tactiq.io) is a bot-free AI meeting assistant that works as a Chrome extension to transcribe Microsoft Teams, Google Meet, and Zoom meetings.
+
+**How It Works with Microsoft Teams:** Install the Chrome extension and join your Teams meeting in the browser. A small transcription widget appears showing live captions with speaker identification. After the meeting, you can use one-click AI actions to generate summaries, action items, or ask specific questions about the conversation.
+
+![Tactiq for microsoft teams](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-7.webp)
+
+#### Key Features
+
+- Browser-based transcription that works without recording meetings or inviting bots
+- Live transcription widget shows real-time captions during meetings with speaker identification
+- One-click AI actions for generating summaries, action items, and custom follow-ups
+- Custom AI prompts that can be saved and reused across meetings for consistent outputs
+- Multi-language support covering 30+ languages including English, Spanish, French, and German
+- Team Spaces for sharing transcripts and collaborating on meeting insights
+- Upload functionality for transcribing existing audio and video files
+- Screenshot capture to save important visual moments from presentations
+
+#### Pros
+
+- No meeting disruption since there's no bot joining your calls
+- Fast setup just requires installing a Chrome extension
+- Clean user interface that's intuitive
+- Strong privacy positioning as transcripts are processed without recording actual meetings
+- Affordable pricing compared to enterprise-focused alternatives
+
+#### Cons
+
+- Chrome extension dependency means it only works in browser versions of meeting apps
+- Limited AI credits even on paid plans restrict how much AI processing you can do
+- No mobile app support since it relies on the Chrome extension. If you need an [AI notetaker for in-person meetings](/blog/best-ai-notetaker-for-in-person-meetings), Tactiq won't work.
+- Basic team collaboration features compared to dedicated team platforms
+- Transcription quality varies depending on browser audio quality and meeting conditions
+- No offline capability requires internet connection and browser access
+
+#### Pricing
+
+Free plan: 10 meetings/month and 5 AI credits. Paid plans start at $12/user/month.
+
+### 4. Fireflies AI: The Conversation Intelligence Platform
+
+[Fireflies](https://fireflies.ai) positions itself as a full conversation intelligence solution for sales teams and growing businesses.
+
+**How It Works with Microsoft Teams:** Fireflies joins your Teams meetings as a bot. You can invite it manually to specific meetings or set it to auto-join based on your calendar integration. The bot records, transcribes, and processes the entire conversation, then automatically sends meeting summaries to designated Teams channels. Setup involves creating a Fireflies account, verifying email, connecting your Microsoft calendar, configuring auto-join preferences, setting up Teams channel integrations for receiving summaries, and potentially getting IT approval for the bot.
+
+![fireflies ai for microsoft teams](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-8.webp)
+
+#### Key Features
+
+- AskFred AI assistant lets you chat with meeting transcripts and ask specific questions about past conversations
+- Conversation intelligence provides talk-time analytics, sentiment analysis, and speaker behavior insights
+- Video recording capability captures screen shares, slides, and visual content alongside audio transcription
+- 69 language support making it suitable for global teams and multilingual meetings
+- Team analytics show meeting patterns, participation rates, and conversation insights for managers
+- AI Apps and custom prompts for generating specialized outputs like follow-up emails and project updates
+
+#### Pros
+
+- Extensive integration ecosystem with 58+ platforms including major CRMs and productivity tools
+- Strong enterprise features including HIPAA compliance, SSO, and private storage options
+- Robust search functionality lets you find specific moments across all past meetings
+- Unlimited transcription even on the free plan
+- Mobile app support for recording and transcribing in-person conversations
+
+#### Cons
+
+- Bot presence can feel intrusive as Fireflies appears as an additional meeting participant
+- Complex interface may overwhelm users who just want simple transcription
+- Storage limitations on lower-tier plans create pressure to upgrade
+- Higher pricing for advanced features compared to basic transcription alternatives
+
+#### Pricing
+
+Free forever with unlimited transcription, but limited AI summaries and 800 minutes storage. Paid plans start at $18/user/month.
+
+Also check: [Top Fireflies AI Alternatives](/blog/fireflies-ai-alternatives)
+
+### 5. tl;dv: The Video-Moment AI Notetaker
+
+[tl;dv](https://tldv.io) is a video-first AI notetaker that turns meeting notes into clickable timestamps, making it easy to navigate directly to specific moments in recordings.
+
+**How It Works with Microsoft Teams:** The tl;dv bot joins your Teams meetings automatically, records both audio and video, then generates AI summaries while allowing you to add manual timestamped notes during the call. Setup involves creating a tl;dv account, connecting your calendar, and configuring recording preferences.
+
+![tl;dv for microsoft teams](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-9.webp)
+
+#### Key Features
+
+- Timestamped manual notes let you add your own observations during meetings that become clickable moments in recordings
+- AI meeting summaries automatically extract key points, decisions, and action items from every conversation
+- Video moment search allows you to search keywords and jump directly to that point in the recording
+- Sales playbook analysis tracks how well team members follow scripts and handle customer objections
+- Multi-meeting intelligence analyzes patterns and trends across multiple similar meetings
+- Clip creation tools make it easy to cut and share important moments from longer recordings
+- 30+ language transcription supports global teams with multilingual meeting capture
+
+#### Pros
+
+- Video navigation capabilities make it easy to find and share specific conversation moments
+- Generous free plan offers unlimited recordings and transcriptions without time limits
+- Strong sales coaching features help managers analyze rep performance and objection handling
+- Extensive integration ecosystem connects with most business tools via Zapier
+
+#### Cons
+
+- Bot presence required means Teams meetings show an additional participant
+- Video storage demands can consume significant space for frequent, long meetings
+- Limited to three platforms only works with Teams, Zoom, and Google Meet
+- No mobile app restricts access to browser and desktop versions only
+- Learning curve for teams to adopt video-based workflow and timestamp navigation
+
+#### Pricing
+
+Free forever plan with unlimited recordings. Pro plans start at $29/month for advanced analytics and coaching features.
+
+---
+
+## My take
+
+If your company is already deep in Microsoft procurement and wants the most familiar path, start with Copilot.
+
+If you want something that is not trapped inside Teams, start with Char. It works with Teams, but it is not dependent on Teams. That matters if you care about keeping the notes as files, keeping the AI stack flexible, or keeping the same workflow across Zoom, Meet, and in-person conversations.
+
+You can [download and start using Char](/download) without calendar connections, account setup, or a meeting bot.
+
+&nbsp;

--- a/apps/web/content/articles/best-ai-notetaker-for-microsoft-teams.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-microsoft-teams.mdx
@@ -171,7 +171,7 @@ Char is [free forever](/blog/free-ai-notetakers) for local transcription, BYOK, 
 - Mature platform with years of development and proven reliability
 - Strong speaker identification that improves with usage
 - Established integration ecosystem especially valuable for sales teams
-- Mobile app handles both virtual and [in-person meetings](/blog/is-otter-ai-safe) effectively
+- Mobile app handles both virtual and [in-person meetings](/blog/best-ai-notetaker-for-in-person-meetings) effectively
 
 #### Cons
 

--- a/apps/web/content/articles/best-ai-notetaker-for-zoom.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-zoom.mdx
@@ -1,0 +1,421 @@
+---
+meta_title: "Best AI Notetaker for Zoom: Top 10 Options"
+meta_description: "Find the best AI notetaker for Zoom with our 2026 guide. Compare real-time transcription, privacy options, CRM integrations, and pricing plans."
+author: "Harshika"
+coverImage: "/api/assets/blog/best-ai-notetaker-for-zoom/cover.png"
+category: "Comparisons"
+date: "2025-09-06"
+---
+
+Zoom is where a lot of AI notetakers look better in a demo than they do in real use.
+
+The real test is not whether a tool can join a call. It is whether it still feels useful when the meeting is messy: bad audio, client sensitivity, technical jargon, IT restrictions, or a team that does not want another bot in the room.
+
+These are the tools that held up best when we evaluated them through that lens.
+
+- **Char** → Zero lock-in, complete control over data and AI stack
+- **Zoom AI Companion** → Teams already invested in Zoom's ecosystem
+- **Fathom** → Sales teams wanting instant CRM integration
+- **Otter AI** → Teams comfortable with established cloud automation
+- **tl;dv** → Sales teams needing detailed video analysis
+- **Fireflies AI** → International teams requiring multilingual support
+- **MeetGeek** → Teams wanting automated workflow integrations
+- **Avoma** → Customer-facing teams extracting revenue insights
+- **Tactiq** → Chrome users wanting real-time browser transcription
+- **Krisp** → Noisy environments needing AI notes bonus
+
+**Also check:** [How to Transcribe Zoom Calls Automatically?](/blog/how-to-transcribe-zoom-calls)
+
+## How We Chose These AI Notetakers
+
+We were not looking for the longest feature list. We were looking for tools that still worked once the easy cases were gone.
+
+We prioritized:
+
+- **Transcription accuracy** - How well does it handle multiple speakers, technical terms, and varying audio quality?
+- **Summary quality** - Can it identify key decisions, action items, and important discussion points?
+- **Integration capabilities** - Does it connect with workflow tools like Slack, CRMs, or project management platforms?
+- **Privacy and security** - Where is data processed and stored? What compliance standards does it meet?
+- **Ease of use** - How quickly can teams start using it without complex setup or training?
+- **Pricing value** - Does it offer good functionality relative to cost, including free tier options?
+
+> **Note:** Zoom's native AI Companion requires a paid plan and has limited customization options. Third-party AI notetakers often provide more sophisticated features, better accuracy, and flexible deployment options worth considering even for Zoom-centric organizations.
+
+## What Are the Best AI Notetakers for Zoom?
+
+### 1. Char
+
+**Best for:** High-agency professionals who demand complete control over their data, AI stack, and workflow.
+
+<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-1.webp" alt="Best ai notetaker for zoom" />
+
+[Char](/) is an open-source AI notepad for meetings built for high-agency people who demand complete control. Everything is stored as plain markdown files on your device—not in proprietary databases. You choose your AI stack: managed cloud, bring your own keys, or run local models.
+
+The interface works like Apple Notes with AI superpowers. Start a meeting and it transcribes in real-time. When you hang up, you get structured summaries with decisions and action items automatically extracted.
+
+The AI can work completely hands-off, generating organized notes without any input from you. Or you can collaborate by jotting down key points, and the AI will expand your rough notes with context you might have missed while actively participating.
+
+#### Key features
+
+- Plain markdown files stored locally—works with any tool (Obsidian, Notion, VS Code)
+- Your choice of AI stack: managed cloud, bring your own keys, or run local models
+- Open source—zero lock-in, full transparency
+- Customizable templates for different meeting types (therapy, legal, interviews)
+- Smart Consent Management Package for enterprise compliance
+- AI Chat with MCP server connections for enhanced functionality
+- Calendar integration with notification system
+- Conversational search across all meeting history
+- Flexible AI model options (local, self-host, or connect to custom AI endpoints)
+
+#### Strengths
+
+- Zero lock-in—plain markdown files, open source, portable format
+- [Free forever](/blog/free-ai-notetakers) for local transcription, BYOK, and all core features
+- Your choice of AI stack—managed cloud ($25/mo), bring your own keys, or run local
+- Works without internet—great for secure environments
+- True file ownership—works with Obsidian, Notion, VS Code, anything
+- IT teams can audit the code and approve the AI provider
+
+#### Considerations
+
+- Mac only right now (Windows and Linux coming in Q2 2026)
+- No video recording by design for maximum privacy
+
+#### Pricing
+
+Char is free forever for local transcription, BYOK, and all core features. Managed cloud service is $25/month for the easiest setup.
+
+Char also offers an Enterprise plan for organizations that need on-premise deployment, SSO integration, or smart consent management for compliance requirements. [Contact sales for a quote](/founders).
+
+### 2. Zoom AI Companion
+
+**Best for:** Teams already invested in Zoom's ecosystem who want built-in AI features.
+
+<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-2.webp" alt="zoom ai companion review" />
+
+[Zoom AI Companion](https://www.zoom.com/en/products/ai-assistant/?cms_guid=false&lang=en-US) is built directly into Zoom Workplace, working across Meetings, Team Chat, Phone, Email, and Whiteboard.
+
+Compared to specialized tools, it's fairly basic. You need a paid Zoom plan to access it. All features are disabled by default, and the core functionality is limited to meeting summaries, smart recording, in-meeting questions, and whiteboard assistance.
+
+Unlike tools like Char that work offline and provide real-time transcription, Zoom AI Companion requires cloud processing and doesn't offer live transcription during meetings.
+
+Any meaningful customization—like custom dictionaries, meeting templates, or third-party integrations—costs an extra $12/user/month.
+
+#### Key features
+
+- Meeting summaries with next steps (no real-time transcription)
+- Smart recording with highlights and chapters
+- In-meeting questions to catch up without interrupting
+- AI-powered whiteboard content generation
+- Custom templates and third-party integrations (paid add-on)
+
+#### Strengths
+
+- Built directly into Zoom with no separate installation (disabled by default—admins must enable)
+- Clear notifications when AI features are active
+- Uses multiple AI models for optimal results
+
+#### Considerations
+
+- Requires paid Zoom subscription—not available on free plans
+- No real-time transcription or live collaboration like other tools
+- Basic customization costs $12/user/month extra—more expensive than most standalone alternatives
+- Not available for [HIPAA-compliant instances](https://zoom.oit.uci.edu/useful-zoom-features/ai-companion/)
+- Limited accuracy and features compared to specialized AI notetakers
+
+#### Pricing
+
+Included with paid Zoom accounts. The custom AI Companion add-on costs $12/user/month.
+
+Also, check out our detailed [Zoom AI Companion review](/blog/zoom-ai-companion-review).
+
+### 3. Fathom
+
+**Best for:** Sales teams and customer-facing professionals who want instant summaries with CRM integration.
+
+<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-3.webp" alt="Fathom for zoom" />
+
+[Fathom](https://www.fathom.ai) joins your Zoom calls as a bot and emphasizes speed—you get meeting summaries within 30 seconds of hanging up. Its main strength is handling the post-meeting workflow, automatically pushing notes and action items into your CRM without manual work.
+
+During calls, you can click buttons to highlight important moments or mark action items. After the meeting, everything gets organized into a summary you can immediately forward to colleagues or sync with Salesforce.
+
+#### Key features
+
+- Direct integrations with major CRMs like Salesforce and HubSpot
+- Works with 28 languages for international teams
+- Custom summary templates you can modify for different meeting types
+- Can create shareable video clips from longer recordings
+- Search feature that works across your entire meeting history
+- Takes screenshots automatically when people share screens
+
+#### Strengths
+
+- Actually free forever for core features (unlimited recordings and storage)
+- CRM integrations work smoothly and save manual data entry
+- Easy to create and share video highlights with teammates
+- Handles multiple speakers and accents reasonably well
+
+#### Considerations
+
+- Bot appears in your meeting participant list (might feel awkward for sensitive calls)
+- AI-powered features limited on free plan after first 5 summaries per month
+- Works best with Zoom, other platforms feel secondary
+
+#### Pricing
+
+Free plan includes unlimited recordings and basic summaries. Premium costs $19/month for unlimited AI features. Team plans start at $29/month with collaboration tools.
+
+### 4. Otter AI
+
+**Best for:** Teams already comfortable with cloud-based tools who want established meeting automation.
+
+<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-4.webp" alt="Otter ai for zoom" />
+
+[Otter AI](https://otter.ai) is probably the most well-known AI meeting assistant—though not always for the right reasons, which we'll address.
+
+Otter pioneered many features that are now standard in the industry. It joins your Zoom, Google Meet, and Teams calls as a visible bot and delivers solid real-time transcription with speaker identification. You can assign action items directly in the transcript, and everyone gets access to searchable meeting notes immediately after calls end.
+
+However, Otter has developed a reputation for privacy issues that have made headlines. Users have reported the bot joining meetings without proper consent and spamming all participants with meeting notes. An [ongoing class-action lawsuit](/blog/is-otter-ai-safe) addresses these privacy practices.
+
+#### Key features
+
+- Real-time transcription with live team collaboration features
+- AI Chat for querying meeting history and generating follow-ups
+- Mobile app that syncs seamlessly across devices
+- Custom vocabulary that learns technical terms and company language
+- Integration with CRMs and productivity tools
+
+#### Strengths
+
+- Excellent real-time collaboration with commenting and highlighting
+- Strong speaker identification that improves with usage
+- Reliable platform with consistent performance and updates
+- Mobile app handles both virtual and [in-person meetings](/blog/best-ai-notetaker-for-in-person-meetings) effectively
+
+#### Considerations
+
+- Free plan limited to 300 monthly minutes (gets consumed quickly)
+- Language support restricted to English, Spanish, and French
+- Bot presence visible in meetings can feel intrusive for sensitive calls
+- Serious privacy considerations
+
+#### Pricing
+
+Free plan with 300 monthly minutes. Paid plans start at $16.99/user/month.
+
+<CtaCard/>
+
+### 5. tl;dv
+
+**Best for:** Sales teams and customer-facing roles who need detailed video analysis and CRM automation.
+
+<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-5.webp" alt="tl;dv for zoom" />
+
+[tl;dv](https://tldv.io) is a video-focused meeting assistant that records your Zoom, Google Meet, and Teams meetings and creates shareable video clips from longer recordings.
+
+What makes tl;dv different is its emphasis on post-meeting workflow automation. It can automatically update your CRM with call details, draft follow-up emails based on conversation content, and generate aggregated insights across multiple meetings. For sales teams, it tracks playbook adherence and objection handling to improve performance.
+
+#### Key features
+
+- Automatic CRM updates and follow-up email drafting
+- Video clip creation and sharing from longer recordings
+- AI-powered sales coaching with playbook tracking
+- Cross-meeting insights and trend analysis
+- Support for 30+ languages with translation capabilities
+
+#### Strengths
+
+- Excellent video handling with easy clip creation and sharing
+- Strong CRM automation that actually saves manual work
+- Good privacy practices with explicit no-training policy
+- Sales-focused features like objection tracking and coaching insights
+
+#### Considerations
+
+- Heavily sales-focused (may feel overkill for general meeting needs)
+- Bot joins meetings visibly which can interrupt flow
+- No mobile app yet (web version works on mobile)
+- Interface can feel complex for users wanting simple note-taking
+
+#### Pricing
+
+Free forever plan with unlimited recordings. Pro plans start at $29/month for advanced analytics and coaching features.
+
+### 6. Fireflies AI
+
+**Best for:** International teams needing multilingual support with comprehensive conversation analytics.
+
+<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-6.webp" alt="fireflies ai for zoom" />
+
+[Fireflies.ai](https://fireflies.ai) works similarly to Otter AI—its AI assistant "Fred" automatically joins your meetings and creates detailed transcripts. When meetings end, it generates structured summaries with clear action items, decisions, and next steps automatically extracted.
+
+Fireflies stands out for multilingual support across 100+ languages and conversation analytics. It tracks speaker talk time, monitors sentiment, identifies key topics, and provides team performance insights to optimize meeting effectiveness.
+
+#### Key features
+
+- Support for 100+ languages with automatic language detection
+- AskFred AI assistant for querying past meeting content
+- Comprehensive conversation analytics including sentiment analysis
+- 200+ AI apps for extracting specific insights (sales scoring, candidate evaluation)
+- Strong integrations with CRMs, project management, and productivity tools
+
+#### Strengths
+
+- Good transcription accuracy with clear speaker identification
+- Comprehensive integration ecosystem with popular business tools
+- Mobile app works well for capturing meetings on the go
+
+#### Considerations
+
+- Default settings are intrusive (auto-joins meetings, spams participants)
+- Frequent upselling and aggressive upgrade prompts
+- Bot presence can feel disruptive in sensitive conversations
+- Free plan limitations aren't clearly communicated upfront
+
+#### Pricing
+
+Free plan with 800 minutes of storage and limited AI credits. Paid plans start at $18/user/month.
+
+**Also check:** [Top Fireflies AI Alternatives](/blog/fireflies-ai-alternatives)
+
+### 7. MeetGeek
+
+**Best for:** Teams wanting automated meeting workflows and seamless integration with existing tools.
+
+<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-7.webp" alt="meetgeek for zoom" />
+
+[MeetGeek](https://meetgeek.ai/?r=0) automatically joins your meetings, records them, and syncs content directly into tools like Slack, HubSpot, or project management apps. The focus is reducing the manual work that happens after meetings—no more copying notes between systems or forgetting to update your CRM.
+
+#### Key features
+
+- Automatic meeting type detection with context-aware summary templates
+- Comprehensive conversation analytics and engagement metrics
+- 7,000+ app integrations via Zapier and direct CRM connections
+- Support for 50+ languages with high transcription accuracy
+- Mobile apps for recording in-person meetings offline
+
+#### Strengths
+
+- Strong analytics and coaching insights for improving meeting culture
+- Excellent integration ecosystem for workflow automation
+- Good multilingual support for international teams
+- Free plan includes 300 minutes with basic features
+
+#### Considerations
+
+- AI-generated summaries can be hit-or-miss, sometimes including irrelevant [small talk](https://www.g2.com/products/meetgeek/reviews/meetgeek-review-7361880)
+- Slower to set up new meetings ([requires 5+ minute advance calendar scheduling](https://www.g2.com/products/meetgeek/reviews/meetgeek-review-7361880))
+- Interface can feel complex for users wanting simple note-taking
+
+#### Pricing
+
+Free plan with 300 minutes monthly. Pro at $19/month for unlimited transcription. Business at $39/month with team features. Enterprise at $59/month.
+
+### 8. Avoma
+
+**Best for:** Customer-facing teams who need to extract revenue insights from their conversations.
+
+<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-8.webp" alt="avoma for zoom" />
+
+[Avoma](https://www.avoma.com) focuses on sales coaching and deal intelligence. The platform provides AI-powered scorecards for call performance, tracks talk patterns and engagement, and offers deal risk analysis. It can automatically update CRM fields based on conversation content and provides win-loss analysis to improve sales strategies.
+
+#### Key features
+
+- AI-powered conversation analysis with custom scorecards and coaching insights
+- Automatic CRM field updates for sales methodologies (MEDDIC, SPICED, etc.)
+- Deal risk alerts and automated win-loss analysis
+- Advanced scheduling with lead routing and qualification
+- Revenue intelligence with pipeline forecasting capabilities
+
+#### Strengths
+
+- Deep sales-focused features that competitors don't offer
+- Comprehensive coaching tools for sales team development
+- Good conversation intelligence with engagement metrics
+
+#### Considerations
+
+- Higher pricing compared to basic transcription tools
+- Can feel complex for teams wanting simple note-taking
+- Does not offer a free plan
+
+#### Pricing
+
+Offers a 14-day free trial, with paid plans starting at $29/month per recorder. Add-ons available for revenue intelligence ($99/month) and lead routing ($69/month).
+
+### 9. Tactiq
+
+**Best for:** Teams that live in Chrome and want real-time transcription without installing separate apps.
+
+<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-9.webp" alt="tactiq for zoom" />
+
+Unlike the standalone apps we've covered so far, [Tactiq](https://tactiq.io) works as a Chrome extension. This means no separate software to install—it just lives in your browser and captures audio directly from Google Meet, Zoom, and Teams tabs.
+
+The integration ecosystem is where Tactiq shines. It pushes meeting insights to Slack, HubSpot, Jira, and everywhere you actually work. You can turn frequent AI prompts into one-click actions, so you don't have to start from scratch every time you need follow-up tasks.
+
+#### Key features
+
+- Live transcription visible during meetings
+- 60+ languages with automatic detection
+- Rich integrations with workplace tools
+- Custom AI workflows for repetitive tasks
+- Automatic saving of in-call messages, links, and comments within transcripts
+
+#### Strengths
+
+- Browser-based approach means instant setup if you live in Chrome
+- Live transcription helps catch names or technical terms you might miss
+- Works seamlessly with your existing browser-based workflow
+
+#### Considerations
+
+- Chrome-only limits flexibility compared to universal tools like Char
+- No audio or video capture capabilities for teams needing meeting recordings
+- Free plan restrictions with only 5 AI credits per month
+
+#### Pricing
+
+Free plan with 10 meetings/month and 5 AI credits. Paid plans start at $12/user/month.
+
+### 10. Krisp
+
+**Best for:** Teams dealing with noisy environments who need AI notes as a bonus feature.
+
+<Image src="/api/assets/blog/best-ai-notetaker-for-zoom/zoom-10.webp" alt="krisp ai for zoom" />
+
+[Krisp](https://krisp.ai) cancels background noise AND takes meeting notes. The platform removes background noises, voices, and echoes from both sides of calls while transcribing meetings in real-time across all communication apps.
+
+The AI meeting notes are more basic than enhanced summaries from other tools, but they capture the essentials without fuss.
+
+#### Key features
+
+- AI-powered noise cancellation that removes background noises, voices, and echoes
+- Real-time transcription and meeting summaries across all communication apps
+- Support for transcripts and summaries in 16 languages
+- Direct integrations with Salesforce, HubSpot, Slack, Google Calendar, and Zapier
+- Mobile apps for iOS and Android to record in-person meetings
+
+#### Strengths
+
+- Works with any communication app as a smart layer between your device and platforms
+- Free plan offers unlimited transcriptions, making it accessible for testing
+- Strong privacy controls with encrypted data storage
+
+#### Considerations
+
+- AI note generation is basic with no ability to customize output beyond manual editing
+- Lacks an AI assistant for follow-up questions or deeper insights
+
+#### Pricing
+
+Offers a free plan with unlimited transcripts and 2 daily meeting notes. Paid plans start at $16/user/month.
+
+## My take
+
+If you already live entirely inside Zoom and want the path of least resistance, Zoom AI Companion may be enough.
+
+If you want notes you can keep, move, audit, and run outside Zoom's ecosystem, the list gets much shorter. That is why Char is the one I would start with. The notes stay as files, the AI layer stays flexible, and the workflow does not collapse if you change providers later.
+
+[Download Char for macOS](/download) if that is the setup you want to own.
+
+<CtaCard/>

--- a/apps/web/content/articles/best-ai-notetaker.mdx
+++ b/apps/web/content/articles/best-ai-notetaker.mdx
@@ -59,7 +59,7 @@ The AI assists with drafting, summarizing long documents, answering questions ab
 
 I'm Char's founder. I'm putting my tool first, though I'll explain why rather than asking you to trust me.
 
-Every AI note-taking tool I tested before building [Char](https://char.com/) forced the same choice: use their cloud, their models, their rules. My data went where they decided, stored how they decided. No way to switch, no way out.
+Every AI note-taking tool I tested before building [Char](https://anarlog.so/) forced the same choice: use their cloud, their models, their rules. My data went where they decided, stored how they decided. No way to switch, no way out.
 
 Char exists because of that. It's an open-source AI notepad for meetings that stores everything as plain markdown files on your device. Zero lock-in. You choose your AI stack: managed cloud, bring your own API keys, or run local models. No bots. No vendor dependency.
 
@@ -287,7 +287,7 @@ $10/month (must pay $120 annually). 14-day free trial.
 
 [Otter](https://www.google.com/url?q=https://otter.ai/&sa=D&source=editors&ust=1768759307570156&usg=AOvVaw1ShKuIeVNtQTONf80caVdW) has been in the AI note-taking space longer than most competitors. The product is feature-rich with extensive integrations (Salesforce, HubSpot, Slack, Notion) and solid team collaboration tools. The bot joins your meetings, transcribes, learns speaker voices, captures slides automatically. AI chat lets you query transcripts.
 
-However, there are significant concerns. A [federal lawsuit](https://char.com/blog/is-otter-ai-safe) alleges Otter records without proper consent. Users report the bot automatically inviting colleagues and joining meetings uninvited. Transcripts get shared externally. Customer support is slow and account cancellations are difficult. Your data gets shared with third parties for AI training. The free tier is deliberately limited to push users toward paid plans.
+However, there are significant concerns. A [federal lawsuit](https://anarlog.so/blog/is-otter-ai-safe) alleges Otter records without proper consent. Users report the bot automatically inviting colleagues and joining meetings uninvited. Transcripts get shared externally. Customer support is slow and account cancellations are difficult. Your data gets shared with third parties for AI training. The free tier is deliberately limited to push users toward paid plans.
 
 If you're comfortable with cloud-only recording, bot-based capture, and the privacy tradeoffs, Otter delivers on features. If data control matters or you work with sensitive information, the problems outweigh the polish.
 
@@ -380,7 +380,7 @@ For actual meeting transcription and note-taking, you need dedicated tools like 
 
 ### 3. Is AI note-taker legal?
 
-Yes, [AI note-takers are legal](https://char.com/blog/is-ai-notetaking-legal), but recording conversations has legal requirements depending on your location. In the US, some states require "two-party consent" (everyone must agree to be recorded), while others only need "one-party consent" (you can record if you're part of the conversation).
+Yes, [AI note-takers are legal](https://anarlog.so/blog/is-ai-notetaking-legal), but recording conversations has legal requirements depending on your location. In the US, some states require "two-party consent" (everyone must agree to be recorded), while others only need "one-party consent" (you can record if you're part of the conversation).
 
 The legal risk comes from recording without consent, not from using AI. Tools like Otter and Fireflies that join meetings as bots make it obvious you're recording. Tools like Char and Granola that capture system audio are invisible—so you need to tell people you're recording.
 

--- a/apps/web/content/articles/best-ai-notetaker.mdx
+++ b/apps/web/content/articles/best-ai-notetaker.mdx
@@ -1,0 +1,405 @@
+---
+meta_title: "What Are the Best AI Note-Taker Apps in 2026?"
+display_title: "What Are the Best AI Note-Taker Apps in 2026?"
+meta_description: "Overwhelmed by messy notes? I tested the top AI note takers in 2026 so you don't have to. From Char to Obsidian, find the best tool for your workflow here."
+author: "John Jeong"
+featured: false
+category: "Comparisons"
+date: "2026-01-18"
+---
+
+I am a big believer in jotting things down. 
+
+If I have an idea, I capture it. The problem is I capture everything. At one point, my note-taking app had so many half-baked ideas that nothing made sense anymore. Then AI changed that.
+
+Those random notes could suddenly be summarized, searched, and connected. I could ask questions across everything I'd written. Turn messy thoughts into clear insights. Find an idea from three months ago in seconds. It's made a real difference.
+
+But AI note-taking apps aren't all built the same.
+
+I've spent considerable time testing these tools. I even built one myself. If you're looking for an AI note-taking app, I've done the research. This guide breaks down the popular options so you can pick the right one.
+
+## What Are the Best AI Note Taker Apps? A Quick Comparison
+
+| Tool          | Platform                            | Best For                              | Pricing                                    |
+| ------------- | ----------------------------------- | ------------------------------------- | ------------------------------------------ |
+| Char      | macOS                               | Zero lock-in, complete control        | Free forever (local + BYOK). Cloud $25/mo  |
+| Obsidian + AI | Windows, macOS, Linux, iOS, Android | Knowledge management                  | Free (Sync $5/mo, Publish $10/mo)          |
+| Granola       | macOS, iPhone                       | Active note takers during meetings    | Free trial, then $14/mo                    |
+| Notion        | Web, Windows, macOS, iOS, Android   | Teams already using Notion            | Free (Business $24/mo for AI)              |
+| Fathom        | Web, Chrome                         | Sales teams needing CRM integration   | Free (Business $28/mo)                     |
+| Reflect       | Web, iOS                            | Daily notes with networked thinking   | $10/mo ($120/year only)                    |
+| Otter AI      | Web, iOS, Android                   | Teams needing a feature-rich solution | Free 300 min (Pro $17/mo, Business $30/mo) |
+| Mem.ai        | Mac, Windows, iOS, web              | Self-organizing notes with AI         | Free 25 notes (Pro $12/mo)                 |
+
+## What Is an AI Note Taker?
+
+An AI note taker uses artificial intelligence to help you capture, organize, and make sense of information. It applies large language models to turn raw input—typed notes, voice recordings, or transcribed conversations—into something useful.
+
+The best ones do more than transcribe or summarize. They let you search across everything you've captured, connect related ideas, answer questions about your notes, and surface insights you'd find difficult to locate manually. The AI extends your note-taking workflow rather than replacing it.
+
+## Types of AI Note Takers
+
+### Speech-to-text AI Note Takers
+
+These tools target calls and meetings. They use speech-to-text models like Whisper to transcribe conversations in real-time, then apply AI to generate summaries, action items, and key takeaways.
+
+Some join meetings as bots (Otter), while others record your system audio directly (Char, Granola, Fathom). The output includes transcripts, summaries, and searchable recordings of what was discussed.
+
+### PKM Note-Taking Apps with AI
+
+Notion and Obsidian were built for personal knowledge management, not meetings—a place to externalize your thinking. They've added AI features to help you write, organize, search, and connect ideas across your notes.
+
+The AI assists with drafting, summarizing long documents, answering questions about your knowledge base, and surfacing related notes. These tools work with whatever you type, not just meeting audio.
+
+## Reviews of the Best AI Note Taker Apps
+
+### 1. Char - Best Free AI Note-Taking App
+
+![](/api/assets/blog/articles/best-ai-notetaker/1768756074373-image-1.png)
+
+I'm Char's founder. I'm putting my tool first, though I'll explain why rather than asking you to trust me.
+
+Every AI note-taking tool I tested before building [Char](https://char.com/) forced the same choice: use their cloud, their models, their rules. My data went where they decided, stored how they decided. No way to switch, no way out.
+
+Char exists because of that. It's an open-source AI notepad for meetings that stores everything as plain markdown files on your device. Zero lock-in. You choose your AI stack: managed cloud, bring your own API keys, or run local models. No bots. No vendor dependency.
+
+Want better AI? Plug in your own OpenAI, Mistral, or any endpoint you prefer. Your files, your AI, your workflow.
+
+This works best for engineers and developers who want files over apps, companies where cloud tools like Otter are banned, privacy-conscious professionals in healthcare and legal, or anyone who refuses to compromise on control.
+
+#### Key Features:
+
+- Plain markdown files: Stored locally, works with any tool (Obsidian, Notion, VS Code)—zero lock-in
+- Your choice of AI stack: Managed cloud, bring your own API keys, or run local models via Ollama
+- Universal meeting compatibility: Works with Zoom, Teams, Meet, and every other platform without bots—system audio capture, no calendar permissions
+- Works offline: Take notes, record, and transcribe without internet connectivity
+- Open-source: Inspect the code, contribute, or customize. Zero vendor lock-in
+- Enterprise deployment: On-prem, VPC, or hybrid options with SSO, consent management, and admin controls
+- Custom templates: Tailored formats for therapy sessions, legal meetings, job interviews, or casual coffee chats
+- Search your meeting history: Ask "What did Sarah say about the budget?" instead of scrolling through months of notes
+- AI chat: Get immediate answers about action items, deadlines, or who said what during meetings
+- AI autonomy control: Choose how much AI changes your notes—minimal improvements to your original thoughts or complete AI restructuring
+- Source analysis: Hover over summaries to see the exact transcript quote behind every AI-generated point
+
+#### Pros:
+
+- Free forever for local transcription, BYOK, and all core features
+- Zero lock-in—switch AI providers anytime, export files anywhere
+- IT teams can audit the code and approve the AI provider
+- Real notepad experience from the moment you open it
+
+#### Cons:
+
+- macOS only currently (Windows and Linux coming in Q2 2026)
+- Manual speaker tagging required (Speaker identification coming soon)
+- No video recording
+
+#### Pricing:
+
+Char is free forever for local transcription, BYOK, and all core features. Managed cloud service is $25/month for the easiest setup without managing API keys.
+
+### 2. Obsidian with AI Plugins - Best for Knowledge Management
+
+![](/api/assets/blog/articles/best-ai-notetaker/1768756074976-image-2.png)
+
+I'm drawn to [Obsidian](https://www.google.com/url?q=https://obsidian.md/&sa=D&source=editors&ust=1768759307556808&usg=AOvVaw3iVOX-hmrHgHJ6pcIa6TfH). Their [file over app](https://www.google.com/url?q=https://stephango.com/file-over-app&sa=D&source=editors&ust=1768759307556926&usg=AOvVaw3EJOrTCKjM4peWuUy6ed1E) philosophy resonates—everything is plain markdown files on your device. If Obsidian shuts down tomorrow, your notes survive.
+
+It's not an AI note taker out of the box. AI features come through [plugins](https://www.google.com/url?q=https://obsidian.md/plugins?search%3Dai&sa=D&source=editors&ust=1768759307557306&usg=AOvVaw1daGV8gnfslZA2Wx03ffID).
+
+The tradeoff is significant. You're building a system, not using an app. Every feature needs a plugin, documentation, setup. I've lost weekends to theme tweaking instead of writing. It's powerful when it works, exhausting when it doesn't.
+
+#### Key Features:
+
+- Local markdown files—you own your data completely
+- 2,700+ community plugins for every use case imaginable
+- AI capabilities through plugins (Copilot, Smart Connections, AI Chat)
+- Graph view for visualizing connections between notes
+- Works offline, syncs across devices (paid Sync add-on or DIY)
+- Integrates with Zotero, Todoist, and other tools via plugins
+
+#### Pros:
+
+- True data ownership
+- Incredibly powerful for linking ideas and building knowledge graphs
+- Active community building plugins constantly
+- Works on Windows, macOS, Linux, iOS, Android
+- Local-first with optional cloud sync
+
+#### Cons:
+
+- Steep learning curve—you're building a system, not using an app
+- AI features require plugin setup and maintenance
+- Can become a productivity procrastination trap (endless tweaking)
+- Not visually polished out of the box, requires theme hunting
+- Markdown editing can feel clunky for rich media
+- Plugin dependency means features can break or get abandoned
+- Overwhelming for simple note-taking needs
+
+#### Pricing:
+
+Free core app with optional paid services (Sync $5/month, Publish $10/month)
+
+### 3. Granola: Best for Active Note Takers During Meetings
+
+![](/api/assets/blog/articles/best-ai-notetaker/1768756075258-image-3.png)
+
+[Granola](https://www.google.com/url?q=https://www.granola.ai/&sa=D&source=editors&ust=1768759307559871&usg=AOvVaw3Ys71lW9lb82dHCgYguOEj) is an AI-powered notepad for people who want to take their own notes while getting intelligent assistance to make them comprehensive.
+
+Like Char, it captures audio directly from your device. Unlike Char, it sends your data to the cloud for AI processing, which creates privacy concerns for organizations with strict compliance requirements.
+
+#### Key Features:
+
+- Hybrid approach: combines your manual notes with AI transcription
+- Bot-free recording—captures system audio directly
+- Granola Chat lets you ask questions across all your meetings
+- Customizable templates for different meeting types
+- "Recipes" for one-click complex prompts (PRD generation, leadership coaching)
+- Works on Mac and iPhone, integrates with Notion, Slack, HubSpot, Attio
+
+#### Pros:
+
+- Familiar notepad interface similar to Apple Notes
+- No complex setup required
+- Works across all video conferencing platforms by capturing device audio directly
+- Notes ready almost immediately after the meeting ends
+
+#### Cons:
+
+- Requires active note-taking during meetings to be most effective
+- No video recording, only provides transcripts and summaries
+- No permanent free tier after the 25-meeting trial period
+
+#### Pricing:
+
+Offers a free plan with limited meeting notes. Paid plans start at $14/month.
+
+### 4. Notion - Best if You Already Live in Notion
+
+![](/api/assets/blog/articles/best-ai-notetaker/1768756075572-image-4.png)
+
+[Notion](https://www.google.com/url?q=https://www.notion.com/product/ai&sa=D&source=editors&ust=1768759307562073&usg=AOvVaw3xCK0DnPNr8VfeqsUU-3ag) is an all-in-one workspace tool that now includes AI—chat that searches your workspace, writing assistance that drafts and edits, and meeting transcription without bots. The appeal is avoiding tool switching.
+
+The problem is that AI feels added on rather than essential. Notion wasn't designed for note-taking. The block system is awkward. Mobile performance lags. Most people capture notes elsewhere, then organize in Notion. The AI helps with organization (search, summaries), but you'll run into limitations. Free and paid plans include limited AI trials.
+
+#### Key Features:
+
+- AI Meeting Notes (transcription, summaries, action items) without bots
+- Databases with custom properties, views, and filters
+- Real-time collaboration with inline comments
+- Customizable templates for every use case
+- Publish pages to the web as websites
+- Integrations with Slack, HubSpot, Zapier, and more
+
+#### Pros:
+
+- True all-in-one platform (notes, tasks, wikis, databases)
+- Excellent for team collaboration and knowledge management
+- Free tier is genuinely useful for individuals
+- Cross-platform (web, Windows, Mac, iOS, Android)
+- AI features built in (chat, generate, autofill, meeting notes)
+- Strong ecosystem of templates and integrations
+
+#### Cons:
+
+- Awkward for actual note-taking (block system fights quick capture)
+- Slow performance, especially mobile
+- Steep learning curve for advanced features
+- Can become overwhelming (tries to do everything)
+- Data lives on their servers
+
+#### Pricing:
+
+You'll need Notion's $24/month Business Plan to use AI features.
+
+### 5. Fathom: Best for Sales Teams
+
+![](/api/assets/blog/articles/best-ai-notetaker/1768756076236-image-5.png)
+
+[Fathom](https://www.google.com/url?q=https://www.fathom.ai/&sa=D&source=editors&ust=1768759307564997&usg=AOvVaw21POtCwmzAEeV4BYAHQQQ2) is built for sales teams who need meeting notes synced to CRM automatically. It records, transcribes, summarizes, but the real value comes from pushing everything to Salesforce, HubSpot, or Close without manual work. Sales calls land in your pipeline with action items already logged.
+
+#### Key Features:
+
+- Auto-sync to Salesforce, HubSpot, Close CRM
+- "Ask Fathom" conversational AI across all calls
+- Coaching metrics and AI scorecards for sales performance
+- Deal View summarizing insights across multiple calls
+- Custom vocabularies for industry jargon
+- Integrates with Slack, Asana, Zapier, Notion
+
+#### Pros:
+
+- Deep CRM integrations (not just basic sync)
+- Conversation intelligence built for sales
+- Accurate transcription handles accents well
+- Generous free tier to test
+- Strong customer support (5/5 on [G2](https://www.google.com/url?q=https://www.g2.com/products/fathom-video/reviews?page%3D2%23reviews&sa=D&source=editors&ust=1768759307566376&usg=AOvVaw3nZnjixlnAFI50kHMLaDs2) from 6,345 reviews)
+
+#### Cons:
+
+- Does not work offline or for in-person meetings
+- Bot presence in the calls may feel intrusive
+- Advanced AI features require paid plans
+
+#### Pricing:
+
+A generous free tier includes basic CRM sync. Team $18/month/user (minimum 2 users) adds collaboration. Business $28/month/user unlocks full CRM field sync, Deal View, and coaching metrics. There's also a $20/month plan with integrations and advanced AI but without collaboration and coaching features.
+
+### 6. Reflect: Best for People Who Found Obsidian Too Complex and Notion Too Slow
+
+![](/api/assets/blog/articles/best-ai-notetaker/1768756076581-image-6.png)
+
+[Reflect](https://www.google.com/url?q=https://reflect.app/&sa=D&source=editors&ust=1768759307567541&usg=AOvVaw1PCJnKZNiP0tu7xN0mhzXX) is a daily notes app with backlinks and AI. You get a new note each day. You write. It links. The AI (GPT-4 and Whisper) can transcribe voice notes, generate summaries, answer questions about your notes. Google Calendar integration puts your meetings in the sidebar, ready for notes.
+
+It's built for people who think in connections rather than folders. Everything is chronological by default. Backlinks surface automatically. End-to-end encryption means only you read your notes. Fast, minimal, opinionated—there's essentially one way to use it.
+
+#### Key Features:
+
+- Daily notes with automatic backlinks
+- AI chat, summaries, and voice transcription (GPT-4 and Whisper)
+- Google Calendar and Outlook integration
+- End-to-end encryption
+- Chrome web clipper and Kindle sync
+- Cross-platform sync (iOS/web)
+
+#### Pros:
+
+- Fast, noticeably faster than Notion or Roam
+- Simple without being limiting
+- AI feels integrated, not tacked on
+- Encrypted without sacrificing features
+- Responsive team shipping constantly
+
+#### Cons:
+
+- No Android (mobile web is bad)
+- Yearly payment only ($120, no monthly)
+- No collaboration features by design
+- iOS/web only (no Windows/Linux desktop)
+- More expensive than alternatives
+
+#### Pricing:
+
+$10/month (must pay $120 annually). 14-day free trial.
+
+### 7. Otter AI: Best if You're Looking for a Feature-rich Solution
+
+![](/api/assets/blog/articles/best-ai-notetaker/1768756076836-image-7.png)
+
+[Otter](https://www.google.com/url?q=https://otter.ai/&sa=D&source=editors&ust=1768759307570156&usg=AOvVaw1ShKuIeVNtQTONf80caVdW) has been in the AI note-taking space longer than most competitors. The product is feature-rich with extensive integrations (Salesforce, HubSpot, Slack, Notion) and solid team collaboration tools. The bot joins your meetings, transcribes, learns speaker voices, captures slides automatically. AI chat lets you query transcripts.
+
+However, there are significant concerns. A [federal lawsuit](https://char.com/blog/is-otter-ai-safe) alleges Otter records without proper consent. Users report the bot automatically inviting colleagues and joining meetings uninvited. Transcripts get shared externally. Customer support is slow and account cancellations are difficult. Your data gets shared with third parties for AI training. The free tier is deliberately limited to push users toward paid plans.
+
+If you're comfortable with cloud-only recording, bot-based capture, and the privacy tradeoffs, Otter delivers on features. If data control matters or you work with sensitive information, the problems outweigh the polish.
+
+#### Key Features:
+
+- Automated transcription (bot joins Zoom, Teams, Google Meet)
+- AI chat across meeting transcripts
+- Slide and screen capture during meetings
+- Speaker identification (learns voices over time)
+- Integrations with Salesforce, HubSpot, Slack, Notion
+- Mobile apps (iOS/Android)
+
+#### Pros:
+
+- Established, reliable transcription
+- Works with major platforms
+- AI chat is useful for querying past meetings
+- Free tier exists (limited but usable)
+- Team collaboration features
+
+#### Cons:
+
+- Federal lawsuit over unauthorized recording practices
+- Automatically invites colleagues and joins meetings without permission
+- Shares data with third parties for AI training
+- Customer support is extremely slow
+- Account deletion doesn't actually delete (fake deletions)
+- Billing traps (non-refundable, misleading plan differences)
+- Internet-dependent (no offline functionality)
+- Restrictive free tier (300 min/month)
+
+#### Pricing:
+
+Free tier is 300 min/month, Pro is $17/month, Business is $30/month where most teams end up.
+
+### 8. Mem AI - Best for Self-Organizing Notes
+
+![](/api/assets/blog/articles/best-ai-notetaker/1768756077113-image-8.png)
+
+[Mem.ai](https://www.google.com/url?q=http://mem.ai&sa=D&source=editors&ust=1768759307573576&usg=AOvVaw2oU1hLmiagi83BTjnTt5Ng) is built on one principle: you shouldn't have to organize notes.
+
+Dump everything in—voice notes, meeting transcripts, web clips, random thoughts—and AI handles the filing.
+
+Mem 2.0 brought improvements (faster, better AI), but my review is mixed. I like the hands-off approach, but the AI sometimes connects things that aren't related.
+
+#### Key Features:
+
+- Voice notes with transcription (turn brain dumps into notes)
+- Meeting recording and transcription
+- AI-powered Collections (auto-organize by topic)
+- Heads Up (surfaces related notes automatically as you write)
+- Mem Chat (ask questions, generate content from your notes)
+- Chrome extension for web clipping
+
+#### Pros:
+
+- Truly zero manual organization required
+- Fast interface, minimal design
+- Voice and meeting features work well
+- Good at retrieving information with AI
+- Works across devices (Mac, Windows, iOS, web)
+
+#### Cons:
+
+- Free tier is useless (25 notes/month)
+- No Android app
+- Slow development (features lag behind competitors)
+- AI over-relates things that aren't related
+- Can't export individual notes as markdown
+- Tab system confusing (opens many tabs unknowingly)
+- Internet required for AI features
+
+#### Pricing:
+
+Offers a free tier, but real use requires Pro at $12/month.
+
+## Frequently Asked Questions
+
+### 1. Can I use AI for note-taking?
+
+Yes. AI note-taking tools transcribe conversations, generate summaries, extract action items, and help you search across everything you've captured. They're particularly useful for meetings, lectures, interviews, or anytime you need to focus on the conversation instead of frantically typing notes.
+
+The right tool depends on your needs. If you want zero lock-in and complete control, use Char. If you need CRM integration, use something built for sales (Fathom). If you want AI to organize your messy thoughts, try Mem.ai.
+
+### 2. Can ChatGPT take notes?
+
+ChatGPT can help you organize and summarize notes you've already taken, but it can't record or transcribe meetings. You'd need to feed it text manually—paste in a transcript, ask it to summarize or extract action items.
+
+For actual meeting transcription and note-taking, you need dedicated tools like Char, Otter, or Granola that capture audio and transcribe in real-time. Some of these tools use GPT-4 for summarization, but the recording and transcription happens separately.
+
+### 3. Is AI note-taker legal?
+
+Yes, [AI note-takers are legal](https://char.com/blog/is-ai-notetaking-legal), but recording conversations has legal requirements depending on your location. In the US, some states require "two-party consent" (everyone must agree to be recorded), while others only need "one-party consent" (you can record if you're part of the conversation).
+
+The legal risk comes from recording without consent, not from using AI. Tools like Otter and Fireflies that join meetings as bots make it obvious you're recording. Tools like Char and Granola that capture system audio are invisible—so you need to tell people you're recording.
+
+For work meetings, check your company's policy. For healthcare, legal, or finance, look for tools that handle consent properly (Char has consent management for enterprise).
+
+### 4. Which AI note-taking app doesn't join video calls?
+
+Char records your microphone and system audio directly on your Mac. No bot, no cloud dependency, everything stored as plain markdown files you own.
+
+Bot-based tools like Otter, Fireflies, and most meeting-focused AI note-takers join as visible participants. If you want invisible recording, use Char—just make sure you tell people you're recording.
+
+### 5. Can AI be 100% trusted?
+
+No. AI makes mistakes—hallucinations, incorrect summaries, missed context. Always review AI-generated notes, especially for important meetings or decisions.
+
+That said, AI transcription accuracy is generally 85-95% with good audio quality.
+
+### 6. Which AI note taker is secure?
+
+Char gives you complete control because everything is stored as plain markdown files on your device. You choose which AI processes your data—or keep it fully local. IT teams can audit the open-source code, and you can use the AI provider your security team approves.
+
+Avoid tools with known security issues. Otter has a federal lawsuit about unauthorized recording. Fireflies has reports of bots joining meetings after account deletion. If control matters, use an open-source tool with zero lock-in.

--- a/apps/web/content/articles/best-ai-notetakers-google-meet.mdx
+++ b/apps/web/content/articles/best-ai-notetakers-google-meet.mdx
@@ -30,7 +30,7 @@ Each of these tools brings different strengths to meeting capture and analysis.
 
 ### 1. Char: complete control over your data and AI stack
 
-Most transcription software forces you into their cloud, their servers, their rules. **[Char](https://char.com)** is an open-source AI note-taker that stores your data locally and gives you complete control over the AI stack.
+Most transcription software forces you into their cloud, their servers, their rules. **[Char](https://anarlog.so)** is an open-source AI note-taker that stores your data locally and gives you complete control over the AI stack.
 
 You decide if your audio, transcripts, or notes ever leave your device. You pick your preferred STT and LLM provider, which means you can go completely local if you want to. No forced stack. No lock-in.
 
@@ -271,7 +271,7 @@ Otter joins your Google Meet as a visible bot participant called "OtterPilot". I
 #### Considerations
 
 - Limited language support restricted to English, Spanish, and French only
-- Privacy concerns with an ongoing **[class-action lawsuit](https://char.com/blog/is-otter-ai-safe)** regarding data handling practices
+- Privacy concerns with an ongoing **[class-action lawsuit](https://anarlog.so/blog/is-otter-ai-safe)** regarding data handling practices
 - Free plan restrictions limited to 300 monthly minutes, which gets consumed quickly
 - Bot presence in meetings can feel intrusive for sensitive client conversations
 

--- a/apps/web/content/articles/best-ai-notetakers-google-meet.mdx
+++ b/apps/web/content/articles/best-ai-notetakers-google-meet.mdx
@@ -1,0 +1,315 @@
+---
+meta_title: "7 Best AI Notetakers for Google Meet in 2026"
+meta_description: "Google's native AI notes falling short? Find the right alternative by comparing the 7 best AI notetakers for Google Meet in 2026. Free & paid options included."
+author: "John Jeong"
+coverImage: "/api/assets/blog/best-ai-notetakers-google-meet/cover.png"
+featured: false
+category: "Comparisons"
+date: "2026-02-11"
+---
+
+Google shipped "Take notes for me," but it still feels like a feature, not a real meeting system.
+
+The limitations show up quickly. Availability is narrow, language support is limited, the output is hard to customize, and there is very little portability once you want something outside Google's flow.
+
+That leaves room for specialized tools. We tested the ones that work with Google Meet while doing more than Google's native notes can.
+
+Here are our top picks: 
+
+1. **Char:** Best for people and teams who seek control over data and AI stack.
+2. **Fireflies AI:** Best for teams needing comprehensive conversation analytics and multilingual support.
+3. **Sembly AI:** Best for teams needing automated deliverable generation and cross-meeting analytics
+4. **tl;dv:** Best for sales teams needing video analysis, coaching insights, and CRM automation
+5. **Tactiq:** Best for Chrome users wanting real-time transcription without installing separate apps
+6. **Krisp:** Best for teams in noisy environments who need both audio enhancement and meeting notes
+7. **Otter AI:** Best for users wanting familiar, mainstream AI transcription with team features
+
+## Best AI notetakers for Google Meet
+
+Each of these tools brings different strengths to meeting capture and analysis.
+
+### 1. Char: complete control over your data and AI stack
+
+Most transcription software forces you into their cloud, their servers, their rules. **[Char](https://char.com)** is an open-source AI note-taker that stores your data locally and gives you complete control over the AI stack.
+
+You decide if your audio, transcripts, or notes ever leave your device. You pick your preferred STT and LLM provider, which means you can go completely local if you want to. No forced stack. No lock-in.
+
+#### How it works with Google Meet
+
+Char doesn't join your Google Meet as a bot. Instead, it captures both your microphone input and your system's audio. During meetings, Char transcribes conversations in real-time. When the meeting ends, it combines any notes you took with your transcripts to create a summary.
+
+![](/api/assets/blog/articles/best-ai-notetakers-google-meet/image-1-2.png)
+
+#### Key features
+
+- **Your notes are just files**: Every meeting saved as a .md file you can open in Obsidian, Notion, VS Code, whatever you use
+- **Flexible AI**: Use the managed service or bring your own key (cloud or local). Switch anytime.
+- **No meeting bots**: System audio capture works on Zoom, Teams, phone calls, in-person
+- **Custom templates**: Structure recurring meetings automatically with community templates or build your own
+- **Searchable notes**: Find anything from any meeting instantly with semantic search and date filters
+- **Open source**: Code is public. Your IT team can audit it, your security team can verify it
+
+#### Strengths
+
+- You own your data—files stay on your device, not in a remote database
+- No internet required for recording or transcription with local models
+- No lock-in. Export anytime, switch AI providers anytime, or stop using it
+- No bots in your meetings, more discreet than competitors
+- Security teams can audit the code before approving it
+- Works for any conversation
+
+#### Considerations
+
+- macOS only currently; Windows and Linux versions coming in Q2 2026
+- No video recordings
+
+#### Pricing
+
+Unlimited free plan with local transcription or bring-your-own-key. Pro is $25/month for managed cloud service.
+
+### 2. Fireflies AI: the conversation intelligence platform
+
+**[Fireflies](http://fireflies.ai/)** positions itself as more than just a transcription tool—it's a full conversation intelligence solution for sales teams and growing businesses.
+
+#### How it works with Google Meet
+
+Fireflies joins your Google Meet as a bot participant called "Fred". You can invite it manually to specific meetings or set it to auto-join based on your calendar integration. The bot records, transcribes, and processes the entire conversation, then automatically sends meeting summaries to designated channels.
+
+![](/api/assets/blog/articles/best-ai-notetakers-google-meet/image-2-2.png)
+
+#### Key features
+
+- **AskFred AI assistant** for chatting with meeting transcripts and querying past conversations
+- **69+ language support** for global teams and multilingual meetings
+- **Advanced conversation analytics** tracking speaker talk time, sentiment, and key topics
+- **Extensive integrations** with 58+ platforms, including major CRMs and productivity tools
+- **Video recording capability**, capturing screen shares and visual content alongside audio
+
+#### Strengths
+
+- Strong multilingual capabilities with automatic language detection
+- Comprehensive analytics for understanding meeting patterns and team performance
+- Unlimited transcription even on the free plan
+- Mobile app support for recording in-person conversations
+
+#### Considerations
+
+- Bot presence in meetings can feel intrusive as Fireflies appears as an additional meeting participant
+- Storage limitations on lower-tier plans create pressure to upgrade
+- May send meeting notes to all participants
+
+#### Pricing
+
+Free forever with unlimited transcription but limited AI features. Paid plans start at $18/user/month.
+
+### 3. Sembly AI: the workflow integration specialist
+
+**[Sembly](https://www.sembly.ai/)** transforms meetings into actionable business deliverables like project plans, requirements documents, and reports. Beyond transcription, it analyzes patterns across multiple meetings, automatically generates artifacts tailored to specific roles, and provides enterprise-grade analytics for team productivity.
+
+#### How it works with Google Meet
+
+You can invite a Sembly agent to your meeting from the Google Chrome Extension or connect your Google Calendar. It records and transcribes the meeting, then uses AI to identify action items, decisions, and key discussion points.
+
+![](/api/assets/blog/articles/best-ai-notetakers-google-meet/image-3-2.png)
+
+#### Key features
+
+- **48+ language support**, including English, French, Spanish, German, Arabic, Japanese, and many others
+- **AI Artifacts generation** (project plans, requirements, reports)
+- **Multi-meeting trend analysis** and insights across conversations
+- **Advanced action item extraction** with assignees and due dates
+- **Enterprise-grade security** (SOC 2 Type II, GDPR compliance)
+
+#### Strengths
+
+- Flexible attendance model allowing the bot to capture meetings even when you're not present
+- Unified meeting intelligence consolidating summaries, transcripts, and analytics in one interface
+- Comprehensive integrations with popular CRMs and project management tools like Trello, ClickUp, Asana
+
+#### Considerations
+
+- Bot presence required, appearing as an additional participant that introduces itself in meetings
+- Steeper learning curve compared to more straightforward tools like Char
+- Limited export options lacking direct Word document export for summaries and tasks
+
+#### Pricing
+
+Free trial available, with paid plans starting at $15/user/month.
+
+### 4. tl;dv: the video-first meeting assistant
+
+**[tl;dv](https://tldv.io/)** turns meeting notes into clickable timestamps, making it easy to navigate directly to specific moments in recordings while providing advanced sales coaching features.
+
+#### How it works with Google Meet
+
+The tl;dv bot joins your Google Meet automatically, records both audio and video, then generates AI summaries while allowing you to add manual timestamped notes during the call. You can create clips and share specific moments from longer recordings.
+
+![](/api/assets/blog/articles/best-ai-notetakers-google-meet/image-4-2.png)
+
+#### Key features
+
+- **Timestamped video navigation** allows you to jump directly to specific moments in recordings
+- **AI meeting summaries** automatically extract key points, decisions, and action items
+- **Sales coaching**, analytics tracking, playbook adherence, and objection handling performance
+- **Video clip creation** for easy sharing of important conversation moments
+- **30+ language transcription** supporting global teams with multilingual meeting capture
+
+#### Strengths
+
+- Generous free plan offering unlimited recordings and transcriptions without time limits
+- Sales-focused features helping managers analyze rep performance and deal progression
+- CRM automation with automatic updates to Salesforce, HubSpot, and other sales tools
+
+#### Considerations
+
+- Bot presence required means Google Meet shows an additional participant during calls
+- Internet dependency for optimal performance
+- Video storage demands consume significant space for frequent, long meetings
+- No mobile app restricting access to browser and desktop versions only
+
+#### Pricing
+
+Free forever plan with unlimited recordings. Pro plans start at $29/month for advanced analytics and coaching features.
+
+### 5. Tactiq: the Chrome extension solution
+
+**[Tactiq](https://tactiq.io/)** works as a Chrome extension rather than a standalone app. It provides live transcription directly in your browser during Google Meet, with powerful workflow automation capabilities.
+
+#### How it works with Google Meet
+
+Tactiq captures audio directly from your Google Meet tab. It shows live transcription as people speak and can push meeting insights to your existing workflow tools without requiring a separate bot to join the meeting.
+
+![](/api/assets/blog/articles/best-ai-notetakers-google-meet/image-5-2.png)
+
+#### Key features
+
+- **Live transcription** visible during meetings as conversations happen
+- **60+ language support** with automatic language detection
+- **Custom AI workflows** for repetitive tasks and meeting follow-ups
+- **Extensive integrations** pushing insights to Slack, HubSpot, Jira, and other business tools
+- **One-click AI actions** for generating summaries, action items, and follow-up emails
+
+#### Strengths
+
+- Real-time visibility allows you to see transcription happening live during meetings
+- Workflow automation seamlessly connects meeting insights to your existing tool stack
+- Bot-free operation captures audio without appearing as an additional meeting participant
+- Quick setup works immediately after installing the Chrome extension
+
+#### Considerations
+
+- Chrome dependency limits flexibility compared to platform-agnostic tools
+- No audio recording, focusing only on transcription without meeting playback capabilities
+- Limited free plan with only 5 AI credits per month, restricting regular use
+
+#### Pricing
+
+Free plan with 10 meetings/month and 5 AI credits. Paid plans start at $12/user/month.
+
+### 6. Krisp: noise cancellation plus AI notes
+
+**[Krisp](https://krisp.ai/)** combines background noise cancellation with meeting transcription. The platform removes background noises, voices, and echoes from both sides of calls while transcribing meetings in real-time.
+
+#### How it works with Google Meet
+
+Krisp installs as a desktop application that creates virtual microphone and speaker devices on your computer. You select Krisp as your microphone and speaker in Google Meet settings, and it processes all audio in real-time—removing noise while recording the conversation for transcription.
+
+![](/api/assets/blog/articles/best-ai-notetakers-google-meet/image-6-2.png)
+
+#### Key features
+
+- **AI-powered noise cancellation** removes background noises, voices, and echoes from both call sides
+- **Real-time transcription** captures conversations across all communication platforms
+- **Universal app compatibility** works with any communication app as an audio processing layer
+- **Direct CRM integrations** with Salesforce, HubSpot, Slack, and Google Calendar
+- **Mobile apps** for iOS and Android to record in-person meetings
+
+#### Strengths
+
+- Platform agnostic, working with any video conferencing app
+- Free unlimited transcripts make it accessible for regular testing and use
+- Strong privacy controls with encrypted data storage and clear security practices
+- No meeting disruption—operates invisibly without bots or participant notifications
+
+#### Considerations
+
+- Basic AI summaries offer simple note generation compared to specialized tools
+- Limited customization with no ability to modify AI output beyond manual editing
+- No AI assistant lacking follow-up question capabilities or deeper meeting insights
+- Simple feature set focusing more on audio enhancement than advanced meeting intelligence
+
+#### Pricing
+
+Free plan with unlimited transcripts and 2 daily meeting notes. Paid plans start at $16/user/month.
+
+### 7. Otter AI: the established cloud solution
+
+**[Otter AI](https://otter.ai/)** is a well-known AI meeting assistant offering cloud-based meeting intelligence that works across Google Meet, [Zoom](/blog/best-ai-notetaker-for-zoom/), and Microsoft Teams with established real-time collaboration features.
+
+#### How it works with Google Meet
+
+Otter joins your Google Meet as a visible bot participant called "OtterPilot". It records the audio, generates real-time transcripts with speaker identification, and creates meeting summaries automatically.
+
+![](/api/assets/blog/articles/best-ai-notetakers-google-meet/image-1-3.png)
+
+#### Key features
+
+- **OtterPilot AI Chat** for asking questions about meeting content during or after calls
+- **Slide capture** automatically screenshots presentations and embeds them in transcripts
+- **Custom vocabulary** for industry terms, names, and company-specific language
+- **Team workspaces** with comment threads and assignable action items
+- **CRM integrations** with Salesforce and HubSpot (Business/Enterprise plans)
+- **OtterPilot for Sales** extracts insights and pushes notes to CRM (Enterprise only)
+
+#### Strengths
+
+- Consistent performance and regular feature updates
+- Reliable speaker identification that improves with usage and learns voice patterns
+- Cross-platform compatibility working reliably across Google Meet, Zoom, and Teams
+- Mobile app functionality handling both virtual meetings and in-person conversation capture
+
+#### Considerations
+
+- Limited language support restricted to English, Spanish, and French only
+- Privacy concerns with an ongoing **[class-action lawsuit](https://char.com/blog/is-otter-ai-safe)** regarding data handling practices
+- Free plan restrictions limited to 300 monthly minutes, which gets consumed quickly
+- Bot presence in meetings can feel intrusive for sensitive client conversations
+
+#### Pricing
+
+Free plan with 300 monthly minutes. Paid plans start at $16.99/user/month.
+
+## My take
+
+If all you want is a lightweight Google-native recap and your Workspace plan includes it, Gemini notes may be enough.
+
+If you want something you can keep using outside Google's stack, with real control over where the data goes, start with Char. You can try it, keep the notes as files, and walk away later without rebuilding your system around one vendor.
+
+## Frequently asked questions
+
+### 1. Can Google Meet do AI notes?
+
+Yes, but with significant limitations. Google's "Take notes for me" feature uses Gemini AI to generate meeting summaries in Google Docs. However, it's only available to a small group of users on expensive Workspace plans (Google One AI Premium or specific Business/Enterprise tiers), works in just 8 languages, and often produces incomplete summaries.
+
+You have no control over the AI processing. It runs in Google's cloud, uses their models, and follows their data handling practices. For organizations with compliance requirements or privacy concerns, that's a non-starter.
+
+### 2. Does Google have a note-taking tool?
+
+Google Docs serves as Google's general note-taking solution, and Google Keep handles quick notes and lists. For meetings specifically, Google offers "Take notes for me" powered by Gemini AI, but it's restricted to select Workspace plans and lacks features teams actually need.
+
+### 3. How do I turn on AI transcription in Google Meet?
+
+If you have access:
+
+- Join a Google Meet
+- Click the three dots menu (bottom right)
+- Select "Take notes for me"
+- Google's AI generates notes in a linked Google Doc during the meeting
+
+### 4. Is there a botless AI notetaker?
+
+Yes. Char and Tactiq both work without sending a bot into your meetings.
+
+### 5. What is the most secure AI note taker for Google Meet?
+
+For maximum security, run Char with fully local AI models (Ollama/LM Studio)—zero data leaves your device. For organizations that need cloud AI, bring your own approved API keys from providers your security team has already vetted.

--- a/apps/web/content/articles/bot-free-ai-meeting-assistants.mdx
+++ b/apps/web/content/articles/bot-free-ai-meeting-assistants.mdx
@@ -1,0 +1,494 @@
+---
+meta_title: "2026's Best Bot-Free AI Meeting Assistants"
+meta_description: "Want AI meeting notes without bots joining your call? Here's a list of the best bot-free AI meeting assistants for secure, distraction-free note-taking."
+author: "John Jeong"
+coverImage: "/api/assets/blog/bot-free-ai-meeting-assistants/cover.png"
+category: "Comparisons"
+date: "2025-08-27"
+---
+
+I'm tired of AI bots crashing my meetings uninvited. You know the drill - you're in a sensitive client call, and suddenly "OtterPilot has joined the meeting." Awkward silence. "Who invited the bot?"
+
+That's why I've been testing bot-free alternatives that capture your meetings without sending virtual party crashers. These tools record directly from your device or browser, so your calls stay natural while you still get AI-powered notes.
+
+According to my research, here are the 12 bot-free meeting assistants worth trying:
+
+- **Char** → Local, offline, open-source, max privacy
+- **Jamie AI** → GDPR-compliant AI with executive recall
+- **Granola AI** → Hybrid human + AI note expansion
+- **Tactiq** → Live transcription with deep integrations
+- **Krisp** → Noise cancellation + simple meeting notes
+- **Superpowered** → Multilingual-focused real-time transcription
+- **Circleback** → CRM-first insights for sales teams
+- **Notta** → Multilingual browser-based transcription
+- **Bluedot AI** → Quiet, template-based workflow automation
+- **Voicenotes** → All-in-one voice + meeting "second brain"
+- **Meeting AI** → Compliance-friendly for regulated industries
+- **Sonnet** → End-to-end CRM automation for sales
+
+---
+
+**💡 Before we proceed:**
+
+- Check out our [full best AI meeting assistants list](/blog/best-ai-meeting-assistant-for-taking-notes) for both bot-free and bot-based tools to get the complete picture.
+- If you're curious about how bot-free assistants work and why to choose them, don't miss the FAQs at the end.
+
+---
+
+## What are the best bot-free meeting assistants?
+
+### 1. Char
+
+[Char](/) is an open-source AI notepad for meetings that gives you complete control over your data and AI stack. Everything is stored as plain markdown files—not in proprietary databases. You choose your AI: managed cloud, bring your own keys, or run local models.
+
+The interface feels like Apple Notes but with AI superpowers running in the background. Start a meeting and it transcribes in real-time. When you hang up, you get structured summaries with decisions and action items automatically extracted.
+
+Char's Smart Consent Management Package for enterprises stands out. It handles consent legally and transparently with multiple options: simple pop-ups, voice recognition that listens for verbal consent, and customizable policies.
+
+**Pricing:** Free forever for local transcription, BYOK, and all core features. Managed cloud $25/month. Enterprise with custom pricing for consent management and on-premises deployment.
+
+[Download Char for MacOS](/download).
+
+<Image src="/api/assets/blog/bot-free-ai-meeting-assistants/hyprnote.webp" alt="Char"/>
+
+#### Top features
+
+- Plain markdown files stored locally—works with any tool (Obsidian, Notion, VS Code)
+- Your choice of AI stack: managed cloud, bring your own keys, or run local models
+- Open source—zero lock-in, full transparency
+- Free forever for local transcription, BYOK, and all core features
+- Customizable templates for different meeting types (therapy, legal, interviews)
+- Smart Consent Management Package for enterprise compliance
+- AI Chat with MCP server connections for enhanced functionality
+- Calendar integration with notification system
+- Conversational search across all meeting history
+- Flexible AI model options (local, self-host, or connect to custom AI endpoints)
+
+#### Perfect if you:
+
+- Are an engineer or developer who wants files over apps
+- Work in healthcare, legal, or finance where compliance matters
+- Want zero lock-in with open-source transparency ([GitHub](https://github.com/fastrepl/char))
+- Your company has banned cloud tools like Otter, ChatGPT, or Granola
+- Already have unused LLM API credits and want to bring your own keys
+
+#### Things to consider:
+
+- Mac only right now (Windows and Linux coming in Q2 2026)
+- No video recording by design for maximum privacy
+
+<CtaCard/>
+
+### 2. Jamie AI
+
+[Jamie AI](https://www.meetjamie.ai/) takes privacy seriously but differently than Char. Instead of keeping everything local, they process your audio in Germany under strict GDPR rules, then immediately delete the recordings. It's like having a very discreet German assistant who forgets everything after writing your notes.
+
+What makes Jamie special is the Executive Assistant feature. Hit Ctrl+J and you get an AI sidebar that remembers everything from past meetings. Ask "What did Sarah say about the Q4 budget?" and it knows instantly.
+
+**Pricing:** Free plan with 10 meetings/month. Paid plans start at €24/month (~$25) with higher tiers available.
+
+<Image src="/api/assets/blog/bot-free-ai-meeting-assistants/jamie.webp" alt="Jamie AI review"/>
+
+#### Top features
+
+- Deletes audio files immediately after processing
+- Works completely offline—great for in-person meetings
+- 20+ languages with automatic detection
+- Executive Assistant sidebar for instant meeting recall
+- Advanced topic detection breaks notes into logical sections
+
+#### Perfect if you:
+
+- Need GDPR compliance with European data hosting
+- Have multilingual meetings or international teams
+- Handle sensitive discussions but need cloud processing power
+
+#### Things to consider:
+
+- No real-time transcription—you wait 5-10 minutes for summaries
+- More expensive than some alternatives at €24/month
+- Limited integrations compared to browser-based tools
+
+### 3. Granola AI
+
+[Granola](https://www.granola.ai/) operates similarly to Char's note-taking approach but sends your data to the cloud instead of processing it locally. You jot down key points during calls, and after the meeting ends, Granola expands your rough notes into actionable summaries.
+
+**Pricing:** 25 free meetings (lifetime), then $18/month individual or $14/user/month for teams.
+
+<Image src="/api/assets/blog/bot-free-ai-meeting-assistants/granola.webp" alt="Granola AI review"/>
+
+#### Top features
+
+- Post-meeting task assistance: drafting follow-up emails, extracting action items, answering questions about discussions
+- Familiar notepad interface similar to Apple Notes—no complex setup required
+- Fast processing—enhanced notes ready almost immediately
+- Chat functionality to query your meeting history and get instant answers
+
+#### Perfect if you:
+
+- Like the hybrid approach of human + AI note-taking
+- Need something that works immediately without complex setup
+- Don't mind cloud processing for better AI capabilities
+- Work primarily on Mac/iOS with some Windows usage
+
+#### Things to consider:
+
+- Only 25 free meetings total, then payment required
+- Limited integrations and search capabilities
+- Privacy approach less clear than Char's local processing or Jamie's explicit deletion
+
+### 4. Tactiq
+
+[Tactiq](https://tactiq.io/) takes a completely different approach from the previous tools. Instead of post-meeting summaries, it shows live transcription as people speak. Watching words appear in real-time is satisfying and surprisingly useful for catching names or technical terms you might miss.
+
+Tactiq's integration ecosystem is where it really shines. It pushes meeting insights to Slack, HubSpot, Jira—basically everywhere you actually work.
+
+**Pricing:** Free plan with 10 meetings/month and 5 AI credits. Paid plans start at $12/user/month.
+
+<Image src="/api/assets/blog/bot-free-ai-meeting-assistants/tactiq.webp" alt="Tactiq AI review bot-free"/>
+
+#### Top features
+
+- Live transcription visible during meetings
+- 60+ languages with automatic detection
+- Rich integrations with workplace tools
+- Custom AI workflows for repetitive tasks
+- No separate app installation needed
+
+#### Perfect if you:
+
+- Want to see transcription happening live instead of waiting
+- Already live in Chrome for most work tasks
+- Need workflow automation to move meeting insights into other tools
+- Primarily use Zoom, Google Meet, or Teams
+
+#### Things to consider:
+
+- Chrome-only limits flexibility compared to universal tools like Char
+- [Accuracy with strong accents is less reliable](https://www.g2.com/products/tactiq/reviews/tactiq-review-5307104) than tools like Jamie
+- Limited to three meeting platforms
+- No offline functionality
+
+### 5. Krisp
+
+[Krisp](https://krisp.ai/) handles two jobs at once—it cancels background noise AND takes meeting notes. If you're working from cafes or dealing with construction next door, this dual functionality is genuinely valuable.
+
+The meeting notes are more basic than the AI-enhanced summaries from Char or Granola, but they capture the essentials without fuss.
+
+**Pricing:** Free plan with 60 minutes/day noise cancellation, and paid plans start at $16/user/month.
+
+<Image src="/api/assets/blog/bot-free-ai-meeting-assistants/krisp.webp" alt="Krisp AI review"/>
+
+#### Top features
+
+- Industry-leading noise cancellation alongside note-taking
+- Works with any meeting platform (more universal than Tactiq)
+- Device-level audio processing (better privacy than Granola)
+- Accent conversion helps with international teams
+- Mobile apps for in-person meeting recording
+
+#### Perfect if you:
+
+- Work in noisy environments and need both clean audio and notes
+- Jump between different meeting platforms constantly
+- Want one tool instead of separate noise cancellation + note-taker
+
+#### Things to consider:
+
+- Note-taking features aren't as sophisticated as dedicated tools
+- Limited conversation analytics and team collaboration features
+- Storage limitations even on paid plans can be restrictive for heavy users
+- [App stability issues](https://apps.apple.com/us/app/krisp-ai-meeting-note-taker/id6740535865?see-all=reviews) reported with crashes and recording interruptions
+
+### 6. Superpowered
+
+[Superpowered](https://superpowered.me/) focuses specifically on multilingual teams—something most other tools handle as an afterthought. With 50+ languages and automatic language detection, it's built for organizations where English isn't everyone's first language.
+
+Like Jamie, it emphasizes privacy through data minimization, automatically deleting audio after generating notes.
+
+**Pricing:** Offers a limited free plan, with paid plans ranging between $36-$108/month.
+
+<Image src="/api/assets/blog/bot-free-ai-meeting-assistants/superpowered.webp" alt="Superpowered ai review"/>
+
+#### Top features
+
+- Support for 50+ languages (more than Jamie's 20+)
+- Audio automatically deleted after 7 days maximum
+- Desktop app with keyboard shortcuts for efficiency
+- Real-time transcription with immediate data deletion
+
+#### Perfect if you:
+
+- Work with international teams across multiple languages
+- Need strong privacy controls but can accept brief cloud processing
+- Want desktop-native performance with quick shortcuts
+
+#### Things to consider:
+
+- Less feature-rich than comprehensive tools like Char or Jamie
+- Desktop dependency limits mobile usage compared to Tactiq's browser approach
+- Smaller user base means less community support
+
+### 7. Circleback AI
+
+[Circleback AI](https://circleback.ai/) provides both bot-free and bot-based recording options, with a strong focus on CRM integration. While tools like Tactiq integrate broadly across many platforms, Circleback is built specifically for sales teams who need meeting insights to flow directly into their CRM.
+
+The tool captures audio via its desktop app or browser extension and automatically pushes structured data—contact details, deal stages, next steps—into systems like Salesforce and HubSpot.
+
+**Pricing:** Free trial available, then paid plans start at $25/month.
+
+<Image src="/api/assets/blog/bot-free-ai-meeting-assistants/circleback.webp" alt="circleback ai review"/>
+
+#### Top features
+
+- Desktop app and browser extension options
+- Automatic contact and deal data extraction
+- Direct integration with major CRM platforms
+- Flexible recording modes (bot-free or bot-based)
+
+#### Perfect if you:
+
+- Live in your CRM and need seamless data flow from meetings
+- Want flexibility between bot-free and bot-based recording
+- Focus on sales conversations that need structured follow-up
+
+#### Things to consider:
+
+- Bot-free mode requires desktop app or browser extension
+- More specialized than general-purpose tools like Jamie or Granola
+- Smaller feature set outside of CRM integration
+
+### 8. Notta Chrome Extension
+
+[Notta's](https://www.notta.ai) browser extension brings multilingual capabilities to the bot-free world. While Tactiq supports 60+ languages, Notta focuses specifically on accuracy across different languages and dialects within the same meeting—something international teams really need.
+
+The extension works similarly to other Chrome-based solutions but with stronger emphasis on translation and cross-language understanding. Think of it as Tactiq's multilingual specialist cousin.
+
+**Pricing:** Free plan with 120 minutes/month, Pro from $13.49/month.
+
+<Image src="/api/assets/blog/bot-free-ai-meeting-assistants/notta.webp" alt="Notta AI review"/>
+
+#### Top features
+
+- Multi-language transcripts with translation capabilities
+- Chrome extension for browser-based recording
+- Strong dialect and accent recognition
+- Searchable summaries across languages
+
+#### Perfect if you:
+
+- Work with international teams speaking multiple languages
+- Want browser convenience with a multilingual focus
+- Convert audio and video files and meetings into shareable text
+
+#### Things to consider:
+
+- Chrome dependency like other browser extensions
+- Limited free plan with 3 minutes of transcription per conversation
+- Live transcription can lag according to [user reports](https://www.g2.com/products/notta/reviews?utf8=%E2%9C%93&filters%5Bsentiment_snippet%5D=1169636)
+- Limited to 30 min/month of imported audio to transcribe
+
+### 9. Bluedot
+
+[Bluedot](https://www.bluedothq.com/) is another Chrome extension positioned as the quiet alternative to more visible tools. Like Circleback, it focuses on workflow integration but with broader scope—pushing meeting insights to both CRM systems like Salesforce and productivity tools like Notion.
+
+Users appreciate that it works without announcing itself, similar to how Granola operates discretely. The template system helps structure different types of meetings automatically.
+
+**Pricing:** Very limited free tier (5 meetings total), then Basic at $18/month, Pro at $25/month, Business at $39/month.
+
+<Image src="/api/assets/blog/bot-free-ai-meeting-assistants/bluedot.webp" alt="Bluedot ai review"/>
+
+#### Top features
+
+- Quiet Chrome recording without disruption
+- Templates for different meeting types
+- CRM and Notion integration
+- Customizable workflow automation
+
+#### Perfect if you:
+
+- Want browser-based recording with template structure
+- Use Notion for project management alongside CRM tools
+- Need discrete operation without drawing attention
+
+#### Things to consider:
+
+- Manual start required unless you enable auto-flows
+- [AI chat features can't jump to exact timestamps](https://www.g2.com/products/bluedot-bluedot/reviews/bluedot-review-11314224) yet
+- [Can't adapt to spontaneous language changes](https://www.g2.com/products/bluedot-bluedot/reviews/bluedot-review-11489988) during meetings
+
+### 10. Voicenotes
+
+[Voicenotes](https://voicenotes.com/) takes a different approach from all the meeting-focused tools above. It's designed as a "second brain" that captures both meetings and voice memos in one unified system. Think of it as Jamie's meeting capabilities combined with a personal voice note system.
+
+The tool supports an impressive 100+ languages (more than Superpowered's 50+) and lets you query your entire voice history—meetings, personal notes, random thoughts—through AI search.
+
+**Pricing:** Offers a free trial, with paid plans starting at $14.99/month.
+
+<Image src="/api/assets/blog/bot-free-ai-meeting-assistants/voicenotes.webp" alt="voicenotes ai review"/>
+
+#### Top features
+
+- Meeting and voice memo capture in one app
+- 100+ language support (most on this list)
+- AI-powered "second brain" for voice content
+- Cross-platform availability (app + desktop + watch)
+
+#### Perfect if you:
+
+- Want one place for all voice content, not just meetings
+- Need extensive language support beyond what other tools offer
+- Like the idea of searchable voice memory across all contexts
+
+#### Things to consider:
+
+- Limited integrations compared to tools like Tactiq
+- Broader focus means less specialized meeting features
+- No advanced admin controls for team usage
+
+### 11. Meeting.ai
+
+[Meeting.ai](https://meeting.ai) focuses specifically on compliance-heavy industries where data handling is critical. With 30+ language support and emphasis on regulatory compliance, it's positioned as the enterprise-safe alternative to consumer-focused tools.
+
+The platform is designed for organizations that need meeting intelligence but can't use tools with unclear data policies or overseas processing. It finds middle ground between Char's local processing and cloud-based tools.
+
+**Pricing:** No free plans. Paid pricing starts at USD 19.99/month.
+
+<Image src="/api/assets/blog/bot-free-ai-meeting-assistants/meeting-ai.webp" alt="meeting ai bot-free tool"/>
+
+#### Top features
+
+- 30+ languages with compliance focus
+- Designed for regulated industries
+- Enterprise-grade data handling
+- Works for both virtual and in-person meetings
+
+#### Perfect if you:
+
+- Work in healthcare, finance, or legal where compliance matters
+- Need cloud processing but with enterprise controls
+- Want meeting intelligence with clear regulatory documentation
+
+#### Things to consider:
+
+- Less feature-rich than consumer tools like Jamie or Granola
+- Higher pricing typical of compliance-focused solutions
+- Smaller user community than mainstream alternatives
+
+### 12. Sonnet AI
+
+[Sonnet](https://www.sonnetai.com/) is the CRM specialist of bot-free tools, designed specifically for sales teams who live in systems like Salesforce and HubSpot. While Circleback offers CRM integration, Sonnet goes deeper—it's built primarily for automating the entire sales meeting workflow.
+
+The tool captures meetings without bots and automatically updates deal stages, contact information, and next steps directly in your CRM. It's like having a dedicated sales assistant who never forgets to log activities.
+
+**Pricing:** Free plan with 5 meetings/month and 30-minute limit, Plus at $25/month, Pro at $35/month.
+
+<Image src="/api/assets/blog/bot-free-ai-meeting-assistants/sonnet.webp" alt="Sonnet AI bot free meeting tool"/>
+
+#### Top features
+
+- End-to-end CRM automation for sales workflows
+- Bot-free recording focused on sales conversations
+- Automatic deal and contact updates
+- Pre-meeting preparation with contact research
+
+#### Perfect if you:
+
+- Live in your CRM and need automated sales workflow
+- Want dedicated sales functionality rather than general meeting notes
+- Need relationship tracking across multiple conversations
+
+#### Things to consider:
+
+- Very sales-focused—less useful for general meeting needs
+- More complex setup compared to simple tools like Granola
+- Higher pricing than general-purpose alternatives
+- Features may be excessive for non-sales use cases
+
+---
+
+## How to choose the best bot-free meeting assistant
+
+Picking from 12 tools can get overwhelming fast. I've grouped them into clear categories based on what really matters when you're picking an AI meeting assistant.
+
+### 1. Privacy & Compliance
+
+If you handle sensitive data in healthcare, finance, law, or enterprise:
+
+- **Char** → Local processing, no data leaves your device
+- **Jamie** → GDPR-compliant, auto-deletes audio
+- **Meeting.ai** → Compliance-grade cloud solution
+
+### 2. Multilingual & global teams
+
+If you work across different languages and accents:
+
+- **Superpowered** → 50+ languages, strong real-time focus
+- **Notta** → Multilingual translation + dialect support
+- **Voicenotes** → 100+ languages, one app for all voice content
+
+### 3. Sales & CRM power users
+
+If your world revolves around client calls and pipeline updates:
+
+- **Sonnet** → Sales-first tool with deep CRM automation
+- **Circleback** → Chrome-based CRM data capture
+- **Bluedot** → CRM + Notion workflow integrations
+
+### 4. Productivity & general use
+
+For everyday team meetings and streamlined workflows:
+
+- **Granola** → Expands quick notes into summaries
+- **Tactiq** → Real-time live transcription + app integrations
+- **Krisp** → Noise cancellation + simple notes in one
+
+---
+
+## Frequently asked questions
+
+### 1. What are bot-free AI meeting assistants?
+
+Bot-free tools record directly from your device or browser instead of joining calls as a visible participant. They provide transcription, summaries, and action items without interrupting sensitive client conversations.
+
+### 2. How are bot-free meeting assistants different from bot-based assistants?
+
+Here's a quick look at bot-free vs. bot-based meeting assistants like Otter AI and Fireflies.
+
+| Aspect                | Bot-Based Meeting Assistants               | Bot-Free Meeting Assistants                  |
+| --------------------- | ------------------------------------------ | -------------------------------------------- |
+| Presence in Meeting   | Visible participants in attendee list      | No participant; works silently in background |
+| Meeting Flow Impact   | Can interrupt or distract meetings         | Keeps meetings smooth and natural            |
+| Audio Processing      | Mostly cloud-based with variable retention | Local processing or strict privacy cloud     |
+| Technical Integration | Connect via meeting platform APIs as users | Capture audio from device/browser output     |
+| Privacy & Security    | Data retention depends on provider         | Designed for strict data control             |
+| Typical Use Cases     | Casual, internal, or less sensitive calls  | Sensitive, regulated, client-facing calls    |
+
+### 3. How do you take AI meeting notes without bots?
+
+Use a bot-free assistant that records system audio or your microphone directly. The tool processes the audio [locally](/blog/local-ai-meeting-notes/) or securely in the cloud, then generates summaries, action items, and searchable transcripts.
+
+### 4. How do botless meeting assistants work?
+
+They rely on local apps or browser extensions that listen to the meeting through your device's audio feed. This eliminates the need for a third-party bot account joining the call.
+
+### 5. How does consent work with bot-free meeting assistants?
+
+Consent is handled differently depending on the tool:
+
+- **Char** → Advanced consent management (pop-ups, voice recognition, customizable enterprise policies).
+- **Jamie/Superpowered** → Inform participants upfront; audio deleted after processing.
+- **Others** → Disclosure often relies on manual policies (users informing participants if needed).
+
+### 6. Why would someone choose a bot-free meeting assistant over a bot-based one?
+
+People often choose bot-free assistants because:
+
+- They want to avoid awkward or distracting bot participants in sensitive meetings.
+- They prioritize maximum privacy and data security with local or minimal cloud processing.
+- They work in regulated industries requiring strict consent and compliance controls.
+- They prefer seamless, natural conversations without extra virtual guests.
+- They need offline or low-bandwidth options that don't depend on cloud connectivity.
+- They want full control over where and how meeting data is processed and stored.
+
+<CtaCard/>

--- a/apps/web/content/articles/can-you-transcribe-meetings-without-sending-data-to-cloud.mdx
+++ b/apps/web/content/articles/can-you-transcribe-meetings-without-sending-data-to-cloud.mdx
@@ -1,0 +1,90 @@
+---
+meta_title: "Can You Transcribe Meetings Without Sending Data to the Cloud?"
+meta_description: "Learn how to transcribe meetings without sending data to the cloud. Discover local AI tools like Char that keep conversations on-device and completely private."
+author:
+  - "Harshika"
+coverImage: "/api/assets/blog/can-you-transcribe-meetings-without-sending-data-to-cloud/cover.png"
+featured: false
+category: "Guides"
+date: "2025-08-22"
+---
+
+**Short answer: Absolutely. And with Char, you choose exactly how.**
+
+Most people don't realize that every time you use cloud-based transcription tools, you're uploading your most sensitive conversations to someone else's servers. Your client calls, strategy sessions, and confidential discussions sit in databases you'll never see. Recent privacy concerns with tools like Otter AI show just how risky this can be.
+
+But the answer isn't to give up on AI-powered meeting notes. It's to take control of how they work.
+
+## What happens to your data with cloud-based transcription tools?
+
+With cloud-based tools, your sensitive discussions, client information, and strategic planning sessions are processed by third-party vendors with varying privacy standards.
+
+Your audio and transcripts may be stored on servers across different countries, used for AI training, and subject to the provider's changing privacy policies.
+
+For organizations in regulated industries, this creates real compliance complexity. You're not just ensuring your own systems meet HIPAA, GDPR, or SOC 2 requirements — you're now responsible for your vendor's compliance across multiple jurisdictions.
+
+Giving teams control over their AI stack reduces dependency on cloud vendors, makes audits easier, and puts data handling decisions with the people who understand the risk.
+
+## **Enter Char: the AI notepad built around your choice**
+
+[Char](https://char.com) is an open-source AI notepad for meetings with zero lock-in and complete control over your data and AI stack.
+
+### **You control how your data is processed**
+
+Char lets you configure your own stack:
+
+- **Transcription** — run it locally on your device, or use cloud APIs like Deepgram or AssemblyAI
+- **AI Summarization** — use your own API keys (OpenAI, Anthropic, and others), run local models via Ollama or LM Studio, or use Char's managed service
+- **Storage** — everything saves as plain markdown files on your device, not in a proprietary database
+
+### **Universal platform compatibility**
+
+Char captures your microphone input and system audio directly — no bots joining your calls, no calendar permissions required. It works with all meeting platforms (Zoom, Teams, Meet, Slack), in-person meetings, and phone calls routed through your computer, with no platform-specific integrations needed.
+
+### **Your files, your format**
+
+Everything saves as plain markdown on your device. Open them in Obsidian, Notion, VS Code, or any text editor. No proprietary databases, no platform dependency.
+
+## **Does more control mean worse performance?**
+
+No. Char delivers real-time transcription, AI summaries with action items and key decisions, custom templates for different meeting types, AI chat to query your transcripts, search across your meeting history, and support for 45+ languages including English, Spanish, French, German, Japanese, Portuguese, Italian, Dutch, Korean, and Chinese.
+
+## **Char's privacy vs. performance spectrum**
+
+**Full Local Mode:** Everything runs on your device. Your conversations never touch the internet. Works well for lawyers, doctors, or anyone handling sensitive information.
+
+*Uses: Local transcription + Local AI models (Ollama, LM Studio) + Device-only storage*
+
+**Hybrid Mode:** Transcription runs locally so your audio stays on your device, while cloud AI handles summarization.
+
+*Uses: Local transcription + Cloud LLM (OpenAI, Anthropic, etc.) + Hybrid storage*
+
+**Performance Mode:** Cloud APIs handle both transcription and AI. You get better accuracy and speed, and you still choose which providers handle your data.
+
+*Uses: Cloud STT (Deepgram, AssemblyAI) + Your own Cloud LLM + Hybrid storage*
+
+### **Enterprise options**
+
+Companies can run everything on their own servers — transcription, AI, and storage. No vendor dependency, full compliance control, and your IT and security teams can audit every part of the stack.
+
+*Uses: On-premise transcription + Company LLM endpoints + Self-hosted storage*
+
+Want help configuring your setup? [Get in touch with our team](https://char.com).
+
+## **Related questions**
+
+### **1. Is there a tool that will listen to meetings via an app and transcribe the notes?**
+
+Yes. Tools like Otter AI and Fireflies send your audio to remote servers for processing. They're convenient, but you don't get a say in how your data is handled.
+
+Char lets you decide — local, hybrid, or cloud with your own API keys — with full visibility into what's happening, backed by open-source code you can inspect.
+
+### **2. Can you transcribe without recording a meeting?**
+
+Yes. Transcription converts speech to text in real-time without saving the audio file itself. Recording saves the actual audio for playback later.
+
+Char can produce transcripts and summaries without retaining the original audio. You decide what gets stored and where.
+
+### **3. Can you use local transcription for languages other than English?**
+
+Yes. Char supports 45+ languages including English, Spanish, French, German, Japanese, Portuguese, Italian, Dutch, Korean, and Chinese. If you want stronger multilingual AI summarization, you can connect your own cloud LLM provider.

--- a/apps/web/content/articles/can-you-transcribe-meetings-without-sending-data-to-cloud.mdx
+++ b/apps/web/content/articles/can-you-transcribe-meetings-without-sending-data-to-cloud.mdx
@@ -27,7 +27,7 @@ Giving teams control over their AI stack reduces dependency on cloud vendors, ma
 
 ## **Enter Char: the AI notepad built around your choice**
 
-[Char](https://char.com) is an open-source AI notepad for meetings with zero lock-in and complete control over your data and AI stack.
+[Char](https://anarlog.so) is an open-source AI notepad for meetings with zero lock-in and complete control over your data and AI stack.
 
 ### **You control how your data is processed**
 
@@ -69,7 +69,7 @@ Companies can run everything on their own servers — transcription, AI, and sto
 
 *Uses: On-premise transcription + Company LLM endpoints + Self-hosted storage*
 
-Want help configuring your setup? [Get in touch with our team](https://char.com).
+Want help configuring your setup? [Get in touch with our team](https://anarlog.so).
 
 ## **Related questions**
 

--- a/apps/web/content/articles/char-is-now-anarlog.mdx
+++ b/apps/web/content/articles/char-is-now-anarlog.mdx
@@ -56,7 +56,7 @@ If that sounds interesting, char.com is the place. If it doesn't — totally fin
 
 ### the journey
 
-If you've been following along, this is the second rename. The first one, [from Hyprnote to Char](/blog/hyprnote-is-now-char), corrected a name we never liked. This one is different. We're not renaming for fashion. We're separating two products that grew up inside one repo and started pulling in opposite directions.
+If you've been following along, this is the second rename. The first one, from Hyprnote to Char, corrected a name we never liked. This one is different. We're not renaming for fashion. We're separating two products that grew up inside one repo and started pulling in opposite directions.
 
 Each rename has been a sharper version of the same conviction: people deserve to own their work. The first time, that conviction was an instinct. The second time, it's a product split — because the people who care most about owning their meeting notes shouldn't have to share a brand with the people who want a notepad that delegates their day.
 

--- a/apps/web/content/articles/char-vs-meetily.mdx
+++ b/apps/web/content/articles/char-vs-meetily.mdx
@@ -1,0 +1,110 @@
+---
+meta_title: "Char vs. Meetily: Which Is Better?"
+meta_description: "Char and Meetily are both local-first, bot-free, open-source AI meeting tools. This comparison explains what sets them apart and which one fits your workflow."
+author:
+  - "Harshika"
+featured: false
+category: "Comparisons"
+date: "2026-04-15"
+---
+
+Char and Meetily were both created in December 2024. Both are written in Rust. Both capture system audio without a bot. Both are open-source and local-first. 
+
+They look like the same product. They are not.
+
+Meetily is a private transcription recorder. It records, transcribes locally, and generates a summary. Char is a meeting notepad. Its bet is that meetings are part of your workflow, not a separate activity. Transcription is one component of that.
+
+## **TL;DR: Char vs Meetily**
+
+**Use Meetily if:** you are on Windows, or you want local transcription that works in minutes with no API keys.
+
+**Use Char if:** you are on Mac, you take active notes during meetings, or you want your meeting history connected to your calendar, contacts, and developer tools.
+
+## **Char vs Meetily: Side-by-Side Comparison**
+
+
+|                  |                                                                      |                                                         |
+| ---------------- | -------------------------------------------------------------------- | ------------------------------------------------------- |
+|                  | **Char**                                                             | **Meetily**                                             |
+| **Platform**     | macOS, Linux (Windows Q2 2026)                                       | macOS, Windows                                          |
+| **Free tier**    | On-device Transcription and Bring Your Own AI Model (cloud or local) | Ollama                                                  |
+| **Entry paid**   | $8/mo (Lite)                                                         | $10/mo (Pro)                                            |
+| **Pro**          | $25/mo or $250/year                                                  | $10/mo                                                  |
+| **License**      | MIT                                                                  | MIT                                                     |
+| **GitHub stars** | [8,213](https://github.com/fastrepl/char)                            | [11,081](https://github.com/Zackriya-Solutions/meetily) |
+| **Calendar**     | Google, Apple, Outlook                                               | Not available                                           |
+| **CLI**          | Yes                                                                  | No                                                      |
+| **Daily notes**  | In preview                                                           | No                                                      |
+
+
+## **Similarities Between Char and Meetily**
+
+Both tools were built as a direct reaction to cloud meeting tools like Otter and Fireflies. They share the same foundational decisions:
+
+- System audio capture. No bot joins your call. No calendar permissions required.
+- 100% local processing available. Audio never has to leave your device.
+- Open-source codebases. You can audit exactly how your data is handled.
+- Ollama support. Both work with locally-run models for fully offline operation.
+- Bot-free recording. No visible recording participant in your meetings.
+- Built in Rust.
+
+If your primary requirement is "no cloud, no bot, open-source," both tools satisfy it. The differences start after that.
+
+## **Differences Between Char and Meetily**
+
+### **1. Platform support**
+
+Meetily runs on macOS and Windows. Char runs on macOS and Linux. If you are on Windows, Meetily is your only option today. Char has Windows on its roadmap but it is not available yet.
+
+### **2. What each tool is built to do**
+
+Meetily is a recorder. Record, transcribe with Whisper or Parakeet via Ollama, get a summary. The product loop is short and intentional.
+
+Char is a meeting notepad. It connects to your calendar (Google, Apple, Outlook), tracks your contacts, gives you a rich editor for notes, ships an AI assistant called Charlie that can edit your notes directly, and has daily notes in preview with task carry-forward. Meetings in Char connect to the rest of your work. 
+
+### **3. Taking notes during a meeting**
+
+Meetily is passive. You get a transcript and summary after the call. There is no editor.
+
+Char has a built-in editor. You write notes before the meeting starts: agenda items, context, things you need to close on. You take notes during the call. After the meeting, the AI folds your notes and the transcript into a structured summary. Your pre-meeting context shapes the output.
+
+Charlie, the persistent chat assistant, keeps the full session in context. It can reformat the summary, draft a follow-up email, or extract decisions. It edits your notes in place.
+
+### **3. Developer tools**
+
+Char ships with a [CLI](https://cli.char.com), a REST API, and an MCP server. Tools like Cursor and Claude Code can query your meeting history directly. A JS plugin runtime lets you write custom extensions. Shell hooks trigger automations when a meeting ends. You can also point Char's storage at your Obsidian vault.
+
+Meetily is a standalone app with no API, CLI, or plugin layer.
+
+Char and Meetily are both MIT licensed.
+
+### **4. Pricing**
+
+Meetily's community edition works out of the box with Ollama. No account required, no API key.
+
+Char's free tier offers unlimited local transcription and requires a BYOK API key for AI summaries (OpenAI, Anthropic, Deepgram) or a local model via Ollama or LM Studio. Two minutes of setup if you have keys already. 
+
+- **Char Lite: $8/month.** Cloud transcription, speaker identification, calendar integrations, sync, shareable links.
+- **Meetily Pro: $10/month.** Enhanced accuracy, auto-meeting detection, PDF and DOCX export, improved diarization. 14-day free trial.
+- **Char Pro: $25/month or $250/year.** Everything in Lite plus granular sync control and DocSend-style shareable links with view tracking and expiration.
+
+## **When Should You Use Meetily?**
+
+- You are on Windows. 
+- You want a local transcription tool with zero configuration. Download, open, record.
+- Your meetings are self-contained. You do not need calendar integration, contacts, or cross-session history.
+- You want MIT-licensed code you can fork or self-host without restrictions.
+
+## **When Should You Use Char?**
+
+- You are on Mac and want meetings connected to your broader workflow.
+- You take notes before or during meetings and want the AI to use that context.
+- You are a developer who wants CLI access, MCP server support, shell hooks, or Obsidian integration.
+- You want calendar-aware sessions: auto-creation from events, participant context, meeting countdown.
+- You want a long-term contact and meeting history that links across sessions.
+
+## **Get Started with Char**
+
+Char is free to download. The free tier works offline with a local model through Ollama or LM Studio. No subscription required to start.
+
+[Download Char for Mac](https://char.com/download) and run your first meeting with full local processing. Upgrade to Lite at $8/month if you want cloud transcription and speaker identification without managing API keys.

--- a/apps/web/content/articles/char-vs-meetily.mdx
+++ b/apps/web/content/articles/char-vs-meetily.mdx
@@ -72,7 +72,7 @@ Charlie, the persistent chat assistant, keeps the full session in context. It ca
 
 ### **3. Developer tools**
 
-Char ships with a [CLI](https://cli.char.com), a REST API, and an MCP server. Tools like Cursor and Claude Code can query your meeting history directly. A JS plugin runtime lets you write custom extensions. Shell hooks trigger automations when a meeting ends. You can also point Char's storage at your Obsidian vault.
+Char ships with a CLI, a REST API, and an MCP server. Tools like Cursor and Claude Code can query your meeting history directly. A JS plugin runtime lets you write custom extensions. Shell hooks trigger automations when a meeting ends. You can also point Char's storage at your Obsidian vault.
 
 Meetily is a standalone app with no API, CLI, or plugin layer.
 
@@ -107,4 +107,4 @@ Char's free tier offers unlimited local transcription and requires a BYOK API ke
 
 Char is free to download. The free tier works offline with a local model through Ollama or LM Studio. No subscription required to start.
 
-[Download Char for Mac](https://char.com/download) and run your first meeting with full local processing. Upgrade to Lite at $8/month if you want cloud transcription and speaker identification without managing API keys.
+[Download Char for Mac](https://anarlog.so/download) and run your first meeting with full local processing. Upgrade to Lite at $8/month if you want cloud transcription and speaker identification without managing API keys.

--- a/apps/web/content/articles/chatgpt-data-retention-policy.mdx
+++ b/apps/web/content/articles/chatgpt-data-retention-policy.mdx
@@ -1,0 +1,110 @@
+---
+meta_title: "ChatGPT Data Retention Policy Including the Court Order"
+meta_description: "A no-BS breakdown of what ChatGPT keeps, for how long, and what controls you actually have"
+author:
+  - "Harshika"
+featured: false
+category: "Guides"
+date: "2026-03-10"
+---
+
+In May 2025, a federal judge ordered OpenAI to preserve every ChatGPT conversation including the ones you deleted. Not just temporarily. Indefinitely, until further notice.  
+
+Most users had no idea this happened. If you're evaluating AI providers before plugging one into your workflow, this is exactly the kind of detail that matters.  
+
+Here's a full breakdown of OpenAI's data retention policy: what they keep, how long, and what you can actually do about it.
+
+## What ChatGPT Stores Data by Default
+
+When you use ChatGPT on a free, Plus, Pro, or Team plan, your conversations are saved to your account automatically. They sit there indefinitely until you delete them.  
+
+Once you delete a conversation, it disappears from your view immediately. But according to [OpenAI's own help documentation](https://help.openai.com/en/articles/8983778-chat-and-file-retention-policies-in-chatgpt), the data isn't actually removed from their servers for another 30 days and that's under normal circumstances.  
+
+One thing most users don't realize: if you've enabled ChatGPT's Memory feature, stored memories are retained separately from your chat history. Deleting a conversation doesn't wipe the memories extracted from it. You have to clear those manually through Settings.
+
+## The Court Order You Probably Missed
+
+In May 2025, a federal judge issued a preservation order requiring OpenAI to retain all ChatGPT user logs as part of the *New York Times* copyright lawsuit. The ruling was explicit: preserve and segregate all output log data that would otherwise be deleted. This includes conversations users had already removed.  
+
+[Bloomberg Law reported](https://news.bloomberglaw.com/ip-law/openai-must-turn-over-20-million-chatgpt-logs-judge-affirms) that by November 2025, the judge further ordered OpenAI to hand over 20 million de-identified ChatGPT logs to the Times and other news plaintiffs.  
+
+The preservation order itself was lifted in late September 2025. OpenAI resumed normal deletion practices after that point. But conversations from the April–September 2025 window remain in secure storage pending the ongoing litigation.  
+
+OpenAI says access to that data is restricted to a small, audited legal and security team. The Times and other plaintiffs don't have open access—any disclosure goes through court-approved discovery procedures. Still, data you thought was gone is sitting in a server somewhere.
+
+## The "Opt Out of Training" Setting and What It Actually Does
+
+ChatGPT uses your conversations to improve its models by default. You can turn this off: **Settings → Data Controls → toggle off "Improve model for everyone."**  
+
+Two important caveats:
+
+- It only affects future conversations. Any data already used for training stays in the training set. Disabling the toggle doesn't reach back.
+- It doesn't change how long your data is stored. Even with the setting off, OpenAI still keeps conversations on their servers for 30 days after deletion. They retain them during this window to screen for abuse and policy violations.
+
+Temporary Chat mode works somewhat differently. Conversations in Temporary Chat are never used for training and are scheduled for deletion within 30 days automatically. You don't need to manually delete them but they're still on OpenAI's servers during that window.
+
+## How ChatGPT's Data Retention Policy Differs by Plan
+
+Not all ChatGPT users are equal when it comes to data retention:
+
+### 1. Free, Plus, Pro, Team
+
+Conversations are retained indefinitely until deleted. After deletion, they remain on OpenAI's systems for up to 30 days. Data may be used for model training unless you opt out. Memory is stored separately until explicitly cleared.
+
+### 2. ChatGPT Enterprise and Edu
+
+Conversations are not used to train OpenAI's models by default—no opt-out required. Workspace admins control retention settings. Deleted conversations are removed within 30 days unless legally required to be kept.
+
+### 3. API (Standard)
+
+Inputs and outputs are retained for up to 30 days for abuse monitoring, then deleted. Not used for model training.
+
+### 4. API (Zero Data Retention)
+
+Inputs and outputs are never logged. There's no retention period because there's no retention. This is the strongest data protection OpenAI offers, and it's only available to qualifying business customers who apply for it through their API account settings.
+
+## What About GDPR and HIPAA?
+
+If you're in a regulated industry or dealing with sensitive data, the consumer-facing ChatGPT product is not the right tool. OpenAI has been explicit about this.  
+
+Standard ChatGPT (Free, Plus, Pro, Team) does not offer a Business Associate Agreement, which means it cannot be used with Protected Health Information under HIPAA. Using it with patient data is a compliance violation.  
+
+For GDPR, OpenAI offers a Data Processing Addendum (DPA) for ChatGPT Team, Enterprise, and API customers, not for consumer accounts. If you're in the EU and not on one of those plans, GDPR compliance is your own responsibility to figure out.  
+
+There's also a jurisdiction question worth flagging. Reddit's r/privacy community has noted that because OpenAI's servers are primarily US-based, data transferred from the EU to process through ChatGPT is subject to cross-border data transfer rules under GDPR. This has compliance implications for European organizations that aren't using a DPA.
+
+## So What's the Practical Risk?
+
+For most individual users, the day-to-day risk is limited. OpenAI doesn't sell your conversations, and the data isn't publicly accessible.  
+
+The risk is more nuanced:
+
+- **Legal exposure**: The court order showed that data you delete can be preserved and disclosed through legal proceedings. If you've had sensitive conversations through ChatGPT, there's a window of time where that data exists outside your control.
+- **Training data reuse**: Unless you've explicitly opted out, your conversations have likely contributed to model training. That data doesn't get unlearned when you opt out later.
+- **Compliance liability**: In healthcare, legal, finance, and other regulated fields, using consumer ChatGPT with client or patient information creates compliance risk regardless of what OpenAI promises about their security practices.
+
+## The OpenAI API Has Meaningfully Better Data Controls
+
+If you're building with OpenAI or using a tool that lets you bring your own API key, then the data situation is materially different from the consumer product.  
+
+With the standard API, OpenAI retains inputs and outputs for 30 days for abuse monitoring, then deletes them. There's no default use of your data for model training. If you qualify for Zero Data Retention endpoints, OpenAI never logs your data at all.  
+
+This is relevant if you're evaluating how OpenAI fits into a broader AI workflow where you want control over which provider sees what data.  
+
+## BTW, Your OpenAI API Key Works for Meeting Notes Too
+
+If you're already paying for API access, you can use that same key for meeting transcription and notes without going through the consumer product.
+
+[Char](https://char.com/) is an open-source AI notepad for meetings that lets you bring your own API key. Connect your OpenAI, Anthropic, Google Gemini, or Azure-hosted GPT key, and your meeting data goes through the API. The retention policies from your API agreement apply, not the consumer defaults described above.
+
+If even API-level retention is too much, Char also runs fully offline with local models through Ollama or LM Studio. Nothing leaves your machine.
+
+No bot in your call. Char captures audio directly from your computer's input and output. No third-party bot joins your Zoom or Google Meet, so no intermediary service handles your meeting data.
+
+Notes stay on your device. Transcripts and summaries are stored as plain markdown files locally—no cloud-synced account storage retaining data on someone else's servers.
+
+More than a transcription tool. Char does real-time transcription while you jot down what matters, then generates summaries from your memos once the meeting ends. Built-in AI chat lets you ask follow-ups—action items, rewrites, translations. It supports customizable note templates and integrates with Apple Calendar, Contacts, and Obsidian, with Notion, Slack, HubSpot, and Salesforce on the way.
+
+You're not locked into one provider. If your security team approves a different model next quarter, switch the key. Your notes stay on your device either way.
+
+[Download Char for macOS](https://char.com/download/apple-silicon) and use the AI provider your security team actually trusts.

--- a/apps/web/content/articles/chatgpt-data-retention-policy.mdx
+++ b/apps/web/content/articles/chatgpt-data-retention-policy.mdx
@@ -95,7 +95,7 @@ This is relevant if you're evaluating how OpenAI fits into a broader AI workflow
 
 If you're already paying for API access, you can use that same key for meeting transcription and notes without going through the consumer product.
 
-[Char](https://char.com/) is an open-source AI notepad for meetings that lets you bring your own API key. Connect your OpenAI, Anthropic, Google Gemini, or Azure-hosted GPT key, and your meeting data goes through the API. The retention policies from your API agreement apply, not the consumer defaults described above.
+[Char](https://anarlog.so/) is an open-source AI notepad for meetings that lets you bring your own API key. Connect your OpenAI, Anthropic, Google Gemini, or Azure-hosted GPT key, and your meeting data goes through the API. The retention policies from your API agreement apply, not the consumer defaults described above.
 
 If even API-level retention is too much, Char also runs fully offline with local models through Ollama or LM Studio. Nothing leaves your machine.
 
@@ -107,4 +107,4 @@ More than a transcription tool. Char does real-time transcription while you jot 
 
 You're not locked into one provider. If your security team approves a different model next quarter, switch the key. Your notes stay on your device either way.
 
-[Download Char for macOS](https://char.com/download/apple-silicon) and use the AI provider your security team actually trusts.
+[Download Char for macOS](https://anarlog.so/download/apple-silicon) and use the AI provider your security team actually trusts.

--- a/apps/web/content/articles/enterprise-ai-notetaking-tools.mdx
+++ b/apps/web/content/articles/enterprise-ai-notetaking-tools.mdx
@@ -1,0 +1,230 @@
+---
+meta_title: "Best AI Notetaking Tools for Enterprises in 2026"
+display_title: "AI Notetaking Tools for Enterprises: 5 Solutions Compared"
+meta_description: "Compare enterprise AI notetaking solutions on security, compliance, deployment options, and limitations. A practical guide for organizations with strict data policies."
+author:
+  - "John Jeong"
+coverImage: "/api/assets/blog/enterprise-ai-notetaking-tools/cover.png"
+featured: false
+category: "Comparisons"
+date: "2025-10-02"
+---
+
+If you're evaluating AI notetaking tools for your organization, you're probably dealing with questions like: "Can our legal team actually use this?" "What happens to our data?" or "Will IT have a meltdown when I suggest this?"
+
+Most AI notetaking tools weren't built for enterprises. They were built for individuals, then scaled up with "enterprise features" bolted on later. This creates predictable friction during procurement: the tool technically works, but it violates data policies, lacks the right deployment options, or creates compliance headaches nobody anticipated.
+
+This guide cuts through the marketing noise and covers five notetaking solutions that work for enterprises.
+
+## AI Notetakers For Enterprises: At a Glance
+
+1. **Char**: Open-source, zero lock-in AI notepad with complete control over data and AI stack
+2. **Read AI**: Cloud platform with unified search across meetings, emails, and messages
+3. **MeetGeek**: Conversation intelligence with team-level analytics and performance tracking
+4. **Fellow**: Internal meeting focus with granular privacy controls for manager workflows
+5. **Plaud**: Hardware devices for field professionals needing portable, offline-capable recording
+
+## How We Chose These AI Notetakers
+
+We evaluated dozens of tools and narrowed the list to five based on what procurement teams actually need to see:
+
+- **Security and compliance readiness**: Does the tool have the certifications, architectural design, or deployment options that let it pass your legal and security review?
+- **Administrative control**: We prioritized tools with SSO, role-based permissions, audit trails, user provisioning, and data retention policies that work across hundreds or thousands of users.
+- **Integration depth**: Does it plug into your existing stack (CRMs, collaboration tools, document repos)? We focused on tools that meet teams where they work.
+- **Production-proven**: We prioritized tools already deployed at Fortune 500 companies, healthcare systems, legal firms, and government agencies.
+
+The five tools we're covering represent fundamentally different architectural approaches. If one doesn't fit your requirements, another likely will.
+
+## Top Enterprise AI Notetaking Solutions: Detailed Reviews
+
+### 1. Char
+
+![Best ai note taker for enteprises](/api/assets/blog/enterprise-ai-notetaking-tools/enterprise-1.webp)
+
+[Char](/) is an open-source AI notepad for meetings built for high-agency organizations that demand complete control over their data, AI stack, and workflow. Everything is stored as plain markdown files—not in proprietary databases. You choose your AI: managed cloud, bring your own keys, or run local models. Zero lock-in fundamentally changes what's possible from both a compliance and ownership perspective.
+
+#### Deployment Options
+
+- **Edge-only**: All processing happens locally with zero external connections—maximum creative IP protection
+- **All-prem**: Complete organizational control with all components running on your infrastructure
+- **Prem-hybrid**: STT and database on-premises while LLM workloads run in controlled environments—balances compliance with powerful AI capabilities
+
+#### Pricing
+
+Char is free forever for local transcription, BYOK, and all core features. Managed cloud service is $25/month for the easiest setup.
+
+Enterprise pricing applies when your organization needs an on-premises deployment, SSO integration, consent management, multi-factor authentication, an agentic workflow builder, 24/7 priority support, or custom branding. [Contact sales for a quote](/founders).
+
+#### Enterprise Features
+
+- **End-to-end encryption**: Zero-trust architecture with hardware security module support protects data at every stage—from capture to storage to processing.
+- **Multi-framework compliance**: Built-in support for HIPAA, SOC 2, ISO 27001, GDPR, and CCPA without requiring new certifications or security reviews. Works with existing compliance frameworks.
+- **Smart consent management**: Built-in recording consent collection with audit logs for all acknowledgments, ensuring compliance with one-party, two-party, or all-party consent laws.
+- **Enterprise authentication**: SSO (SAML 2.0/OIDC) and Multi-Factor Authentication (MFA) with seamless integration into your existing identity provider.
+- **Access management**: Advanced role-based permissions and granular controls for managing who can record, access, and share meeting data across the organization.
+- **Audit and monitoring**: Comprehensive audit trails and real-time monitoring track all access and usage, with a custom admin dashboard builder for visibility.
+- **Team collaboration**: Securely share notes with team-level controls, ensuring information flows to the right people while maintaining governance.
+- **Universal meeting compatibility**: Works with all platforms (Zoom, Teams, Meet, etc.) without requiring bots—captures both microphone and system audio directly.
+- **Vendor-agnostic AI**: Connect to OpenAI, Mistral, Ollama (via LM Studio), or any custom endpoint—no vendor lock-in for LLM processing.
+- **Workflow integrations**: Current integrations with Obsidian and Attio, with enterprise customers driving additional integration priorities based on their tech stack.
+- **Custom model support**: Bring your own speech-to-text and language models, plus calendar integration for automatic meeting detection.
+
+#### How it works
+
+Char uses two types of models: speech-to-text (STT) and large language models (LLMs).
+
+For transcription, Char uses the Whisper series from Hugging Face, which ranges from the lightweight Tiny and Base models to the V3 Large Turbo. Users choose based on their accuracy vs. speed requirements.
+
+For summarization and intelligence, Char developed HyperLLM-V1, a custom model based on Qwen 1.7B architecture. At just 1.1GB (compared to LLaMA's 2.0GB), it delivers high-quality summaries optimized for English while being extremely fast.
+
+All of this happens locally. Char captures both microphone input and system audio output, allowing it to work universally across various meeting platforms without requiring bots. No internet required for core functionality.
+
+Your transcription and note data never touch external servers unless you explicitly choose to connect an LLM provider for additional features. Speaker identification works automatically for one-on-one calls by distinguishing between the microphone and system audio.
+
+For group meetings, users manually tag speakers using the transcript editor. Real-time transcription is supported with latency varying based on model size and hardware capabilities. Export options include Markdown, PDF, and Rich Text.
+
+#### Limitations & Trade-offs
+
+- **Platform availability**: Currently macOS only (Sonoma 14.2+), optimized for Apple Silicon.
+- **Speaker identification**: Limited to basic two-channel distinction (mic vs. system audio). Real-time speaker diarization for multi-person meetings isn't available yet.
+- **Language support**: Transcription supports all languages, but quality varies (strong for English/Korean, weaker for Hindi/Persian). HyperLLM-V1 summarization is fine-tuned exclusively for English.
+
+&nbsp;
+
+### 2. Read AI
+
+![Read AI for enterprises](/api/assets/blog/enterprise-ai-notetaking-tools/enterprise-4.webp)
+
+[Read AI](https://www.read.ai) is a cloud-based AI copilot that transforms meetings, emails, and messages into searchable insights across your entire workspace. It functions as a unified intelligence layer connecting all your communication platforms.
+
+**Deployment options**: Cloud-based (SaaS only)
+
+**Pricing**: Enterprise ($29.75/month, 10+ licenses) includes unlimited transcripts, video playback, custom branding, and premium integrations. Enterprise+ ($39.75/month, 10+ licenses) adds HIPAA compliance, SSO/SAML, domain capture, and custom data retention.
+
+#### Enterprise Features
+
+- **Role-based access control**: Assign User, Manager, or Admin roles with customizable permissions controlling who can view analytics at organization, team, and individual levels.
+- **Domain capture**: Enterprise+ automatically provisions and adds users from your company domain to the workspace without manual invitations.
+- **Meeting policy configuration**: Set organizational standards for meeting timing, size, and duration based on performance data showing Read Score, engagement, sentiment, and on-time rates.
+- **Security & compliance**: SOC 2 Type 2 and GDPR certified, with HIPAA compliance (including Business Associates Agreement) on Enterprise+. No data selling, opt-out model training by default. Custom data retention policies and SSO/SAML on Enterprise+.
+- **Search Copilot**: Free unified AI search across meetings, emails, chats, CRMs, and workflows for all users. Query in natural language, get answers with citations showing sources.
+- **Integrations**: Native with Zoom, Teams, Google Meet (joins as bot). Premium tier connects Notion, Salesforce, HubSpot, Jira, Confluence, Zapier, and webhooks. Chrome extension for Gmail/Outlook, Slack for sharing reports.
+
+#### How it works
+
+Read AI joins meetings as a visible bot that announces itself and requires host approval. Cloud-based STT transcribes in 20+ languages, then LLMs generate summaries, action items, topics, and coaching insights on metrics like speaker time and engagement. Video/audio playback available on Enterprise tier and above.
+
+#### Limitations & Trade-offs
+
+- **Bot visibility**: Joins as participant, which can affect conversation dynamics in sensitive meetings
+- **Cloud-only**: No on-premises option, data sovereignty requirements make this a non-starter for some organizations
+- **Platform lock-in**: Can't bring your own AI models or switch providers
+
+### 3. MeetGeek
+
+![meetgeek for enterprises](/api/assets/blog/enterprise-ai-notetaking-tools/enterprise-5.webp)
+
+[MeetGeek](https://meetgeek.ai/) is a cloud-based conversation intelligence platform focused on tracking meeting performance across teams and departments. It emphasizes analytics, measuring things like engagement, sentiment, and meeting effectiveness at an organizational scale.
+
+**Deployment options**: Cloud-based (SaaS), with private data storage on Enterprise
+
+**Pricing**: Business ($39/month) includes 100 hours monthly transcription, team spaces, meeting insights by team/call type, and unlimited transcript storage. Enterprise ($59/month) adds unlimited transcription, custom branding, custom data retention, custom speech models, branded emails, and private data storage.
+
+#### Enterprise Features
+
+- **Team spaces**: Organize meetings by department or project with granular sharing controls for who can access specific recordings and transcripts.
+- **Organization-wide settings**: Enterprise tier lets admins configure default settings, permissions, and policies that apply across the entire company.
+- **Performance analytics**: Track meeting metrics at department, team, and individual levels. Measure engagement, meeting management effectiveness, and topic interest with sentiment analysis and AI coaching tips.
+- **Automated workflows**: Set rules to auto-share meeting records with specific teams based on meeting type, and push summaries to document repos, chat platforms, CRMs, and task management tools.
+- **Security & compliance**: SOC 2 Type 2, GDPR, CCPA certified with HIPAA compliance via Business Associate Agreement. Enterprise includes private data storage option where data stays in isolated infrastructure. AES-256 and TLS encryption with regular third-party penetration testing.
+- **Custom speech models**: Enterprise tier trains the transcription system on industry-specific terminology for better accuracy in specialized fields.
+- **Integrations**: Works with Microsoft Teams, Zoom, Google Meet. Syncs with Google/Microsoft calendars, Google Drive, Notion, Slack, Teams, HubSpot, Salesforce, Asana, Monday, ClickUp, plus 10,000+ apps through Zapier, Make, and n8n. Public API and webhooks available.
+
+#### How it works
+
+Bot-based assistant with automatic language detection across 100+ languages and automatic speaker recognition. The platform generates AI summaries and highlights automatically, extracts next steps and action items, and creates follow-up emails.
+
+#### Limitations & Trade-offs
+
+- **Bot-based only**: Visible participant that can affect sensitive conversations
+- **Aggressive storage limits on lower tiers**: Free keeps transcripts only 3 months
+- **100-hour monthly limit on Business tier**—high-volume teams need Enterprise or pay overages
+- **No on-premises deployment** except the Enterprise private data storage option
+
+### 4. Fellow
+
+![fellow ai for enterprises](/api/assets/blog/enterprise-ai-notetaking-tools/enterprise-6.webp)
+
+[Fellow](https://fellow.ai) is a cloud-based meeting assistant designed around internal meeting workflows, particularly manager tools like one-on-ones, team meetings, and collaborative agendas. Its distinguishing feature is granular recording controls for internal conversations.
+
+**Deployment options**: Cloud-based (SaaS)
+
+**Pricing**: Enterprise ($25/month, minimum 10 users) includes unlimited AI notes/recordings, advanced recording permissions, domain control, transcript redaction, org-wide analytics, AI-powered CRM field updates, dedicated account management.
+
+#### Enterprise Features
+
+- **Advanced recording permissions**: Granular control over who can record meetings, what meetings can be recorded, and what recordings get shared across the workspace with org-level policy settings.
+- **Transcript redaction**: Remove sensitive information from transcripts before sharing with tools to edit out confidential data, client names, or proprietary details.
+- **Custom recording channels**: Organize recordings by team, department, or project with customizable access controls determining who can view each channel.
+- **Domain control & provisioning**: Automatically provision users from your company domain with HRIS sync, keeping user access current as people join or leave.
+- **Admin governance**: Role-based permissions with admin role limits control who manages workspace settings. Detailed audit logs track who accessed recordings and when.
+- **Security & compliance**: SOC 2 Type II, GDPR, and HIPAA/BAA compliant with military-grade encryption (AES-256 and TLS 1.2+). Fellow explicitly doesn't train AI models on your meeting data. SSO integration with Okta and OneLogin.
+- **Org-wide meeting analytics**: Track patterns across departments—meeting frequency, duration, participant engagement, with keyword tracking to monitor specific topics across all meetings.
+- **Meeting policy enforcement**: Tools include meeting cost calculator, optimal attendees suggestions, no-meeting day enforcement, and short notice booking restrictions to improve meeting culture.
+- **AI-powered CRM integration**: Automatic field updates sync meeting notes and action items to Salesforce or HubSpot. Sales AI recap templates standardize sales call summaries. Private coaching comments let managers give feedback on sales calls invisibly.
+- **Integrations**: Works with Google Meet, Zoom, MS Teams. Connects to Asana, Monday, Confluence, Notion, Slack. Glean integration makes meeting content searchable across your entire knowledge base. 50+ integrations total.
+
+#### How it works
+
+Fellow operates as a bot that joins meetings to record and transcribe. It supports 99 languages for transcription and generates AI summaries, action items, and agendas automatically.
+
+#### Limitations & Trade-offs
+
+- **Bot visibility** can feel intrusive in internal conversations
+- **Cloud-only**: No on-premises for data sovereignty needs
+- **Internal meeting focus**: Less robust than dedicated sales tools for customer-facing conversation intelligence
+- **Minimum 10 Enterprise licenses**
+- **Free/Team plans cap at 10 AI notes/recordings per user monthly**
+
+### 5. Plaud
+
+![plaud](/api/assets/blog/enterprise-ai-notetaking-tools/enterprise-7.webp)
+
+[Plaud](https://www.plaud.ai) takes a completely different approach: hardware-first AI notetaking. Instead of bots joining meetings, you get physical devices that capture conversations anywhere, anytime.
+
+**Deployment options**: Cloud-based with hardware devices
+
+**Pricing**: Hardware from $159 (Plaud Note) includes a 300-minute monthly transcription quota. AI membership: Pro ($99.99/year) or Unlimited ($239.99/year). Enterprise pricing for PLAUD for Business not yet public—contact sales.
+
+#### Enterprise Features
+
+- **Hardware-based capture**: Plaud leverages dedicated sensors to capture conversations in multiple scenarios, unlocking previously untapped real-life data.
+- **Security & compliance**: HIPAA and SOC 2 compliant with GDPR and EN18031 certification. End-to-end encryption with custom data storage options for where your meeting data lives.
+- **Multi-language transcription**: AI transcription in 112 languages with automatic speaker labels and custom vocabulary that learns industry-specific terminology for better accuracy.
+- **Template library**: Over 3,000+ summary templates for generating multidimensional summaries, mind maps, and structured outputs for different meeting types and use cases.
+- **Ask Plaud AI**: Chatbot provides timestamped insights across all recordings—query meetings in natural language and get answers with exact timestamps to the original audio.
+- **Cross-platform access**: Record on physical devices, then access transcripts and summaries on the mobile app, web browser, and desktop with unlimited cloud storage.
+- **Dual-mode recording**: One-button switch between phone call recording mode and in-person conversation mode for different capture scenarios.
+- **Multimodal input**: Combine audio recording with typed notes, images, and press-to-highlight key moments for richer context and documentation.
+
+#### How it works
+
+Hardware sensors capture high-quality audio locally (up to 64GB) then sync to cloud for AI processing. Devices work offline for recording, sync when connected—ideal for field professionals in environments where laptops aren't practical.
+
+#### Limitations & Trade-offs
+
+- **Hardware dependency**: $159+ upfront cost per user plus ongoing subscription
+- **300-minute base quota**: Heavy users need Pro ($99.99/year) or Unlimited ($239.99/year)
+- **Cloud processing required** for transcription and AI features
+- **Manual device management**: Remember to carry, charge, and position devices
+- **Less convenient for virtual-only meetings** compared to automatic software bots
+
+## Why Choose Char
+
+Every enterprise has unique compliance requirements, workflow needs, and technical constraints. Char's flexible architecture adapts to all three. Whether you need edge-only deployment for maximum IP protection, all-prem for complete infrastructure control, or prem-hybrid to balance compliance with powerful AI, there's a configuration that fits.
+
+Our team works with Fortune 500 companies, healthcare systems, legal firms, financial institutions, and government agencies to deploy AI notetaking that fits their security posture.
+
+Ready to see how zero-lock-in AI works in practice? [Contact Sales](/founders) to discuss your specific needs, explore deployment options, and schedule a demo tailored to your organization's use cases.
+
+&nbsp;

--- a/apps/web/content/articles/fathom-ai-alternatives.mdx
+++ b/apps/web/content/articles/fathom-ai-alternatives.mdx
@@ -1,0 +1,273 @@
+---
+meta_title: "5 Best Fathom AI Alternatives in 2026"
+meta_description: "Discover the 5 best alternatives to Fathom AI in 2026. Get better conversation insights, stronger security, and truly unlimited note-taking."
+author: "John Jeong"
+coverImage: "/api/assets/blog/fathom-ai-alternatives/cover.png"
+category: "Comparisons"
+date: "2025-10-15"
+---
+
+If bots make you nervous, privacy is on your mind, and you want more than simple note-taking and unlimited free recordings, you should look beyond Fathom AI.
+
+## Quick Fathom AI review
+
+I tested Fathom AI for weeks. It does what it says on the tin—a meeting bot that transcribes your Zoom, Meet, or Teams calls and generates summaries in about 30 seconds after the call ends. The CRM sync works well for sales teams.
+
+But the limitations become apparent quickly:
+
+- **They're training AI on your meetings.** Unless you manually dig into settings and opt out, your data trains their models. Most users don't know this is happening.
+- **You can end up in their database without signing up.** If someone uses Fathom in a meeting with you, your voice, email, and conversation content gets collected—and they might market to you.
+- **The desktop app is just a recording widget.** There's nowhere to write down your thoughts during the meeting.
+- **No real-time transcription.** You're flying blind during calls, and it doesn't work without internet. Dead WiFi means a dead tool.
+- **The bot is always visible.** For sensitive client calls or therapy sessions, having "Fathom Notetaker" in your participant list changes the dynamic.
+- **The unlimited free plan is actually quite limited.** You get unlimited transcription and recordings, but AI summaries cap out at five per month.
+
+If any of that bothers you, here are the top Fathom AI alternatives.
+
+## Top Fathom AI alternatives: quick comparison
+
+| Tool      | Best For                                           | Starting Price                  |
+| --------- | -------------------------------------------------- | ------------------------------- |
+| Char  | Zero lock-in, complete control                     | Free forever (local + BYOK). Cloud: $25/mo |
+| Avoma     | Sales teams needing coaching & deal intelligence   | $19/mo base ($54-109 realistic) |
+| Read AI   | Teams wanting unified search across communications | $19.75/mo                       |
+| Fireflies | Teams needing deep conversation analytics          | Free (Pro: $18/mo)              |
+| Sembly AI | Enterprise compliance certifications               | $15/mo                          |
+
+## 5 best Fathom alternatives: detailed reviews
+
+### 1. Char: For When Control Actually Matters
+
+Full disclosure—I'm the co-founder of [Char](/). I built it because every other tool locked you into their cloud, their models, their rules. No way to switch, no way out.
+
+Char is an open-source AI notepad for meetings. Everything is stored as plain markdown files on your device—not in proprietary databases. You choose which AI processes your data: managed cloud, bring your own API keys, or run local models.
+
+You get a real notepad interface. Open Char and you see a notepad. Type notes during meetings, and the AI enhances them with context from the transcript. Real-time transcription appears while people are talking, not after.
+
+**Best For:** Engineers, developers, and technical founders. Privacy-conscious professionals in healthcare, legal, and finance. People who already use tools like Obsidian or local-first workflows. Anyone whose company has banned cloud tools like Otter or Granola.
+
+<Image src="/api/assets/blog/fathom-ai-alternatives/fathom-1.webp" alt="Char vs Fathom" />
+
+#### Key features
+
+- Real-time transcription during meetings (unlike Fathom's post-meeting approach)
+- Instant summary generation within seconds
+- Notepad-like interface for active note-taking
+- Customizable templates for any meeting type (therapy, legal, sales, interviews)
+- AI Chat for follow-up questions with source verification
+- Conversational search across all meeting history
+- Multiple export formats (Markdown, PDF, Rich Text)
+- Works with any meeting platform and in-person meetings
+- Smart Consent Management Package for compliance
+- Flexible deployment options (local, self-host, or custom AI endpoints)
+
+#### Strengths vs Fathom
+
+- Zero lock-in—plain markdown files, open source, portable format
+- Your choice of AI stack—managed cloud, bring your own keys, or run local
+- True file ownership—works with Obsidian, Notion, VS Code, anything
+- Works completely offline—airplane meetings or sketchy WiFi work fine
+- No bot in your meetings—zero meeting disruption
+- Open source code for security audits and customization
+
+#### Limitations
+
+- macOS only currently
+- Basic speaker identification—distinguishes mic vs system audio, but can't automatically separate multiple Zoom participants
+- Fewer integrations—no direct CRM sync like Fathom's Salesforce/HubSpot automation
+
+#### Pricing
+
+Free forever for local transcription, BYOK, and all core features. No usage caps, no artificial limits. Managed cloud service is $25/month for the easiest setup. Enterprise pricing covers on-prem deployment, smart consent management, and SSO—[contact sales for a quote](/founders).
+
+<CtaCard/>
+
+### 2. Avoma: if you're serious about sales
+
+[Avoma](https://www.avoma.com) is a complete revenue intelligence platform that actually helps your sales team improve.
+
+It joins meetings as a bot, but unlike Fathom's basic summaries, it automatically structures notes around what matters for sales—pain points, budget, decision criteria, next steps. If you're using MEDDIC or SPICED frameworks, it populates those fields automatically.
+
+**Best For:** Sales teams needing coaching analytics, deal intelligence, and automated CRM updates. Works best for teams of 10+ reps who need scalable coaching.
+
+<Image src="/api/assets/blog/fathom-ai-alternatives/fathom-2.webp" alt="Avoma vs fathom ai" />
+
+#### Key features
+
+- Automated CRM field updates (pain points, budget, buying intent, next steps)
+- Two-way CRM sync with Salesforce and HubSpot—update anywhere, reflects everywhere
+- Deal risk analysis flagging when engagement drops or stakeholders go silent
+- Sales methodology tracking (MEDDIC, SPICED, NEAT, BANT, Sandler)
+- Competitive intelligence tracking mentions across all conversations
+- AI-powered call scoring based on custom criteria
+- Talk-listen ratio, question quality, objection handling analysis
+- Filler word tracking and monologue alerts
+- Topic tracking showing what your team spends time discussing
+- Curated playlists of best calls for training new reps
+
+#### Strengths vs Fathom
+
+- Automated CRM field updates—goes way beyond Fathom's basic note sync
+- Call scoring without manager time—every call graded automatically (Fathom requires manual review)
+- Deal risk analysis—flags problems before they kill deals (Fathom doesn't track this)
+- Comprehensive coaching analytics—performance trends, not just transcripts
+- Complete meeting lifecycle—scheduling through follow-up (Fathom is recording only)
+
+#### Limitations
+
+- Expensive—realistically $54-109/user/month once you add features you actually need (vs Fathom's $20)
+- Complex setup—expect 1-2 weeks getting everything configured (Fathom works in 5 minutes)
+- Steep learning curve—not "install and forget" software
+- Bot-based recording—still joins as visible participant like Fathom
+- English-focused—works in 30+ languages but optimized for English
+
+#### Pricing
+
+Starts at $19/user/month base, but you'll need add-ons ($35-70/user/month) for conversation intelligence and coaching features. Realistic total: $54-109/user/month for full functionality. Free 14-day trial available.
+
+### 3. Read AI: the everything-everywhere tool
+
+[Read AI](https://www.read.ai) takes a completely different approach than Fathom. Instead of just doing meetings, it connects meetings, emails, and messages into one searchable knowledge base.
+
+Read's Search Copilot works across everything. Ask "What did the engineering team say about the API redesign?" and it pulls answers from meetings, Slack threads, and email chains. This is genuinely useful when you're piecing together decisions made across multiple channels.
+
+**Best For:** Teams who need unified search across all communications, not just meetings. Works well for product teams, executives, and anyone coordinating across multiple platforms.
+
+<Image src="/api/assets/blog/fathom-ai-alternatives/fathom-3.webp" alt="Read ai vs fathom ai" />
+
+#### Key features
+
+- Search Copilot querying meetings, emails, Slack, and CRM data in one place
+- Pre-meeting summaries showing what happened last time and open action items
+- Multi-meeting insights tracking discussions over time
+- Custom tags for organizing meetings by type, team, or project
+- "Send Read instead"—let the bot join meetings you can't attend
+- Real-time transcription with speaker identification
+- Automated meeting reports with summaries, action items, key questions
+- Engagement metrics showing who's checked out or dominating conversations
+- 20+ language transcription support
+- Recording playback with synchronized transcripts
+
+#### Strengths vs Fathom
+
+- Unified search—one query across all communication channels (Fathom only searches meetings)
+- Pre-meeting context—shows relevant past discussions automatically (Fathom doesn't do this)
+- Email and message summarization—beyond just meetings (Fathom is meeting-only)
+- Engagement analytics—track who's participating (Fathom's metrics are more basic)
+- Send bot to meetings you skip—still get notes without attending
+
+#### Limitations
+
+- Stingy free plan—only 5 meetings/month vs Fathom's unlimited recordings
+- Bot joins uninvited sometimes—users report this happening despite settings
+- No offline mode—requires internet like Fathom
+- Limited free features—5-meeting cap feels restrictive for regular users
+- No in-person meeting support—meeting platforms only, like Fathom
+
+#### Pricing
+
+Free plan offers 5 meetings per month with basic features. Paid plans start at $19.75/user/month.
+
+### 4. Fireflies: when you need conversation analytics
+
+[Fireflies.ai](https://fireflies.ai) has been around longer than most competitors, and it shows in the analytics depth.
+
+The conversation analytics go way deeper than Fathom. Speaker talk time, sentiment analysis, topic tracking, even monitoring for specific keywords across all calls. If you're tracking how often competitors get mentioned or what objections keep coming up, Fireflies surfaces those patterns automatically.
+
+**Best For:** Teams needing conversation analytics, sales teams tracking objections, product teams monitoring feature requests, or anyone managing high meeting volume.
+
+<Image src="/api/assets/blog/fathom-ai-alternatives/fathom-4.webp" alt="fireflies ai vs fathom ai" />
+
+#### Key features
+
+- AskFred AI assistant answering questions across entire meeting history
+- Speaker analytics showing talk time distribution, monologue alerts
+- Sentiment analysis tracking emotional tone throughout conversations
+- Topic tracking with automatic keyword extraction
+- Unlimited transcription even on free plan (vs Fathom's 5 AI summary limit)
+- 69+ language support with automatic detection
+- Smart search across meetings with keyword and semantic search
+- Auto-generated action items with assignee tracking
+- Collections for organizing related meetings
+- Video playback with synchronized transcripts
+
+#### Strengths vs Fathom
+
+- Unlimited free transcription—no limits like Fathom's 5 AI summaries/month
+- Deeper conversation analytics—pattern recognition across meetings (Fathom is surface-level)
+- 69+ languages—much broader than Fathom's 25
+- More extensive integrations—58+ vs Fathom's handful
+- Mobile app—record in-person meetings (Fathom has no mobile app)
+- Better search functionality—semantic search understands context (Fathom is keyword-only)
+
+#### Limitations
+
+- Storage limits on lower tiers—free plan only keeps 800 minutes per seat (Fathom has unlimited storage)
+- Auto-shares summaries—sends to all participants by default, must manually disable
+- Bot announces itself—"Fred" appears as visible participant like Fathom
+- Billing surprises reported—trial-to-paid transition isn't always clear
+- Language support hit-or-miss—claims 69 languages but works best in English
+- [Privacy concerns](/blog/is-fireflies-ai-safe)—cloud processing like Fathom, no local option
+
+#### Pricing
+
+Free plan includes unlimited transcription with 800 minutes of storage and limited AI summaries. Paid plans start at $18/user/month.
+
+**Also check:** [Top Fireflies AI Alternatives](/blog/fireflies-ai-alternatives)
+
+### 5. Sembly AI: the enterprise compliance specialist
+
+[Sembly AI](https://www.sembly.ai) built its reputation on one thing: meeting the compliance requirements that make procurement teams happy. SOC 2 Type II, HIPAA, GDPR—Sembly checks boxes that most meeting assistants ignore.
+
+Fathom gives you basic summaries and expects you to handle compliance yourself. Sembly was designed from the ground up for regulated industries. Healthcare, finance, legal—teams that can't afford to mess around with data security.
+
+**Best For:** Enterprise organizations needing strict compliance, regulated industries (healthcare, finance, legal), teams building secure knowledge bases, or anyone where HIPAA/SOC 2 certification isn't optional.
+
+<Image src="/api/assets/blog/fathom-ai-alternatives/fathom-5.webp" alt="Sembly ai vs fathom ai" />
+
+#### Key features
+
+- SOC 2 Type II, HIPAA, GDPR, FERPA, PCI DSS, and Microsoft 365 certification
+- AI artifact generation turning meetings into business deliverables (project plans, requirements documents, reports)
+- 42+ core languages with 32 additional beta languages (48 total) for global teams
+- Advanced action item extraction with automatic assignee tracking and due dates
+- Collections feature grouping related meetings for project or client-specific organization
+- Enterprise-grade security with data encryption, audit trails, role-based access
+- EU data residency options for GDPR compliance requirements
+- Upload pre-recorded meetings for transcription and analysis
+- AI chat querying past meetings for specific information
+
+#### Strengths vs Fathom
+
+- Enterprise compliance certifications—SOC 2, HIPAA, GDPR out of the box
+- Artifact generation—creates actual business documents, not just summaries
+- Multi-meeting analysis—tracks trends across conversations (Fathom analyzes one at a time)
+- Flexible attendance—bot captures meetings you can't attend (Fathom requires you present)
+- EU data residency options for compliance (Fathom doesn't offer this)
+
+#### Limitations
+
+- Bot-based recording affects meeting dynamics like Fathom
+- Steeper learning curve than simpler alternatives—more features means more complexity
+- Cloud-only processing—no on-premises option like Char
+- Limited export options—no direct Word document export for summaries
+- Higher price point than Fathom for full feature access
+- Requires stable internet connection—no offline mode like Fathom
+
+#### Pricing
+
+Free plan offers 60 minutes of transcription per month. Paid plans start at $15/user/month.
+
+## Which is the best Fathom AI alternative?
+
+**If control and zero lock-in matter, use Char.** Plain markdown files, your choice of AI stack, and complete ownership. Engineers, developers, privacy-conscious professionals in healthcare and legal, or anyone whose company has banned cloud tools—Char gives you ownership at the foundational level. You also get real-time transcription and offline support that Fathom can't match.
+
+**If you're running a sales team and budget allows, go with Avoma.** The automated CRM updates and call scoring actually improve team performance. The coaching analytics are worth the price if you're serious about revenue. Budget realistically—you'll need $70-110/user/month for features you actually want.
+
+**If you need unified search across all communications, Read AI is worth exploring.** The ability to query meetings, emails, and Slack in one place is genuinely useful for product teams and executives tracking decisions across channels. Negotiate the Pro pricing—don't accept the first quote.
+
+**If you want conversation analytics on a budget, Fireflies works.** The unlimited free transcription beats Fathom's 5-summary cap, and the pattern recognition across meetings is deeper. Watch the storage limits and disable auto-sharing to all participants.
+
+**If compliance certifications are required, Sembly is your answer.** SOC 2, HIPAA, GDPR out of the box. Regulated industries can't use tools without these certifications, and Sembly was built for that purpose.
+
+<CtaCard/>

--- a/apps/web/content/articles/filesystem-is-coretex.mdx
+++ b/apps/web/content/articles/filesystem-is-coretex.mdx
@@ -1,0 +1,76 @@
+---
+meta_title: "Why Your Notes Should Live as Files, Not Database Rows"
+display_title: "The Filesystem Is the Cortex"
+meta_description: "Why file-based systems matter in the AI era, and how Char fits into the future of note-taking."
+author: "John Jeong"
+category: "Founders' notes"
+date: "2025-12-30"
+---
+
+Most businesses win not because they have more features, but because they communicate a clearer philosophy—a picture of the future that some people want to live inside.
+
+In older eras, religion acted as the gravity of communities. Today, we're still pulled by gravity, just different kinds: interests, crafts, identities, missions. People want to become good at something. They want to enjoy something deeply. They want to find tools that make their journey feel coherent.
+
+A startup's job is to make a specific journey possible and to make it feel inevitable.
+
+## Notes Are Not Productivity. They're Mind Extension.
+
+Note-taking is one of the most underestimated categories in software because it looks simple. But notes aren't documents or content. They're closer to memory, and memory is closer to identity. A note-taking system is an extension of your mind: a place where thoughts land, take shape, connect, and return later as insight.
+
+The mind operates in modes. There's private thinking—personal thoughts, half-formed ideas, internal reflections. There's work mode—decisions, planning, collaboration, outcomes. There's publishing mode—writing for other people, making ideas legible, shipping something public.
+
+Good note-taking tools don't force those modes into a single abstraction. They let them coexist.
+
+This is why many serious note-takers end up with multiple tools:
+
+- Obsidian for long-term knowledge and personal/work thinking
+- Logseq for daily bullets and chronological capture
+- A dedicated folder for meeting notes, recordings, and attachments
+
+These aren't competing products. They're compatible because they share a common substrate: Markdown files on disk.
+
+## Files Are a Human Interface, Not a Technical Detail
+
+File-based systems are a cognitive model, not a relic. Humans have organized information spatially for centuries: drawers, cabinets, boxes, folders. We remember where something is. Location is recall. Structure is memory.
+
+This is why the terminal still feels natural. `ls`, `pwd`, `grep`—these commands mirror how people already understand information. There's a place, there's a name, there's content, there's a way to find it. Computers didn't invent this model. They adopted it.
+
+When we talk about "local-first" and "file-based," we're discussing something beyond implementation: trust. A note-taking system is a memory prosthetic. Memory needs to feel owned, reliable, and genuinely yours. When notes live as files, they feel like part of you. When notes live as opaque blobs behind an API, they feel like someone else's product.
+
+## Why AI Works So Well in Coding (and Why Writing Is Following)
+
+Coding agents feel effective right now partly because models are capable, but also because code is file-based. Software lives as artifacts—foo.tsx, bar.py, main.rs, README.md—not rows in a database or JSON stuffed inside Postgres fields. Real files with real names, clear structure, readable content.
+
+AI agents can traverse repositories, read context, understand conventions, search across files, and generate changes that fit the existing structure. The agent sees the artifact, diffs it, rewrites it, reasons about it.
+
+The best coding tools work because they're not inventing a new abstraction. They ride the filesystem—the same abstraction humans have used to manage complexity for decades.
+
+Writing is following the same pattern. People draft blog posts and essays inside coding environments. It seems odd on the surface, but writing and coding are closer than we admit. In both cases you're composing, shaping intent into an artifact, embedding values into structure, turning a vague thought into something executable—either by machines (code) or by humans (writing).
+
+"Agents for writing" are happening inside code tools because those tools are file-native. They treat writing as a first-class artifact, not as a database record.
+
+## The Endgame: Less Folder Worship, More Meaning
+
+The future probably isn't "more folders." Folders are useful as a spatial index for recall, but they're a human workaround.
+
+In the AI era, titles matter less than content. Location matters less than meaning. The real organizing principle will shift toward content semantics, metadata, search, retrieval, and links between ideas. The filesystem remains the substrate. The intelligence layer sits on top.
+
+## Where Char Fits
+
+In the note-taking ecosystem, Obsidian communicates a clearer picture of the future than most. It's an incredible interface on top of a file-based knowledge base, and it has influenced how an entire generation thinks about notes. I've subscribed for years because of what it represents, not because of one feature.
+
+We don't want to replace Obsidian. We want to be part of the same movement: tools that respect files, respect ownership, and respect the mind.
+
+Char is built to become the best interface for meeting notes and a connector across the full meeting workflow. Before the meeting: context, agenda, prep. During: capture, audio, real-time structure. After: summaries, decisions, action items, follow-ups. Eventually, a command center where you can direct AI instead of being replaced by it.
+
+Because Char is file-based and local-first, it can sit alongside your existing vault. It can read from your knowledge base and write back into it. It treats meetings as a specialized region of your brain—deeply integrated, but not controlling everything else.
+
+That's the direction that matters: building a tool that fits into the cortex, not another walled garden.
+
+## Closing
+
+This isn't nostalgia for old-school files. It's a belief about the future: if AI is going to help humans think, it needs access to artifacts humans can own, inspect, move, and understand. Markdown, plain text, files.
+
+The filesystem is the cortex. In the AI era, it becomes even more important, not less.
+
+Char is our contribution to that future: a meeting-native interface inside a file-native world.

--- a/apps/web/content/articles/fireflies-ai-alternatives.mdx
+++ b/apps/web/content/articles/fireflies-ai-alternatives.mdx
@@ -1,0 +1,421 @@
+---
+meta_title: "9 Best Fireflies.ai Alternatives in 2026"
+meta_description: "Complete Fireflies.ai review plus 9 alternative comparisons. Compare AI meeting assistants by features, pricing, privacy, and platform support."
+author: "Harshika"
+coverImage: "/api/assets/blog/fireflies-ai-alternatives/cover.png"
+category: "Comparisons"
+date: "2025-09-23"
+---
+
+Fireflies is easy to adopt, which is why so many teams try it first.
+
+It is also one of those products that feels different after the novelty wears off. The complaints are consistent: a bot people do not always want in the room, pricing that gets messy, multilingual performance that sounds better on the landing page than in practice, and upsells that show up once your team depends on it.
+
+So this list is for a specific buyer. Not someone new to the category. Someone who already understands what Fireflies gets right and wants a better trade-off.
+
+## Quick Fireflies AI review
+
+Fireflies is an AI meeting assistant that automatically joins your Zoom, Google Meet, or Teams calls through a bot. Once there, it records everything, transcribes the conversation in real-time, and shares AI-generated summaries with action items and key highlights.
+
+<Image src="/api/assets/blog/fireflies-ai-alternatives/fireflies-0.webp" alt="Fireflies AI 1-pager"/>
+
+### The good stuff
+
+**Setup is genuinely easy:** Connect your calendar, and the bot starts auto-joining your scheduled meetings without any extra work from you. For people managing tons of meetings, this automation is a significant timesaver.
+
+**Transcription quality is decent:** In good conditions—clear audio, minimal background noise—you're looking at around 85-90% accuracy. That's solid enough to capture the gist of conversations and make them searchable later.
+
+**AI summaries save time:** When they work well, the auto-generated summaries do capture key discussion points and action items. No more scrambling to remember what was decided three meetings ago.
+
+**The search feature is actually useful:** Being able to type in keywords and instantly find where specific topics were discussed months ago is valuable, especially for sales teams tracking client conversations over time.
+
+**Integrations work well:** If you're using a CRM, having meeting notes automatically sync there saves a ton of manual work. The Slack integration is particularly handy for team updates.
+
+**Mobile app is convenient:** You can record and transcribe conversations on the go, which is useful for interviews or in-person meetings.
+
+### Where things get messy
+
+**The billing situation is concerning:** Multiple users report being charged for plans they didn't knowingly sign up for. The trial cancellation process seems deliberately confusing, and many people only discover unexpected charges when reviewing their credit card statements. Some users even mention being unable to remove their payment information from the platform.
+
+<Image src="/api/assets/blog/fireflies-ai-alternatives/fireflies-1.webp" alt="Fireflies 1"/>
+
+**Privacy issues are real:** By default, Fireflies shares meeting summaries with all attendees without asking first. You have to manually opt out of this behavior. For sensitive business discussions, that's problematic. We've covered [Fireflies' safety and data practices in detail](/blog/is-fireflies-ai-safe/). Even more concerning, several users report the bot continuing to join meetings even after they've cancelled their accounts and deleted everything.
+
+<Image src="/api/assets/blog/fireflies-ai-alternatives/fireflies-2.webp" alt="Fireflies 2"/>
+
+**Language support is limited:** Despite claims of supporting 100+ languages, Fireflies works best only in English. If your team is multilingual or you work with international clients, you'll likely run into accuracy problems.
+
+<Image src="/api/assets/blog/fireflies-ai-alternatives/fireflies-3.webp" alt="Fireflies 3"/>
+
+**Hidden costs add up quickly:** Those fancy AI features like smart summaries and action items require additional "AI credits" that aren't included in your base subscription. What looks like a $29/month Business plan can easily become much more expensive once you factor in the credits needed for core functionality.
+
+<Image src="/api/assets/blog/fireflies-ai-alternatives/fireflies-4.webp" alt="Fireflies 4"/>
+
+**Aggressive upselling tactics:** Users report extremely aggressive upselling tactics for non-pro accounts. The combination of storage restrictions and AI credits creates constant pressure to upgrade to higher-tier plans.
+
+<Image src="/api/assets/blog/fireflies-ai-alternatives/fireflies-5.webp" alt="Fireflies 5"/>
+
+### The bottom line on Fireflies
+
+Fireflies does what it promises for basic transcription and automation, especially if you're working in English and don't mind having a bot in your meetings. But between the billing issues, privacy concerns, and accuracy limitations, there are serious trade-offs to consider. You have other options available.
+
+## Top Fireflies AI alternatives: at a glance
+
+| Tool      | Best For                                                 | Pricing                                           | Platforms                                        |
+| --------- | -------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------ |
+| Char  | Zero lock-in, complete control over data and AI stack    | Free forever (local + BYOK). Cloud: $25/mo        | All platforms (system audio capture) + in-person |
+| Avoma     | Sales teams needing revenue intelligence                 | $29-39/month base + $35-70/month add-ons          | Zoom, Teams, Google Meet, Webex                  |
+| Otter AI  | Teams wanting established platform with collaboration    | $16.99/user/mo (Free: 300 min)                    | Zoom, Teams, Google Meet                         |
+| MeetGeek  | Teams needing automated workflows & meeting analytics    | $19/user/mo (Free: 3 hours of transcription/mo)   | Zoom, Teams, Google Meet, Webex + 50 languages   |
+| Read AI   | Enterprises needing unified search across communications | $19.75/month (Free: 5 transcripts/mo)             | All major platforms + email/messaging            |
+| Tactiq    | Chrome users wanting real-time browser transcription     | $12/user/mo (Free: 10 meetings)                   | Chrome extension for Meet, Zoom, Teams           |
+| Sembly AI | Teams needing compliance & workflow automation           | $15/user/mo (Free: 60 mins/mo)                    | Zoom, Teams, Google Meet, Webex + file upload    |
+| Fathom    | Small teams wanting generous free plan + CRM sync        | Free unlimited (Premium: $19/mo)                  | Zoom, Teams, Google Meet                         |
+| Sonnet AI | Teams wanting enhanced meeting prep + bot-free capture   | $25/month (Free: 5 recordings/mo)                 | All platforms (device-level capture)             |
+
+## 9 best Fireflies.ai alternatives: detailed reviews
+
+### 1. Char
+
+Char is an open-source AI notepad for meetings built for high-agency people who demand complete control over their data and AI stack. Everything is stored as plain markdown files—not in proprietary databases. It works like Apple Notes with AI superpowers, capturing audio from any meeting platform without joining as a bot.
+
+<Image src="/api/assets/blog/fireflies-ai-alternatives/hyprnote.webp" alt="Char"/>
+
+#### How it compares to Fireflies
+
+Fireflies processes everything in the cloud, locks you into their platform, and uses a bot to join meetings. Char gives you complete control—choose your AI stack, own your files as plain markdown, and capture system audio directly. Zero lock-in, zero compromises.
+
+#### Top features
+
+- Plain markdown files stored locally—works with any tool (Obsidian, Notion, VS Code)
+- Your choice of AI stack: managed cloud, bring your own keys, or run local models
+- Open source—zero lock-in, full transparency
+- Customizable templates for different meeting types (therapy, legal, interviews)
+- Smart Consent Management Package for enterprise compliance
+- AI Chat with MCP server connections for enhanced functionality
+- Calendar integration with notification system
+- Conversational search across all meeting history
+- Flexible AI model options (local, self-host, or connect to custom AI endpoints)
+
+#### Pros
+
+- Zero vendor lock-in—switch AI providers anytime, export your files anywhere
+- No meeting bots to disrupt conversations
+- Open source with full transparency
+- Free forever for local transcription, BYOK, and all core features
+- Works with any meeting platform or in-person discussions
+
+#### Cons
+
+- Currently macOS only (Windows and Linux coming in Q2 2026)
+- No video recording by design for maximum privacy
+- Limited integrations compared to cloud platforms
+- Mic level speaker identification
+
+#### Pricing
+
+Char is free forever for local transcription, BYOK, and all core features. The managed cloud service is $25/month for those who want the easiest setup. Enterprise plans include on-premises deployment, SSO integration, and consent management for compliance requirements. Contact sales for a quote.
+
+<CtaCard/>
+
+### 2. Avoma
+
+Avoma is a conversation intelligence platform designed specifically for revenue teams, combining meeting transcription with sales coaching, deal tracking, and revenue analytics.
+
+<Image src="/api/assets/blog/fireflies-ai-alternatives/avoma.webp" alt="Avoma"/>
+
+#### How it compares to Fireflies
+
+While Fireflies provides basic conversation analytics, Avoma focuses on sales-specific insights like objection handling, talk time analysis, and deal progression tracking. It's built for revenue optimization rather than general meeting documentation.
+
+#### Top features
+
+- Sales methodology tracking (MEDDIC, SPICED, Sandler)
+- AI-powered call scoring and coaching scorecards
+- Automated CRM field updates and data entry
+- Deal risk analysis and revenue forecasting
+- Custom conversation analytics and reporting
+- Round-robin scheduling with lead routing automation
+
+#### Pros
+
+- Automated call scoring and coaching insights
+- Deep CRM integration with field automation
+- Deal risk analysis and forecasting
+- Comprehensive revenue intelligence dashboard
+
+#### Cons
+
+- Higher pricing than general transcription tools
+- Complex feature set may overwhelm non-sales users
+- English language limitation
+- Steep learning curve for full utilization
+
+#### Pricing
+
+Base plans run $19-$39/user/month, with add-ons for sales features costing $35-$70/user/month extra. Total realistic cost for full functionality is $74-$109/user/month.
+
+### 3. Otter AI
+
+Otter AI is an established cloud-based AI meeting assistant that automatically joins video calls to record, transcribe, and summarize conversations with team collaboration features.
+
+<Image src="/api/assets/blog/fireflies-ai-alternatives/otter.webp" alt="Otter AI"/>
+
+#### How it compares to Fireflies
+
+Both use meeting bots and cloud processing, but Otter focuses more on collaborative editing and team workspaces while Fireflies emphasizes conversation analytics and broader language support.
+
+#### Top features
+
+- Real-time transcription with live team collaboration features
+- AI Chat for querying meeting history and generating follow-ups
+- Mobile app that syncs seamlessly across devices
+- Custom vocabulary that learns technical terms and company language
+- Integration with CRMs and productivity tools
+
+#### Pros
+
+- Excellent real-time collaboration with commenting and highlighting
+- Strong speaker identification that improves with usage
+- Reliable platform with consistent performance and updates
+- Mobile app handles both virtual and in-person meetings effectively
+
+#### Cons
+
+- Limited to only 3 languages (English, Spanish, and French)
+- 300-minute monthly limit on the free plan
+- Meeting bot can feel intrusive
+- No video recording on the lower tiers
+- Privacy concerns with an ongoing class-action lawsuit regarding data handling practices
+
+#### Pricing
+
+Free plan with 300 minutes/month. Pro starts at $16.99/user/month.
+
+Also check: Top Otter AI's Alternatives
+
+### 4. MeetGeek
+
+MeetGeek is an AI meeting assistant that automatically detects meeting types and applies context-aware templates, workflows, and insights based on whether you're in sales calls, interviews, or team meetings.
+
+<Image src="/api/assets/blog/fireflies-ai-alternatives/meetgeek.webp" alt="MeetGeek"/>
+
+#### How it compares to Fireflies
+
+While Fireflies treats all meetings similarly, MeetGeek intelligently categorizes meetings and provides specialized insights for different contexts like hiring, sales, or project discussions.
+
+#### Key features
+
+- Automatic meeting type detection with context-aware summary templates
+- Comprehensive conversation analytics and engagement metrics
+- 7,000+ app integrations via Zapier and direct CRM connections
+- Support for 50+ languages with high transcription accuracy
+- Mobile apps for recording in-person meetings offline
+
+#### Strengths
+
+- Strong analytics and coaching insights for improving meeting culture
+- Excellent integration ecosystem for workflow automation
+- Good multilingual support for international teams
+- Free plan includes 300 minutes with basic features
+
+#### Considerations
+
+- AI-generated summaries can be hit-or-miss, sometimes including irrelevant small talk
+- Slower to set up new meetings (requires 5+ minute advance calendar scheduling)
+- Interface can feel complex for users wanting simple note-taking
+
+#### Pricing
+
+Starts at $19/user/month with meeting type detection and workflow automation.
+
+### 5. Read AI
+
+Read AI is a comprehensive AI platform that provides meeting intelligence alongside unified search across emails, messages, and CRM data, treating meetings as part of broader business communications.
+
+<Image src="/api/assets/blog/fireflies-ai-alternatives/read-ai.webp" alt="Read AI"/>
+
+#### How it compares to Fireflies
+
+Fireflies focuses specifically on meeting intelligence, while Read.ai connects meeting insights with your entire communication ecosystem for unified knowledge management.
+
+#### Top features
+
+- Unified search across meetings, emails, and messages
+- Real-time transcription with speaker coaching insights
+- Platform-agnostic integration with all major tools
+- Advanced participant engagement and sentiment analysis
+- AI-powered insights across communication channels
+- Enterprise-grade security and compliance controls
+
+#### Pros
+
+- iPhone application enables mobile recording with real-time transcription and summarization
+- Automatic speaker detection and identification in recorded conversations
+- Smart notifications that differentiate between in-person and virtual meeting contexts
+- Real-time transcript generation is visible during recording sessions
+- Cross-platform synchronization displays mobile recordings alongside virtual meetings
+
+#### Cons
+
+- Requires internet connectivity for real-time transcription and AI processing
+- No offline processing capabilities for transcription or summarization
+- Limited information available about speaker identification accuracy in group settings
+
+#### Pricing
+
+Free plan includes 5 monthly meeting reports. Paid plans start at $19.75/user/month.
+
+### 6. Tactiq
+
+Tactiq operates as a Chrome extension providing real-time transcription directly in your browser during Google Meet, Zoom, and Teams meetings without requiring separate app downloads.
+
+<Image src="/api/assets/blog/fireflies-ai-alternatives/tactiq.webp" alt="Tactiq"/>
+
+#### How it compares to Fireflies
+
+Unlike Fireflies' bot-based approach, Tactiq works invisibly within your browser, showing live transcription as people speak without appearing as a meeting participant.
+
+#### Top features
+
+- Real-time transcription visible during live meetings
+- Custom AI workflows and automated action generation
+- 60+ language support with automatic detection
+- Highlight and tag functionality during meetings
+- One-click AI actions for summaries and follow-ups
+- Direct integration with productivity tools via Chrome
+
+#### Pros
+
+- No separate app download required
+- Works invisibly without meeting bot disruption
+- Extensive productivity tool integrations via Chrome
+- Fast setup - works immediately after installation
+- Custom prompts for specific meeting outputs
+
+#### Cons
+
+- Chrome browser dependency limits flexibility
+- No audio recording, focusing only on transcription without meeting playback capabilities
+- Limited free plan with only 5 AI credits per month, restricting regular use
+
+#### Pricing
+
+Free plan with 10 meetings/month. Paid plans start at $12/user/month.
+
+### 7. Sembly AI
+
+Sembly AI focuses on enterprise compliance and workflow automation, transforming meeting discussions into business artifacts like project plans, requirements documents, and automated task assignments.
+
+<Image src="/api/assets/blog/fireflies-ai-alternatives/sembly-ai.webp" alt="Sembly AI"/>
+
+#### How it compares to Fireflies
+
+While Fireflies provides meeting summaries, Sembly generates actionable business deliverables and offers stronger compliance features for regulated industries.
+
+#### Top features
+
+- AI artifact generation (project plans, requirements, reports)
+- Multi-meeting trend analysis and pattern recognition
+- 45+ language support with multilingual team capabilities
+- Advanced action item extraction with assignee tracking
+- Enterprise-grade security (SOC 2, GDPR, HIPAA compliance)
+- Collections feature for organizing related meetings
+
+#### Pros
+
+- Flexible attendance model allowing the bot to capture meetings even when you're not present
+- Unified meeting intelligence consolidating summaries, transcripts, and analytics in one interface
+- Comprehensive integrations with popular CRMs and project management tools like Trello, ClickUp, Asana, etc.
+- Cross-meeting trend analysis and insights
+
+#### Cons
+
+- Bot-based recording affects meeting dynamics
+- Steeper learning curve than simpler alternatives
+- Limited export options lacking direct Word document export for summaries and tasks
+
+#### Pricing
+
+Starts at $15/user/month with enterprise compliance features.
+
+### 8. Fathom
+
+Fathom provides unlimited meeting recording and transcription for free, with paid features focused on sales team needs, including CRM automation and conversation intelligence.
+
+<Image src="/api/assets/blog/fireflies-ai-alternatives/fathom.webp" alt="Fathom"/>
+
+#### How it compares to Fireflies
+
+Both offer comprehensive meeting intelligence, but Fathom's completely free core functionality and sales-specific features make it more accessible for small teams and revenue-focused organizations.
+
+#### Top features
+
+- Unlimited free recording and transcription
+- Instant processing with immediate post-meeting delivery
+- "Ask Fathom" AI assistant for meeting content queries
+- CRM automation with Salesforce and HubSpot sync
+- Video highlight creation and sharing capabilities
+- Sales conversation intelligence and coaching insights
+
+#### Pros
+
+- CRM integrations work smoothly and save manual data entry
+- Easy to create and share video highlights with teammates
+- Handles multiple speakers and accents reasonably well
+
+#### Cons
+
+- Team collaboration requires paid plans
+- Limited language support compared to competitors
+- Works best with Zoom, other platforms feel secondary
+
+#### Pricing
+
+Free unlimited basic features. Premium plans start at $19/month for team features.
+
+### 9. Sonnet AI
+
+Sonnet AI is a bot-free AI meeting assistant that focuses on the complete meeting lifecycle—from pre-meeting participant research to automatic CRM updates after calls.
+
+<Image src="/api/assets/blog/fireflies-ai-alternatives/sonnet.webp" alt="Sonnet"/>
+
+#### How it compares to Fireflies
+
+Sonnet records device audio without visible meeting bots and emphasizes relationship management with automatic contact enrichment and conversation history tracking.
+
+#### Top features
+
+- Enhanced meeting preparation with participant research
+- Device-level audio capture without meeting bots
+- Automated CRM synchronization and data updates
+- Calendar integration with meeting context analysis
+- Tailored note templates for different meeting types
+- Relationship tracking over time with meeting insights
+
+#### Pros
+
+- Reduces post-meeting administrative work
+- Maintains natural meeting flow without disruptions
+- Combines preparation and recording in a single workflow
+
+#### Cons
+
+- Currently macOS only
+- Stores meeting data, including audio/video recordings on their servers
+- Limited customization options for note templates
+- Requires a stable internet connection for optimal performance
+
+#### Pricing
+
+Free plan with 5 recordings/month and a 30-minute recording limit. Paid plans start at $25/month.
+
+## Where I'd start
+
+If you like the idea of AI meeting notes but hate the idea of giving a vendor permanent leverage over your meeting data, start with Char.
+
+It drops the bot, keeps the notes as files, and lets you decide whether AI runs through your own keys, the managed cloud, or a local model. That is a more durable setup than hoping one SaaS company keeps its pricing, privacy posture, and product direction aligned with yours.
+
+[**Download Char for macOS**](/download) if that is the kind of system you would rather build on.
+
+<CtaCard/>

--- a/apps/web/content/articles/free-ai-notetakers.mdx
+++ b/apps/web/content/articles/free-ai-notetakers.mdx
@@ -1,0 +1,307 @@
+---
+meta_title: "9 Best Free AI Notetakers with Forever-Free Plans in 2026"
+meta_description: "Review of 9 genuinely free AI meeting assistants that provide transcription, summaries, and note-taking without expiration dates or payment pressure."
+author:
+  - "Harshika"
+coverImage: "/api/assets/blog/free-ai-notetakers/cover.png"
+featured: false
+category: "Comparisons"
+date: "2025-08-07"
+---
+
+This guide reviews the best free AI notetakers that provide AI meeting summaries, real-time transcription, and meeting intelligence with permanent free access - no trials, no payment, no features that disappear when you need them most.
+
+## How We Selected the Best Free AI Notetakers
+
+We evaluated each free AI notetaker based on:
+
+- **Permanent free access** -- No expiration dates or artificial limitations that force paid upgrades
+- **Core functionality** -- Transcription quality, summarization capabilities, and meeting intelligence
+- **Platform compatibility** -- Support for major video conferencing tools and in-person meetings
+- **Privacy and security** -- Data handling practices and compliance considerations
+- **User experience** -- Interface design, reliability, and ease of use
+
+**Note:** If you're interested in premium options or tools with free trials, check out our comprehensive guide on the [best AI meeting assistants for taking notes](/blog/best-ai-meeting-assistant-for-taking-notes) that covers all available options.
+
+## Top 9 Truly Free AI Notetakers for Meetings
+
+### 1. Char: Best for Local Processing and Data Control
+
+[Char](/) is an open-source AI notepad for meetings built for people who want complete control over their data and AI stack. It captures audio directly from your system, transcribes it in real-time, and combines your notes with the transcript to generate structured summaries, which are saved as plain Markdown files on your device.
+
+![Char](/api/assets/blog/free-ai-notetakers/free-1.webp)
+
+**Best for:**
+Anyone who wants enterprise-grade AI note-taking without vendor lock-in, cloud dependency, or data privacy compromises.
+
+#### What's Free Forever
+
+- Unlimited AI meeting summaries (most tools limit this heavily)
+- Real-time transcription with Whisper models
+- Connect your own AI models (OpenAI, Gemini, custom endpoints)
+- Conversational search across all meeting history
+- Customizable templates for any meeting type
+- Universal platform compatibility ([Zoom](/blog/best-ai-notetaker-for-zoom), Google Meet, Teams, In-person Meetings) without bots
+- Complete offline AI notetaker functionality
+- Open-source transparency with full code access
+- 45+ language support 
+
+#### When Will You Need to Pay?
+
+![Char pricing](/api/assets/blog/Screenshot-2026-03-04-at-9.01.49-PM.png)
+
+Char is free forever for local transcription, BYOK, and all core features. The managed cloud service ($25/month) adds the easiest setup without managing API keys. Enterprise is relevant when your organization needs on-premises deployment, SSO integration, or custom branding for compliance requirements.
+
+### 2. tl;dv: Best for Unlimited Recording
+
+[tl;dv](https://tldv.io) is a cloud-based AI meeting assistant that automatically joins your video calls to record, transcribe, and summarize conversations.
+
+It focuses heavily on video recording capabilities, creating shareable clips and reels from meetings, plus multi-meeting analytics to track trends across customer calls and team discussions.
+
+![tl;dv](/api/assets/blog/free-ai-notetakers/free-3.webp)
+
+**Best for:**
+Sales and customer success teams that want unlimited video recordings and transcriptions with AI-powered summaries.
+
+#### What's Free Forever
+
+- Unlimited meeting recordings and video storage
+- Real-time transcription in 30+ languages with speaker identification
+- 10 AI-generated meeting summaries (lifetime limit)
+- Timestamping and highlighting of key moments
+- Basic search functionality across transcripts
+- Integration with Zoom, Google Meet, and Microsoft Teams
+
+#### When Will You Need to Pay?
+
+![tldv pricing](/api/assets/blog/free-ai-notetakers/free-4.webp)
+
+ *Source*
+
+After 10 AI summaries (lifetime limit), you'll need the $29 Pro plan. This covers most regular users. The $98 Business tier adds coaching features, speaker insights, and API access, which is useful for sales teams focused on revenue operations.
+
+### 3. Fathom: Best for Small Teams
+
+[Fathom](https://www.fathom.ai) is an AI meeting assistant that automatically joins your meetings as a bot participant to record, transcribe, and generate instant summaries.
+
+It focuses on simplicity and ease of use, with a highlight feature that lets you bookmark important moments during meetings and jump directly to those sections later.
+
+![Fathom](/api/assets/blog/free-ai-notetakers/free-5.webp)
+
+**Best for:**
+Individual professionals and small teams who want reliable meeting transcription with instant summaries and CRM integration.
+
+#### What's Free Forever
+
+- Unlimited meeting recordings and video storage with no time limits
+- Real-time transcription in 28 languages with speaker identification
+- First 5 AI-generated summaries per month (then basic chronological summaries)
+- Highlight and bookmark feature for key meeting moments
+- Basic integration with Zoom, Google Meet, and Microsoft Teams
+- Instant access to fully transcribed recordings
+
+#### When Will You Need to Pay?
+
+![Fathom pricing](/api/assets/blog/free-ai-notetakers/free-6.webp)
+
+ *Source*
+
+After your first 5 AI summaries each month, the $19 Premium plan is necessary for regular meeting attendees. The $29 Team Edition adds shared meeting access, playlists, and global search. The $39 Team Pro works for sales teams needing CRM syncing and coaching analytics.
+
+### 4. Tactiq: Best for Chrome Users
+
+[Tactiq](https://tactiq.io) is a Chrome extension-based AI note taker that provides real-time transcription you can see during meetings, with no bots joining your calls.
+
+It emphasizes live note-taking with the ability to highlight, tag, and comment on transcripts as conversations happen, plus custom AI workflow automation.
+
+![Tactiq ai](/api/assets/blog/free-ai-notetakers/free-7.webp)
+
+**Best for:**
+Chrome users who want to see transcripts live during meetings and need customizable AI prompts for generating specific types of summaries.
+
+#### What's Free Forever
+
+- 10 meeting transcriptions per month with unlimited recording length
+- Real-time transcription in 30+ languages with speaker identification
+- 5 AI credits monthly for summaries, action items, and custom prompts
+- Live highlighting, tagging, and commenting during meetings
+- Screenshot capture and visual moment saving
+- Basic integrations with Google Meet, Zoom, and Microsoft Teams
+- Search functionality across all transcripts
+
+#### When Will You Need to Pay?
+
+![Tactiq pricing](/api/assets/blog/free-ai-notetakers/free-8.webp)
+
+ *Source*
+
+Most regular users reach the 10 monthly transcription limit quickly, requiring the $12 Pro plan. The $20 Team plan adds automatic transcript sharing and unlimited AI credits for summaries. The $40 Business tier is for mid-size companies (20+ users) needing SAML SSO and dedicated customer success support.
+
+Check out other [bot-free meeting assistants](/blog/bot-free-ai-meeting-assistants) like Tactiq.
+
+&nbsp;
+
+### 5. Fireflies.ai: Best for Team Analytics
+
+[Fireflies.ai](https://fireflies.ai) is a bot-based notetaker that automatically joins meetings to record, transcribe, and analyze conversations with a focus on conversation intelligence and team analytics.
+
+The "Fred" bot captures meetings and provides detailed speaker analytics, sentiment analysis, and topic tracking capabilities.
+
+![fireflies.ai](/api/assets/blog/free-ai-notetakers/free-9.webp)
+
+**Best for:**
+Teams and organizations that want comprehensive conversation analytics, speaker insights, and detailed team performance metrics alongside basic transcription and summaries.
+
+#### What's Free Forever
+
+- Unlimited transcription for meetings and audio files
+- Limited AI summaries with basic meeting insights
+- 800 minutes of storage per seat
+- Integration with Zoom, Google Meet, Microsoft Teams, and 20+ platforms
+- Transcription in 100+ languages with speaker identification
+- Real-time notes and live transcriptions
+- Meeting search functionality
+- AskFred AI assistant for querying meeting content
+- Upload and transcribe audio/video files
+- API access for developers
+
+#### When Will You Need to Pay?
+
+![Fireflies pricing](/api/assets/blog/free-ai-notetakers/free-10.webp)
+
+ *Source*
+
+You can use Fireflies.ai free indefinitely for basic transcription, but the $18 Pro plan becomes necessary when you hit the 800-minute storage limit or need to download recordings. The $29 Business plan adds conversation analytics, unlimited storage, and admin features. Enterprise applies to organizations requiring HIPAA compliance and dedicated account management.
+
+**Also check:** [Top Fireflies AI Alternatives](/blog/fireflies-ai-alternatives)
+
+### 6. Otter.ai: Best for Collaboration Features
+
+[Otter.ai](https://otter.ai) is an AI meeting assistant that automatically joins meetings as OtterPilot to record, transcribe, and summarize conversations in real-time.
+
+It emphasizes collaboration and team features, with strong integration capabilities across popular meeting platforms and productivity tools, plus AI chat functionality for querying meeting content.
+
+![otter ai](/api/assets/blog/free-ai-notetakers/free-11.webp)
+
+**Best for:**
+Individual professionals and small teams who want a well-established transcription service with solid collaboration features and don't mind the 300-minute monthly limit on the free plan.
+
+#### What's Free Forever
+
+- 300 monthly transcription minutes with a 30-minute limit per conversation
+- Real-time transcription and meeting summaries in English, French, and Spanish
+- 3 lifetime audio/video file imports for processing existing recordings
+- OtterPilot automatically joins Zoom, Microsoft Teams, and Google Meet
+- AI Chat functionality to query meeting content and collaborate with teammates
+- Basic sharing and collaboration features
+- Mobile and desktop app access
+
+#### When Will You Need to Pay?
+
+![Otter pricing](/api/assets/blog/free-ai-notetakers/free-12.webp)
+
+ *Source*
+
+The 300-minute monthly limit is hit quickly by regular users, making the $16.99 Pro plan necessary for 1,200 minutes and additional file imports. The $30 Business plan adds 6,000 minutes, concurrent meeting support, and team admin features. Enterprise is for large organizations requiring SSO, compliance controls, and OtterPilot for Sales integration.
+
+**Also check:** [Top Otter AI's Alternatives](/blog/otter-ai-alternatives)
+
+### 7. MeetGeek: Best for Automated Meeting Workflows
+
+[MeetGeek](https://meetgeek.ai/?r=0) is an AI meeting companion that offers automated meeting workflows, intelligent meeting type detection, custom workflow triggers, and automated content distribution to specific team members based on meeting context.
+
+![MeetGeek](/api/assets/blog/free-ai-notetakers/free-13.webp)
+
+**Best for:**
+Teams that want automated meeting workflows with smart templates that adapt to different meeting types, plus robust action item tracking and automated follow-up processes.
+
+#### What's Free Forever
+
+- 3 hours of transcription per month with a 2-hour limit per meeting
+- Unlimited AI meeting summaries with automatic meeting type detection
+- 3 months of transcript storage and 1 month of audio storage
+- Automatic action item detection and next steps extraction
+- Global search across meetings and meeting folders
+- File upload functionality and basic integrations
+- AI Chat for querying past meetings
+- Mobile apps and Chrome extension for offline recording
+
+#### When Will You Need to Pay?
+
+![Meetgeek pricing](/api/assets/blog/free-ai-notetakers/free-14.webp)
+
+ *Source*
+
+Regular meeting attendees may exceed 3 monthly hours of transcription, requiring the $19 Pro plan. The $39 Business plan adds 100 hours, unlimited storage, and collaborative features like comments. The $59 Enterprise tier is for organizations requiring custom speech models and private data storage for compliance.
+
+### 8. Notta: Best for Multi-Langual Transcription and Summaries
+
+[Notta](https://www.notta.ai/en) is an AI note taker that automatically joins meetings and generates AI-powered summaries with exceptional multi-language capabilities.
+
+Notta excels at creating meeting notes from diverse accents and multiple languages within the same conversation, unlike tools that primarily serve English-speaking teams.
+
+![notta ai](/api/assets/blog/free-ai-notetakers/free-15.webp)
+
+**Best for:**
+International teams, multilingual users, and professionals who need high-accuracy transcription with translation capabilities.
+
+#### What's Free Forever
+
+- 120 minutes of transcription per month (limited to 3 minutes per conversation)
+- 50 uploaded files per month for processing existing recordings
+- AI-generated meeting summaries and speaker identification
+- Support for all 58 languages and translation features
+- Integration with Zoom, Microsoft Teams, Google Meet, and Webex
+- Basic export options and sharing capabilities
+- Mobile and web app access with cross-device sync
+
+#### When Will You Need to Pay?
+
+![Notta pricing](/api/assets/blog/free-ai-notetakers/free-16.webp)
+
+ *Source*
+
+The 120 monthly minutes (3 minutes per conversation) means regular users need the $13.49 Pro plan, which provides 1,800 minutes and unlimited conversation length. The $27.99 Business plan adds collaborative editing, CRM integrations, and team workspace features. Enterprise applies to organizations requiring advanced security controls and dedicated support.
+
+### 9. Sonnet AI: Best for Automatic CRM Updates
+
+[Sonnet AI](https://www.sonnetai.com) is a bot-free AI meeting assistant that focuses on the complete meeting lifecycle—from pre-meeting participant research to automatic CRM updates after calls.
+
+It records device audio without visible meeting bots and emphasizes relationship management with automatic contact enrichment and conversation history tracking.
+
+![sonnet ai](/api/assets/blog/free-ai-notetakers/free-17.webp)
+
+**Best for:**
+Sales professionals who prioritize relationship management over just note-taking.
+
+#### What's Free Forever
+
+- 5 monthly meeting recordings with a 30-minute recording limit
+- 2-month storage for recordings and transcripts
+- 3 AI insight generations per meeting (summaries, action items)
+- Automated personal relationship tracker and CRM functionality
+- Pre-meeting participant background reports
+- Customizable note templates and automated follow-ups
+- Integration with Google Calendar and Microsoft Outlook
+
+#### When Will You Need to Pay?
+
+![Sonnet ai pricing](/api/assets/blog/free-ai-notetakers/free-18.webp)
+
+ *Source*
+
+Sales professionals typically exceed 5 monthly recordings quickly, requiring the $25 Plus plan. The $35 Pro plan adds 100 monthly recordings and unlimited storage for extensive client call history. Enterprise is necessary when your sales team needs custom integrations, team functionality, and dedicated account management for revenue operations.
+
+## Why Char May Be Your Best Choice
+
+These 9 tools offer genuine value without upfront costs—unlimited transcription from Fireflies, solid team features from Otter, multilingual support from Notta, and reliable recording from tl;dv.
+
+But there's a catch in every "free" offering: your privacy and data. Fireflies analyzes your conversation patterns. Fathom's bot joins sensitive client calls. Tactiq processes confidential discussions on remote servers. You're paying with access to your most private conversations.
+
+Char operates entirely on your device. No cloud processing, no data collection, no privacy trade-offs. It delivers unlimited AI summaries, real-time transcription, and meeting intelligence on your hardware.
+
+When "free" means no cost and no compromise, that's when you've found the right choice.
+
+[Download Char for macOS](/download) to experience meeting intelligence that costs nothing and compromises nothing (Windows and Linux versions coming in Q2 2026).
+
+&nbsp;

--- a/apps/web/content/articles/free-transcription-software.mdx
+++ b/apps/web/content/articles/free-transcription-software.mdx
@@ -1,0 +1,266 @@
+---
+meta_title: "Top 6 Truly Free Transcription Software in 2026"
+display_title: "Best Free Transcription Software in 2026"
+meta_description: "Find truly free transcription solutions in 2026 that offer real usability, privacy, and accuracy for all your speech-to-text needs. No surprises or limits."
+author:
+  - "Harshika"
+coverImage: "/api/assets/blog/free-transcription-software/cover.png"
+featured: false
+category: "Comparisons"
+date: "2025-10-08"
+---
+
+If you're looking for free transcription tools to automatically transcribe your meetings, video, or audio files, we've researched the options for you.
+
+Most "free" tools cap you at 30 minutes total, force upgrades after a trial period, or lock basic features behind paywalls.
+
+This guide reviews genuinely free transcription software that works without constant payment prompts.
+
+## Best free transcription software: quick comparison
+
+
+| Tool           | Best For                   | Transcription Type                       | Real-Time | Monthly Limit               | Export Formats           |
+| -------------- | -------------------------- | ---------------------------------------- | --------- | --------------------------- | ------------------------ |
+| Char           | Privacy & unlimited use    | Meeting + live video/audio transcription | ✅ Yes     | Unlimited                   | MD, PDF, RTF             |
+| Transcript LOL | Multi-source imports       | Files + URL imports                      | ❌ No      | 2 files daily (20 min each) | TXT, DOCX, PDF, SRT, VTT |
+| Riverside      | Unlimited no-signup tool   | Files only                               | ❌ No      | Unlimited                   | TXT, SRT                 |
+| Otter AI       | Meeting bot automation     | Meeting bot + files                      | ✅ Yes     | 300 min (30 min/recording)  | MP3, TXT (PDF/DOCX paid) |
+| Notta          | Multi-language translation | Meeting bot + files                      | ✅ Yes     | 120 min (3 min/recording)   | TXT (others paid)        |
+| MacWhisper     | Simple Mac transcription   | Files only                               | ❌ No      | Unlimited                   | TXT, SRT, VTT            |
+
+
+## How we chose these tools
+
+We evaluated dozens of transcription tools using these criteria:
+
+- **Automatic transcription only**: Manual transcription assistants help you type faster while listening to audio, but don't transcribe automatically. This guide focuses on software that actually transcribes for you.
+- **Genuine free access**: We prioritized tools with permanent free plans, not trials disguised as "free" offerings.
+- **Usable limitations**: Many "free" tools impose restrictions that make them unusable—10-minute one-time trials or 3-minute recording limits. We focused on tools where the free tier actually works for real-world use.
+- **Transcription quality**: All selected tools use modern AI models (primarily OpenAI's Whisper) that deliver genuine accuracy.
+- **Privacy and data handling**: We noted whether tools process locally or in the cloud, and whether your data gets used for AI training.
+- **No hidden costs**: We clearly documented where free plans end and paid features begin.
+
+## Popular transcription tools we didn't include (and why)
+
+### 1. oTranscribe
+
+[oTranscribe](https://otranscribe.com) is a manual transcription assistant. You still type everything yourself; they just provide keyboard shortcuts and audio playback controls.
+
+**Consider for**: Academic research or journalism, where you need complete control over every word transcribed.
+
+### 2. Rev
+
+[Rev](https://www.rev.com) only offers 45 minutes of AI transcription per month on the free plan, which most regular users exhaust within days.
+
+**Consider for**: The hybrid model offering both AI transcription and the option to upgrade to 99% accurate human transcription for critical documents.
+
+### 3. Sonix
+
+[Sonix](https://sonix.ai) only offers a 30-minute one-time trial with no ongoing free plan. After that, you must pay $10/hour for transcription.
+
+**Consider for**: Multi-language support across 53+ languages and team collaboration features with shared folders.
+
+### 4. Trint
+
+[Trint](https://trint.com) provides a 7-day free trial (up to 3 files) with no ongoing free tier. Plans start at $80/month.
+
+**Consider for**: Newsrooms and media professionals who need fast turnaround times and collaborative editing workflows.
+
+### 5. Happy Scribe
+
+[Happy Scribe](https://www.happyscribe.com) offers only 10 minutes of transcription total (one-time, not monthly) and doesn't allow file exports on the free tier.
+
+**Consider for**: Subtitle creation with support for 120+ languages and automated translation capabilities.
+
+You can check detailed reviews of these tools in our guide to [best transcription software for Mac](/blog/transcription-software-mac).
+
+## Best free transcription software: detailed reviews
+
+### 1. Char: best for local processing and unlimited transcription
+
+![Char](/api/assets/blog/free-transcription-software/transcription-1.webp)
+
+[Char](/) is an open-source AI notepad for meetings that gives you complete control over your data and AI stack. Everything is stored as plain markdown files—not in proprietary databases. You choose your AI: managed cloud, BYOK, or run local models.
+
+Zero lock-in means you can switch AI providers anytime and your files work with any tool (Obsidian, Notion, VS Code).
+
+#### What's free forever
+
+- Unlimited transcription with no monthly caps or per-minute charges
+- Real-time transcription using Whisper models (Tiny, Base, V3 Large Turbo)
+- Conversational search across all transcription history
+- Custom vocabulary support for industry-specific terminology
+- Universal platform compatibility without bots
+- Works completely offline for maximum privacy
+- Export as Markdown, PDF, or Rich Text
+- Open-source transparency with full code access
+- Connect your own AI models (OpenAI, Gemini, Ollama via LM Studio)
+
+#### When will you need to pay?
+
+![Char pricing](/api/assets/blog/Screenshot-2026-03-04-at-9.01.49-PM.png)
+
+Free forever for local transcription, BYOK, and all core features. The managed cloud service ($25/month) adds the easiest setup without managing API keys.
+
+Enterprise licensing is available when your organization needs on-premises deployment, SSO integration, consent management, or custom branding. [Contact sales for a quote](/founders).
+
+&nbsp;
+
+### 2. Transcript.LOL: best for multi-source imports
+
+![is transcript lol free](/api/assets/blog/free-transcription-software/transcription-3.webp)
+
+Transcript.LOL is a cloud-based transcription platform powered by OpenAI's Whisper that converts audio and video files into text across 100+ languages.
+
+The platform handles imports directly from Google Drive, Dropbox, YouTube, and Zoom, so you can transcribe content without downloading files first. You can also transcribe audio from WhatsApp or Telegram messages directly through integrations.
+
+The daily allocation model provides 2 transcripts per day (up to 20 minutes each) rather than a monthly bucket that disappears quickly. For podcasters processing a few episodes weekly or professionals with regular but moderate transcription needs, this daily reset provides consistent access.
+
+#### What's free forever
+
+- 2 transcripts daily (up to 20 minutes each)
+- 99.8% accuracy with OpenAI Whisper
+- Speaker detection and recognition
+- Import from Google Drive, Dropbox, YouTube, Zoom, URLs
+- Basic editing tools (find & replace, speaker assignment, highlighting)
+- Export as TXT, DOCX, PDF, SRT, VTT
+- Chrome extension, WhatsApp, and Telegram integrations
+- Low priority processing (slower turnaround)
+
+#### When will you need to pay?
+
+![transcript lol pricing](/api/assets/blog/free-transcription-software/transcription-4.webp)
+
+The $20/month Unlimited plan is necessary when you exceed 2 daily transcripts, need files longer than 20 minutes, want AI summaries and custom prompts, require chatbot features for querying transcripts, or need high-priority faster processing.
+
+The $40/month Team plan adds shared workspaces for collaboration, multiple user accounts under one subscription, and team access management.
+
+### 3. Riverside: best for no-signup transcription
+
+![riverside free transcription](/api/assets/blog/free-transcription-software/transcription-5.webp)
+
+While Riverside is primarily known as a podcast and video recording platform, their [standalone transcription tool](https://riverside.com/transcription) works as a simple web utility that converts any audio or video file to text.
+
+The tool uses OpenAI's Whisper model and handles files up to 5GB across 100+ languages. Upload your file, wait a few minutes (a 50-minute file processes in roughly 5 minutes), and download your transcript as plain text or SRT format for video captions.
+
+#### What's free forever
+
+- Unlimited transcriptions with no signup required
+- 99% accuracy using OpenAI Whisper
+- Supports 100+ languages and accents
+- Files up to 5GB (approximately 50+ minutes)
+- Real-time processing (transcribes while you wait)
+- Download as TXT or SRT (caption format)
+- Timestamps included in transcript
+- Works with MP3, WAV, MP4, MOV formats
+
+#### When will you need to pay?
+
+![riverside pricing](/api/assets/blog/free-transcription-software/transcription-6.webp)
+
+Riverside's paid platform ($19/month Standard or $29/month Pro) adds speaker detection and labeling, in-tool transcript editing with audio playback sync, AI-powered Magic Clips for social media, automated show notes generation, text-based video editing, and professional recording features with 4K video and separate audio tracks.
+
+The free transcription tool handles basic text conversion. Serious content creators will outgrow its limitations and upgrade for editing workflow integration.
+
+### 4. Otter.ai: best for meeting bot integration
+
+![otter ai transcription review](/api/assets/blog/free-transcription-software/transcription-7.webp)
+
+Otter.ai is a meeting assistant similar to Char. It transcribes conversations, generates summaries, and helps you search through meeting history. The key difference is that Char processes everything locally on your device, while Otter sends all your audio to the cloud for processing.
+
+The cloud approach enables Otter's signature feature: the meeting bot that automatically joins your Zoom, Microsoft Teams, and Google Meet calls based on your calendar, records everything, and shares notes with participants afterward.
+
+**Also read**: [Otter AI Review](/blog/otter-ai-review)
+
+#### What's free forever
+
+- 300 transcription minutes per month (resets monthly)
+- 30-minute max per conversation
+- Live transcription in English, Spanish, or French
+- Automatic meeting bot joins Zoom, Teams, Google Meet
+- Speaker identification and AI summaries
+- 20 AI Chat queries per month (3 per conversation)
+- iOS and Android apps
+- Search by keywords and basic playback
+- Export as MP3 or TXT only (no PDF, DOCX, or SRT on free)
+- 25 most recent conversations stored (older ones deleted)
+
+#### When will you need to pay?
+
+![otter ai pricing](/api/assets/blog/free-transcription-software/transcription-8.webp)
+
+The $16.99/month Pro plan becomes necessary when you exceed 300 minutes, need 90-minute conversations instead of 30, want 1,200 monthly minutes, require PDF/DOCX/SRT exports, need unlimited conversation history, or want advanced search and custom vocabulary features.
+
+The $30/month Business plan adds 6,000 minutes per user, 4-hour meeting support, unlimited file imports, concurrent meeting joining, usage analytics, and prioritized support.
+
+Enterprise is relevant for organizations requiring SSO, HIPAA compliance, domain capture, custom CRM integrations, video replay features, or dedicated customer success management.
+
+### 5. Notta: best for multi-language transcription
+
+![Notta transcription review](/api/assets/blog/free-transcription-software/transcription-9.webp)
+
+[Notta](https://www.notta.ai/en) is a cloud-based transcription platform that handles 58 languages with claimed 98% accuracy.
+
+Similar to Otter.ai, Notta automatically joins your Zoom, Google Meet, Microsoft Teams, and Webex meetings to transcribe conversations in real-time. The platform also accepts file uploads from YouTube, Google Drive, and Dropbox.
+
+#### What's free forever
+
+- 120 transcription minutes per month (resets monthly)
+- 3-minute maximum per recording (severely limiting)
+- 50 file uploads per month
+- 10 AI summaries per month
+- Live transcription for Zoom, Google Meet, Teams, Webex
+- Speaker identification
+- Chrome extension, web app, iOS and Android apps
+- Basic editing and playback features
+- Export as TXT only (no PDF, DOCX, or SRT on free)
+- Cross-device sync
+
+#### When will you need to pay?
+
+![notta pricing](/api/assets/blog/free-transcription-software/transcription-10.webp)
+
+The 3-minute recording limit makes the free plan nearly useless for actual meeting transcription. The $13.49/month Pro plan is necessary immediately, providing 1,800 minutes monthly, up to 5 hours per recording, 100 file uploads, 100 AI summaries, transcript translation, custom vocabulary, and exports in multiple formats (TXT, PDF, DOCX, SRT, XLSX).
+
+The $27.99/month Business plan adds unlimited transcription, video recording for web meetings, CRM integrations with Salesforce and HubSpot, Zapier automation, usage analytics, and collaborative workspace features.
+
+Enterprise becomes relevant for organizations requiring SAML SSO, audit logs, no AI training on your data, flexible payment options, priority support, and customized transcription quotas.
+
+### 6. MacWhisper: best for simple Mac transcription
+
+![mac whisper review](/api/assets/blog/free-transcription-software/transcription-11.webp)
+
+[MacWhisper](https://goodsnooze.gumroad.com/l/macwhisper) is a Mac app that wraps OpenAI's Whisper technology in a simple drag-and-drop interface.
+
+While tools like Char use Whisper as part of a complete meeting assistant, MacWhisper focuses purely on transcription. You drop in an audio file, it gives you text. The interface is minimal: drag your file, select a model size based on how much accuracy versus speed you want, and get your transcript with synced audio playback.
+
+Performance depends heavily on your hardware. Apple Silicon Macs (M1/M2/M3) handle transcription smoothly, processing files at roughly 15x real-time speed. Older Intel Macs work but run significantly slower, especially with larger models that require more than 8GB of RAM.
+
+#### What's free forever
+
+- Unlimited transcriptions with no usage caps
+- Three Whisper models: Tiny (fastest), Base (balanced), Small (more accurate)
+- Plain markdown files, zero lock-in, your choice of AI stack
+- Drag-and-drop interface for audio files
+- Supports 100+ languages with automatic detection
+- Audio playback synced to transcript
+- Search and highlight keywords in transcripts
+- Export as SRT, VTT, TXT, or copy to clipboard
+- Supports MP3, WAV, M4A, MP4, MOV, OGG, OPUS formats
+- Works completely offline once installed
+
+#### When will you need to pay?
+
+![Mac whisper pricing](/api/assets/blog/free-transcription-software/transcription-12.webp)
+
+MacWhisper Pro ($29-35 one-time payment, no subscription) unlocks better accuracy with Medium, Large, Large-V2, or Large-V3 models, batch transcription to process multiple files simultaneously, speaker identification for multi-person conversations, system audio recording to transcribe Zoom or Teams meetings directly, and advanced exports including Word, PDF, and HTML formats.
+
+## Our top recommendation for free transcription
+
+If data privacy matters and you need truly unlimited transcription without hidden costs, Char is the clear choice.
+
+Unlike most transcription tools that lock you into their cloud, Char stores everything as plain markdown files and lets you choose your AI stack. Zero lock-in, complete control.
+
+Ready to take control of your transcription data? **[Download Char for macOS](/download)** and get unlimited private transcription (Windows and Linux versions coming in Q2 2026).
+
+<CtaCard/>

--- a/apps/web/content/articles/google-gemini-data-retention-policy.mdx
+++ b/apps/web/content/articles/google-gemini-data-retention-policy.mdx
@@ -1,0 +1,106 @@
+---
+meta_title: "Everything You Should Know About Google Gemini Data Retention Policy"
+meta_description: "Gemini doesn't just store your AI conversations. It can connect them to your Gmail, Calendar, and location history. Here's exactly what Google keeps and how to control it."
+author:
+  - "Harshika"
+featured: false
+category: "Guides"
+date: "2026-03-13"
+---
+
+Every AI provider in this series stores your conversations to some degree. Google Gemini does that too. But Gemini sits inside an ecosystem that already holds your email, your calendar, your location history, and your search activity. That changes the risk profile entirely.
+
+When you evaluate [OpenAI](/blog/chatgpt-data-retention-policy/) or Anthropic, you're asking what they do with your AI conversations. When you evaluate Google, you're asking what they do with your AI conversations and everything else they already know about you.
+
+Here is the full picture.
+
+## Quick Reference: Gemini Data Retention by Tier
+
+
+| Feature           | Consumer Gemini    | Gemini API                      | Workspace Enterprise |
+| ----------------- | ------------------ | ------------------------------- | -------------------- |
+| Default Retention | 18 months          | 55 days (abuse monitoring only) | Admin-defined        |
+| Human Review      | Yes, up to 3 years | No                              | No (by default)      |
+| Model Training    | Yes (opt-out)      | No                              | No                   |
+| Gmail Access      | Default ON in US   | No                              | Admin-controlled     |
+
+
+## What Gemini Stores by Default?
+
+For consumer accounts, Google stores your Gemini conversations in your Google Account with a default retention period of 18 months. You can change this to 3 months or 36 months in your settings, but 18 months is what you get if you never touch it.
+
+There is a floor on this. Even if you turn off Gemini Apps Activity entirely, Google still retains your conversations for up to 72 hours to operate the service. There is no configuration that gives you zero retention on the Google consumer product.
+
+Here is the part that catches most people off guard: if Google's human reviewers look at one of your conversations, that conversation is retained for up to 3 years, disconnected from your Google Account. Deleting your Gemini activity does not remove those reviewed conversations. They persist regardless.
+
+Google says it tries to anonymize or disconnect reviewed chats before humans see them. But if you typed personal information directly into the conversation, that information is part of the message and visible to the reviewer.
+
+## The Gmail Access Story
+
+In late 2025, Google enabled Gemini access to Gmail, Google Chat, and Google Meet by default for US users. By early 2026, Google rebranded this cross-app data flow under the name "Personal Intelligence," which now manages how Gemini connects to Gmail, Drive, Maps, and other Google services. When enabled, Gemini can read your entire email history to power features like email summarization, draft suggestions, and surfacing relevant information across your inbox.
+
+In the US, this was opt-out. You had to actively turn it off. In Europe, the same feature required an opt-in before Gemini could access your Gmail, because GDPR places stricter requirements on default data sharing.
+
+Malwarebytes reported that the integration was enabled without prominent notification, and Snopes documented the subsequent confusion around what Gemini could actually access. The case Thele v. Google LLC, filed in the Northern District of California, alleges a violation of the California Invasion of Privacy Act (CIPA). The argument is that Google used the existing "Smart Features" toggle as a backdoor to enable Gemini's deeper data access without a clear second consent prompt. As of March 2026, the case is in the discovery phase.
+
+Google's position is that this data is used only to power features for individual users, not to train its public AI models. That is a meaningful distinction. But for anyone evaluating Gemini as a provider for sensitive work, the default-on access to your full email history is worth knowing about upfront.
+
+## How to Control Your Data?
+
+To turn off training and human review: myaccount.google.com → Data and Privacy → Gemini Apps Activity → Turn off.
+
+With activity off, future conversations will not be sent for human review and will not be used to train Google's AI models. The 72-hour operational retention still applies.
+
+To control Gmail and cross-app access: as of early 2026, Google groups these permissions under a Personal Intelligence dashboard inside the Gemini interface. This is the central place to control which Google services Gemini can read across Gmail, Drive, Maps, and Calendar. You can also disable Gmail access specifically via Gmail Settings → See all settings → General → Gemini for Gmail without affecting the rest of your account.
+
+To adjust the default 18-month retention: open Gemini Apps Activity in your Google Account, select "Auto-delete," and choose your preferred window.
+
+## Human Review in Plain Terms
+
+Google's [Gemini Apps Privacy Hub](https://support.google.com/gemini/answer/13594961) states that trained human reviewers check conversations to evaluate whether responses are low quality, inaccurate, or harmful. This is standard practice across AI providers, but Google's retention policy for reviewed conversations is notably long at 3 years.
+
+This means that in practice, a conversation you have today could be read by a human reviewer and retained until 2029, even if you delete it tomorrow.
+
+One area that often gets overlooked: if you use Gems, which are custom versions of Gemini configured with specific instructions and uploaded knowledge files, that configuration data carries the same 3-year human review risk as your regular conversations, as long as Gemini Apps Activity is turned on.
+
+Google advises users not to enter confidential information they would not want a reviewer to see. That is practical advice, but it places the compliance burden squarely on users rather than on the product design.
+
+## How the API Is Different?
+
+If you use the Gemini API directly rather than the consumer product, the data policy is different. Google retains API inputs and outputs for up to 55 days for abuse monitoring. This data is not used for model training.
+
+Two newer API features add nuance here. The first is Context Caching: users can store large amounts of data on Google's servers to reduce token costs when making repeated calls against the same content. This cached data has its own TTL (Time-to-Live) setting that you control, and it sits outside the standard 55-day abuse monitoring window. It is a flexible feature, but it means you may have data on Google's servers for longer than the default if you use it.
+
+The second is Session Resumption for the Gemini Live API. If you use this to keep a voice session active across interruptions, Google caches that session data in memory for up to 24 hours. That is a separate and shorter window from the 55-day abuse logs, but it is worth knowing if you are using the voice API for sensitive conversations.
+
+For Vertex AI on Google Cloud, Google offers a Zero Data Retention option on certain endpoints. Under ZDR, prompts and responses are not logged or stored beyond what is needed to return the result.
+
+The API does not carry the same Gmail integration or Gemini Apps Activity settings as the consumer product. If you access Gemini through an API key, your data stays within the API policy.
+
+## How Retention Works for Workspace and Enterprise Plans
+
+For Google Workspace Enterprise customers, the rules are more protective. Prompt content is not used to train Google's public AI models without explicit permission. Human review of your conversations does not happen without your organization's consent. Workspace admins can shorten or fully disable prompt storage for their domain.
+
+On HIPAA: as of September 30, 2025, [Gemini for Workspace is included](https://workspace.google.com/terms/user_features.html) under Google's HIPAA Business Associate Addendum. As of Q1 2026, this is fully stable and has been widely adopted by healthcare organizations. You need a signed BAA and the appropriate project flags enabled through the Admin Console. The free consumer version is not covered and should not be used with protected health information.
+
+On GDPR: Google offers a Data Processing Addendum for Workspace customers. Consumer accounts are subject to Google's standard privacy policy. EU consumer users have GDPR rights including access and deletion, but those rights do not remove reviewed conversations from Google's systems during the 3-year retention window.
+
+## The Broader Context
+
+OpenAI and [Anthropic](/blog/anthropic-data-retention-policy/) each had a single data retention policy story to tell. Google's story is more layered because of how deeply Gemini integrates with the rest of their products.
+
+The consumer product connects to Gmail, Calendar, Drive, and location data. The retention periods are longer by default than either OpenAI or Anthropic. The human review window is the longest of the three. And in the US, the Gmail integration was enabled without asking users first.
+
+For personal productivity use, most of this will not matter day to day. For professionals handling sensitive conversations, client data, or regulated information, the picture is more complicated.
+
+## Use Gemini's API for Meeting Notes Through Char
+
+If you want to use Gemini without routing data through the consumer product, connecting your own Google AI API key through [Char](https://char.com) gives you API-level data handling: 55-day retention, no model training, no Gmail integration.
+
+Char is an open-source AI notepad for meetings that lets you bring your own API key for Gemini, OpenAI, Anthropic, Mistral, or others. Your meeting notes are stored on your device. You choose which AI provider processes your data, and you can change that decision without rebuilding your workflow.
+
+For teams that need to go further, Char supports fully local models via Ollama. Your conversations never leave your device at all.
+
+That is the practical difference between using a consumer AI product and choosing your own stack. The first gives you a privacy policy. The second gives you control.
+
+[Download Char for macOS](https://char.com/download/apple-silicon) and use the AI provider your security team actually trusts.

--- a/apps/web/content/articles/google-gemini-data-retention-policy.mdx
+++ b/apps/web/content/articles/google-gemini-data-retention-policy.mdx
@@ -95,7 +95,7 @@ For personal productivity use, most of this will not matter day to day. For prof
 
 ## Use Gemini's API for Meeting Notes Through Char
 
-If you want to use Gemini without routing data through the consumer product, connecting your own Google AI API key through [Char](https://char.com) gives you API-level data handling: 55-day retention, no model training, no Gmail integration.
+If you want to use Gemini without routing data through the consumer product, connecting your own Google AI API key through [Char](https://anarlog.so) gives you API-level data handling: 55-day retention, no model training, no Gmail integration.
 
 Char is an open-source AI notepad for meetings that lets you bring your own API key for Gemini, OpenAI, Anthropic, Mistral, or others. Your meeting notes are stored on your device. You choose which AI provider processes your data, and you can change that decision without rebuilding your workflow.
 
@@ -103,4 +103,4 @@ For teams that need to go further, Char supports fully local models via Ollama. 
 
 That is the practical difference between using a consumer AI product and choosing your own stack. The first gives you a privacy policy. The second gives you control.
 
-[Download Char for macOS](https://char.com/download/apple-silicon) and use the AI provider your security team actually trusts.
+[Download Char for macOS](https://anarlog.so/download/apple-silicon) and use the AI provider your security team actually trusts.

--- a/apps/web/content/articles/google-gemini-meeting-notes.mdx
+++ b/apps/web/content/articles/google-gemini-meeting-notes.mdx
@@ -1,0 +1,161 @@
+---
+meta_title: "I Tested Google Gemini Meeting Notes So You Don't Have To"
+meta_description: "Can Google Gemini take meeting notes? Yes, but only in Google Meet with paid plans. If you use Teams or Zoom, then you'll need workarounds. Know more."
+author:
+  - "John Jeong"
+coverImage: "/api/assets/blog/google-gemini-meeting-notes/cover.png"
+featured: false
+category: "Comparisons"
+date: "2025-09-24"
+---
+
+If you've come to rely on Gemini for day-to-day admin tasks, you're probably wondering whether it can handle meeting notes. It can, but there are significant limitations.
+
+## Can Google Gemini take meeting notes?
+
+Gemini, the AI assistant you're familiar with, doesn't join your meetings like other [AI notetakers](/blog/best-ai-meeting-assistant-for-taking-notes). There's no "Gemini bot" that automatically hops into your Zoom calls or Teams meetings.
+
+Google has built "Take notes with Gemini" into Google Meet instead. It's part of their premium Google Workspace offering and works differently from the regular Gemini you use for other tasks.
+
+When you use this feature, Gemini listens to your Google Meet conversations and creates structured notes in real-time. It shows running summaries during the call and generates a polished document afterward with key points, decisions, and action items.
+
+The catch: it only works with Google Meet. If your team uses Zoom, Teams, or any other meeting platform, you won't be able to use the built-in solution.
+
+## How to use Google Gemini to take meeting notes
+
+The approach depends on whether you're using Google's ecosystem or need to work with other meeting platforms.
+
+### 1. If you're on a Google Meet call
+
+If your organization uses Google Workspace and hosts Google Meet calls, the process is straightforward.
+
+&nbsp;
+
+**During the meeting:**
+
+- Gemini listens to the entire conversation
+- Creates real-time summaries as the meeting progresses
+- Shows you "Summary so far" that updates throughout the call
+- Organizes everything in a structured Google Doc
+
+**After the meeting:**
+
+- Automatically generates a complete meeting summary
+- Creates suggested next steps and action items
+- Saves everything to the meeting organizer's Google Drive
+- Attaches the notes doc to your Calendar event
+- Emails a summary to the host and co-hosts
+
+**Prerequisites:**
+
+- Google Workspace Business Standard or higher ($12/user/month minimum)
+- Meeting in one of nine supported languages: English, French, German, Italian, Japanese, Korean, Portuguese, or Spanish
+- Sufficient storage space in your Google Drive
+- Desktop access only—no mobile support
+
+### 2. The manual approach (for everything else)
+
+![Gemini](/api/assets/blog/google-gemini-meeting-notes/gemini-1.webp)
+
+For people using Zoom, Teams, or other platforms, you'll need a hands-on approach. Get the transcript from your meeting platform, paste it into Gemini, and ask for summarization.
+
+Zoom includes cloud recording with transcription on paid plans. Teams automatically transcribes when you record. Once you have that text, feed it to Gemini.
+
+💡 Try this prompt:
+"Please summarize this meeting transcript. Include key decisions, action items, and next steps. Format it professionally with clear sections for main topics discussed, decisions made, and follow-up tasks assigned."
+
+Gemini does excel at taking messy transcripts and turning them into clean, organized notes. This approach requires more work than the automated Google Meet solution, and it won't give you real-time transcription.
+
+## What are the pros and cons of using Gemini to take meeting notes?
+
+### The good stuff
+
+**It produces strong summaries.** When Gemini works, it catches key decisions, identifies action items, and organizes everything in a clean format you can actually use.
+
+**Real-time summaries help during calls.** The "Summary so far" feature during Google Meet is handy if you want to glance over and check what you might have missed without interrupting the conversation.
+
+**It integrates with your existing tools.** Notes automatically attach to your calendar events and save to your Drive with no extra steps.
+
+### The not-so-good stuff
+
+**Subscription costs are steep.** Google Workspace plans with this feature run $12-18 per user per month. A 20-person company pays $2,880-4,320 annually just to take meeting notes.
+
+**Privacy concerns matter.** Every word spoken gets uploaded to Google's servers. That works fine for internal team meetings, but client consultations, legal discussions, or healthcare conversations pose real risk. Many organizations can't justify it.
+
+**Manual workflows defeat the purpose.** For non-Google Meet platforms, you download transcripts, copy text, craft prompts, and organize results yourself. You're doing the AI's job.
+
+&nbsp;
+
+### Should you use it?
+
+After testing Google Gemini meeting notes extensively, it works well only if you meet three specific criteria:
+
+- Your entire organization uses Google Meet exclusively
+- You're comfortable with Google processing sensitive conversations
+- You're already paying for expensive Workspace subscriptions
+
+Most teams don't meet all three. You'll likely find yourself working around limitations rather than benefiting from the automation.
+
+## What is the best alternative to Gemini for note-taking?
+
+The list of alternatives is substantial—any decent AI meeting assistant does a better job. We have guides for [Google Meet](/blog/best-ai-notetakers-google-meet), [Zoom](/blog/best-ai-notetaker-for-zoom), and [Microsoft Teams](/blog/best-ai-notetaker-for-microsoft-teams).
+
+If I have to recommend one platform that works universally, is free, and keeps your data local, it's Char.
+
+Quick note: I'm the co-founder of Char, but my recommendation isn't just personal bias—the platform delivers results.
+
+Here's what it does:
+
+- Real-time transcription with no bots or calendar permissions required
+- Works with Zoom, Teams, Google Meet, and in-person meetings without any setup
+- Your choice of AI: managed cloud, bring your own API keys (OpenAI, Anthropic, Mistral, and others), or run local models via Ollama or LM Studio
+- Smart consent management for enterprises with options from simple pop-ups to verbal consent recognition
+- Saves your notes as plain markdown files that work with Obsidian, Notion, VS Code, or any text editor
+
+Char's note-taking features specifically:
+
+![Char](/api/assets/blog/google-gemini-meeting-notes/gemini-2.webp)
+
+- **Familiar interface.** Feels like Apple Notes with powerful AI running locally.
+- **Custom templates.** Tailored formats for therapy sessions, legal meetings, job interviews, or casual conversations.
+- **Search your meeting history naturally.** Ask "What did Sarah say about the budget?" instead of scrolling through months of notes.
+- **AI chat for clarification.** Get immediate answers about action items, deadlines, or who said what.
+- **Verify with source analysis.** Hover over summaries to see the exact transcript quote behind every AI-generated point.
+
+The difference is substantial. Instead of hoping Google's limited solution works with your workflow, you get a tool that adapts to how your team actually meets.
+
+Want to try Char? [Download it for free](/download)!
+
+## Frequently asked questions
+
+### 1. Can Google Gemini transcribe audio files?
+
+Yes, you can upload audio files directly to Gemini and ask it to transcribe them. This works for recorded meetings, interviews, or voice memos, but your audio goes to Google's servers.
+
+### 2. Can Gemini generate meeting notes?
+
+Absolutely. Gemini works well when you give it transcripts and ask for structured notes. The key is writing prompts that specify what sections and format you want.
+
+### 3. Is Gemini note taker free?
+
+The basic Gemini chatbot has free and paid versions, but automatic meeting note-taking requires Google Workspace Business subscriptions starting at $12/user/month.
+
+### 4. How do I transcribe Google Meet calls?
+
+You have two main options: Google Meet's built-in transcription (which requires expensive Workspace subscriptions) or a third-party tool like Char.
+
+Unlike cloud-based tools like Otter or Fireflies that send your conversations to their servers, Char provides unlimited real-time transcription completely free while keeping everything local on your device.
+
+### 5. Does Google Meet transcription work in all languages?
+
+No. Google Meet only supports transcription in 9 languages: English, French, German, Italian, Japanese, Korean, Portuguese, and Spanish. You can only use one language per meeting.
+
+### 6. Is there a free AI note taker for Google Meet?
+
+Yes—Char is a completely [free AI note taker](/blog/free-ai-notetakers) that works with Google Meet, Zoom, Teams, and any other meeting platform.
+
+Unlike Google's "Take notes with Gemini" feature, which requires expensive Workspace subscriptions, Char's core transcription and note-taking features are free forever.
+
+Your conversations stay private since everything processes locally on your device instead of being sent to the cloud.
+
+&nbsp;

--- a/apps/web/content/articles/granola-ai-alternatives.mdx
+++ b/apps/web/content/articles/granola-ai-alternatives.mdx
@@ -1,0 +1,276 @@
+---
+meta_title: "6 Best Granola AI Alternatives in 2026"
+meta_description: "Looking for Granola AI alternatives? Compare top meeting assistants with better privacy, platform support, integrations & pricing."
+author: "John Jeong"
+coverImage: "/api/assets/blog/granola-ai-alternatives/cover.png"
+category: "Comparisons"
+date: "2025-08-15"
+---
+
+Granola gets one thing very right: it makes AI notes feel like note-taking, not like operating a meeting bot.
+
+That is why people try it. It is also why the trade-offs become obvious fast. You are still tied to their stack, their platform support, and their decisions about where your meeting data goes.
+
+This list is for people who like the notepad-first workflow but want a better trade-off on privacy, portability, integrations, or platform coverage.
+
+> 💡 **Before we proceed:** You might want to check out our comparison of the [best bot-free AI meeting assistants](/blog/bot-free-ai-meeting-assistants) like Granola.
+
+## Our Top Picks
+
+1. **Char:** Open-source AI notepad with zero lock-in and complete control over your data and AI stack
+2. **Jamie AI:** GDPR-compliant European alternative with 100+ language support
+3. **Tactiq:** Chrome extension with real-time transcription and rich integrations
+4. **Krisp:** Audio enhancement specialist with noise cancellation and accent conversion
+5. **Sonnet AI:** CRM automation expert for sales teams
+6. **tl;dv:** Video-first platform with advanced sales coaching
+
+## How We Selected the Best Granola AI Alternatives
+
+We did not treat this like a generic feature checklist. Granola already does a few things well: the interface is simple, it stays out of the participant list, and it works for people who still want to type during meetings.
+
+So we looked for alternatives that break from Granola in useful ways, not just tools with longer feature pages.
+
+### 1. Privacy & Data Control
+
+Granola processes meeting data through external AI providers with limited privacy controls. We looked at tools that keep data local or provide stronger privacy protections.
+
+<Image src="/api/assets/blog/granola-ai-alternatives/granola-1.webp" alt="Granola Data Processing"/>
+Source: [Granola's Data Processing Addendum](https://help.granola.ai/article/data-processing-addendum#5-security-of-personal-data)
+
+### 2. Platform Compatibility
+
+Granola currently supports Mac only and lacks mobile apps, which restricts usage on other devices or while traveling.
+
+### 3. Integration Limitations
+
+Granola doesn't integrate with popular workplace tools like Asana, ClickUp, or Zapier, which limits its usefulness for teams wanting to share notes automatically. We focused on tools with robust third-party integrations beyond basic calendar sync.
+
+<Image src="/api/assets/blog/granola-ai-alternatives/granola-2.webp" alt="G2 Review Screenshot"/>
+Source: [G2](https://www.g2.com/products/granola/reviews/granola-review-10322423)
+
+### 4. Missing Advanced Features
+
+Granola doesn't record video or allow access to audio recordings, making it less suitable for hiring interviews or user research.
+
+### 5. Value & Pricing Concerns
+
+Granola's $18/month individual plan and limited free tier prompted us to look for alternatives offering better features-to-price ratios or more generous free plans for teams and individuals.
+
+> 💡 If budget is a concern, explore our guide to [free AI notetakers](/blog/free-ai-notetakers) that offer powerful features at no cost.
+
+## Review of The 6 Best Granola AI Alternatives
+
+### 1. Char: The Open-Source Granola Alternative
+
+**Best for:** High-agency professionals who demand complete control over their data, AI stack, and workflow—especially engineers, developers, and teams in regulated industries.
+
+<Image src="/api/assets/blog/granola-ai-alternatives/granola-3.webp" alt="Char"/>
+
+[Char](/) is an open-source AI notepad for meetings that gives you complete control over your data, AI stack, and workflow. Everything is stored as plain markdown files on your device—not in proprietary databases or cloud servers.
+
+You can inspect the code, customize functionality, and choose which AI processes your data. Zero lock-in, zero compromises.
+
+#### Key Features
+
+- Plain markdown files stored locally—works with any tool (Obsidian, Notion, VS Code)
+- Your choice of AI stack: managed cloud, bring your own API keys, or run local models
+- Works with all meeting platforms and offline scenarios
+- Real-time transcription with system audio capture (no bots, no calendar permissions)
+- Open-source with full customization capabilities
+- Zero vendor lock-in—switch AI providers anytime
+- Currently macOS only (Windows and Linux coming in Q2 2026)
+- Unlimited AI summaries and conversational search
+
+#### Char vs Granola Strengths
+
+You take notes, the AI enhances them with transcript insights, and you get polished summaries. The difference is who controls the stack. With Char, you own your files, choose your AI, and have zero lock-in. Granola sends your meetings to OpenAI and Anthropic with no way out.
+
+| Feature                 | Char                                                                                        | Granola                                                    |
+| ----------------------- | ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **Ownership**           | Plain markdown files on your device. Your data, your files.                                     | Proprietary format locked in their platform                |
+| **AI Stack**            | Your choice: managed cloud, bring your own keys, or run local models                            | Sends your meetings to OpenAI and Anthropic for processing |
+| **Lock-in**             | Zero. Open source, portable format, switch AI providers anytime                                 | Third-party vendor lock-in                                 |
+| **Real-time Features**  | Live transcription visible during meetings                                                      | Post-meeting processing only                               |
+| **Pricing**             | Free forever for local transcription, BYOK, and all core features. $25/month for managed cloud. | $10/month per user (adds up fast for teams)                |
+| **Transparency**        | Open source—audit the code, customize functionality, and know exactly how your data is processed | Closed source—you have no idea how it works                |
+
+#### Char vs Granola Limitations
+
+- No mobile app currently available
+- May not include the absolute latest AI capabilities if you prioritize cutting-edge features over privacy
+
+---
+
+### 2. Jamie AI - The Best Bot-Free European Alternative
+
+**Best for:** Privacy-focused teams, multilingual organizations, and users requiring GDPR compliance
+
+<Image src="/api/assets/blog/granola-ai-alternatives/granola-4.webp" alt="Jamie AI"/>
+
+#### Jamie AI vs Granola
+
+[Jamie AI](https://www.meetjamie.ai/) creates comprehensive meeting notes and action items across any meeting platform without using visible bots. It hosts all data in Europe and supports offline capabilities and 100+ languages for global teams.
+
+#### Jamie vs Granola Strengths
+
+Both tools deliver intelligent meeting assistance by combining transcription with AI-powered enhancement. Jamie focuses on privacy and European data hosting, while Granola prioritizes simplicity.
+
+| Feature                  | Jamie                                                       | Granola                                          |
+| ------------------------ | ----------------------------------------------------------- | ------------------------------------------------ |
+| **Meeting Experience**   | No bots, plus works offline for in-person meetings          | No bots, clean meeting experience                |
+| **Privacy & Compliance** | GDPR-compliant with all data hosted in Europe               | Data processed by OpenAI and Anthropic in the US |
+| **Language Support**     | 100+ languages with automatic detection and transcription   | Limited language capabilities                    |
+| **Offline Capability**   | Works completely offline for in-person meetings             | Requires internet for all AI processing          |
+| **Data Sovereignty**     | European data residency meets stricter privacy requirements | US-based cloud processing                        |
+
+#### Jamie vs Granola Limitations
+
+- Costs €24/month compared to Granola's $18/month
+- Summaries take 5-8 minutes to generate after meetings
+- Only connects to Google/Outlook calendars; no Slack, Notion, or CRM integrations
+- Even paid plans have monthly meeting quotas (20-50 meetings)
+
+---
+
+### 3. Tactiq: The Best Chrome Extension Solution
+
+**Best for:** Chrome users, teams wanting real-time transcription, and budget-conscious users
+
+<Image src="/api/assets/blog/granola-ai-alternatives/granola-5.webp" alt="Tactiq"/>
+
+#### Tactiq vs Granola
+
+[Tactiq](https://tactiq.io/) provides real-time AI meeting transcription for Google Meet, Zoom, and Microsoft Teams. It runs directly in your browser without requiring software installation, capturing live transcripts with speaker identification and generating AI-powered summaries and action items after meetings.
+
+#### Tactiq vs Granola Strengths
+
+Both tools provide intelligent meeting assistance. Tactiq operates as a Chrome extension and offers real-time transcription, while Granola requires a native desktop app installation.
+
+| Feature                   | Tactiq                                              | Granola                                  |
+| ------------------------- | --------------------------------------------------- | ---------------------------------------- |
+| **Setup & Installation**  | Simple Chrome extension, instant setup              | Native desktop app installation required |
+| **Real-time Features**    | Live transcription visible during meetings          | Post-meeting processing only             |
+| **Language Support**      | 60+ languages with automatic detection              | Limited language capabilities            |
+| **Integration Ecosystem** | Rich integrations (Slack, HubSpot, Jira, Linear)    | Minimal third-party integrations         |
+| **Workflow Automation**   | Custom AI actions and reusable prompts              | Basic note enhancement                   |
+| **Pricing**               | $12/month for unlimited transcripts + 10 AI credits | $18/month for unlimited meetings         |
+
+#### Tactiq vs Granola Limitations
+
+- Only works in Chrome, limiting flexibility for users of other browsers
+- Limited to three meeting platforms vs Granola's universal compatibility
+- AI summaries often need manual correction for accuracy
+
+---
+
+### 4. Krisp: The Audio Enhancement Specialist
+
+**Best for:** Users in noisy environments, teams prioritizing audio quality, and professionals needing accent clarity
+
+<Image src="/api/assets/blog/granola-ai-alternatives/granola-6.webp" alt="Krisp"/>
+
+#### Krisp vs Granola AI
+
+[Krisp](https://krisp.ai/) combines strong AI noise cancellation with meeting transcription, delivering clear audio quality and accurate meeting documentation without visible bots.
+
+#### Krisp vs Granola Strengths
+
+Both tools provide bot-free meeting assistance. Krisp's unique focus on audio quality sets it apart from purely transcription-focused solutions.
+
+| Feature                     | Krisp                                                       | Granola                           |
+| --------------------------- | ----------------------------------------------------------- | --------------------------------- |
+| **Audio Quality**           | Bidirectional noise cancellation           | Standard meeting audio processing |
+| **Accent Support**          | AI accent conversion for clearer communication              | No accent assistance features     |
+| **Environment Flexibility** | Specifically designed for noisy environments                | Works in quiet environments       |
+| **Meeting Coverage**        | Virtual + in-person meetings with mobile apps               | Virtual meetings only             |
+| **Pricing**                 | $16/month for unlimited features + noise cancellation       | $18/month for unlimited meetings  |
+| **Language Support**        | 16+ languages with multilingual transcription               | Limited language capabilities     |
+| **Processing Approach**     | Local audio processing                                      | Cloud-based AI processing         |
+| **Integration Scope**       | CRM integrations (Salesforce, HubSpot) + productivity tools | Minimal third-party connections   |
+
+#### Krisp vs Granola Limitations
+
+- Free tier limited to 60 minutes/day noise cancellation vs Granola's 25 full meetings
+- English-only on free tier, limited multilingual support
+- Requires desktop app installation vs Granola's simpler approach
+
+---
+
+### 5. Sonnet AI: The CRM Integration Expert
+
+**Best for:** Sales teams, customer success professionals, and CRM-heavy workflows
+
+<Image src="/api/assets/blog/granola-ai-alternatives/granola-7.webp" alt="Sonnet"/>
+
+#### Sonnet AI vs Granola AI
+
+[Sonnet AI](https://www.sonnetai.com/) is an end-to-end meeting assistant that specializes in automatically updating CRM systems with meeting insights. Founded by Y Combinator alumni, Sonnet records device audio without visible bots and transforms conversations into structured CRM data, eliminating manual data entry while providing customizable AI-generated meeting notes.
+
+#### Sonnet AI vs Granola Strengths
+
+Both tools provide bot-free meeting assistance. Sonnet AI's focus on CRM automation and relationship management sets it apart from general note-taking solutions.
+
+| Feature                     | Sonnet AI                                                | Granola                       |
+| --------------------------- | -------------------------------------------------------- | ----------------------------- |
+| **CRM Integration**         | Automatic CRM data population and updates                | No built-in CRM functionality |
+| **Pre-meeting Prep**        | Participant research and background information          | Basic meeting preparation     |
+| **Data Structure**          | Structured CRM data and custom templates                 | General meeting notes format  |
+| **Relationship Management** | Comprehensive relationship tracking across conversations | Individual meeting focus      |
+| **Follow-up Automation**    | Automated follow-up emails and task creation             | Manual follow-up required     |
+| **Recording & Sharing**     | Shareable recordings for absent team members             | No recording functionality    |
+| **Workflow Integration**    | End-to-end meeting workflow automation                   | Basic note enhancement        |
+
+#### Sonnet AI vs Granola Limitations
+
+- More complex setup and configuration vs Granola's simplicity
+- Stores audio, video, and transcripts on servers vs Granola's lighter approach
+- Many features may be excessive for simple note-taking needs
+- Paid plans start at $25/month compared to Granola's pricing structure
+
+---
+
+### 6. tl;dv: The Video-First Meeting Intelligence Platform
+
+**Best for:** Sales teams, customer success managers, and organizations needing video recording capabilities
+
+<Image src="/api/assets/blog/granola-ai-alternatives/granola-8.webp" alt="tl;dv"/>
+
+#### tl;dv vs Granola AI
+
+[tl;dv](https://tldv.io/) is a comprehensive AI meeting assistant that records video, provides sales coaching, and analyzes multiple meetings for patterns. It goes beyond simple note-taking to transform conversations into actionable insights with enterprise-grade video capabilities that bot-free alternatives cannot match.
+
+> **Note:** tl;dv is the only bot-based tool in this comparison list. Unlike the other bot-free alternatives, tl;dv sends a visible bot to join your meetings to enable video recording and advanced features that aren't possible with device-level audio capture alone.
+>
+> For more bot-based options similar to tl;dv, explore our [comprehensive AI meeting assistant guide](/blog/best-ai-meeting-assistant-for-taking-notes).
+
+#### tl;dv vs Granola Strengths
+
+While both tools provide meeting intelligence, tl;dv's bot-based approach enables video capabilities and advanced features that device-level solutions cannot offer.
+
+| Feature                        | tl;dv                                                                | Granola                                |
+| ------------------------------ | -------------------------------------------------------------------- | -------------------------------------- |
+| **Video Recording**            | High-quality video recording with unlimited meetings                 | No video capabilities                  |
+| **Pricing Value**              | $20/month for advanced features + unlimited video recordings         | $18/month for basic unlimited meetings |
+| **Sales Coaching**             | Advanced playbook tracking, objection analysis, performance insights | Basic meeting notes only               |
+| **Multi-Meeting Intelligence** | Cross-meeting trend analysis and aggregated insights                 | Single meeting focus                   |
+| **Content Sharing**            | Video clips, highlight reels, and training content creation          | Text-based notes sharing               |
+| **Language Support**           | 30+ languages with high-accuracy transcription                       | Limited language capabilities          |
+| **Integration Depth**          | 5,000+ tool integrations with workflow automation                    | Basic note enhancement                 |
+
+#### tl;dv vs Granola Limitations
+
+- Relies on meeting platform bot capabilities and permissions
+- Video files require significant storage vs text-only notes
+- More features mean steeper learning curve for basic users
+
+---
+
+## Choose the Best Granola AI Alternative
+
+The real question is not whether you want AI meeting notes. Granola already proved there is demand for that workflow.
+
+The real question is what you want to own.
+
+If you want the closest thing to Granola with more control, Char is the cleanest fork in the road. You keep the notepad-first workflow, but your notes stay as files, your AI stack stays flexible, and you are not betting your whole system on one vendor's roadmap.
+
+[Download Char](/download) if that trade-off sounds closer to how you actually want to work.

--- a/apps/web/content/articles/how-to-have-productive-one-on-one-meetings.mdx
+++ b/apps/web/content/articles/how-to-have-productive-one-on-one-meetings.mdx
@@ -1,0 +1,168 @@
+---
+meta_title: "How to Run Productive One-on-One Meetings as a Manager"
+display_title: "How to Have Productive One-on-One Meetings: A Guide for Managers"
+meta_description: "Stop wasting time on status updates disguised as 1:1s. Learn how to run one-on-one meetings that actually develop your team without burning you out."
+author: "John Jeong"
+coverImage: "/api/assets/blog/how-to-have-productive-one-on-one-meetings/cover.png"
+category: "Guides"
+date: "2025-11-10"
+---
+
+One-on-ones should reduce your management overhead, not add to it. They should catch small problems before they become crises. They should help your team grow.
+
+Instead, they've become just another meeting in your calendar.
+
+You're asking "how's everything going?" because you forgot what you talked about last time.
+
+You're making commitments you don't track.
+
+You're having the same conversation about career development every month with no actual progress.
+
+## What makes one-on-ones actually productive
+
+A productive 1:1 focuses on surfacing real concerns before they escalate, identifying patterns across conversations, and making concrete commitments that both of you actually follow through on.
+
+It's not a status update (that's what standups are for). It's not you doing all the talking. It's not checking boxes on generic development questions or rehashing things everyone already knows.
+
+Instead, your direct report gets uninterrupted time to raise concerns. You identify patterns in what's blocking them across multiple conversations. Both of you make commitments and follow through. Your team member feels heard and supported. You understand where each person is heading and help them get there.
+
+If your 1:1s are draining you, you're doing them wrong.
+
+## 5 strategies to run better one-on-ones without burning out
+
+### 1. Stop starting every conversation from scratch
+
+Most 1:1s lose their first fifteen minutes to reconstruction. You're trying to remember what you talked about last time. Your direct report is doing the same thing. You're both pulling from vague memories instead of picking up where you left off.
+
+This is why managers end up asking "so... how's everything going?" It's the default question when nobody actually remembers specifics from three weeks ago.
+
+Before each 1:1, spend five minutes reviewing your actual conversation history with this person. Not bullet points you wrote down—the actual conversations.
+
+If you're using Char AI Notetaker, open Contacts View in Finder and search the person's name. You'll see every 1:1 you've had with them, organized chronologically. Click on any past meeting and use AI Chat to ask:
+
+- "What concerns has Alex raised in our last three conversations?"
+- "What did we commit to last time?"
+- "What career goals has she mentioned?"
+
+You get specific answers pulled from actual transcripts, not your faulty reconstruction. This preparation takes five minutes but transforms the conversation. You walk in knowing exactly where you left off: "Last time you mentioned feeling blocked on the API refactor because docs were incomplete. How did that resolve?"
+
+Your direct report immediately knows you're paying attention and the conversation moves forward.
+
+### 2. Be fully present—let AI handle the documentation
+
+The biggest drain on 1:1s isn't the conversation itself. It's trying to listen, engage, and document simultaneously.
+
+You're having a meaningful discussion about someone's career concerns while frantically typing notes, worried you'll forget the important parts. Your attention is split. Your direct report can tell.
+
+Use Char to automatically capture the entire conversation. It's open source, stores everything as plain markdown files, and lets you choose your AI stack—critical for sensitive conversations about performance, compensation, or personal issues. No bot joins your call. No lock-in.
+
+After the meeting, Char gives you a complete transcript. Hover over any part of your AI-generated summary to see the exact quote from the conversation. Your manual notes get enhanced with full context without you having to choose between being present and capturing information.
+
+<CtaCard/>
+
+### 3. Use templates to structure your 1:1s consistently
+
+Every manager develops patterns for their one-on-ones. You ask certain questions. You cover specific topics. You have a framework for what makes a productive conversation.
+
+That framework lives in your head, which means it's inconsistent across team members and forgotten when you're rushed.
+
+With Char's custom templates, you can define exactly how your one-on-one notes should be structured. A 1:1 template might include:
+
+- What they wanted to discuss (their agenda, not yours)
+- Current blockers and what's preventing resolution
+- Wins and progress since last time
+- Development areas and growth opportunities
+- Commitments made (both manager and direct report)
+- Concerns or tensions that need addressing
+
+To create a custom template, define your sections and add system instructions. For instance: "For every commitment made, note who owns it and extract the specific deadline mentioned. Highlight any recurring concerns that appeared in previous conversations."
+
+Set this as your default template in Settings, and every 1:1 automatically gets summarized in this format. No more inconsistent notes. No more forgetting to cover important areas.
+
+Your direct reports also benefit. When they know the structure, they can prepare better. When notes are consistent, they can track their own progress over time.
+
+### 4. Document commitments immediately (both yours and theirs)
+
+Your direct report mentions a blocker. You say "I'll look into that." Then you forget. They bring it up again next time. You forgot again.
+
+Same thing happens in reverse. They say "I'll draft that proposal." Next 1:1, you don't ask about it. They didn't do it, but they didn't have to explain why. The accountability is missing on both sides.
+
+Right after each 1:1, capture what needs follow-up action. With Char, ask AI Chat: "What commitments did I make?" and "What commitments did Alex make?"
+
+You'll get specific items:
+
+- **You:** Follow up with design team about feedback delays
+- **You:** Check with HR about flexible work policy
+- **Alex:** Draft team charter by next Tuesday
+- **Alex:** Send feedback on the API proposal
+
+Add these to your task system with specific language. Not vague items like "follow up on Alex's stuff" but concrete tasks: "Email design lead about feedback turnaround time - due Friday."
+
+Share the action items with your direct report right after the meeting. Send them a quick message: "Here's what we both committed to - me: design feedback and HR policy by Friday. You: team charter and API review by Tuesday." Now you're both clear on what needs to happen before the next 1:1.
+
+### 5. Separate career conversations from tactical ones
+
+Most managers try to pack everything into one 1:1: status updates, immediate blockers, long-term development, career goals, feedback, team dynamics.
+
+The result: You spend thirty minutes on tactical issues and rush through "so, uh, how are you thinking about your career?" in the last five minutes. The answer is always generic: "Yeah, I want to grow, maybe move toward senior engineer eventually."
+
+Nobody benefits from that conversation.
+
+**Weekly/bi-weekly tactical 1:1s (30 minutes):** Focus on the immediate work and blockers. What's getting in their way? What decisions need making? What support do they need this week?
+
+Keep it tight. If you're spending more than 30 minutes on tactical issues every week, something's broken in your team's communication or planning.
+
+**Monthly career conversations (60 minutes):** Deep dive on development, growth, and trajectory. These need space and focus, not five rushed minutes at the end of a tactical meeting.
+
+Use Char to track development over time. Search across all your career conversations with someone to see: What goals did they set six months ago? Did they actually work toward them? What barriers kept coming up?
+
+This longitudinal view is impossible to maintain in your head across multiple reports. But it's exactly what makes career conversations productive instead of generic.
+
+## The manager's system: putting it all together
+
+Here's what the actual workflow looks like when you're using Char:
+
+**Before each 1:1 (5 minutes):**
+
+- Open Contacts View and review past conversations with this person
+- Ask AI Chat about past concerns, commitments, and career goals mentioned
+- Check your task list for commitments you made to them
+
+**During the 1:1:**
+
+- Listen more than you talk
+- Ask follow-up questions on what they raise, not your prepared script
+- Let Char capture the conversation automatically—stay present, don't take frantic notes
+
+**After the 1:1 (3 minutes):**
+
+- Ask AI Chat: "What commitments did I make?" and "What commitments did [person] make?"
+- Add these to your task system with specific deadlines
+- Share the commitments with your direct report
+- Block time to actually complete your commitments
+
+**Monthly review (30 minutes):**
+
+- Review past 1:1s with each person in Contacts View
+- Identify recurring themes and patterns by scanning through summaries
+- Prepare for career conversations with specific examples and observations
+
+This system reduces prep time while improving quality. You're not scrambling before each meeting because context is always available. You're not forgetting commitments because they're systematically tracked and shared. You're not missing patterns because you can review conversation history in one place.
+
+Your mental energy goes to the actual conversation, not the overhead of managing the conversation.
+
+## Stop treating one-on-ones like they're optional
+
+Management advice hasn't evolved, but the tools have.
+
+You don't need to manually track everyone's development in spreadsheets. You don't need to remember every conversation across eight direct reports. You don't need to start each 1:1 from scratch, reconstructing context from memory.
+
+Use AI to handle the overhead that's not actually management. Let Char capture conversations automatically—it's open source with zero lock-in, storing everything as plain markdown files you fully own.
+
+Search across all your 1:1s to identify patterns. Ask AI about recurring themes and commitments. Track what each person cares about over time without drowning in manual documentation.
+
+Your brain should be doing what it does best: connecting with people, identifying what they need, helping them grow. Not trying to be a human database of scattered conversations.
+
+[Download Char free](/) and run one-on-ones that actually develop your team without burning you out.
+
+<CtaCard/>

--- a/apps/web/content/articles/how-to-participate-in-meetings-effectively.mdx
+++ b/apps/web/content/articles/how-to-participate-in-meetings-effectively.mdx
@@ -1,0 +1,142 @@
+---
+meta_title: "Top 5 Strategies to Participate in Meetings Effectively"
+display_title: "How to Participate in Meetings Effectively?"
+meta_description: "Learn how to contribute meaningfully in meetings without exhausting your brain. Strategies for speaking strategically, building on context, and following through."
+author: "John Jeong"
+coverImage: "/api/assets/blog/how-to-participate-in-meetings-effectively/cover.png"
+featured: false
+category: "Guides"
+date: "2025-11-07"
+---
+
+You've heard the advice. "Be an active listener." "Come prepared." "Ask thoughtful questions."
+
+Solid advice, sure. But it doesn't help much when you're in your sixth meeting of the day, someone asks you a direct question, and you realize you have no idea what the last ten minutes were about because your brain was still processing the previous meeting.
+
+Standard meeting participation advice assumes you're operating at peak cognitive capacity—rested, focused, with unlimited mental bandwidth to engage deeply and track everything simultaneously.
+
+In reality, you're context-switching between seven different projects, pulled into this meeting with five minutes' notice, trying to look engaged while your brain screams for a break.
+
+So let's talk about what actually works when you need to participate effectively but you're running on cognitive fumes.
+
+## The real problem with meeting participation
+
+Effective participation requires doing multiple things at once:
+
+- Processing what's being said in real-time
+- Connecting it to relevant context from past conversations
+- Formulating thoughtful responses
+- Tracking action items and decisions
+- Maintaining awareness of group dynamics
+- Documenting important points for later
+
+That's a lot of cognitive load. When you're trying to do all of it simultaneously, you end up doing none of it particularly well.
+
+Research from Stanford shows that multitasking can reduce productivity by up to 40%. Yet meetings expect people to effectively "multitask" their attention: listening, thinking, responding, and documenting all at once.
+
+The solution isn't to "focus harder." It's to build systems that reduce the cognitive overhead of participation so your brain can focus on what actually matters: thinking and contributing.
+
+## Meeting participation strategies that work
+
+### 1. Pre-load context instead of reconstructing it live
+
+You walk into a meeting and spend the first ten minutes trying to remember what was discussed last time. Who said what. What was decided. What's still unresolved.
+
+While you're mentally reconstructing context, the conversation has already moved on. You're three steps behind, and by the time you catch up, you've missed the critical moment to contribute.
+
+Instead, prep before the meeting starts.
+
+Open your notes from the last relevant conversation and recap:
+
+- What decisions were made that you need to reference?
+- What concerns did people raise that might resurface?
+- What did I commit to that needs an update?
+
+If you're using [Char AI Notetaker](/), use Search (cmd + k) to find every past mention of the project or topic. Type the project name, and you'll see every note where it was discussed, with the exact context of who said what and when.
+
+Then use AI Chat to ask targeted questions: "What were the main objections to the pricing model?" or "What did Sarah say about the technical constraints?" You get specific answers pulled from actual transcripts, not your faulty memory.
+
+This takes five minutes. Those five minutes mean you walk in prepared to contribute immediately instead of spending the first chunk of the meeting getting oriented.
+
+**Want to optimize your entire meeting workflow?** Check out our [meeting preparation checklist](/blog/meeting-preparation-checklist) for the pre-meeting work that sets up better participation.
+
+### 2. Use strategic silence, not constant commentary
+
+Effective participation doesn't mean contributing often. The people who talk the most in meetings aren't necessarily the most effective participants. Often they're thinking out loud, working through their ideas in real-time at everyone else's expense.
+
+The most effective participants speak strategically:
+
+- **Ask the question everyone's thinking but no one wants to ask.** "Before we go further, can we confirm we all have budget approval for this?" This saves twenty minutes of discussion on something that might be blocked anyway.
+- **Redirect when the conversation drifts.** "This is interesting, but I want to make sure we answer the original question first." You don't need to be the meeting leader to do this.
+- **Surface the unspoken tension.** "I'm sensing some hesitation about this approach. Can we talk about that directly?" Naming the dynamic everyone feels but no one acknowledges moves conversations forward faster than pretending everything's fine.
+- **Bridge perspectives.** "It sounds like engineering is concerned about timeline while marketing needs this for the launch. Can we discuss what's actually negotiable?" This identifies the actual problem to solve.
+
+The rest of the time, listen actively, track what's being said, and let others take the floor. Your silence is strategic, not disengagement.
+
+### 3. Separate capture from processing
+
+The biggest cause of [meeting fatigue](/blog/how-to-reduce-meeting-fatigue) is trying to participate and document simultaneously.
+
+You're in the middle of making a point, and someone drops a critical piece of information. Do you stop mid-sentence to write it down and lose your train of thought? Keep talking and hope you remember later? Try to hold it in working memory while finishing your point?
+
+This is why people take terrible notes. They're not bad at note-taking; they're trying to do two incompatible tasks at once.
+
+During the meeting, focus entirely on participation. Use a tool like Char that runs locally on your device, automatically capturing both what's said and what you're thinking. No bot joining the call, no data leaving your machine, just automatic documentation.
+
+If you prefer manual note-taking, jot down fragments, keywords, reactions. But don't try to create polished, comprehensive notes in real-time. You can use Char to enhance your manual notes using the meeting transcript afterward.
+
+After the meeting, process what was captured. This is when you review the transcript, identify action items, connect dots, and organize information. Your AI-generated summary is already waiting. Hover over any part to see the exact quote from the conversation.
+
+Ask AI Chat "What are my action items from this meeting?" instead of hunting through notes. Search across meetings to track how topics have evolved over time.
+
+Your brain is fully engaged during the conversation, and organizing happens later when you have the mental space for it.
+
+### 4. Manage your energy, not just your calendar
+
+You can't participate effectively if you're mentally exhausted. And you will be mentally exhausted if you're trying to engage deeply in eight back-to-back meetings.
+
+The standard advice is "schedule breaks between meetings." Except you don't control half your calendar. Meetings get added, extended, moved with no regard for your carefully planned buffer time.
+
+Instead of controlling your schedule, manage your participation energy strategically:
+
+- **Identify which meetings need your best thinking.** A status update needs your attention but not your deepest analytical thinking. A strategic planning session does.
+- **Frontload your energy to high-stakes meetings.** If you have a critical client call at 2 PM, don't schedule three cognitively demanding meetings before it.
+- **Use lighter participation modes when you're drained.** If you're running on fumes, you can still contribute by asking clarifying questions, taking on action items for later execution, or providing specific factual information.
+- **Actually take the micro-breaks you have.** Between meetings, resist the urge to immediately process what just happened or prep for what's next. Take sixty seconds to look away from your screen. Stand up. Your brain needs transition time.
+
+Use Char's automatic capture so you're not doing the mental gymnastics of trying to remember everything from each meeting.
+
+### 5. Close the loop on your commitments immediately
+
+You say "I'll look into that" in a meeting. The meeting ends. You move to the next thing. Three days later someone asks about it, and you've completely forgotten.
+
+It's not that you didn't care. You relied on memory instead of systems.
+
+Right after the meeting:
+
+- **Review your action items immediately.** Don't wait until later when everything blurs together. With Char, ask AI Chat "What are my action items?" and get them instantly from your meeting transcript.
+- **Add them to your task system with specific deadlines.** "Look into X" is not actionable. "Research X and send summary to team by Thursday 3 PM" is.
+- **Block time to actually do them.** An action item without calendar time is wishful thinking.
+
+Before the next meeting:
+
+- **Check what you committed to in the last one.** Search your past notes for action items with your name. With Char's Search, find every instance where you said "I'll handle this" or "I'll follow up on that."
+- **Update the group proactively.** Don't wait to be asked. "Quick update on the database research I said I'd do—found three options, here's my recommendation."
+
+When you consistently deliver on commitments, people take your contributions seriously. When you don't, your participation becomes background noise.
+
+## Stop participating like it's 2015
+
+Meeting participation advice hasn't evolved, but the tools have.
+
+You don't need to frantically take notes while trying to contribute. You don't need to reconstruct context from memory. You don't need to manually track every commitment across dozens of conversations.
+
+Use AI to handle the cognitive overhead that's not actually thinking. Let Char capture conversations automatically, locally on your device without any data leaving your machine. Search across all your past meetings to find context instantly. Ask AI specific questions about what was discussed instead of hunting through transcripts.
+
+Your brain should do what it does best: connecting ideas, spotting patterns, contributing unique insights. Not being a human tape recorder.
+
+Meetings haven't changed. Your system for participating in them can.
+
+[Download Char free](/download) and participate in meetings without the cognitive overhead.
+
+<CtaCard/>

--- a/apps/web/content/articles/how-to-reduce-meeting-fatigue.mdx
+++ b/apps/web/content/articles/how-to-reduce-meeting-fatigue.mdx
@@ -1,0 +1,121 @@
+---
+meta_title: "How to Reduce Meeting Fatigue When Meetings Are Your Job"
+meta_description: "Can't cut meetings? Learn how AI note-taking and smart systems reduce meeting fatigue for sales, consulting, and customer-facing roles."
+author: "John Jeong"
+coverImage: "/api/assets/blog/how-to-reduce-meeting-fatigue/cover.png"
+category: "Guides"
+date: "2025-10-31"
+---
+
+You've read the articles. You know the drill. "Cut unnecessary meetings!" "Block focus time!" "Just say no!"
+
+Great advice. Truly. Except when your job literally is meetings.
+
+If you're in sales, customer success, consulting, recruiting, or any role where human conversation is the actual work—not a distraction from it—then the standard productivity advice feels backwards. It's like telling a marathon runner to just run less. Sure, that would help with fatigue, but you wouldn't finish the race.
+
+So let's talk about the meeting fatigue nobody wants to acknowledge: the kind that happens even when every single meeting on your calendar matters. You optimize your schedule, batch your calls, and still end each day feeling like your brain has been through a blender.
+
+## What causes meeting fatigue? The science behind Zoom exhaustion
+
+[Microsoft Research ran studies](https://www.microsoft.com/en-us/worklab/work-trend-index/brain-research) using EEG monitoring and found something striking: back-to-back video meetings cause stress to build up over time, with beta wave activity (associated with stress and anxiety) increasing progressively throughout the day.
+
+Even brief transitions between meetings—a short walk, some light stretching—don't clear this buildup. Your mental state stays stuck between calls.
+
+The real issue isn't the meetings themselves. It's the cognitive load of trying to capture and retain information while simultaneously participating in the conversation. You're listening, responding thoughtfully, asking follow-up questions, and frantically typing notes you hope to decipher later. Your brain is juggling three jobs at once: processing, engaging, and documenting.
+
+Then the meeting ends. You've got seven minutes before your next call. Do you polish your notes while everything's fresh? Actually process what you learned? Take a breath and reset? Or are you already in your next meeting?
+
+Most people end up in option D. By day's end, you've had eight substantive conversations with fragments of notes scattered across documents, half-remembered insights, and a vague sense that someone said something important in the 2 PM call but you can't quite recall what.
+
+The fatigue isn't from talking. It's from the constant effort of trying to be present and preserve information simultaneously.
+
+## 5 ways to reduce meeting fatigue without cutting meetings
+
+If you can't reduce your meeting load, focus on reducing the cognitive overhead around meetings.
+
+(Note: Char appears a few times below because I built it to solve these exact problems.)
+
+### 1. Use AI note-taking tools to stop multitasking during calls
+
+Your brain excels at thinking but struggles with storage. Holding meeting details in your head while participating in new conversations drains attention and energy.
+
+Better systems eliminate the need for memory altogether. [AI meeting assistants](/blog/best-ai-meeting-assistant-for-taking-notes) like Char run entirely on your device, transcribing conversations in real-time without you doing anything. No bot joins your calls. No data leaves your machine. Just automatic documentation of what was said.
+
+When the meeting ends, you don't need to do anything immediately. Take that two-minute break. Actually transition. The conversation is captured for later.
+
+If you're someone who feels productive taking manual notes during meetings, keep doing it. Char still helps by enhancing your fragments with full transcript context. Hover over any part of the AI-generated summary to see the exact quote from the conversation—you get active note-taking without worrying you missed something important.
+
+### 2. Use voice notes instead of typing when possible
+
+Speaking for an hour, then switching to typing mode, then back to speaking, then typing again for follow-ups burns mental energy with each switch.
+
+Use voice notes instead:
+
+- **Before the meeting**: Record your prep thoughts—context you want to remember, questions to ask, background on attendees
+- **During the meeting**: Keep it running to capture the conversation
+- **After the meeting**: Capture your immediate reactions and insights before switching tasks
+
+Tools like Char weave together your pre-meeting context, the conversation itself, and your post-meeting thoughts into one cohesive summary. You're not constantly shifting between communication modes, which means less cognitive friction as the day progresses.
+
+### 3. Review meeting notes strategically using AI
+
+You've got maybe 10 minutes between meetings. Don't scroll through transcripts or organize scattered notes. Use AI to extract what you actually need.
+
+With Char, each meeting already has a summary with action items. When you need to review, you can:
+
+- Ask AI Chat "What are my action items?" instead of hunting through notes
+- Search across all meetings with cmd + k to find what someone said about a specific topic
+- Ask broad questions like "Bring up notes related to product" and let AI search through your notes (works with GPT-4o/Claude Sonnet)
+
+Spend your between-meeting time on thinking and follow-up, not reconstructing what happened or figuring out what to do next.
+
+<CtaCard/>
+
+### 4. Use meeting templates to reduce prep fatigue
+
+Templates prevent you from starting from scratch each time, wondering how to structure the conversation. Your brain focuses on the actual discussion, not the meta-work of designing it.
+
+Create standard templates for recurring meeting types. Customer discovery calls might follow: intro (5 min), pain points (15 min), solution fit (15 min), next steps (5 min). 1-on-1s: wins, blockers, growth, action items. Demos: context questions, walkthrough, Q&A, close.
+
+Char includes built-in templates for common meeting types, and you can create custom ones. Set a default template in Settings so every meeting gets summarized in that format, or select a template after finishing a recording for specific meetings.
+
+To create a custom template, define your sections and add system instructions for the AI. If you do user interviews, your instruction could be: "For every bullet point, attach the user's actual quote as a reference." Every user interview summary then comes with supporting evidence automatically. For sales calls, output in JSON format with fields like pain points, budget, timeline, and decision makers—perfect for pushing data to a CRM.
+
+### 5. Stop reinventing the wheel in every single meeting
+
+You've given hundreds of demos and handled dozens of objections. All that data is captured. But you treat every conversation as if it's the first time.
+
+With AI notetaking, create a system to learn from your patterns, identify what worked, and refine it with each subsequent conversation:
+
+- Search past successful demos to see exactly how you explained complex features when prospects got excited
+- Ask AI about specific objections and how you've handled them before. Use what worked instead of improvising the same responses from scratch
+- Before any call, search the person's name to see your complete conversation history. What they cared about, what questions they asked, where you left off
+- Use the Contacts View in Finder to see all meetings with a company organized in one place. Spot patterns in what resonates with that organization
+
+Each conversation gets easier because you're building on what worked instead of starting from scratch every time.
+
+## Meeting fatigue vs burnout: what's the difference?
+
+Meeting fatigue is the daily exhaustion from too many conversations without adequate breaks or processing time. Burnout is a chronic state of physical and emotional exhaustion that doesn't improve with rest.
+
+Meeting fatigue can contribute to burnout, but they're different. Meeting fatigue typically improves with the strategies above, better meeting hygiene (breaks, scheduling), and rest.
+
+Burnout requires deeper intervention: job changes, therapy, or significant life restructuring.
+
+If you're implementing all the strategies in this article and still feeling chronically exhausted, you might be dealing with burnout rather than just meeting fatigue. That's worth addressing with a professional.
+
+## Reducing meeting fatigue
+
+The advice to "have fewer meetings" isn't wrong. If you can cut unnecessary meetings, do it.
+
+But if that's not possible, reduce the cognitive overhead around meetings. Stop trying to listen, engage, document, and remember everything at once.
+
+I built Char because I was exhausted from the mental gymnastics: frantically typing notes, wondering if I captured things correctly, reconstructing conversations from fragments. It wasn't the talking that drained me—it was everything else.
+
+Your meetings don't need to change. Your system does. Let AI handle documentation and organization so your brain can focus on the actual conversation.
+
+Six months in, meetings still tire me out. But it's the good kind of tired—from doing meaningful work, not from trying to be a human tape recorder.
+
+**Ready to stop the mental juggling?** [Download Char for free](/download). It runs on your Mac, keeps everything local, and handles the exhausting parts automatically.
+
+<CtaCard/>

--- a/apps/web/content/articles/how-to-transcribe-zoom-calls.mdx
+++ b/apps/web/content/articles/how-to-transcribe-zoom-calls.mdx
@@ -1,0 +1,187 @@
+---
+meta_title: "How to Transcribe Zoom Calls Automatically?"
+meta_description: "Learn how to automatically transcribe Zoom calls using Zoom's built-in feature or powerful third-party AI tools. Step-by-step guide with accuracy comparisons."
+author: "Harshika"
+coverImage: "/api/assets/blog/how-to-transcribe-zoom-calls/cover.png"
+category: "Guides"
+date: "2025-09-16"
+---
+
+Transcribing Zoom calls manually is time-consuming and error-prone. You can automate this process using either Zoom's built-in transcription feature or third-party AI tools.
+
+This article covers both approaches and helps you decide which works for your workflow.
+
+## Method 1: Transcribing Zoom calls using Zoom's built-in transcription
+
+Zoom provides audio transcription that automatically transcribes the audio of meetings or webinars recorded to the cloud.
+
+### What you need to get started
+
+- **Zoom account type:** Pro, Business, Education, or Enterprise account (basic free plan doesn't include transcription)
+- **Cloud recording enabled:** Transcription only works with cloud recordings
+- **Admin permissions:** Depending on your organization's setup
+
+If you're interested in Zoom's meeting summaries feature, see our [Zoom AI Companion Review](/blog/zoom-ai-companion-review).
+
+### Setting up Zoom's built-in transcription
+
+<Image src="/api/assets/blog/how-to-transcribe-zoom-calls/auto-1.webp" alt="How to set up Zoom's built-in transcription" />
+
+1. Log into your Zoom web portal
+2. Navigate to Settings → Recording
+3. Toggle on "Cloud Recording"
+4. Under Cloud Recording section, check "Audio transcript" box
+5. Go to Settings → Meeting → In Meeting (Advanced)
+6. Find "Automated captions" and toggle it on
+7. Enable "Full transcript" for running transcript alongside captions
+8. Save all changes
+
+### Enabling transcription during a meeting
+
+<Image src="/api/assets/blog/how-to-transcribe-zoom-calls/auto-2.webp" alt="How to Turn On Zoom's Native Transcription Feature During a Meeting" />
+
+1. Start your Zoom meeting
+2. Click "Record" and select "Record to the Cloud"
+3. For live transcription, click "Live Transcript" in the toolbar and select "Enable"
+4. Zoom automatically generates a transcript after the meeting ends
+5. You receive an email with links to the recording and transcript (VTT format)
+
+## Method 2: Using third-party tools to transcribe Zoom calls
+
+Many excellent options exist for Zoom transcription. See our comprehensive guide on the [best AI notetakers for Zoom](/blog/best-ai-notetaker-for-zoom) for a detailed comparison. Char is a complete AI notetaking solution that goes beyond simple transcription.
+
+### What is Char?
+
+Char is an open-source AI notepad for meetings that gives you complete control over your data and AI stack. Everything is stored as plain markdown files with zero lock-in. This matters for:
+
+- **Privacy-sensitive conversations** -- Healthcare professionals, lawyers, counselors, and anyone handling confidential information
+- **Compliance-heavy industries** -- Organizations meeting HIPAA, GDPR, SOX, or CCPA requirements
+- **Offline functionality** -- Works without internet connectivity
+- **Universal compatibility** -- Works with all meeting platforms without requiring bots
+
+Char transcribes your meeting in real-time and generates actionable summaries automatically, without bots joining your call.
+
+### How to transcribe Zoom meetings with Char
+
+#### Step 1: Download and install the Char app
+
+<Image src="/api/assets/blog/how-to-transcribe-zoom-calls/auto-3.webp" alt="download Char app for Zoom" />
+
+1. Visit [char.com](/) and click "Download"
+2. Download the macOS app (Windows and Linux coming in Q2 2026)
+3. Open the DMG file and drag Char to your Applications folder
+4. Launch Char from Applications
+
+#### Step 2: Start recording your meeting
+
+<Image src="/api/assets/blog/how-to-transcribe-zoom-calls/auto-4.webp" alt="How does Char work for Zoom" />
+
+1. Open Char before or during your Zoom call
+2. Press the red recording button to start listening
+3. Char captures both system audio (speakers/headphones) and your microphone
+4. Real-time transcript appears in the right panel as people speak
+
+**Important:** Always ask for consent, especially in all-party consent states like California.
+
+#### Step 3: Let AI create your notes
+
+<Image src="/api/assets/blog/how-to-transcribe-zoom-calls/auto-5.webp" alt="Char for zoom calls" />
+
+1. After your meeting ends, press the stop button
+2. Char automatically processes the transcript using its custom HyperLLM-V1 model
+3. AI generates a personalized summary with key points, action items, and insights
+4. Review and edit the enhanced notes as needed
+5. Export in multiple formats (Markdown, PDF, Rich text)
+
+### Why Char outperforms Zoom's native transcription
+
+#### 1. Accuracy and reliability
+
+<Image src="/api/assets/blog/how-to-transcribe-zoom-calls/auto-6.webp" alt="Zoom native transcription review" />
+*Source*
+
+Zoom users often spend hours editing 45-60 minute transcripts due to poor accuracy and formatting issues. Char's AI models deliver better transcription quality with minimal manual cleanup.
+
+#### 2. Privacy and control
+
+Zoom processes conversations in the cloud, raising compliance concerns for sensitive industries. Char keeps everything on your device with no data leaving your computer.
+
+#### 3. Structured notes vs. raw text
+
+Zoom delivers raw transcript files that require manual organization. Char extracts key points, decisions, and action items automatically.
+
+#### 4. Long-term value
+
+Zoom transcripts sit in isolation. Char builds a searchable knowledge base where you can find patterns, track decisions, and understand how projects evolved.
+
+#### 5. Interactive intelligence
+
+Char lets you ask questions about your meeting notes through AI chat—"What are my action items?" or "What exactly did Sarah say about the budget?"—without scrolling through pages of text. Zoom gives you static files.
+
+#### 6. Flexibility
+
+Char works with any meeting platform, offers custom templates, and gives you complete deployment flexibility—local-only processing, on-premises deployment, or private cloud options. Zoom locks you into their ecosystem.
+
+Char offers unlimited AI summaries and transcription free forever.
+
+[Download Char for macOS](/download)
+
+## Best practices for automatic Zoom transcription and note-taking
+
+Regardless of which method you choose, follow these practices to get the best results:
+
+### Audio quality optimization
+
+- Use a quality microphone or headset
+- Choose quiet environments for meetings
+- Ask participants to mute when not speaking
+- Speak clearly and avoid overlapping conversations
+
+### Meeting preparation
+
+- Test your setup before important meetings
+- Inform participants about recording and transcription
+- Do a quick audio test to check levels
+
+### Post-meeting workflow
+
+- Review AI-generated notes for accuracy and completeness
+- Edit important details, names, and technical terms
+- Organize notes in your preferred system
+- Share relevant sections with team members
+
+## Frequently asked questions
+
+### 1. How to get Zoom transcript without recording?
+
+Zoom's native transcription feature only works with cloud recordings. You cannot generate transcripts without recording the meeting first.
+
+Third-party tools like Char can capture and transcribe Zoom audio in real-time without requiring cloud recording to Zoom's servers.
+
+### 2. Where are Zoom transcripts stored?
+
+Zoom transcripts are stored in Zoom's cloud servers alongside your recorded meetings. You can access them through the Zoom web portal under "Recordings."
+
+The transcripts are saved in VTT format, which you can download and convert to other formats like Word documents or PDFs. This cloud storage raises privacy concerns for sensitive meetings.
+
+### 3. What's the best alternative to Zoom's transcription?
+
+For users who want complete control, Char offers the best alternative with zero lock-in—plain markdown files, your choice of AI stack, and true file ownership.
+
+For those comfortable with cloud processing, other popular alternatives include Otter AI, Fathom, and Tactiq. See our comprehensive guide on the [best AI notetakers for Zoom](/blog/best-ai-notetaker-for-zoom) for a detailed comparison.
+
+### 4. How accurate is Zoom's native transcription?
+
+Zoom's transcription has significant accuracy issues. [Users report](https://community.zoom.com/t5/Zoom-Meetings/Transcription-Highly-Inaccurate/m-p/130271) incorrect speaker identification, common words requiring editing even with clear speech, and frequent formatting errors.
+
+### 5. Can I transcribe Zoom calls offline?
+
+Zoom's native transcription requires an internet connection and cloud processing, so offline transcription isn't possible.
+
+Char can transcribe Zoom calls completely offline using local AI models, making it ideal for situations with unreliable internet.
+
+### 6. Do I need a paid Zoom account for transcription?
+
+Yes, Zoom's transcription feature requires a Pro, Business, Education, or Enterprise account. The basic free Zoom plan does not include transcription.
+
+Char offers unlimited transcription and AI summaries free forever, regardless of your Zoom account type.

--- a/apps/web/content/articles/is-ai-notetaking-legal.mdx
+++ b/apps/web/content/articles/is-ai-notetaking-legal.mdx
@@ -1,0 +1,166 @@
+---
+meta_title: "Is AI note-taking legal? Everything You Need to Know"
+meta_description: "AI note-taking is legal, but selecting the wrong tool or missing compliance requirements can expose you to privacy and compliance risks. Learn more."
+author:
+  - "Harshika"
+coverImage: "/api/assets/blog/is-ai-notetaking-legal/cover.png"
+featured: false
+category: "Guides"
+date: "2025-08-26"
+---
+
+AI notetaking is legal, but the devil's in the details. While you can absolutely use these tools, certain missteps can trigger privacy violations, consent law breaches, and compliance nightmares that cost millions.
+
+Most compliance issues stem from overlooking consent requirements and choosing tools without understanding their data practices. Get these fundamentals right, and you can stay productive while staying protected.
+
+**TL;DR:**
+
+- **Consent is non-negotiable:** Always assume you need all-party consent, especially across states/countries.
+- **Data practices matter:** Many tools record, train AI, and store conversations—creating legal exposure.
+- **Privilege risks:** Using cloud AI can waive attorney-client, medical, or corporate confidentiality.
+- **Industry compliance:** Different laws (HIPAA, GDPR, CCPA, FERPA, SOX) impose strict safeguards.
+- **Safer choice:** Cloud-based tools demand heavy due diligence, while zero-lock-in solutions (like Char) minimize compliance risks with complete control over your data and AI stack.
+
+👉 **Bottom line:** Get consent, vet your vendor, protect confidentiality, and if compliance is key, use an open-source AI notepad with zero lock-in.
+
+## What are the key legal considerations for AI note-taking?
+
+### 1. Consent requirements: you must comply with the strictest applicable state law
+
+Recording consent laws form the foundation of AI note-taking legality, and they're more complex than most people realize.
+
+At the federal level, the Electronic Communications Privacy Act allows "[one-party consent](https://detectiveservices.com/2012/02/state-by-state-recording-laws/)", meaning you can legally record a conversation if you're a participant or if one participant consents with full knowledge. A majority of states require only one-party consent—any party to the conversation can record it without getting the consent of anyone else.
+
+However, 11-13 states require "[all-party consent](https://detectiveservices.com/2012/02/state-by-state-recording-laws/)", meaning everyone involved must agree to be recorded. These states include California, Connecticut, Delaware, Florida, Illinois, Maryland, Massachusetts, Michigan, Montana, Nevada, New Hampshire, Pennsylvania, and Washington.
+
+When participants are in different states, the strictest standard generally applies. This means obtaining consent from all parties is necessary to ensure compliance.
+
+### 2. Data processing: understanding where your data goes and how it's used
+
+Many cloud-based AI note-taking tools like Otter AI don't just transcribe your meetings—they learn from them. This creates data processing issues most organizations never consider.
+
+A [recent lawsuit against Otter](/blog/is-otter-ai-safe) alleges the service automatically joins meetings through calendar integrations "without obtaining the affirmative consent from any meeting participant." The recordings are then used to train Otter's AI systems without participants knowing their private conversations became training data.
+
+Cross-border data transfers add another layer of complexity. If your AI note-taking service processes data outside your home country, you may need to comply with additional regulations about international data transfers, especially under frameworks like GDPR.
+
+### 3. Third-party access: what your vendor really does with your data
+
+Most people using AI note-taking tools have never read their vendor's data processing agreements, and this oversight can be costly.
+
+Businesses should purchase licensed AI applications and ensure meeting recordings and AI outputs are retained in their own AI cloud instance, used to train AI only for their own purposes, and encrypted during transmission and at rest.
+
+Many popular AI note-taking tools don't offer this level of control in their standard plans. They may store your data indefinitely on their servers, use your conversations to improve their AI models, share data with third-party partners for analysis, or lack proper encryption for data in transit and at rest.
+
+This makes Business Associate Agreements (BAAs) crucial for organizations in regulated industries. Businesses should structure their relationship with AI providers through appropriate data processing agreements, which ensure compliance with cybersecurity and privacy laws and outline the parties' respective roles and liabilities.
+
+The vendor security assessment should cover:
+
+- Where data is stored geographically
+- Who has access to your data within the vendor organization
+- Whether data is used for AI training purposes
+- Encryption standards for data at rest and in transit
+- Data retention and deletion policies
+- Incident response procedures
+- Compliance certifications (SOC 2, ISO 27001, etc.)
+
+### 4. Privilege protection: when AI recording breaks confidentiality
+
+Attorney-client privilege can be waived if confidential information is shared with a third party. Since AI transcription services may store transcripts, privilege could be inadvertently waived if a third party outside the circle of privilege has access to that data storage.
+
+The implications extend beyond legal conversations. Healthcare providers risk violating doctor-patient confidentiality, financial advisors may breach client confidentiality requirements, and any organization could inadvertently disclose trade secrets or sensitive business information.
+
+AI-produced content could be seen as a neutral document and easily [discoverable by opposing parties during legal proceedings](https://www.huffpost.com/entry/ai-notetaker-meetings-privacy_l_683dda81e4b0cceca4075fc6), whereas human-generated notes may fall under attorney-client privilege or other confidentiality safeguards.
+
+### 5. Compliance standards: navigating industry-specific regulations
+
+Different industries face different regulatory requirements, and AI note-taking can trigger compliance obligations you might not expect.
+
+#### HIPAA (Healthcare)
+
+Healthcare organizations face some of the strictest requirements. HIPAA's Security Rule mandates specific technical, administrative, and physical safeguards for electronic protected health information (ePHI), including end-to-end encryption, access controls, audit logging, and Business Associate Agreements with AI vendors.
+
+Any AI note-taking tool used in healthcare settings must:
+
+- Be covered by a signed Business Associate Agreement
+- Encrypt data throughout the entire lifecycle
+- Provide audit trails for all data access
+- Allow for patient data deletion upon request
+- Meet HITRUST validation requirements
+
+HIPAA violations carry severe penalties, ranging from thousands to millions of dollars, plus potential criminal charges.
+
+#### GDPR (Global/EU)
+
+The General Data Protection Regulation applies to any organization serving EU residents and requires explicit consent for processing personal data, data minimization principles, and the ability for individuals to access, correct, and delete their personal information.
+
+For AI note-taking, GDPR creates several specific challenges:
+
+- Recording a person's voice itself constitutes personal data processing
+- Explicit consent is required from all EU participants
+- Individuals have the right to request deletion of their voice data
+- Data transfers outside the EU require additional safeguards
+- Violations can result in fines up to 4% of annual global revenue
+
+#### CCPA/CPRA (California)
+
+California's privacy laws require businesses to provide notice at collection of personal information, including the categories collected and purposes of use. The California Privacy Rights Act expands protections for "sensitive personal information" including biometric data.
+
+Voice recordings can be considered biometric identifiers, so AI note-taking may trigger CCPA's sensitive data provisions, requiring additional consent and opt-out mechanisms.
+
+#### SOX (financial services)
+
+Financial services firms using AI note-taking for client communications must ensure proper data governance and retention policies. Client conversations may need to be preserved for regulatory examination while remaining protected from unauthorized access.
+
+#### FERPA (education)
+
+Educational institutions must be particularly careful about AI note-taking in settings where student information might be discussed. Student records and information are protected under FERPA, and unauthorized disclosure can result in loss of federal funding.
+
+#### SOC 2 (system and organization controls)
+
+SOC 2 is a security framework that evaluates how organizations handle customer data. For AI note-taking tools, SOC 2 Type II compliance demonstrates that the vendor has implemented proper security controls around data processing, access management, and system monitoring.
+
+## AI note-taking legal compliance checklist
+
+Use this checklist to ensure your AI note-taking practices meet legal requirements and protect your organization from compliance risks.
+
+- ✅ Get consent from all meeting participants before recording (assume all-party consent required)
+- ✅ Verify where your data is stored and whether it's used for AI training
+- ✅ Review your vendor's data processing agreements - ensure they limit data use and provide proper security controls
+- ✅ Protect privileged communications - ensure attorney-client, doctor-patient, or confidential business discussions remain protected (local processing helps maintain privilege)
+- ✅ Ensure compliance with your industry regulations (HIPAA for healthcare, GDPR for EU data, CCPA for California residents, etc.)
+- ✅ Implement data retention and deletion policies for meeting transcripts
+- ✅ Monitor for unauthorized AI tool usage by employees ("[shadow AI](https://www.ibm.com/think/topics/shadow-ai)")
+- ✅ Verify vendors encrypt data in transit and at rest, or use local processing to avoid data transmission entirely
+- ✅ Maintain access controls for who can view transcripts
+- ✅ Schedule regular compliance reviews as regulations change frequently
+
+## Choosing the right AI note-taking solution
+
+Your choice of AI note-taking tool largely determines whether compliance is a complex ongoing challenge or a manageable one-time setup.
+
+With most tools, you don't get a say in how your data is handled. Your audio goes to their servers, gets processed by their AI, and lives in their database. Every regulation you need to comply with becomes your vendor's problem to solve and yours to verify.
+
+Char works differently. You decide how your data is processed — [local models on your device](/blog/local-ai-meeting-notes/), your own cloud API keys, or Char's managed service. Everything saves as plain markdown files on your device, and IT teams can audit the open-source code. When you control the stack, you control the compliance surface.
+
+For organizations serious about both productivity and legal protection, that level of control makes both feasible.
+
+## About Char's AI notetaker
+
+![Char ai notetaker](/api/assets/blog/is-ai-notetaking-legal/legal-1.webp)
+
+Char has an Apple Notes-like interface that feels instantly familiar, with AI running in the background.
+
+When you launch a meeting, it starts transcribing speech in real-time — no bots joining your call, no calendar permissions required. When the meeting ends, it presents a structured summary with key decisions, action items, and discussion themes.
+
+The AI works hands-off if you want it to. You can also jot down key points yourself, and Char will expand your notes with context from the transcript.
+
+**Key benefits:**
+
+- Your choice of AI stack: managed cloud, bring your own API keys, or run local models
+- Works with any meeting platform without bots or integrations
+- Plain markdown files stored on your device — no proprietary databases
+- Reduces compliance surface area by keeping data handling under your control
+- Enterprise features including on-premises deployment and SSO integration
+- Open-source code your IT and security teams can audit
+
+[Download Char for MacOS](/download) to take control of your meeting data.

--- a/apps/web/content/articles/is-fireflies-ai-safe.mdx
+++ b/apps/web/content/articles/is-fireflies-ai-safe.mdx
@@ -1,0 +1,181 @@
+---
+meta_title: "Is Fireflies AI Safe? The No BS Truth"
+meta_description: "Thinking about using Fireflies AI? We dug into their data collection practices and found some red flags you should know about."
+author:
+  - "John Jeong"
+coverImage: "/api/assets/blog/is-fireflies-ai-safe/cover.png"
+featured: false
+category: "Comparisons"
+date: "2025-09-23"
+---
+
+You're in a Zoom call when suddenly "Fred from Fireflies" joins the meeting. That little bot starts recording everything you say, transcribing your conversation, and promising to send you a nice summary afterward.
+
+It's convenient. Until you start wondering: where do all those recordings actually go? And what exactly is Fireflies doing with them?
+
+We decided to find out.
+
+## What Is Fireflies AI?
+
+![Fireflies](/api/assets/blog/is-fireflies-ai-safe/fireflies-1.webp)
+
+Fireflies AI is a cloud-based service that automatically joins your video calls as a bot participant. It records everything, transcribes the conversation, and uses AI to create summaries and insights. The bot integrates with popular platforms like Zoom, Google Meet, and Microsoft Teams.
+
+Everything gets processed on Fireflies' servers, not your device. Your conversations become their data. [Otter AI raises similar concerns](/blog/is-otter-ai-safe/) with its own cloud-based recording practices.
+
+## What does Fireflies actually do with your data?
+
+I went through their privacy policy and terms of service. Here's what I found.
+
+### 1. They're collecting everything about you
+
+**Your meetings and more:**
+
+- Complete audio recordings of every conversation
+- Full transcripts and meeting summaries
+- Your calendar data and scheduling details
+- Information about everyone who attended
+
+**Your personal details:**
+
+- Name, company, email, home address, phone number
+- Account passwords and login information
+- Payment and billing data
+
+**Your digital footprint:**
+
+- Your exact location
+- Your device IDs and MAC address
+- What you search for and click on
+- Your network information and browsing habits
+
+**Access to your other accounts:**
+
+When you connect Google Calendar or other services, Fireflies can access and store "any content that you have provided to and stored in your Third-Party Account" - including your contact lists.
+
+### 2. The fine print that should worry you
+
+**They're not responsible if their AI messes up:** Their terms explicitly say that while they use AI to process your conversations, "Fireflies is not liable for any loss or harm resulting from the user's use of AI." If something goes wrong with how they handle your data, you're on your own.
+
+**Your data becomes theirs forever:** Fireflies keeps "all rights to aggregated and anonymous data derived from your use of the Service" with no expiration date. Even if they can't identify you personally, they own insights from your conversations permanently.
+
+**They share your data widely:** Your information gets shared with their business partners, service providers, any company that might buy Fireflies in the future, or government authorities if they think it's necessary.
+
+**You're legally responsible for everything:** Their terms say "You are responsible for compliance with all recording laws." If you accidentally record someone without consent, that's your legal problem, not theirs. This becomes especially problematic when users can't actually control when Fireflies records—you're still legally liable even if their bot shows up uninvited.
+
+### 3. Their liability? Basically nothing
+
+Even if Fireflies completely screws up and causes major damage, their maximum liability is capped at either what you paid them in the last six months or $100—whichever is less. Your confidential business meeting gets leaked and costs you a major client, and Fireflies owes you maybe $100.
+
+## Real privacy problems users are experiencing with Fireflies AI
+
+The privacy policy issues aren't just theoretical. Real users are reporting some concerning problems:
+
+### 1. It won't go away
+
+![Fireflies won't go away](/api/assets/blog/is-fireflies-ai-safe/fireflies-2.webp)
+
+Source: [Reddit](https://www.reddit.com/r/sales/comments/1gw2xpk/how_to_uninvite_fireflies_from_my_meetings/)
+
+Multiple people report that Fireflies keeps showing up in their meetings even after they deactivated their accounts, tried to uninstall it, asked their IT department for help, or explicitly requested it to stop recording. One user described it as "trying to remove a deer tick from your leg—messy and painful."
+
+### 2. It shares transcripts with people who never signed up
+
+![Fireflies shares transcripts without permission](/api/assets/blog/is-fireflies-ai-safe/fireflies-3.webp)
+
+Source: [Reddit](https://www.reddit.com/r/SaaS/comments/1dznmxo/fireflies_is_a_nightmare/)
+
+Fireflies automatically sends meeting summaries to everyone on the calendar invite, including people who never consented to being recorded, external clients and partners, former employees who still have access to recurring meetings, and anyone who happened to be invited but didn't even attend.
+
+### 3. It installs itself without permission
+
+![Fireflies installs itself without permission](/api/assets/blog/is-fireflies-ai-safe/fireflies-4.webp)
+
+Source: [Reddit](https://www.reddit.com/r/SaaS/comments/1dznmxo/fireflies_is_a_nightmare/)
+
+Several users report that just by joining a meeting where someone else used Fireflies, the software somehow installed itself on their computers and started recording their future meetings without their knowledge.
+
+## Should I trust Fireflies with sensitive information?
+
+**Definitely avoid Fireflies for:**
+
+- Healthcare discussions with patient information
+- Legal meetings requiring attorney-client privilege
+- Financial services conversations with client data
+- Any government or defense-related discussions
+- International calls with people protected by GDPR
+- Client consultations involving confidential business information
+
+**Use extreme caution for:**
+
+- Internal team meetings with sensitive company information
+- Job interviews or HR discussions
+- Sales calls with prospect data
+- Executive or board-level conversations
+
+**Use for:**
+
+- Public webinars or presentations
+- Non-confidential training sessions
+- Casual team social meetings
+
+Even then, everyone in the meeting needs to consent to being recorded, and you're legally responsible if they don't.
+
+&nbsp;
+
+## Is there a safer Fireflies alternative?
+
+If you need AI-powered meeting transcription but don't want to hand over your conversations to a cloud service, there's a better way. [Local AI meeting notetakers](/blog/local-ai-meeting-notes/) process everything on your device.
+
+### Meet Char: Zero lock-in AI note-taker
+
+![Char](/api/assets/blog/is-fireflies-ai-safe/fireflies-5.webp)
+
+Char is an an open-source AI notepad for meetings that gives you complete control. While Fireflies locks you into their cloud, Char stores everything as plain markdown files and lets you choose your AI stack. Zero lock-in, zero compromises. It's the only truly open-source AI notepad for meetings.
+
+Check out our [Fireflies AI Alternatives](/blog/fireflies-ai-alternatives) article for a detailed Char vs Fireflies review.
+
+### How Char keeps you safe:
+
+**Your choice of AI stack:**
+
+Managed cloud service ($25/mo), bring your own API keys, or run local models via Ollama. You choose which AI processes your data—not Fireflies.
+
+**Universal compatibility without bots:**
+
+Works with any meeting platform (Zoom, Teams, Google Meet, etc.) without joining your meetings as a bot. Records both your microphone and system audio directly, and works for in-person meetings too.
+
+**You control your data:**
+
+Export to Markdown, PDF, or rich text. Integrate with tools you already use like Obsidian or Attio. Connect to any AI provider you choose—OpenAI, Mistral, or custom endpoints. No vendor lock-in.
+
+**Built for compliance:**
+
+Meets HIPAA, GDPR, SOX, and other privacy requirements. Perfect for healthcare, legal, and financial professionals. No third-party data processors involved. Complete audit trail stays local.
+
+**Enterprise-ready:**
+
+On-premises deployment options, SSO integration and user management, custom branding available, and consent management built-in.
+
+### What Char collects (for full transparency):
+
+Unlike Fireflies, Char collects minimal, anonymous usage data that you can opt out of:
+
+- **Optional analytics:** Anonymous session IDs and feature usage patterns (via PostHog)—disable in Settings
+- **Optional crash reports:** Error traces to fix bugs (via Sentry)—disable in Settings
+- **Website interactions:** If you use live chat or submit feedback
+- **Payment info:** Only for paid users, processed through Stripe
+
+Char never collects your recordings, transcripts, notes, meeting participant information, conversations, or personal files.
+
+[Check Char's take on Privacy](/privacy)
+
+## Is Fireflies AI Safe?
+
+Fireflies AI might seem convenient, but convenience comes at a steep privacy cost. Their extensive data collection, broad sharing permissions, minimal liability, and documented issues with user control make it risky for most business conversations.
+
+If you need AI-powered meeting assistance, choose a solution with zero lock-in that gives you complete control. Char proves you don't have to sacrifice ownership for functionality.
+
+Your conversations are valuable. Don't give them away for free.
+
+&nbsp;

--- a/apps/web/content/articles/is-otter-ai-safe.mdx
+++ b/apps/web/content/articles/is-otter-ai-safe.mdx
@@ -1,0 +1,167 @@
+---
+meta_title: "Is Otter AI Safe: What You Need to Know"
+meta_description: "Otter AI faces a class-action lawsuit over privacy violations and secret recordings. Is it safe to use? Discover user complaints, data risks, and alternatives."
+author: "John Jeong"
+coverImage: "/api/assets/blog/is-otter-ai-safe/cover.png"
+category: "Comparisons"
+date: "2025-08-18"
+---
+
+[A federal class-action lawsuit](https://www.npr.org/2025/08/15/g-s1-83087/otter-ai-transcription-class-action-lawsuit) filed in August 2025 has thrust popular AI transcription service Otter AI into the spotlight, with allegations that the company "deceptively and surreptitiously" records private conversations without proper consent.
+
+The lawsuit, filed in the U.S. District Court for the Northern District of California, represents a growing pattern of privacy concerns surrounding the Mountain View-based company that has processed more than 1 billion meetings since 2016 for its 25 million users.
+
+The case raises fundamental questions about consent, privacy, and data use in the age of AI-powered workplace tools—questions that extend far beyond a single company to the entire automated transcription industry.
+
+---
+
+**💡 Before we proceed, you might want to check out:**
+
+- [List of Best Otter AI Alterntives in 2026](/blog/otter-ai-alternatives)
+- [List of Bot-free AI meeting Assistants](/blog/bot-free-ai-meeting-assistants)
+
+---
+
+## What Are the Key Allegations in the Otter AI Lawsuit?
+
+<Image src="/api/assets/blog/is-otter-ai-safe/otter-1.webp" alt="Otter AI Lawsuit"/>
+Source: [NPR](https://www.npr.org/2025/08/15/g-s1-83087/otter-ai-transcription-class-action-lawsuit)
+
+The lawsuit centers on plaintiff Justin Brewer of San Jacinto, California, who alleges his privacy was "severely invaded" upon realizing Otter was secretly recording a confidential conversation.
+
+The complaint alleges that Otter Notebook, which provides real-time transcriptions of Zoom, Google Meet, and Microsoft Teams meetings, "by default does not ask meeting attendees for permission to record and fails to alert participants that recordings are shared with Otter to improve its artificial intelligence systems."
+
+The system can automatically join meetings. As detailed in the lawsuit:
+
+> "If the meeting host is an Otter accountholder who has integrated their relevant Google Meet, Zoom, or Microsoft Teams accounts with Otter, an Otter Notetaker may join the meeting without obtaining the affirmative consent from any meeting participant, including the host."
+
+The legal filing claims this practice violates both state and federal privacy and wiretap laws, with lawyers arguing that Otter uses these recordings to "derive financial gain" through AI model training.
+
+The lawsuit also challenges Otter's "de-identification" process. It argues that "Otter's deidentification process does not remove confidential information or guarantee speaker anonymity" and that the company "provides no public explanation of its 'de-identifying' process."
+
+## Other User Incidents Concerning Otter's Consent and Recording Issues
+
+Real users have reported their own experiences with Otter's privacy issues, providing concrete examples of the problems outlined in the lawsuit:
+
+### 1. The VC Meeting Data Leak
+
+Alex Bilzerian described a particularly damaging incident in a viral tweet:
+
+<Image src="/api/assets/blog/is-otter-ai-safe/otter-2.webp" alt="Otter AI Lawsuit 2"/>
+
+Lior Yaari, CEO and Co-Founder at Grip Security, [shared a similar incident on LinkedIn](https://www.linkedin.com/posts/lioryaari_interesting-story-on-otter-ai-leaking-sensitive-activity-7245408622065647616-yUqh) that occurred when one of their sales managers signed up for Otter.
+
+### 2. Corporate Security Breaches
+
+Attorney Anessa Allen Santos [warned of organizational security risks in a LinkedIn PSA](https://www.linkedin.com/posts/anessaallensantos_psa-otterai-may-cause-a-security-breach-activity-7330556174783696897-N7oT/):
+
+<Image src="/api/assets/blog/is-otter-ai-safe/otter-3.webp" alt="Otter AI Lawsuit 3"/>
+
+### 3. Otter Spam Warning
+
+A Reddit user in r/projectmanagement [described how Otter automatically places links in meetings](https://www.reddit.com/r/projectmanagement/comments/1j0cfei/do_not_join_otterai_unless_you_want_your_whole) to share notes with others, causing confusion for those unfamiliar with the service:
+
+<Image src="/api/assets/blog/is-otter-ai-safe/otter-4.webp" alt="Otter AI Lawsuit 4"/>
+
+### 4. Interview Incident
+
+One Reddit user shared [how they lost a job opportunity](https://www.reddit.com/r/projectmanagement/comments/1j0cfei/comment/n3p3bnn):
+
+> "I am so upset - yesterday I was in an interview, and one of the interviewers asked me if it was being recorded (apparently, Otter AI had joined without my permission or knowledge). To my horror, I found out only after, that I believe it was indeed recorded- and sent out to me and all the interviewers! Otter AI is seriously intrusive and I have no idea who now has access to a private meeting that I ensured all was NOT being recorded."
+
+<Image src="/api/assets/blog/is-otter-ai-safe/otter-5.webp" alt="Otter AI Lawsuit 5"/>
+
+### 5. Gartner Community Response
+
+IT professionals on [Gartner's peer community](https://www.gartner.com/peer-community/post/how-managing-risk-ai-transcription-bots-like-otter-ai-fireflies-ai) raised concerns about the tool. [Fireflies AI faces similar scrutiny](/blog/is-fireflies-ai-safe/) from users reporting comparable privacy issues.
+
+<Image src="/api/assets/blog/is-otter-ai-safe/otter-6.webp" alt="Otter AI Lawsuit 6"/>
+
+A VP Information Security Officer commented:
+
+> "We block otter ai.. Way too much data for a company to have without a contract, security review and relationship."
+
+A Director of Engineering added:
+
+> "I think most companies policies are to not have these capabilities enabled until the understand the data risk posed, infrastructure, used for training or not, etc."
+
+## What Does Otter's Privacy Policy Explain About These Privacy Issues?
+
+Otter.ai's official privacy policy and privacy & security pages reveal practices that many users may not fully understand.
+
+While the company emphasizes security and privacy protections, the detailed policies show extensive data collection, usage, and sharing that goes well beyond simple transcription.
+
+### 1. Data Collection and AI Training
+
+[Otter's privacy policy](https://otter.ai/privacy-policy) openly states it uses customer data for AI training purposes:
+
+> "We train our proprietary artificial intelligence technology on de-identified audio recordings. We also train our technology on transcriptions to provide more accurate services, which may contain Personal Information."
+
+<Image src="/api/assets/blog/is-otter-ai-safe/otter-7.webp" alt="Otter AI Lawsuit 7"/>
+
+The policy also reveals manual review of recordings when users provide consent:
+
+> "We obtain explicit permission (e.g. when you rate the transcript quality and check the box to give Otter ai and its third-party service provider(s) permission to access the conversation for training and product improvement purposes) for manual review of specific audio recordings to further refine our model training data."
+
+The [privacy & security FAQ](https://otter.ai/privacy-security) claims that "audio recordings and transcripts are not manually reviewed by a human" as part of the automatic training process, yet the privacy policy clearly states that manual review occurs when users provide explicit permission. This creates ambiguity about when human access to recordings actually happens.
+
+<Image src="/api/assets/blog/is-otter-ai-safe/otter-8.webp" alt="Otter AI Lawsuit 8"/>
+
+### 2. Extensive Third-Party Data Sharing
+
+The breadth of third-party data sharing outlined in Otter's privacy policy is significant. The company shares personal information with multiple categories of external parties, including:
+
+- "Cloud service providers who we rely on for compute and data storage, including Amazon Web Services, based in the United States"
+- "Data labeling service providers who provide annotation services and use the data we share to create training and evaluation data for Otter's product features"
+- "Artificial intelligence service providers that provide backend support for certain Otter product features"
+- "Platform support providers who help us manage and monitor the Services, including Amplitude, which is based in the U.S. and provides user event data for our Services"
+
+<Image src="/api/assets/blog/is-otter-ai-safe/otter-9.webp" alt="Otter AI Lawsuit 9"/>
+
+### 3. The De-identification Problem
+
+Otter claims to use "a proprietary method to de-identify user data before training our models so that an individual user cannot be identified," but provides no public explanation of how this process works.
+
+The privacy policy also acknowledges that transcriptions used for training "may contain Personal Information," which raises questions about anonymization effectiveness.
+
+### 4. Automatic Data Collection
+
+The privacy policy reveals extensive automatic data collection beyond recordings and transcripts:
+
+- **Usage Information:** "When you use the Services, you generate information pertaining to your use, including timestamps, such as access, record, share, edit and delete events, app use information, screenshots/screen captures taken during the meeting, interactions with our team, and transaction records"
+- **Device Information:** "We assign a unique user identifier ('UUID') to each mobile device that accesses the Services"
+- **Location Information:** "When you use the Services, we receive your approximate location information"
+
+<Image src="/api/assets/blog/is-otter-ai-safe/otter-10.webp" alt="Otter AI Lawsuit 10"/>
+
+## How Safe is Otter AI
+
+The privacy concerns surrounding Otter.ai reflect broader issues that affect anyone using AI-powered workplace tools.
+
+Organizations in heavily regulated industries face potential violations when sensitive conversations are automatically recorded and processed by third-party services without proper consent mechanisms or data controls.
+
+Individual employee adoption of cloud-based AI tools can create organization-wide data exposure, especially when these tools share information with multiple external processors and lack enterprise-grade security controls. For teams that need transcription without these risks, [local AI meeting notetakers](/blog/local-ai-meeting-notes/) keep data on your device entirely.
+
+Automatic recording features can damage business relationships, compromise confidential discussions, and create legal exposure when private conversations are captured without all participants' knowledge.
+
+The fundamental issue extends beyond any single company. As AI tools become more automated, the gap between user expectations and actual data practices widens, creating risks that users may not realize they're accepting.
+
+## Is There a Safer Otter AI Alternative?
+
+The privacy concerns around Otter AI highlight the need for transcription solutions that prioritize user privacy and data control.
+
+For organizations and individuals seeking AI-powered transcription without vendor lock-in, open-source alternatives offer a compelling option.
+
+**Char** is the [best Otter AI alternative](/blog/otter-ai-alternatives) and an open-source AI notepad for meetings that gives you complete control over your data and AI stack. Everything is stored as plain markdown files—not in proprietary databases.
+
+This approach addresses the core issues raised in the Otter AI lawsuit and user complaints:
+
+- **Zero lock-in:** Plain markdown files, open source, portable format—your data works with any tool
+- **Complete control:** Choose your AI stack: managed cloud, bring your own keys, or run fully local
+- **True ownership:** Your files live on your device, not in someone's database
+- **Simplified compliance:** Reduces the compliance surface area by minimizing dependency on cloud vendors, making audits easier
+- **Complete transparency:** As an open-source solution, IT teams can audit the code and you can use the AI provider your security team approves
+
+Char is free forever for local transcription, BYOK, and all core features. For enterprises navigating compliance frameworks like HIPAA, SOC 2, or GDPR, Char's zero-lock-in architecture makes it easier to fulfill data subject rights, maintain audit trails, and enforce access controls.
+
+[Download Char for MacOS](/download) and experience meeting notes with zero lock-in.

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -1,0 +1,220 @@
+---
+meta_title: "5 Best Local AI Meeting Notetakers in 2026"
+meta_description: "Local AI meeting notes tools that transcribe and summarize on your device. For engineers, legal teams, and anyone whose company banned cloud recording tools."
+author:
+  - "Harshika"
+featured: false
+category: "Comparisons"
+date: "2026-04-10"
+---
+
+Every meeting notetaker calls itself "local" or "private" now. The word has become a marketing checkbox. But local means wildly different things depending on which tool you pick.
+
+Some tools transcribe on your device but send the transcript to a cloud LLM for summarization. Some store notes locally but make them accessible via a shareable link by default. Some process everything on-device but only work on one operating system, or only on recent hardware. And some are fully local until you look at the fine print and discover your data trains their models unless you opt out.
+
+I tested five tools that take different positions on this spectrum. For each one, I dug into what "local" actually means in practice: what stays on your machine, what leaves, what the tradeoffs are, and what it costs.
+
+## How These Local AI Meeting Notetakers Compare
+
+
+|                |                                                                    |                                |
+| -------------- | ------------------------------------------------------------------ | ------------------------------ |
+| **Tool**       | **Best For**                                                       | **Pricing**                    |
+| **Char**       | Users who want complete control over data and AI stack             | Free (local/BYOK), Pro $25/mo  |
+| **Meetily**    | Teams on Windows or Mac who want a polished open-source option     | Community free, Pro $10/mo     |
+| **Shadow**     | Client-facing roles who need screen capture alongside audio        | Free transcription, Plus $8/mo |
+| **Talat**      | People who want Granola's UX without the cloud, for a one-time fee | $49 pre-release, $99 at 1.0    |
+| **Screenpipe** | Developers who want meeting notes as part of full desktop memory   | $400 lifetime                  |
+|                |                                                                    |                                |
+
+
+## 5 Tools for Local AI Meeting Notes: A Closer Look
+
+### 1. Char
+
+![](/api/assets/blog/blog/char-summary.png "char-editor-width=80")
+
+[Char](https://char.com) is an open-source AI notepad for meetings, built for people who want complete control over their data and AI stack. It captures system audio from any meeting platform without joining your call and without requiring calendar permissions. 
+
+You can take notes during the meeting in Char's built-in editor while it transcribes in the background, and the AI combines both into a structured summary after the call. 
+
+The AI stack is yours to choose: Char's managed cloud service, your own API keys from OpenAI, Anthropic, or Deepgram, or fully local models through Ollama or LM Studio for offline operation. Every audio file, transcript, and note lives on your computer. You decide if data ever leaves your device.
+
+#### How local is it actually
+
+- Transcription: local or BYOK. Supports Ollama and LM Studio for fully on-device processing.
+- Summarization: your choice. Managed cloud, BYOK API keys, or local models. You control the boundary.
+- Storage: all data stored locally on your device. Your files, your folder structure, zero lock-in.
+- Open-source codebase. Your security team can audit exactly how data is handled.
+
+If you run Char with local models, nothing leaves your machine. If you plug in an API key, only the transcript goes to that provider for summarization. For companies that have banned cloud-based meeting tools, Char is one of the few options where "local-first" means exactly what it says.
+
+#### Where it falls short
+
+- macOS and Linux only. No Windows client yet.
+- No mobile app, no video recording.
+- No built-in CRM integrations. If you need notes pushed into Salesforce, you will need to build that yourself.
+- No team dashboard or cross-meeting cloud search. Your notes live in your file system.
+
+#### Pricing
+
+Free for unlimited loacl transcription and AI. A lite plan at $8/month with Char cloud and pro at $25/month for integrations, advanced templates, and more.
+
+### 2. Meetily
+
+![meetily review](/api/assets/blog/blog/image-20.png "char-editor-width=80")
+
+[Meetily](https://meetily.ai) is an open-source meeting assistant (MIT license) that runs transcription entirely on your device using Whisper or Parakeet models. 
+
+It captures system audio [without a bot](/blog/bot-free-ai-meeting-assistants/), works with Zoom, Teams, Meet, and anything else that produces audio on your machine. Parakeet is the default engine and runs significantly faster than Whisper with lower resource usage, with GPU acceleration built in for Apple Silicon, NVIDIA, and AMD hardware.
+
+Summaries are pluggable: use Ollama for fully local processing, or connect your own API key to Claude, Groq, or OpenRouter. The app is built in Rust with a Next.js frontend and ships as a single installer for macOS and Windows. Linux users can build from source.
+
+#### How local is it actually
+
+- Transcription: 100% local. Whisper or Parakeet models running on your hardware.
+- Summarization: pluggable. Ollama for fully local, or BYOK with cloud providers.
+- Storage: local SQLite database. Audio files stored on your device.
+- GPU acceleration: Apple Silicon (Metal), NVIDIA (CUDA), AMD/Intel (Vulkan).
+
+The team is transparent that local model summarization does not match cloud quality yet, especially on longer meetings. They document the tradeoffs in their blog and are actively working on closing the gap.
+
+#### Where it falls short
+
+- Speaker diarization is still in development.
+- Local summarization quality lags cloud on long meetings.
+- Linux requires building from source.
+- No mobile app.
+
+#### Pricing
+
+Community Edition is free forever. Pro is at $10/month, billed annually, includes enhanced accuracy models, auto-meeting detection, PDF/DOCX export, and custom templates.
+
+### 3. Shadow
+
+![shadow.do review](/api/assets/blog/blog/Screenshot-2026-04-10-at-7.43.38-PM.png "char-editor-width=80")
+
+[Shadow](https://shadow.do) captures both channels of a meeting: what is said and what is shown on screen. It runs on macOS, records system audio without a bot, and automatically takes timestamped screenshots of whatever is displayed during your call: slides, code, dashboards, design mockups. Those screenshots are embedded directly in your notes alongside the transcript.
+
+This matters the moment someone says "look at the numbers on slide four" and you need to know what those numbers were. Every other tool on this list captures audio only. Shadow also has autopilot mode that detects meetings and starts recording without you pressing anything, real-time speaker identification, and custom post-meeting AI "Skills" that run automatically.
+
+#### How local is it actually
+
+- Transcription: local. Audio never leaves your Mac.
+- Screen capture: local. Screenshots stored on device.
+- Summarization: cloud LLM APIs by default. Can be disabled, but you lose summaries, action items, and the "Ask Shadow" chatbot.
+- Export: .md files to a local folder. Works with Obsidian out of the box, webhooks for Zapier/Make/n8n.
+
+Shadow is local for capture but not fully local for intelligence. The AI features route through external APIs. You can turn them off and keep just the transcript and screenshots, but then you lose the analysis layer.
+
+#### Where it falls short
+
+- macOS only.
+- AI features use cloud APIs, so not fully local end-to-end.
+- Free tier caps AI-powered features at 25 lifetime meetings.
+- No real-time collaborative editing.
+
+#### Pricing
+
+Free for unlimited transcription and 25 lifetime meetings for AI features. Plus, at $8/month, billed annually.
+
+### 4. Talat
+
+![talat notetaker review](/api/assets/blog/blog/image-25.png "char-editor-width=80")
+
+[Talat](https://talat.app) runs transcription and summarization entirely on your Mac's Neural Engine. It captures both sides of your call (system audio and microphone), transcribes in real time with speaker identification, and generates summaries using a local LLM (Qwen3-4B-4bit by default). The whole app is 20 MB. It detects when a conferencing app grabs your microphone and starts recording in the background.
+
+The focus is configurability. You choose your LLM provider: the built-in local model, OpenAI, Anthropic, OpenRouter, or Ollama. You can write custom summarization prompts, auto-export notes to Obsidian, fire webhooks when a meeting ends, and run an MCP server so AI coding tools can query your meeting history. No analytics, no telemetry, no data collection.
+
+#### How local is it actually
+
+- Transcription: 100% on-device via FluidAudio on Apple's Neural Engine. Audio never leaves your Mac.
+- Summarization: local by default (Qwen3-4B-4bit). Optional BYOK with OpenAI, Anthropic, OpenRouter, or Ollama.
+- Storage: local database. Auto-export to Obsidian, webhooks, MCP server.
+- Zero analytics, zero telemetry.
+
+If you never configure a cloud LLM, nothing leaves your machine. Talat was [featured in TechCrunch](https://techcrunch.com/2026/03/24/talats-ai-meeting-notes-stay-on-your-machine-not-in-the-cloud/) in March 2026 and is a one-time purchase from a bootstrapped two-person team.
+
+#### Where it falls short
+
+- macOS only, M-series chips only (M1 or later).
+- Pre-release software. Speaker diarization is rough.
+- Local LLM summarization can be hit or miss on longer meetings.
+- No calendar integration yet (planned).
+
+#### Pricing
+
+$49 one-time purchase (pre-release price). $99 at version 1.0. 10 hours of free recordings to try before buying.
+
+### 5. Screenpipe
+
+![screenpipe review](/api/assets/blog/blog/image-26.png "char-editor-width=80")
+
+[Screenpipe](https://screenpi.pe) records your screen and audio 24/7, transcribes everything locally with Whisper, and indexes it in a searchable local database. 
+
+It is not a meeting tool. It is an open-source AI memory layer for your entire desktop that happens to be very good at meeting notes, because meeting notes are a side effect of it always running.
+
+After a call, you ask the AI: "Summarize my meeting from 2 to 3pm and list action items." Screenpipe searches your audio transcripts and screen content from that time window. 
+
+It captures what audio-only tools miss: the URL someone dropped in the Zoom chat, the spreadsheet someone shared, the code someone walked through in a terminal. It also runs as an MCP server, so Cursor, Claude Code, and Cline can query your meeting history directly.
+
+#### How local is it actually
+
+- Transcription: local Whisper by default. Optional Deepgram (cloud) for faster processing.
+- Summarization: any model. Ollama for local, or connect cloud models.
+- Storage: local SQLite database in ~/.screenpipe/data/.
+- Screen capture: local. Accessibility APIs + OCR fallback.
+- Runs on macOS, Windows, and Linux. MIT-licensed open source.
+
+#### Where it falls short
+
+- Not purpose-built for meetings. Always running, always capturing.
+- Higher resource usage (~5-10% CPU, ~20 GB storage/month).
+- Setup is more involved: configuring audio devices, transcription engines, pipe automations.
+- $400 is steep if you only want meeting notes.
+
+#### Pricing
+
+$400 lifetime (one-time). All features, all future updates. $600 lifetime + 1 year of Pro (cloud sync, priority support).
+
+**Which Local AI Meeting Notetaker Is Right for You?**
+
+Local processing means accepting tradeoffs. Local models are not as accurate as cloud transcription on messy audio, speaker diarization is still maturing across the board, and most of these tools are macOS-only or macOS-first. The gap is closing fast, though, and for anyone handling sensitive conversations, the architectural guarantee that your audio never left your device is worth more than a privacy policy that can change with a terms-of-service update.
+
+Char is the strongest choice if you want complete control: open-source, your choice of AI provider, and data that lives on your device in a format you own. 
+
+Meetily is the best open-source option if you need Windows support or want a free polished app. 
+
+Shadow is the only tool that captures what is on screen alongside what is said. 
+
+Talat is for people who loved Granola but could not accept cloud dependency, and it is the only one-time purchase purpose-built meeting tool here.
+
+Screenpipe is the power user's option: not just meeting notes but a searchable memory of your entire workday. 
+
+If you want to start with local AI meeting notes that give you full ownership, [try Char](https://char.com). It is free, open-source, and works offline with local models. Your first meeting's notes will land on your device, readable by any tool you already use.
+
+## Frequently Asked Questions
+
+### 1. Is Granola a local AI notetaker?
+
+No. Granola captures system audio locally, which is why it gets grouped with local tools, but the similarity ends there. Your audio is sent to Deepgram for transcription, your transcript is processed through GPT-4o or Claude for summarization, and your notes are stored on AWS servers. There is no offline mode and no option to run local models. Granola is a cloud tool with a local audio capture step. 
+
+### 2. Can I use these tools for in-person meetings?
+
+Yes. Tools that capture microphone input (Char, Meetily, Talat, Screenpipe) work for in-person conversations. Place your laptop near the speakers and let the mic pick up the room. Speaker diarization accuracy varies since it was primarily designed for virtual calls with separate audio channels.
+
+### 3. Do local meeting notetakers work offline?
+
+If both transcription and summarization use local models, yes. Char with Ollama, Meetily with Parakeet + Ollama, Talat with its built-in LLM, and Screenpipe with local Whisper all work without an internet connection. Shadow's transcription works offline but the AI summary features need a connection.
+
+### 4. What hardware do I need to run local transcription?
+
+Most tools work on any Mac from the last five years. Apple Silicon (M1 or later) gives the best performance due to the Neural Engine. Intel Macs are supported by Meetily and Screenpipe but transcription will be slower. Talat requires M-series specifically. On Windows, a modern multi-core processor with 8+ GB RAM handles Whisper fine. A dedicated GPU (NVIDIA with CUDA) speeds things up significantly for Meetily and Screenpipe.
+
+### 5. Is it legal to record meetings without telling participants?
+
+Recording laws vary by jurisdiction. In many US states and most of Europe, you need consent from all parties to record a conversation. The fact that these tools do not send a bot into the meeting makes them less visible, but that does not remove your legal obligation to inform participants. Always tell the people on your call that you are recording.
+
+### 6. Are local AI meeting notes as accurate as cloud-based tools?
+
+It depends on the model and your hardware. Cloud transcription services like Deepgram still have an edge on messy audio, heavy accents, and cross-talk. But local models like Parakeet and Whisper Large V3 have closed the gap significantly, especially on clear audio from a decent microphone. For most one-on-one and small group calls, the difference is negligible.

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -34,7 +34,7 @@ I tested five tools that take different positions on this spectrum. For each one
 
 ![](/api/assets/blog/blog/char-summary.png "char-editor-width=80")
 
-[Char](https://char.com) is an open-source AI notepad for meetings, built for people who want complete control over their data and AI stack. It captures system audio from any meeting platform without joining your call and without requiring calendar permissions. 
+[Char](https://anarlog.so) is an open-source AI notepad for meetings, built for people who want complete control over their data and AI stack. It captures system audio from any meeting platform without joining your call and without requiring calendar permissions. 
 
 You can take notes during the meeting in Char's built-in editor while it transcribes in the background, and the AI combines both into a structured summary after the call. 
 
@@ -191,7 +191,7 @@ Talat is for people who loved Granola but could not accept cloud dependency, and
 
 Screenpipe is the power user's option: not just meeting notes but a searchable memory of your entire workday. 
 
-If you want to start with local AI meeting notes that give you full ownership, [try Char](https://char.com). It is free, open-source, and works offline with local models. Your first meeting's notes will land on your device, readable by any tool you already use.
+If you want to start with local AI meeting notes that give you full ownership, [try Char](https://anarlog.so). It is free, open-source, and works offline with local models. Your first meeting's notes will land on your device, readable by any tool you already use.
 
 ## Frequently Asked Questions
 

--- a/apps/web/content/articles/local-ai-privacy-tools.mdx
+++ b/apps/web/content/articles/local-ai-privacy-tools.mdx
@@ -1,0 +1,96 @@
+---
+meta_title: "The Rise of Local AI: How the Next Wave of Privacy Tools Will Be Built"
+meta_description: "From DuckDuckGo to Proton, privacy-first apps have earned user trust. Now, local AI is carrying that vision forward."
+author: "John Jeong"
+coverImage: "/api/assets/blog/local-ai-privacy-tools/cover.png"
+category: "Engineering"
+date: "2025-07-28"
+---
+
+## Intro
+
+In the past decade, we've watched a new generation of software companies win not by collecting more data, but by collecting none. [DuckDuckGo](https://duckduckgo.com/) built a search engine without profiling users. [Brave](https://brave.com/) gave people a browser that blocked trackers by default. [Proton](https://proton.me) delivered email and cloud storage that not even they could read.
+
+Each of these tools rejected the tradeoffs that Big Tech made years ago—usability traded for privacy, performance traded for control. They proved that privacy isn't just a niche preference. It's a product category.
+
+Now, AI is testing that principle again.
+
+## Privacy, revisited
+
+The AI boom has delivered impressive capabilities but also renewed surveillance. A meeting you record with an AI notetaker gets sent to the cloud. A contract you upload for AI review gets logged on someone else's server. Even just asking ChatGPT a question reveals more about you than most search queries ever did.
+
+The current generation of AI tools is fundamentally cloud-first. To use them is to surrender control over what you share, where it goes, and who might see it later.
+
+Where are the privacy-first tools in AI?
+
+Just as DuckDuckGo and Brave offered new choices for search and browsing, and Proton reimagined communications, we now need tools that bring the same principles into this new era.
+
+<CtaCard/>
+
+## Why local AI works
+
+When it comes to AI, there's only one model that offers true privacy assurance: local AI.
+
+Two things make this work:
+
+### 1. Physical assurance
+
+When AI runs on your device, no data ever needs to leave it. Cloud-based models promise "we won't look." Local AI guarantees "we can't look." This shifts privacy from policy to physics.
+
+### 2. No training risk
+
+Even if cloud tools promise not to store data, many reserve the right to learn from your inputs. Your private content can help train models that power other people's experiences. With local AI, there's no risk of data reuse because there's no training loop. What happens on your device stays on your device.
+
+This is a trust decision. And it's becoming foundational to privacy in the AI age.
+
+## A familiar pattern
+
+We've seen this before.
+
+When DuckDuckGo launched, a search engine that didn't track you felt almost paradoxical. But people wanted it, and the company grew as users chose control over convenience.
+
+Brave did the same for browsing. Their browser shipped with ad-blocking, fingerprinting prevention, and default tracker protection. People already understood why this mattered.
+
+Proton entered a crowded market of productivity apps but stood out by offering zero-access encryption. Users weren't just buying features. They were buying values.
+
+These companies didn't invent new use cases. They reimagined familiar ones—search, browsing, email—and recentered them around privacy.
+
+AI is the next interface ripe for that shift.
+
+<Image src="/api/assets/blog/local-ai-privacy-tools/your-data-is-wanted.png" alt="Your data is wanted by everyone"/>
+
+## Where Char comes in
+
+At [Char](/), we're building an open-source AI notepad for meetings that gives you complete control. Everything is stored as plain markdown files. You choose your AI stack—managed cloud, bring your own keys, or run local models. Zero lock-in, zero compromises.
+
+We open-sourced our core app so anyone can audit it. We support offline mode by default, and for teams that need collaboration, we offer self-hosted options that never touch external servers. You can even bring your own models.
+
+Our users include salespeople, engineers, lawyers, doctors, and founders—people who deal with sensitive conversations every day.
+
+Char isn't just about note-taking. It lets AI enhance your work without owning it.
+
+## The privacy stack is evolving
+
+Privacy-first software now means building an ecosystem of tools that work locally, transparently, and under your control.
+
+The early stack looked like:
+
+- **Search** → DuckDuckGo
+- **Browsing** → Brave
+- **Communication** → Proton
+
+With the rise of AI, a new layer is forming:
+
+- **Cognition** → Char (and others like it)
+
+This stack isn't defined by features. It's defined by where your data lives and who controls it. Users are increasingly choosing tools where they can answer "me" to both questions.
+
+## Final thoughts
+
+Cloud-first AI is colliding with growing demand for control and ownership. As more workflows get automated and augmented by AI, the need for zero-lock-in, transparent, user-controlled solutions will only grow.
+
+Local AI is the inevitable future, driven by both performance and principle. Just as early privacy pioneers reshaped the web, we're helping reshape AI.
+
+If you've ever used DuckDuckGo, Brave, or Proton and wished there was something similar for your meetings, we built Char for you.
+
+<CtaCard/>

--- a/apps/web/content/articles/mac-productivity-apps.mdx
+++ b/apps/web/content/articles/mac-productivity-apps.mdx
@@ -1,0 +1,406 @@
+---
+meta_title: "9 Best Mac Productivity Apps for 2026"
+meta_description: "Discover the best Mac productivity apps for 2026. A vetted list of tools for AI meeting notes, file management, and automation."
+author:
+  - "J"
+  - "o"
+  - "h"
+  - "n"
+  - " "
+  - "J"
+  - "e"
+  - "o"
+  - "n"
+  - "g"
+featured: true
+category: "Guides"
+date: "2026-02-13"
+---
+
+Every January hits the same. New year energy kicks in, I get that productivity rush, and suddenly I'm downloading every app that promises to "transform my workflow." Most of them? Gone by February. Deleted after the free trial ends or sitting in my Applications folder collecting dust.
+
+But some apps stick. They become so embedded in how I work that trying to function without them feels wrong. Like muscle memory, but for software.
+
+This year, I'm skipping the usual "top 10 productivity apps" listicle and just sharing what actually works. Some of these I found recently and can't believe I lived without. Others have been riding with me for years. A few I built myself because nothing else solved the problem right.
+
+If you're a Mac user looking to actually get more done (not just feel productive while reorganizing your dock for the third time this week), here's what's worth your time.
+
+## My favorite productivity apps for Mac
+
+
+| Tool             | Best For                                                                | Pricing                             |
+| ---------------- | ----------------------------------------------------------------------- | ----------------------------------- |
+| Char             | AI note-taker with complete control over data and AI stack              | Free, Pro $25/mo                    |
+| Cowork           | AI agent that handles tedious file work and research                    | Claude Pro/Team/Enterprise required |
+| Raycast          | Replacing Spotlight with a command center that actually does things     | Free, Pro $10/mo                    |
+| Obsidian         | Building a personal knowledge base with files you actually own          | Free, Sync $8/mo                    |
+| Things 3         | Task management that's beautiful enough to actually open daily          | $50 Mac, $10 iPhone (one-time)      |
+| CleanShot X      | Screenshots and screen recordings for people who share a lot of visuals | $29 one-time, Pro $8/mo             |
+| Keyboard Maestro | Automating repetitive tasks you do every single day                     | $36 one-time                        |
+| Hazel            | File organization that runs on autopilot forever                        | $42 one-time                        |
+| Reeder           | Following blogs and content without algorithmic feeds                   | $10/year                            |
+
+
+## Best Mac productivity apps in 2026
+
+### 1. Char (formerly Hyprnote): best Mac app for meeting notes
+
+![Char review](/api/assets/blog/articles/mac-productivity-apps/image-1.png)
+
+Meetings suck, but they're inevitable. The next best thing is making sure you never miss a detail with a note-taker that doesn't lock your data in someone else's cloud. I built Char for this reason.
+
+[Char](https://char.com/) is an open-source AI note-taker that stores your data locally and gives you complete control over the AI stack. You decide if your audio, transcripts, or notes ever leave your device. You pick your preferred STT and LLM provider, which means you can go completely local if you want to. No forced stack. No lock-in.
+
+#### Key Features:
+
+- System audio capture: No bots; works on Zoom, Teams, phone calls, and in-person
+- Real-time transcription: See what's being said as the meeting happens
+- AI summaries: Combines your notes + transcript to generate summaries with action items
+- Files over apps: Every meeting is a .md file you fully own
+- Flexible AI stack: Use managed cloud, bring your own API key (Cloud or local)
+- Custom templates: Structure recurring meetings automatically
+- Searchable: Semantic search across all meetings with date filters
+- 45+ languages: Including English, Spanish, French, German, Japanese, Mandarin
+- Open source: Code is public, auditable by IT/security teams
+
+#### Pros:
+
+- You actually own your data. The files stay on your device
+- No internet required with local models
+- No lock-in. You can switch AI providers anytime
+- More discreet than bot-based note-takers
+- Security teams can audit the code before approving
+- Works for any conversation (not just video calls)
+- Integrates into existing markdown workflows
+
+#### Cons:
+
+- macOS only currently (Windows and Linux versions coming in Q2 2026)
+- No video recordings
+- No mobile app yet
+
+#### Pricing:
+
+Unlimited free plan with local transcription or bring-your-own-key. Pro is $25/month for managed cloud service.
+
+### 2. Cowork: best AI agent for file management and research on Mac
+
+![claude cowork review](/api/assets/blog/articles/mac-productivity-apps/image-2.png)
+
+[Cowork](https://www.google.com/url?q=https://claude.com/product/cowork&sa=D&source=editors&ust=1771000364592542&usg=AOvVaw3IUGqoH1gDbJb37GIIwVaY) is Claude Code's friendlier cousin, built for people who don't want to touch a terminal but still want an AI that can handle multi-step tasks across their actual files and folders.
+
+#### Key Features:
+
+- Local file access: Give Claude permission to specific folders and it'll read, edit, organize, and create files without you manually uploading anything
+- Multi-step task execution: Set it loose on a project and it'll work through multiple steps autonomously, checking in when it needs guidance
+- Built-in skills: Comes with pre-loaded expertise for creating presentations, spreadsheets, and documents with proper formatting
+- Works with your connectors: Integrates with MCP servers you already have set up (like Google Drive, Slack)
+- Task queueing: Drop multiple requests and let Claude work through them in parallel—feels less like a conversation, more like delegating to a coworker
+
+#### Pros:
+
+- Handles tedious work you'd normally grind through for hours (organizing downloads, processing receipts, restructuring notes)
+- No bot joining your Zoom calls or needing calendar permissions
+- Works seamlessly with tools like Obsidian, Notion, VS Code since everything's just files
+- Can handle complex workflows like "find all my unpublished blog drafts that are almost done"
+
+#### Cons:
+
+- Burns through your usage limits fast
+- Still in research preview, so you'll run into bugs
+- Security concerns around prompt injection aren't fully solved yet
+- Requires explicit folder permissions, which can feel limiting if you want it to work across your whole system
+- Can potentially delete files if it misunderstands instructions
+
+#### Pricing:
+
+Available to paid subscribers, with pricing starting at $17/month for Pro users, or via higher-tier Max plans ($100–$200/month) for increased usage capacity.
+
+### 3. Raycast: best Spotlight replacement for Mac power users
+
+![raycast for mac review](/api/assets/blog/articles/mac-productivity-apps/image-3.png)
+
+[Raycast](https://www.google.com/url?q=https://www.raycast.com/&sa=D&source=editors&ust=1771000364595764&usg=AOvVaw1B62lKeEaYHNZvmw5VzjNK) is Spotlight done right. Need to paste something from ten minutes ago? It's there. Want to tile a window left without touching your trackpad? Done. Converting 50 GBP to USD? Type it. Most of this you can technically do elsewhere, but Raycast puts it behind one hotkey.
+
+#### Key Features:
+
+- Spotlight on steroids: Launch apps, search files, do calculations, convert currencies, faster
+- Clipboard history: Never lose something you copied three pastes ago; search through everything with a keystroke
+- Window management: Snap windows into place without needing Rectangle or Magnet
+- 1,000+ extensions: Control Spotify, manage Linear issues, search Notion, check your calendar without opening any of them
+- Snippets & quicklinks: Type shortcuts that expand into full text blocks or URLs instantly
+- AI integration: Access ChatGPT, Claude, and other AI models right from your command bar
+- Custom scripts: Run shell commands and automate workflows directly from Raycast
+
+#### Pros:
+
+- Genuinely fast; no lag between typing and results appearing
+- Free tier is incredibly generous; most people never need Pro
+- Extensions are easy to install and actually useful (not bloatware)
+- Can map any action to a global hotkey that works system-wide
+- Active development with constant updates and new features
+- Clean, modern interface that doesn't feel cluttered despite doing so much
+- Works seamlessly across macOS versions
+
+#### Cons:
+
+- Some extensions can be hit-or-miss in quality
+- Pro subscription feels overpriced for what's essentially AI access
+- Takes time to build muscle memory and really leverage all features
+
+#### Pricing:
+
+Free forever for core features. Raycast Pro is $10/month for AI features, unlimited clipboard history, and cloud sync. Pro + Advanced AI is $20/month for premium AI models. Team plans start at $15/user/month.
+
+### 4. Obsidian: best PKM app for Mac
+
+![obsidian review for mac users](/api/assets/blog/articles/mac-productivity-apps/image-4.png)
+
+I've been an [Obsidian](https://www.google.com/url?q=https://obsidian.md/&sa=D&source=editors&ust=1771000364598966&usg=AOvVaw3BuiZ2NKCDRiSA5vb0cKU2) power user for years. I started using it to link random thoughts together and eventually got deep enough to build my own plugins.
+
+When everything's markdown files on your computer and you can extend it however you want, it stops feeling like an app and starts feeling like your system. That sense of ownership changes how you work.
+
+#### Key Features:
+
+- Wiki-style links: Connect notes by typing [[note name]]. It helps you build a web of related ideas
+- Graph view: Visual map of how all your notes connect (looks cool, rarely useful in practice)
+- Local markdown files: Everything stored as .md files you fully control and can open anywhere
+- 1,000+ community plugins: Extend functionality with everything from task management to chart generation
+- Canvas mode: Infinite whiteboard for brainstorming and laying out ideas visually
+- Custom themes and CSS: Make it look however you want (if you're willing to tinker)
+- Daily notes: Built-in journaling system with templates
+- No internet required: Works completely offline
+
+#### Pros:
+
+- Your data is actually yours
+- Works with any sync service (iCloud, Dropbox, Google Drive) or use Obsidian Sync
+- Free for personal use with no feature restrictions
+- Pairs perfectly with markdown-based tools like Char
+- Active community constantly building new plugins and themes
+
+#### Cons:
+
+- Steep learning curve if you want to do anything beyond basic notes
+- Can become a productivity procrastination trap (endless tweaking)
+- Not visually polished out of the box, requires theme hunting
+- File-based organization can get messy fast without discipline (Cowork can help)
+- Closed source despite storing files locally
+
+#### Pricing:
+
+Free for personal use. Obsidian Sync is $10/month for encrypted cloud sync across devices. Commercial use (revenue over $1M/year) requires a $50/user/year license. 
+
+### 5. Things 3: best task manager for Mac users
+
+![things 3 review for mac users](/api/assets/blog/articles/mac-productivity-apps/image-5.png)
+
+[Things 3](https://www.google.com/url?q=https://culturedcode.com/things/&sa=D&source=editors&ust=1771000364602479&usg=AOvVaw0tDIV9BWpoHkd0i3v2HhpO) is what happens when designers actually care about how software feels. It's not trying to be everything; just a beautiful way to track what you need to do today. Expensive and missing features, but the best tool is the one you actually want to use.
+
+#### Key Features:
+
+- Today + This Evening: Smart way to separate daytime tasks from evening ones
+- Upcoming view: See your week at a glance with scheduled tasks and deadlines
+- Headings: Break projects into sections without creating separate lists
+- Quick Entry: CMD+Space to capture tasks from anywhere on Mac
+- Calendar integration: See events alongside tasks in your Today view
+- Magic Plus button: Drag to insert tasks exactly where you want them (iPad/iPhone)
+- Natural dates: Type "tomorrow" or "next Friday" and it just works
+- Checklists: Break down tasks without creating full projects
+- Apple Watch integration: Quick capture and task viewing on your wrist
+
+#### Pros:
+
+- Fast and responsive, never lags
+- Today view keeps you focused on what matters now
+- Works completely offline
+- Calendar events show up in your task list
+- Apple Shortcuts integration for automation
+- Feels calming to use instead of overwhelming
+
+#### Cons:
+
+- No collaboration features whatsoever
+- Expensive ($50 Mac, $10 iPhone, $20 iPad. Separate purchases)
+- Missing features power users expect (priorities, smart lists, attachments)
+- Development is slow—major updates are years apart
+- No natural language input beyond dates
+- Can't attach files or images to tasks
+
+#### Pricing:
+
+One-time purchase @ $49.99. No subscription, no sync fees. Buy once and own it forever. Frequently goes on sale.
+
+### 6. Cleanshot X: best screenshot and screen recording tool for Mac
+
+![cleanshot x review](/api/assets/blog/articles/mac-productivity-apps/image-6.png)
+
+If you work async and live in screenshots and screen recordings, [CleanShot X](https://www.google.com/url?q=https://cleanshot.com/&sa=D&source=editors&ust=1771000364605619&usg=AOvVaw1HJzhohEHlKcDZigtE4_qO) is essential. I capture 20-30 things a day explaining designs, reporting bugs, documenting workflows. CleanShot makes the entire flow invisible. You can capture, annotate in seconds, share a link, move on.
+
+The free alternative Shottr exists if you're on a budget, but CleanShot's polish and speed make the $29 worth it.
+
+#### Key Features:
+
+- Scrolling capture: Capture entire web pages or long documents that don't fit on screen
+- Pin screenshots: Float captures above all windows for reference while you work
+- Quick annotations: Add arrows, text, highlights, and shapes instantly
+- Background tool: Automatically add professional backgrounds and shadows to screenshots
+- Screen recording: Record video with webcam overlay, microphone, and system audio
+- OCR text recognition: Copy text from images on-device, super fast
+- Hide desktop icons: Clean screenshots without desktop clutter
+- GIF export: Turn screen recordings into optimized GIFs
+- Quick Access Overlay: Drag and drop screenshots directly to other apps
+- CleanShot Cloud: Share captures via link with optional custom domain and branding
+
+#### Pros:
+
+- Scrolling capture works in every app
+- Pin feature is genuinely useful for keeping references visible
+- Quick Access Overlay makes sharing frictionless
+- Screen recordings with webcam overlay rival Loom
+- OCR is accurate and lightning fast
+- Automatic background styling saves manual editing in design tools
+
+#### Cons:
+
+- One-time purchase only includes one year of updates ($19/year renewal for updates after)
+- Quick Access Overlay sometimes blocks the area you need to capture next
+- No collaboration features beyond link sharing
+
+#### Pricing:
+
+$29 one-time for the app with one year of updates and 1GB Cloud storage (optional $19/year renewal). Pro plan is $8/month annually or $10/month for unlimited Cloud storage, custom domain, team features, and perpetual updates.
+
+### 7. Keyboard Maestro: best for automating Mac workflows
+
+![keyboard maestro review](/api/assets/blog/articles/mac-productivity-apps/image-7.png)
+
+I started using [Keyboard Maestro](https://www.google.com/url?q=https://www.keyboardmaestro.com/&sa=D&source=editors&ust=1771000364610296&usg=AOvVaw1jyo6W6fR-iyYESZAK31bc) to save a few clicks here and there. Six months in, I'm automating things I didn't know were annoying me. It's not sexy, it's not flashy, but it quietly saves me hours every week by making my Mac work exactly how I want it to.
+
+#### Key Features:
+
+- Conflict Palettes: Assign multiple macros to one hotkey, get a menu to choose from
+- Hundreds of triggers: Time-based, app launch, file changes, login, volume mount, typed strings, and more
+- Application control: Launch apps, arrange windows, quit specific programs automatically
+- Text manipulation: Expand snippets, transform clipboard content, OCR images
+- Web automation: Fill forms, click buttons, download files on schedule
+- Clipboard management: Multiple clipboard history with filters
+- Window management: Position windows with keyboard shortcuts
+- Conditional logic: If/then statements, loops, variables for complex workflows
+- URL scheme support: Trigger macros from other apps like Raycast or Alfred
+- Schedule actions: Run tasks at specific times or intervals
+
+#### Pros:
+
+- Active forum community with helpful users
+- Stable and reliable, rarely crashes
+- Can integrate with other automation tools (Shortcuts, AppleScript, shell scripts)
+- Conflict palettes solve the "too many hotkeys to remember" problem
+- Macros can be as simple or complex as you need
+
+#### Cons:
+
+- Requires time investment to figure out what's worth automating
+- Documentation is comprehensive but not always beginner-friendly
+- You need to maintain your macros as macOS updates change things
+- Some tasks better handled by dedicated tools (Hazel for file automation, BTT for gestures)
+
+#### Pricing:
+
+$36 one-time purchase for version 11. Upgrades to major versions cost $25 (every ~2 years). Free upgrades for purchases after March 1, 2023. Free trial available. No subscription required.
+
+### 8. Hazel: best file organization app for Mac
+
+![hazel for mac review](/api/assets/blog/articles/mac-productivity-apps/image-8.png)
+
+[Hazel](https://www.google.com/url?q=https://www.noodlesoft.com/&sa=D&source=editors&ust=1771000364613390&usg=AOvVaw0BwJkCYVk6cGFJAzMEa-Ak) watches folders and runs rules on autopilot. Move PDFs to project folders, delete DMGs after install, archive old screenshots. Unlike Cowork, which uses AI to make decisions, Hazel does exactly what you tell it forever. Set up rules once, your downloads folder stays at zero without thinking.
+
+Keyboard Maestro can watch folders too, but Hazel's built for files specifically—PDF content reading, App Sweep cleanup, better reliability.
+
+#### Key Features:
+
+- Rule-based automation: Watch folders and automatically move, rename, tag, or process files based on conditions you set
+- PDF content recognition: Read text inside PDFs without OCR to sort bills, invoices, statements by content
+- App Sweep: When you delete an app, Hazel finds and offers to delete its leftover support files
+- Smart trash management: Auto-delete old trash or clear it when it gets too large
+- Pattern matching: Sort files by name patterns, dates, file types, source URLs, and more
+- File actions: Open, archive, compress, tag, rename, upload files automatically
+- Subfolder organization: Create date-based or name-based folder structures automatically
+- Import to Photos/Music: Automatically import media files to system apps
+- AppleScript & Shortcuts integration: Run scripts or shortcuts as part of file rules
+- Notification support: Get alerts when rules run or conditions are met
+
+#### Pros:
+
+- Set it and forget it. It runs silently in background for years
+- Incredibly reliable, rarely breaks
+- Can eliminate entire categories of manual work (DMG cleanup, screenshot archiving, file sorting)
+- PDF content reading works without separate OCR setup
+- App Sweep finds leftover files other cleaners miss
+- Version 6 adds pause functionality for temporary rule suspension
+
+#### Cons:
+
+- Steep learning curve for complex rules
+- Interface feels dated and intimidating at first
+- Regex and advanced pattern matching requires technical knowledge
+- Easy to create conflicting rules that fight each other
+- No built-in AI for smart file categorization (yet)
+
+#### Pricing:
+
+$42 one-time purchase for Hazel 6. Major version upgrades typically cost ~$30 for existing users. Free trial available. No subscription required. License covers all your Macs with the same Apple ID.
+
+### 9. Reeder: best RSS reader for Mac users
+
+![reeder for mac review](/api/assets/blog/articles/mac-productivity-apps/image-9.png)
+
+[Reeder](https://www.google.com/url?q=https://reederapp.com/&sa=D&source=editors&ust=1771000364617108&usg=AOvVaw0BNNB6XOn5voQYO6hND4M_) is for people who got tired of algorithms deciding what they see. Add your favorite blogs, YouTube channels, podcasts, newsletters, and everything flows into one chronological timeline. No engagement optimization, no unread anxiety, just scroll until you're done and pick up where you left off tomorrow.
+
+I use it because doomscrolling Twitter for news made me miserable, and RSS feeds give me back control over what I consume.
+
+#### Key Features:
+
+- Unified timeline: RSS feeds, YouTube, podcasts, Reddit, Mastodon, Bluesky all in one chronological feed
+- Timeline syncing: Pick up exactly where you left off across iPhone, iPad, Mac
+- No unread counts: Scroll through content like a magazine instead of inbox-zero anxiety
+- Filters: Create custom timelines by keyword, media type, or source
+- Save links: Use share extension to save articles to read later
+- Shared feeds: Turn any tag into a public feed others can subscribe to
+- iCloud sync: Subscriptions and position sync instantly, content fetched directly from sources
+- Minimal podcast player: Basic playback built-in, not meant to replace dedicated apps
+- Open in other apps: Tap to open videos in YouTube, podcasts in Overcast, etc.
+
+#### Pros:
+
+- Beautiful, minimal design that gets out of the way
+- No ads, no tracking, no data collection
+- Fast and responsive
+- Developer actively maintains it (unlike Reeder 4 which went years without updates)
+- Reeder Classic (old version) still available and maintained
+
+#### Cons:
+
+- Requires iOS 17+ / macOS 14+ (cuts off older devices)
+- Lost Feedbin and other RSS service integrations from Reeder Classic
+- No folder organization for feeds anymore
+- Upward scrolling timeline feels backwards for some people
+- Podcast player is basic (not replacing Overcast)
+- Developer doesn't respond to support emails reliably
+- Deliberately disabled app on Apple Vision Pro (strange choice)
+
+#### Pricing:
+
+$10/year subscription (roughly $1/month). Reeder Classic remains available as separate one-time purchase if you prefer the old model. 30-day free trial available.
+
+## What is the best Mac productivity app?
+
+Here's what nobody tells you about productivity apps: at some point, you have to stop optimizing your workflow and actually do the work.
+
+I've spent years building this setup. Some of these apps have been with me so long I forget what it was like before them. Others are new enough that I'm still discovering features. But they all have one thing in common—they make me think less about how I'm working so I can focus on what I'm working on.
+
+That's the only metric that matters.
+
+Download what sounds useful. Try it for two or three weeks. If you're not using it without thinking about it by then, delete it and move on. Your dock doesn't need another icon. You need tools that disappear.
+
+If you're drowning in meetings and losing track of what was said, try Char.

--- a/apps/web/content/articles/mac-productivity-apps.mdx
+++ b/apps/web/content/articles/mac-productivity-apps.mdx
@@ -49,7 +49,7 @@ If you're a Mac user looking to actually get more done (not just feel productive
 
 Meetings suck, but they're inevitable. The next best thing is making sure you never miss a detail with a note-taker that doesn't lock your data in someone else's cloud. I built Char for this reason.
 
-[Char](https://char.com/) is an open-source AI note-taker that stores your data locally and gives you complete control over the AI stack. You decide if your audio, transcripts, or notes ever leave your device. You pick your preferred STT and LLM provider, which means you can go completely local if you want to. No forced stack. No lock-in.
+[Char](https://anarlog.so/) is an open-source AI note-taker that stores your data locally and gives you complete control over the AI stack. You decide if your audio, transcripts, or notes ever leave your device. You pick your preferred STT and LLM provider, which means you can go completely local if you want to. No forced stack. No lock-in.
 
 #### Key Features:
 

--- a/apps/web/content/articles/markdown-note-taking-apps.mdx
+++ b/apps/web/content/articles/markdown-note-taking-apps.mdx
@@ -33,7 +33,7 @@ This list covers five apps, each strong for a specific use case, so you can find
 
 ![](/api/assets/blog/articles/markdown-note-taking-apps/image-1.png)
 
-**[Char](https://char.com/)** (formerly Hypernote) is an open-source AI notepad built specifically for meetings. It transcribes your conversations in real-time, and when the meeting ends, it combines the transcript with your manual notes to create the perfect summary. No bots join your calls, everything is stored as plain markdown files with zero lock-in, and you get to choose your preferred STT and LLM provider.
+**[Char](https://anarlog.so/)** (formerly Hypernote) is an open-source AI notepad built specifically for meetings. It transcribes your conversations in real-time, and when the meeting ends, it combines the transcript with your manual notes to create the perfect summary. No bots join your calls, everything is stored as plain markdown files with zero lock-in, and you get to choose your preferred STT and LLM provider.
 
 #### Key Features:
 

--- a/apps/web/content/articles/markdown-note-taking-apps.mdx
+++ b/apps/web/content/articles/markdown-note-taking-apps.mdx
@@ -1,0 +1,261 @@
+---
+meta_title: "The Best Markdown Note-Taking Apps in 2026"
+meta_description: "We tested the best markdown note-taking apps in 2026. From meeting notes to PKM, find the right app for your workflow."
+author:
+  - "John Jeong"
+featured: false
+category: "Comparisons"
+date: "2026-02-18"
+---
+
+Markdown note-taking apps have quietly become the default for anyone serious about owning their knowledge long-term. The format is future-proof, the files are portable, and you're never one pricing change away from losing access to years of work.
+
+"Markdown app" covers a lot of ground though. Some are built for linking ideas across thousands of notes. Some are built for developers who think in code blocks. Some are built for people who just want their notes encrypted and synced without drama.
+
+This list covers five apps, each strong for a specific use case, so you can find the one that fits how you actually think and work.
+
+## Top markdown note-taking apps compared
+
+
+| &nbsp;   | &nbsp;                         | &nbsp;          | &nbsp;          | &nbsp;            |
+| -------- | ------------------------------ | --------------- | --------------- | ----------------- |
+| **App**  | **Best For**                   | **Open Source** | **Local Files** | **Price**         |
+| Char     | Meeting notes                  | ✅               | ✅               | Free / $25/mo     |
+| Obsidian | Personal knowledge management  | ❌               | ✅               | Free / $4/mo sync |
+| Logseq   | Daily journaling & outlining   | ✅               | ✅               | Free              |
+| Joplin   | Cross-device sync with privacy | ✅               | ✅               | Free / 2.99€/mo   |
+| Inkdrop  | Developers                     | ❌               | ❌               | $8.31/mo          |
+
+
+## The best markdown note-taking apps, reviewed
+
+### 1. Char: best markdown note-taking app for meetings
+
+![](/api/assets/blog/articles/markdown-note-taking-apps/image-1.png)
+
+**[Char](https://char.com/)** (formerly Hypernote) is an open-source AI notepad built specifically for meetings. It transcribes your conversations in real-time, and when the meeting ends, it combines the transcript with your manual notes to create the perfect summary. No bots join your calls, everything is stored as plain markdown files with zero lock-in, and you get to choose your preferred STT and LLM provider.
+
+#### Key Features:
+
+- System audio capture - No bots joining your calls. No calendar permissions needed. Works on Zoom, Teams, phone calls, and in-person conversations
+- Real-time transcription - Live transcript generates as the meeting happens, so you can follow along instead of furiously typing
+- AI summaries - Combines your own notes with the transcript to produce structured summaries with action items
+- Your choice of AI stack - Use Char's managed cloud service, bring your own API keys (OpenAI, Anthropic, Deepgram, others), or run fully local via Ollama or LM Studio
+- Plain markdown files - Every meeting is a .md file stored on your computer. Open it in Obsidian, VS Code, Notion, anywhere
+- Custom templates - Set up templates for recurring meeting types so your summaries are always structured the same way
+- AI chat - Query your transcripts after the fact. Ask what was decided, what's pending, what someone said
+- Search - Semantic search across every meeting you've ever recorded
+- 45+ language support
+- Open source - IT and security teams can audit the code before approving it
+
+#### Pros:
+
+- Data never has to leave your device
+- Switch AI providers anytime - no forced stack
+- Works with local models, so you can go fully offline
+- Open source builds trust for regulated industries and security-conscious teams
+- Works for any conversation, not just video calls
+
+#### Cons:
+
+- macOS only currently - Windows and Linux coming in Q2 2026
+- No mobile app yet
+- No video recording
+
+#### Pricing:
+
+Free plan with local transcription or bring-your-own-key. Pro is $25/month for the managed cloud service.
+
+### 2. Obsidian - best markdown note-taking app for personal knowledge management
+
+![](/api/assets/blog/articles/markdown-note-taking-apps/image-2.png)
+
+Most note apps make you forget what you wrote six months ago. **[Obsidian](https://obsidian.md/)** keeps everything linked instead.
+
+Opening one note pulls you into three others you forgot existed but suddenly need. The more you use it, the more useful it gets. It's built for people who think in connections, not folders.
+
+#### Key Features:
+
+- Wiki-style links - Connect notes by typing [[note name]]. Build a web of linked ideas, people, projects, books, anything
+- Graph view - Visual, interactive map of how all your notes connect
+- Canvas - Infinite whiteboard for brainstorming, diagramming, and laying out ideas spatially
+- Local markdown files - Everything stored as .md files on your device. Open them in any editor, any time
+- 1,000+ community plugins - Extend Obsidian into basically whatever you need it to be
+- Obsidian Sync - Optional end-to-end encrypted sync across devices with one year of version history and shared vault collaboration
+- Obsidian Publish - Turn your notes into a public wiki, knowledge base, or digital garden
+- Works completely offline - No internet required for core functionality
+- Mobile apps - iOS and Android, with full vault access
+
+#### Pros:
+
+- Free for personal use with zero feature restrictions, no sign-up required
+- Sync works with whatever you already use (iCloud, Dropbox, Google Drive) or pay for Obsidian Sync if you want something purpose-built
+- Plugin ecosystem means the app grows with your needs
+- [Meeting notes](/blog/obsidian-meeting-notes/) from Char land directly in your vault since both use markdown
+- Active community with real depth - forums, Discord, YouTube channels dedicated to workflows
+
+#### Cons:
+
+- The flexibility comes with complexity. Learning curve is steep if you want anything beyond basic note-taking
+- Easy to fall into the productivity trap of endlessly tweaking your system instead of using it
+- Not visually polished out of the box - you'll want to install a theme
+- Closed source, which is a notable tension for a tool that markets hard on trust and ownership
+- No built-in AI - you'll need plugins or external tools for that
+
+#### Pricing:
+
+Free for personal use, no limits, no sign-up. Obsidian Sync is $4/user/month billed annually. Obsidian Publish is $8/site/month. Commercial use requires a $50/user/year license.
+
+### 3. Logseq - best markdown note-taking app for daily journaling & outlining
+
+![](/api/assets/blog/articles/markdown-note-taking-apps/image-3.png)
+
+**[Logseq](https://logseq.com/)** clicked when I stopped trying to organize it and just started writing. You open it, land on today's journal page, and go. No deciding where a note lives. No folder structure to maintain.
+
+Every bullet point is a block that can be linked, referenced, and surfaced anywhere else in your graph. Organization happens as a byproduct of writing, not before it.
+
+#### Key Features:
+
+- Daily journal - Every day starts with a fresh page. Just write. No upfront organization required
+- Outliner-first - Everything is a block. Indent, collapse, reference, and embed blocks across any page
+- Bidirectional linking - [[link]] anything and backlinks surface every place it's been mentioned
+- PDF annotations - Highlight and annotate PDFs directly inside Logseq, with annotations linked back into your notes
+- Flashcards - Built-in spaced repetition from any block
+- Whiteboards - Infinite canvas for pulling notes out of the graph and thinking spatially
+- Queries - Pull any information back out of your graph with structured queries
+- 150+ plugins - Task management, custom views, integrations
+- Local markdown files - Everything stored as .md files you own
+- Logseq Sync - Encrypted file syncing across devices (beta)
+- Mobile apps - iOS and Android
+
+#### Pros:
+
+- The daily journal approach cuts friction. You stop procrastinating on "where to put this" and just write
+- Bidirectional linking is more fluid here than elsewhere - connections emerge naturally rather than being manually managed
+- PDF annotation is class-leading and built in natively, not a plugin afterthought
+- Free forever for personal use, open source, data stays local
+- The longer you use it, the more useful the graph becomes
+
+#### Cons:
+
+- Performance degrades with large graphs - slow startup, laggy rendering, real complaints at scale
+- Mobile app is rough, sync is still beta, and reliability issues have frustrated longtime users
+- Development has stalled. The team has been deep in a database rewrite for years, the plugin ecosystem has quieted, and community momentum has noticeably dropped
+- The upcoming database version moves away from pure markdown, which is a genuine concern for anyone who picked Logseq specifically for file portability
+- Advanced queries have a steep learning curve and poor documentation
+
+#### Pricing:
+
+Free for personal use. Logseq Sync is in beta. No paid tiers beyond sync.
+
+### 4. Joplin - best markdown note-taking app for cross-device sync with privacy
+
+![](/api/assets/blog/articles/markdown-note-taking-apps/image-4.png)
+
+**[Joplin](https://joplinapp.org/)** does one thing exceptionally well: keeping your notes encrypted, portable, and in sync across every device you own using whatever cloud storage you already pay for. No vendor lock-in on sync, no paywall surprises, no compromise on privacy.
+
+#### Key Features:
+
+- End-to-end encryption - Notes are encrypted before they ever leave your device. Nobody else can read them, including the Joplin team
+- Flexible sync - Works with Joplin Cloud, Dropbox, OneDrive, Nextcloud, WebDAV, or S3. You're never locked to one provider
+- Rich and markdown editors - Switch between a rich text editor and a markdown editor depending on your preference. Markdown isn't mandatory
+- Web clipper - Browser extension for Chrome and Firefox to save web pages directly as notes
+- Notebooks and tags - Hierarchical notebooks with sub-notebooks, plus tags for cross-cutting organization
+- Multimedia notes - Images, PDFs, audio, video, and file attachments all supported
+- To-do lists and reminders - Built-in task management with checkboxes and due dates
+- Plugins - Extensible via community plugins on desktop
+- OCR search - Find text inside images and PDFs
+- Terminal app - Full CLI version for the truly keyboard-driven
+- Available on Windows, macOS, Linux, Android, and iOS
+
+#### Pros:
+
+- The sync flexibility is genuinely unmatched - no other free app lets you bring your own backend with E2EE
+- Desktop app is solid and reliable, users regularly report six-plus years of daily use without issues
+- Completely free with no note limits, no device limits, no paywall surprises
+- Rich text editor means markdown is optional - lower barrier than most apps in this list
+- Open source with an active community and web clipper that actually works
+- Exports to JEX, PDF, HTML, and raw markdown - getting your data out is never a problem
+
+#### Cons:
+
+- Mobile app lags significantly behind the desktop - no background sync means you have to babysit it, and conflicts happen if you forget to sync before switching devices
+- UI feels dated, especially on Android - functional but not something you'd call polished
+- Sync setup has a learning curve; first-time configuration trips up non-technical users
+- Plugin support is desktop-only, so the mobile experience is notably more limited
+- Not designed for linked, networked notes - if you want backlinks and graph views, this isn't that
+
+#### Pricing:
+
+Completely free with self-managed sync. Joplin Cloud starts at 2.99€/month for hosted sync if you'd rather not set it up yourself.
+
+### 5. Inkdrop - best markdown note-taking app for developers
+
+![](/api/assets/blog/articles/markdown-note-taking-apps/image-5.png)
+
+Most note apps tolerate developers. **[Inkdrop](https://www.inkdrop.app/)** is built for them. Vim keybindings, multi-language code highlighting, Mermaid diagrams, KaTeX math, multi-cursor editing - it's all there without hunting for plugins. The whole thing is built by a single developer, Takuya Matsuyama, who clearly uses it himself, and that shows in how deliberate every feature decision feels.
+
+Where Obsidian gives you a blank canvas to build whatever system you want, Inkdrop gives you a clean, opinionated workflow that gets out of your way. Less tinkering, more writing.
+
+#### Key Features:
+
+- Markdown editor built for code - multi-language syntax highlighting, multi-cursors, line numbers, invisible character display, and vim/emacs/Sublime keybindings
+- 100+ plugins - extend with math (KaTeX), Mermaid diagrams, table of contents, code titles, and more
+- End-to-end encrypted sync - notes encrypted before they leave your device, synced instantly across all platforms
+- Note status - mark notes as active, on hold, completed, or dropped. Useful for tracking work in progress
+- Nestable notebooks + tags + pin-to-top - flexible organization without forcing a rigid structure
+- Distraction-free mode - clean writing environment that hides everything but the text
+- Web clipper - Chrome and Firefox extensions to clip articles directly into your notes
+- MCP server - lets AI tools search your notes, understand context, and generate new notes from existing content
+- Revision history - every note version saved automatically
+- Raycast and Alfred integration - access notes without ever opening the app
+- Available on macOS, Windows, Linux, iOS, and Android
+
+#### Pros:
+
+- The most polished cross-platform experience in this list - desktop and mobile feel consistent, sync is instant and reliable
+- Developer-specific features are native, not bolted on via plugins
+- Offline-first, so the app is always ready regardless of connectivity
+- UI is genuinely clean - users consistently praise how unobtrusive it feels
+
+#### Cons:
+
+- Notes are stored in an internal database, not plain markdown files - you can export, but you can't just open your vault in another editor
+- Pricing jumped from $4.99 to $8.31/month, which stings for a single-developer app and has driven some users away
+- No backlinks or graph view - not designed for networked knowledge, purely note organization
+- Smaller plugin ecosystem compared to Obsidian
+- The whole product depends on one person - not a criticism of Takuya, but worth knowing
+
+#### Pricing:
+
+$8.31/month billed annually. 30-day free trial, no credit card required.
+
+## Other markdown note-taker apps worth knowing
+
+### 1. Zettlr
+
+**[Zettlr](https://www.zettlr.com/)** is a strong app with a specific audience: academics and researchers doing citation-heavy writing. The Zotero integration, reference manager support, and export pipeline to LaTeX and PDF work well for that workflow. If you're writing papers with footnotes and bibliographies, Zettlr deserves a serious look. For everyone else, it's more tool than needed.
+
+### 2. MarkText
+
+**[MarkText](https://github.com/marktext/marktext)** has one of the cleanest writing experiences in this list - distraction-free, real-time preview, good theme selection. Development has stalled though, which is a real concern for a tool you're trusting with long-term notes. Worth trying if you need a focused writing editor, but not somewhere to plant your entire knowledge base.
+
+### 3. Notable
+
+**[Notable](https://github.com/notable/notable)** is deliberately minimal: tag-based organization, split-pane editor, no frills. For users who find Obsidian overwhelming and just want a clean place to write and find notes quickly, that simplicity is appealing. It didn't make the cut because the feature set hasn't kept pace with the alternatives, and development has been sparse in recent years.
+
+### 4. Zim
+
+**[Zim](https://zim-wiki.org/)** is the oldest app on this list and quietly one of the most reliable. Long-time users describe it as bulletproof - fast, stable, and does exactly what it claims. The interface looks like it was built in 2008 because it was, and that puts off a lot of people. But if you run Linux and want a desktop wiki that just works forever without surprises, Zim has a loyal following.
+
+## What are the best markdown apps for note-taking?
+
+If you're in back-to-back meetings and losing track of what was said and decided, start with **Char**. Everything else on this list is for organizing knowledge you've already captured - Char is for capturing it in the first place.
+
+If you want to build a knowledge base that gets more valuable the longer you use it, **Obsidian** is the answer. It takes investment to set up, but nothing compounds like a well-linked vault over years.
+
+If you hate deciding where to put things and just want to write, **Logseq** removes that friction entirely. Open it and start. The graph does the organizing for you. Go in aware of the development uncertainty though.
+
+If you need your notes on every device, encrypted, without paying anyone a monthly fee, **Joplin** is the most practical choice here. The desktop app is rock solid. Manage your expectations on mobile.
+
+If you're a developer and the first thing you check in any note app is whether it has Vim mode, download **Inkdrop**.

--- a/apps/web/content/articles/meetily-review.mdx
+++ b/apps/web/content/articles/meetily-review.mdx
@@ -1,0 +1,139 @@
+---
+meta_title: "Meetily Review (2025): Is It the Best Local AI Meeting Tool?"
+meta_description: "An honest review of Meetily, the open-source local AI meeting assistant. What it does well, where it falls short, and who it is actually built for."
+author:
+  - "Harshika"
+featured: false
+category: "Guides"
+date: "2026-04-15"
+---
+
+Meetily is a [local AI meeting tool](https://char.com/blog/local-ai-meeting-notes/) launched in December 2024. It now has over 11,000 GitHub stars and more than 88,000 downloads. It runs on macOS and Windows. It transcribes your meetings locally, no cloud required.
+
+The pitch is simple: a private meeting recorder that works out of the box, costs nothing to start, and never sends your audio to a third-party server.
+
+This review covers what Meetily actually does, what it lacks, and whether it is worth using.
+
+## **Meetily at a Glance**
+
+
+|                   |                                                         |
+| ----------------- | ------------------------------------------------------- |
+|                   | **Meetily at a glance**                                 |
+| **Developer**     | Zackriya Solutions                                      |
+| **License**       | MIT                                                     |
+| **GitHub stars**  | [11,081](https://github.com/Zackriya-Solutions/meetily) |
+| **Platform**      | macOS, Windows (Linux: build from source)               |
+| **Free tier**     | Yes, full community edition. No account required.       |
+| **Pro price**     | $10/month or $120/year. 14-day free trial.              |
+| **Transcription** | Parakeet or Whisper, 100% local                         |
+| **Summaries**     | Ollama (local) or BYOK (Claude, Groq, OpenRouter)       |
+| **Storage**       | Local SQLite database                                   |
+| **Calendar**      | Not available                                           |
+| **Speaker ID**    | In development                                          |
+
+
+## **What Is Meetily?**
+
+Meetily is a desktop app for recording, transcribing, and summarizing meetings locally. It captures system audio directly from your device. No bot joins your call. No calendar permissions are required.
+
+It works with any conferencing tool that produces audio on your machine: Zoom, Google Meet, Microsoft Teams, Discord, and anything else. Because it reads system audio rather than joining as a participant, the people on your call never see a recording notification from Meetily.
+
+The codebase is MIT licensed and public on GitHub. The community edition is free with no feature restrictions. There is no account required to use it.
+
+## **How Does Meetily Work?**
+
+Meetily captures audio from your microphone and system output as separate channels. Transcription runs on your device using either Parakeet (the default) or Whisper Large V3. Both are open-source models that run entirely on local hardware.
+
+Parakeet is the faster option. It runs at roughly 4x the speed of Whisper with lower resource usage. GPU acceleration works on Apple Silicon via Metal, NVIDIA via CUDA, and AMD/Intel via Vulkan. On a modern Mac, transcription happens in real time without visible CPU strain.
+
+After the meeting, a local LLM generates the summary. By default this goes through Ollama, which means the entire loop, audio capture, transcription, and summarization, stays on your device. If you prefer a cloud model, you can connect your own API key for Claude, Groq, or OpenRouter. That choice is yours to make.
+
+Audio files and transcripts are stored in a local SQLite database on your device.
+
+## **Is Meetily Actually Private?**
+
+This matters more for Meetily than for most tools, so it is worth being specific.
+
+- **Transcription:** 100% local. Whisper or Parakeet runs on your hardware. Your audio never leaves your machine.
+- **Summaries:** Local by default via Ollama. If you connect a cloud LLM key, the transcript goes to that provider for summarization.
+- **Storage:** Local SQLite database on your device. No cloud sync, no server.
+- **Account:** Not required for the community edition. No email, no sign-in.
+
+## **Meetily Features**
+
+### **What the free community edition includes**
+
+- Real-time transcription with Parakeet or Whisper
+- AI-generated summaries and action item extraction
+- Works with Zoom, Meet, Teams, Discord, or any app with system audio
+- Export to Markdown
+- Local SQLite storage
+- No account, no subscription, no expiry
+
+### **What Pro adds ($10/month)**
+
+- Enhanced accuracy transcription models
+- Auto-meeting detection: starts recording when a meeting begins
+- Improved speaker diarization
+- PDF and DOCX export
+- Custom summarization templates
+- Priority support
+
+## **What Works Well in Meetily**
+
+**Windows support.** This is the single biggest practical advantage. Meetily is one of the only serious local-first meeting tools that runs on Windows. Char, Granola, Talat, and most others are macOS-only. If you or your team is on Windows, Meetily is the answer.
+
+**Zero setup for the free tier.** Download the app, open it, start a meeting. Ollama handles local summarization. You do not need an API key, an account, or any configuration to get a working transcript and summary.
+
+**Transcription speed.** Parakeet is fast. On Apple Silicon, it keeps up with live speech without lag. The output is clean enough for most use cases without any post-processing.
+
+**MIT license.** You can fork it, modify it, self-host it, or build on top of it with no restrictions. For teams with strict compliance requirements, this matters more than it sounds.
+
+**Genuinely free community tier.** It is not a trial and it is not crippled. The core functionality, record, transcribe, summarize, works without paying anything.
+
+## **Meetily Limitations**
+
+**No calendar integration.** Meetily does not connect to your calendar. There is no automatic meeting detection on the free tier, no participant context pulled from calendar events, and no way to organize recordings by event. You start and stop recording manually.
+
+**Summarization quality drops on long meetings.** The Meetily team document this themselves. Local LLMs via Ollama handle short focused calls well. On hour-long or multi-topic meetings, the output falls noticeably behind what cloud models produce. Worth testing before committing if you regularly run long calls.
+
+**No mobile app.** There is no iOS or Android client. You cannot review, search, or annotate meeting recordings from your phone.
+
+**Summaries are English-only for now.** Transcription works across languages via Whisper, but AI-generated summaries are currently English only. Multi-language summary support is on the roadmap but not yet shipped.
+
+**No search across meetings.** There is no way to query your meeting history. You cannot search for a decision, a name, or a topic across past sessions. Each meeting is self-contained.
+
+**No integrations.** Nothing pushes automatically to Notion, Slack, Salesforce, or anywhere else. You export a file and move it yourself. Fine for individuals, limiting for team workflows.
+
+**Linux requires building from source.** There is no pre-built Linux installer. Technical users can build from the repo, but it is not a one-step install.
+
+**No CLI or API.** There is no way to automate Meetily, query it from other tools, or plug it into a developer workflow. It is a standalone app.
+
+## **Meetily Pricing**
+
+The community edition is free and MIT licensed. No account required, no trial period, no feature restrictions on core functionality.
+
+Meetily Pro costs $10/month or $120/year. A 14-day free trial is available with no credit card required. Pro adds enhanced transcription models, auto-meeting detection, improved speaker diarization, and PDF/DOCX export.
+
+There is also an Enterprise tier with custom pricing for teams that need volume licensing, admin controls, and compliance support.
+
+At $10/month, Meetily Pro is priced competitively. Otter costs $16.99/month, Fireflies costs $18/month per user, and tl;dv starts at $29/month. The tradeoff is feature depth: those tools have integrations, CRM push, and search that Meetily does not.
+
+## **Who Should Use Meetily?**
+
+- Windows users who want local AI transcription. This is the clearest use case. Meetily is the best option on Windows.
+- Anyone who wants a local meeting recorder that works immediately with no configuration.
+- Teams that need an MIT-licensed codebase for compliance, auditing, or self-hosting.
+- People who want transcription only and have no need for calendar integration, contacts, or a rich editor.
+- Developers or researchers who want to build on top of local meeting transcription without cloud dependency.
+
+## **Meetily Review: Final Verdict**
+
+Meetily does what it says. Local transcription, local summaries, nothing leaving your machine. The community edition works out of the box. The Parakeet engine is fast. Windows support is real and maintained.
+
+The gaps are real. No calendar, summarization struggles on long calls, no search across sessions, no integrations, and no mobile app.
+
+If you want a focused local recorder and especially if you are on Windows, Meetily is the best option in its category. If you are on Mac and want meetings integrated into your broader workflow, with calendar context, a note editor, and developer tooling, [Char](https://char.com) covers that ground instead.
+
+Deciding between the two? Read our [Char vs Meetily](https://char.com/blog/char-vs-meetily/) comparison for a full head-to-head breakdown.

--- a/apps/web/content/articles/meetily-review.mdx
+++ b/apps/web/content/articles/meetily-review.mdx
@@ -8,7 +8,7 @@ category: "Guides"
 date: "2026-04-15"
 ---
 
-Meetily is a [local AI meeting tool](https://char.com/blog/local-ai-meeting-notes/) launched in December 2024. It now has over 11,000 GitHub stars and more than 88,000 downloads. It runs on macOS and Windows. It transcribes your meetings locally, no cloud required.
+Meetily is a [local AI meeting tool](https://anarlog.so/blog/local-ai-meeting-notes/) launched in December 2024. It now has over 11,000 GitHub stars and more than 88,000 downloads. It runs on macOS and Windows. It transcribes your meetings locally, no cloud required.
 
 The pitch is simple: a private meeting recorder that works out of the box, costs nothing to start, and never sends your audio to a third-party server.
 
@@ -134,6 +134,6 @@ Meetily does what it says. Local transcription, local summaries, nothing leaving
 
 The gaps are real. No calendar, summarization struggles on long calls, no search across sessions, no integrations, and no mobile app.
 
-If you want a focused local recorder and especially if you are on Windows, Meetily is the best option in its category. If you are on Mac and want meetings integrated into your broader workflow, with calendar context, a note editor, and developer tooling, [Char](https://char.com) covers that ground instead.
+If you want a focused local recorder and especially if you are on Windows, Meetily is the best option in its category. If you are on Mac and want meetings integrated into your broader workflow, with calendar context, a note editor, and developer tooling, [Char](https://anarlog.so) covers that ground instead.
 
-Deciding between the two? Read our [Char vs Meetily](https://char.com/blog/char-vs-meetily/) comparison for a full head-to-head breakdown.
+Deciding between the two? Read our [Char vs Meetily](https://anarlog.so/blog/char-vs-meetily/) comparison for a full head-to-head breakdown.

--- a/apps/web/content/articles/meeting-minutes-software.mdx
+++ b/apps/web/content/articles/meeting-minutes-software.mdx
@@ -1,0 +1,411 @@
+---
+meta_title: "Best Meeting Minutes Software in 2026"
+meta_description: "Compare the best meeting minutes software for 2026. We tested AI and manual tools to find the top solutions for note-taking, collaboration, and governance."
+author: "Harshika"
+coverImage: "/api/assets/blog/meeting-minutes-software/cover.png"
+featured: false
+category: "Comparisons"
+date: "2026-01-10"
+---
+
+If you're worried about missing important details while taking minutes of the meeting, here are some tools you'll find useful. 
+
+## Meeting minutes software comparison
+
+| &nbsp;         | &nbsp;                         | &nbsp;                      |
+| -------------- | ------------------------------ | --------------------------- |
+| **Tool**       | **Best For**                   | **Starting Price**          |
+| Char           | Control over data and AI stack | Free. $25/month for Pro     |
+| Fellow         | Remote Teams                   | $7/user/mo                  |
+| MeetGeek       | Sales Teams                    | $19/user/mo                 |
+| Diligent       | Board Meetings                 | Custom                      |
+| Fireflies.ai   | Transcription                  | $10/user/mo                 |
+| Beenote        | Structured Meetings            | $552/yr (10 users)          |
+| MeetingBooster | Enterprise                     | Custom                      |
+| Fathom         | CRM Integration                | Free. $20/month for Premium |
+| tl;dv          | Video recordings               | Free. $18/month for Pro     |
+
+
+## Detailed reviews of meeting minutes software
+
+### 1. Char - control over your data and AI stack
+
+![Char (foremly Char)](/api/assets/blog/blog/char-summary.png)
+
+**[Char](https://char.com)** is an open-source AI note-taker that stores your data locally and gives you complete control over the AI stack.
+
+You decide if your audio, transcripts, or notes ever leave your device. You pick your preferred STT and LLM provider, which means you can go completely local if you want to.
+
+#### How it works
+
+Char captures system audio without joining meetings as a bot. During meetings, it transcribes conversations in real-time and combines any notes you've taken with transcripts to create a summary when the meeting ends.
+
+#### Key Features
+
+- **Your notes are just files** -- every meeting saved as a .md file you can open in Obsidian, Notion, VS Code, whatever you use
+- **Flexible AI** lets you use the managed service or bring your own key (cloud or local). Switch anytime.
+- **No meeting bots** because system audio capture works on Zoom, Teams, phone calls, in-person
+- **Custom templates** structure recurring meetings automatically with community templates or your own
+- **Searchable notes** let you find anything from any meeting instantly with semantic search and date filters
+- **Open source** with public code. Your IT team can audit it, your security team can verify it
+
+#### Pros
+
+- You own your data—files stay on your device, not in a remote database
+- No internet required for recording or transcription with local models
+- No lock-in. Export anytime, switch AI providers anytime, or stop using it
+- No bots in your meetings
+- Security teams can audit the code before approving it
+- Works for any conversation
+
+#### Cons
+
+- macOS only currently; Windows and Linux versions coming in Q2 2026
+- No video recordings 
+- No built-in CRM integrations (though files export to anything)
+
+#### Pricing
+
+Unlimited free plan with local transcription or bring-your-own-key. Pro is $25/month for managed cloud service.
+
+### 2. Fellow - for remote teams
+
+![](/api/assets/blog/articles/meeting-minutes-software/image-1.png)
+
+**[Fellow](https://fellow.ai/)** covers the entire meeting lifecycle: preparation with shared agendas, live note-taking during meetings, and organized follow-ups afterward.
+
+Unlike tools that focus only on transcription, Fellow handles collaborative meeting management from start to finish.
+
+#### Key features
+
+- **Collaborative agendas with 500+ templates** let you create shared meeting agendas where team members add talking points together, with pre-built templates for 1-on-1s, standups, and retrospectives
+- **Pre-meeting briefs** provide automatic reminders showing what was discussed in previous iterations of recurring meetings
+- **Ask Fellow (AI Copilot)** is a chatbot that answers questions about meeting history, drafts follow-up emails, and catches you up on missed meetings
+- **Centralized library with access controls** stores all recordings and notes in one searchable place with granular permissions for who can view what
+- **Deep CRM integrations** automatically sync meeting summaries and action items to Salesforce, HubSpot, Asana, Jira, and 50+ other tools
+- **No AI training on your data** as Fellow explicitly doesn't use meeting content to train models
+
+#### Pros
+
+- Comprehensive meeting lifecycle management in one platform
+- Strong collaborative features with shared agendas and real-time editing
+- Enterprise-grade security (SOC 2, GDPR, HIPAA compliance)
+- Excellent for recurring meetings with templates and context continuity
+- 92-language transcription support for global teams
+
+#### Cons
+
+- Bot-based recording joins as visible participant
+- Cloud-only processing with no on-premises option
+- Free plan limited to 10 AI recordings per month
+- Online meetings only; doesn't work for in-person conversations
+- Internal meeting focus makes it less robust than dedicated sales intelligence tools
+
+#### Pricing
+
+Free plan includes 10 AI recordings per user per month. Paid plans start at $7/user/month (3-user minimum) for Pro, and go up to $25/user/month for Business with full admin controls and HIPAA compliance.
+
+### 3. MeetGeek - for conversation intelligence and sales teams
+
+![](/api/assets/blog/articles/meeting-minutes-software/image-2.png)
+
+**[MeetGeek](https://meetgeek.ai/)** is designed for sales teams and enterprises that want conversation analytics and performance tracking beyond transcription.
+
+It captures data-driven insights into communication patterns, not just meeting notes.
+
+#### Key features
+
+- **Automatic meeting type detection** recognizes your call type and applies context-aware summary templates without manual selection
+- **Team spaces and analytics** organize meetings by department with performance metrics tracking engagement, sentiment, and effectiveness at team and individual levels
+- **Automated workflows** let you set rules to auto-share meeting records with specific teams based on meeting type, pushing summaries to CRMs and task management tools
+- **Custom speech models** on the enterprise tier train the transcription system on your industry-specific terminology for better accuracy
+- **50+ language support** with automatic language detection and 95%+ transcription accuracy
+- **Mobile apps** let you record and summarize in-person meetings on iOS and Android, even offline
+
+#### Pros
+
+- Powerful conversation intelligence with department-level analytics
+- Strong compliance certifications (SOC 2, GDPR, CCPA, HIPAA-ready)
+- Extensive integration ecosystem (7,000+ apps via Zapier)
+- Custom speech models for specialized industries
+
+#### Cons
+
+- Bot-based only, which can feel intrusive in sensitive conversations
+- Aggressive storage limits on lower tiers (free keeps transcripts only 3 months)
+- 100-hour monthly limit on Business tier means high-volume teams need Enterprise
+- Cloud-only processing with no on-premises option
+
+#### Pricing
+
+Free plan includes 5 hours of transcription per month with 3 months of transcript storage and 1 month of audio storage. Paid plans start at $19/user/month for Pro with unlimited transcription.
+
+### 4. Diligent - for board meeting minutes
+
+![](/api/assets/blog/articles/meeting-minutes-software/image-3.png)
+
+**[Diligent](https://www.diligent.com/solutions/board-and-leadership-collaboration)** is built specifically for corporate boards, executive committees, and governance-focused organizations. It's designed for high-stakes board-level governance, not general meetings.
+
+#### Key features
+
+- **Secure board book creation and distribution** includes drag-and-drop document uploads with automatic agenda updates, last-minute adjustments that retain director notes, and user-based watermarking for content protection
+- **AI-powered risk and analytics** provides pre-formatted risk reports on cybersecurity, sustainability, shareholder activism, and other critical issues with integrated dashboards for board-level insights
+- **Digital voting and approvals** enable real-time voting directly from the dashboard with comment boxes for explanatory narratives, plus streamlined signature collection
+- **Board evaluations and D&O questionnaires** support secure creation and monitoring of evaluations using best practice templates with digital signing and exporting
+- **Version control and audit trails** let directors view updated documents with change tracking, retain notes when materials are updated, and maintain complete audit logs for regulatory compliance
+
+#### Pros
+
+- Industry-leading security with enterprise-grade encryption and compliance
+- Comprehensive governance features beyond basic meeting management
+- Trusted by Fortune 500 companies and major organizations globally
+- AI-powered analytics provide board-level insights on critical issues
+- Seamless mobile access from any device
+
+#### Cons
+
+- Premium pricing that may be prohibitive for smaller organizations or NGOs
+- Some features require additional fees beyond base subscription
+- Occasional difficulty renaming or editing documents directly in portal
+- Auto-renewal can include significant price increases (20%+) if not negotiated
+
+#### Pricing
+
+Diligent offers custom pricing based on organization size and requirements. Contact sales for enterprise quotes.
+
+### 5. Fireflies.ai - for meeting transcription
+
+![](/api/assets/blog/articles/meeting-minutes-software/image-4.png)
+
+**[Fireflies.ai](http://fireflies.ai)** excels at helping you find specific information months later through advanced search functionality. While many tools transcribe meetings, Fireflies focuses on searchable archives and powerful search capabilities across all conversations.
+
+#### Key features
+
+- **Powerful search functionality** lets you search across all meetings using keywords, phrases, topics, or sentiment to find exact conversations and timestamps
+- **50+ language support** transcribes meetings in over 50 languages with automatic language detection
+- **Sentiment analysis** tracks positive, negative, and neutral sentiment throughout conversations to identify key emotional moments
+- **Topic tracking** automatically identifies and categorizes topics discussed, with custom topic trackers you can create for your specific needs
+- **Automated workflows** let you set rules to auto-share meeting summaries with specific team members or departments based on participants or topics
+- **Custom vocabulary** lets you train the system on your industry-specific terminology, acronyms, and product names for better accuracy
+- **Mobile apps** let you record and transcribe in-person meetings using iOS or Android apps
+
+#### Pros
+
+- Excellent search functionality across entire meeting history
+- Sentiment analysis provides conversation insights
+- Strong integration ecosystem (7,000+ apps via Zapier)
+- Works well for both online and in-person meetings with mobile apps
+
+#### Cons
+
+- Bot-based recording joins as visible participant
+- Free tier has restrictive storage limits (transcripts kept only 3 months)
+- 100-hour monthly limit on Business tier
+- Cloud-only processing with no local option
+
+#### Pricing
+
+Free plan includes 800 minutes of storage with 3 months of transcript retention and 1 month of audio storage. Pro plan starts at $10/user/month with unlimited transcription. Business plan at $19/user/month includes advanced analytics. Enterprise pricing is custom.
+
+### 6. Beenote - for collaborative agenda building and governance
+
+![](/api/assets/blog/articles/meeting-minutes-software/image-5.png)
+
+**[Beenote](https://beenote.io/)** focuses on collaborative planning, real-time note-taking, and organized follow-up with a generous free tier. It's designed for teams that need structured meeting workflows without AI automation.
+
+#### Key features
+
+- **Collaborative draft agendas** let team members see the writing status and add content before meetings, ensuring nothing important gets missed
+- **Multiple items per agenda topic** means each agenda item can have multiple notes, decisions, and tasks, all organized under one discussion point
+- **Timekeeper per subject** provides a built-in timer that helps you know when to move to the next topic, saving precious meeting time
+- **Voice recording segments** let you record specific parts of discussions or entire agenda items for reference later
+- **Task synchronization** syncs assigned tasks directly to Google Task or Microsoft To Do, optimizing follow-ups without leaving your workflow
+- **Customizable templates** let you create different formats for various meeting types like board meetings, team standups, or project reviews
+
+#### Pros
+
+- Strong governance features for boards and executive committees
+- Integration with Microsoft 365, Teams, and Google Workspace
+- Grammar checking with Antidote integration
+- Free tier is genuinely useful for small teams
+
+#### Cons
+
+- Manual note-taking required—no AI transcription
+- No Slack integration despite being a popular team communication tool
+- Learning curve for users unfamiliar with structured meeting management
+- Mobile apps available but desktop experience is primary focus
+
+#### Pricing
+
+Beenote is free forever with basic features. Paid plans start at $552/year for 10 users with additional collaboration and branding features.
+
+### 7. MeetingBooster - for enterprise meeting management
+
+![](/api/assets/blog/articles/meeting-minutes-software/image-6.png)
+
+**[MeetingBooster](https://www.meetingbooster.com/meeting-minutes-software)** works well for mid-size to large companies running structured meetings with serious accountability requirements. It handles project change management meetings, board sessions, and cross-functional team coordination where nothing can slip through the cracks.
+
+#### Key features
+
+- **Meeting series functionality** automatically groups related meetings together, making it easy to track recurring items and see action items across an entire project or committee
+- **Pre-meeting task assignment** lets you assign tasks that need completion before meetings, with status tracking to hold attendees accountable
+- **Advanced meeting tools** include built-in voting, pros/cons analysis, and rating features to facilitate decisions during meetings
+- **Comprehensive task management** provides a full task system with due dates, priorities, and cross-meeting project tracking that syncs seamlessly to Outlook tasks
+- **Meeting agenda module** is a separate module for agenda creation that forces pre-planning and prevents off-topic additions during meetings
+- **Parking topics feature** lets you park both main topics and sub-topics for future discussion, with automatic carry-forward to next meetings
+
+#### Pros
+
+- Powerful for complex enterprise workflows with multiple stakeholders
+- Deep Outlook integration makes adoption easier in Microsoft-heavy organizations
+- Meeting series feature provides excellent continuity for recurring meetings
+- Advanced meeting facilitation tools (voting, pros/cons) improve decision quality
+- Proven track record with 30+ years in the market
+
+#### Cons
+
+- Interface feels more traditional/corporate compared to modern tools
+- Requires manual note-taking during meetings
+- Limited flexibility in some task management functions
+- Steeper learning curve than simpler alternatives
+
+#### Pricing
+
+MeetingBooster offers custom pricing based on organization size and needs. They provide site licenses for large deployments and on-premises installation options for enterprises with strict data requirements.
+
+### 8. Fathom - for sales CRM integration
+
+![](/api/assets/blog/articles/meeting-minutes-software/image-7.png)
+
+**[Fathom](https://www.fathom.ai/)** automatically logs everything to Salesforce, HubSpot, and other platforms immediately after each call. While other tools require you to copy-paste summaries into your CRM, Fathom eliminates that step.
+
+#### Key features
+
+- **Automatic CRM logging** syncs meeting summaries automatically to Salesforce, HubSpot, and Close after every call
+- **Free forever plan** offers unlimited meetings, unlimited transcription, completely free for individuals
+- **Instant highlights** let you click a button during meetings to create timestamped highlights of important moments
+- **AI-generated summaries** provide automatic summaries with key points, action items, and next steps
+- **Multi-language support** transcribes meetings in 28 languages
+- **Team collaboration** lets you share meeting clips and highlights with teammates instantly
+
+#### Pros
+
+- Completely free for unlimited meetings
+- Excellent CRM integration eliminates manual data entry
+- Simple, clean interface with minimal setup required
+- Fast AI processing—summaries available within minutes
+
+#### Cons
+
+- Bot-based recording joins as visible participant
+- Primarily designed for sales use cases
+- Limited customization compared to enterprise tools
+- Fewer advanced analytics than dedicated conversation intelligence platforms
+
+#### Pricing
+
+Free forever for individuals with unlimited meetings and transcription. Team plans available with additional collaboration features and admin controls.
+
+### 9. tl;dv - free meeting recorder with AI summaries
+
+![](/api/assets/blog/articles/meeting-minutes-software/image-8.png)
+
+**[tl;dv](https://tldv.io/)** offers genuinely unlimited recordings on its free plan. Unlike other "free" options with restrictive limits, it's ideal for individuals and small teams on tight budgets.
+
+#### Key features
+
+- **AI-generated summaries** provide automatic summaries with key takeaways, action items, and decisions
+- **Timestamped highlights** let you click during meetings to bookmark important moments with timestamps
+- **Video clip sharing** lets you create and share short video clips from longer meetings
+- **20+ language support** transcribes meetings in multiple languages
+- **Meeting library** provides a searchable archive of all recordings with tags and filters
+- **Integration with tools** connects to Slack, Notion, Google Docs, CRM systems
+
+#### Pros
+
+- Truly unlimited recordings on free plan (no monthly hour caps)
+- Video clip feature makes it easy to share key moments
+- Simple, intuitive interface with minimal setup
+- Works well for both Zoom and Google Meet
+
+#### Cons
+
+- Bot-based recording joins as visible participant
+- Limited to Zoom and Google Meet only
+- Advanced features like custom vocabulary require paid plans
+- Cloud-only processing with no local option
+
+#### Pricing
+
+Free plan includes unlimited recordings and AI summaries. Pro plan starts at $18/user/month with additional features like speaker insights, custom branding, and advanced integrations.
+
+## Key features that matter in meeting minutes software
+
+When evaluating meeting minutes software, focus on these five categories:
+
+### 1. Transcription accuracy
+
+Accuracy matters if you're relying on automated transcription. Look for:
+
+- 90%+ accuracy rates for clear audio
+- Speaker identification capabilities
+- Support for technical terminology and industry jargon
+- Custom vocabulary training for specialized terms
+- Multi-language support if needed
+
+Most AI meeting minutes software achieves 90-95% accuracy in ideal conditions, but accuracy drops significantly with background noise, accents, or multiple speakers talking simultaneously.
+
+### 2. Privacy & security
+
+For sensitive conversations, privacy architecture matters more than compliance certifications:
+
+- **Local-first processing** (Char) provides maximum privacy
+- **End-to-end encryption** protects data in transit
+- **Compliance certifications** (HIPAA, SOC 2, GDPR) verify security practices
+- **Data retention policies** control how long recordings are stored
+- **Access controls** manage who can view sensitive meetings
+
+If your conversations involve confidential information, prioritize tools with local processing or strong encryption over convenient cloud-based options.
+
+### 3. Integrations
+
+Meeting minutes software should connect with your existing workflow:
+
+- **Calendar integration** (Google Calendar, Outlook) for automatic meeting detection
+- **CRM systems** (Salesforce, HubSpot) for sales and customer data
+- **Project management** (Asana, Jira, Monday.com) for task tracking
+- **Communication platforms** (Slack, Teams) for sharing summaries
+- **Document storage** (Google Drive, Dropbox) for archival
+
+The best integrations are bidirectional—not just pushing data out, but pulling context in to make summaries more relevant.
+
+### 4. Collaboration features
+
+Teams need to work together on meeting documentation:
+
+- **Real-time co-editing** for collaborative note-taking
+- **Commenting and mentions** for feedback and questions
+- **Shared agendas** built collaboratively before meetings
+- **Approval workflows** for formal minutes requiring sign-off
+- **Version control** to track changes and revert if needed
+
+Remote teams particularly benefit from strong collaboration features that keep everyone aligned regardless of location.
+
+### 5. Search & retrieval
+
+Meeting minutes are only valuable if you can find information later:
+
+- **Keyword search** across all transcripts and summaries
+- **Semantic search** that understands context and intent
+- **Filter by date, participant, or meeting type**
+- **Topic-based organization** and automatic categorization
+- **Quick access** to specific timestamps in recordings
+
+The difference between a searchable meeting archive and 100 unsearchable documents is the difference between institutional knowledge and lost information.
+
+## Our top recommendation
+
+If you value both functionality and control, Char is worth a look. You get AI-powered features without giving up ownership of your data, and you can export everything as plain markdown with zero lock-in.
+
+You can try the tool out for free. If it's not for you, export everything and walk away.

--- a/apps/web/content/articles/meeting-minutes-software.mdx
+++ b/apps/web/content/articles/meeting-minutes-software.mdx
@@ -32,7 +32,7 @@ If you're worried about missing important details while taking minutes of the me
 
 ![Char (foremly Char)](/api/assets/blog/blog/char-summary.png)
 
-**[Char](https://char.com)** is an open-source AI note-taker that stores your data locally and gives you complete control over the AI stack.
+**[Char](https://anarlog.so)** is an open-source AI note-taker that stores your data locally and gives you complete control over the AI stack.
 
 You decide if your audio, transcripts, or notes ever leave your device. You pick your preferred STT and LLM provider, which means you can go completely local if you want to.
 

--- a/apps/web/content/articles/meeting-preparation-checklist.mdx
+++ b/apps/web/content/articles/meeting-preparation-checklist.mdx
@@ -1,0 +1,156 @@
+---
+meta_title: "My Go-to Meeting Preparation Checklist"
+display_title: "Meeting Preparation Checklist: 7 Steps to Run More Productive Meetings"
+meta_description: "Use this meeting preparation checklist to walk into every call with clarity and confidence. Build a repeatable system to have productive meetings."
+author: "John Jeong"
+coverImage: "/api/assets/blog/meeting-preparation-checklist/cover.png"
+featured: false
+category: "Guides"
+date: "2025-11-03"
+---
+
+Walk into your next meeting with clarity instead of chaos. This checklist covers the preparation steps that [reduce meeting fatigue](/blog/how-to-reduce-meeting-fatigue) and help you run focused, effective meetings.
+
+## Meeting preparation checklist
+
+### 1. Context mining: review past conversations and unresolved items
+
+Before walking into any meeting, you need to know what's already been said. Not just the official minutes, but the actual conversations, the decisions made, the action items that fell through the cracks.
+
+Most people show up with a vague memory of "we discussed this before" but can't recall the specifics. Who said what? What was decided? What got left unresolved?
+
+Digging through old emails, Slack threads, and scattered notes takes hours and you still miss things.
+
+**A better system 💡:** Use an AI notetaker that lets you search across all past conversations instantly. With Char's Search feature, press cmd + k and type any keyword: a project name, a person, a specific topic. You'll see every note containing that term, along with when it was mentioned and who said it.
+
+<Image src="/api/assets/blog/meeting-preparation-checklist/prep-1.png" alt="Preparation Checklist"/>
+
+Open AI Chat for any past meeting and ask questions like "What did Sarah say about the budget constraints?" or "Bring up notes related to the product launch timeline." The AI pulls exact context from transcripts so you're not working from memory.
+
+Walking into a meeting with specific references keeps conversations focused on moving forward, not rehashing what's already been covered.
+
+### 2. Stakeholder research & profiling: know who you're talking to
+
+Effective meeting prep recognizes that every person brings different priorities, communication styles, and decision-making authority.
+
+Before the meeting, research each participant:
+
+- **Professional background** -- What's their role? What projects are they currently focused on? What's their expertise?
+- **Communication style** -- Do they prefer data and analytics, or stories and examples? Do they ask lots of questions or prefer to listen first?
+- **Decision-making authority** -- Can this person say yes, or do they need to escalate? Who influences their thinking?
+- **Recent context** -- What wins or setbacks have they experienced lately that might affect their perspective?
+
+This research helps you tailor your communication approach and anticipate conflicts before they surface. When you know that two participants have historically disagreed on resource allocation, or that the legal team has concerns about compliance implications, you can address these tensions in your preparation rather than getting blindsided mid-meeting.
+
+**Where to gather this intel 💡:** LinkedIn for professional background, your CRM for past interactions, and your meeting history.
+
+<Image src="/api/assets/blog/meeting-preparation-checklist/prep-2.png" alt="Preparation Checklist"/>
+
+Check the Contacts View in Char's Finder to see every meeting you've had with each person, what they care about, and where previous conversations left off. Filter contacts by organization to understand team dynamics and spot patterns in what resonates with that company.
+
+### 3. Sending the briefing package and meeting details
+
+Send a briefing package 24-48 hours before the meeting. When participants show up informed, you skip the "let me catch everyone up" phase and jump straight into productive discussion.
+
+Include:
+
+- **Meeting logistics** -- Date, time, duration, platform (with login details for virtual meetings), physical location with map link if in-person
+- **Clear meeting objective** -- One sentence stating exactly what you need to accomplish. "Decide on Q2 marketing budget allocation" is clear. "Discuss marketing stuff" is not.
+- **Meeting agenda** -- Specific topics, time allocations, and who's leading each discussion point
+- **Pre-reading materials** -- Background documents, relevant data, context from previous meetings. Keep these concise; nobody reads 40-page reports.
+- **Preparation expectations** -- Be explicit. "Please review the budget scenarios and come prepared with your preference" tells people what to actually do.
+- **Decision framework** -- If you're making decisions, explain how. Consensus? Voting? Executive call? When people know the rules upfront, meetings run faster.
+- **Recording notice** -- If you're recording (and if you're using Char), mention it in the invite. Transparency builds trust, especially in compliance-sensitive industries.
+
+**Pro tip 💡:** Create a single source of truth: a shared doc, a sales room, a project page, and link to it clearly in the calendar invite. Don't bury this in a massive email thread.
+
+<CtaCard/>
+
+### 4. Participation strategy: design for diverse voices
+
+The loudest voices dominate meetings by default. Without a deliberate participation strategy, the same three people speak while everyone else checks out.
+
+**Round-robin for key decisions:** When you need input on important decisions, explicitly go around the (virtual) table. "Let's hear from everyone on this. Maya, would you start us off?" This ensures quieter team members don't get talked over.
+
+**Parking lot for tangents:** Create a "parking lot" list visible to everyone (a shared doc, whiteboard, or someone taking notes). When important but off-topic items come up, acknowledge them: "That's worth discussing, let's add it to the parking lot and schedule time for it." This keeps the current meeting focused without dismissing valid concerns.
+
+**Structured Q&A segments:** Instead of "any questions?" which usually gets silence, try "I'm going to pause here for questions, please drop them in chat or unmute." Or assign specific Q&A windows: "After the budget overview, we'll have 10 minutes for questions about resource allocation."
+
+**Pre-assign speaking roles:** If you need input from specific people, tell them before the meeting. "Dev, I'd like you to speak to the technical feasibility. Priya, can you cover the customer impact?" People contribute better when they know they're expected to speak and have time to prepare.
+
+This ensures you actually hear the perspectives that matter before making decisions.
+
+### 5. Fallback plans: prepare for when discussions stall
+
+Even well-planned meetings hit roadblocks. A key stakeholder is missing. The group can't reach consensus. The discussion reveals new information that changes everything.
+
+Prepare for these contingencies:
+
+**If consensus fails:** Have a tiebreaker mechanism ready. "If we can't reach agreement today, [person] will make the final call by Friday." Or: "We'll test both approaches for two weeks and decide based on data."
+
+**If key information is missing:** Acknowledge the gap: "We need the cost estimates before deciding. Let's table this specific decision, finalize the other items, and reconvene on Thursday." Have a clear process for who's getting what information by when.
+
+**If a participant is absent:** For critical attendees, either reschedule or have an asynchronous way for them to contribute. "We'll proceed with the discussion, record it, and get Jamie's input before finalizing tomorrow."
+
+**If discussion reveals unexpected complexity:** Recognize when you're in over your head. "This is clearly more involved than we thought. Let's spend the remaining time identifying what we need to research, assign owners, and schedule a follow-up next week."
+
+**If conflict escalates:** Have a pressure release valve. "I can see we have strong perspectives on this. Let's take a 10-minute break to reset." Or redirect: "Let's document both viewpoints and their rationale, then revisit this after we've had time to reflect."
+
+When something goes sideways, you're steering the meeting back on track instead of watching it crash.
+
+### 6. Meeting recording: capture everything without the overhead
+
+Traditional meeting documentation either misses crucial details or requires so much effort that nobody maintains it. Taking manual notes means you're distracted from the actual conversation. Inviting a bot to your call announces to everyone that their words are being sent to the cloud—not ideal for sensitive discussions.
+
+Char runs entirely on your device. No bot joins your call. No data leaves your machine. It just captures the conversation, both your microphone and system audio, so you have a complete record without the overhead.
+
+<Image src="/api/assets/blog/meeting-preparation-checklist/prep-3.webp" alt="Char"/>
+
+**What to consider when recording 💡:**
+
+- **Consent management:** In many jurisdictions and industries, you need explicit consent to record conversations. Mention recording in your meeting invite. For higher-stakes meetings, consider verbal confirmation at the start: "Just confirming we're recording this for our records, everyone comfortable with that?"
+- **For compliance-sensitive industries** (healthcare, legal, finance), zero-lock-in tools like Char give you complete control. When discussing patient information, legal matters, or confidential business details, choosing your own AI stack and storing files as plain markdown helps you meet HIPAA, attorney-client privilege, and other regulatory requirements.
+- **Environment matters:** Find a quiet space. Use a decent microphone. Background noise and poor audio quality break transcription accuracy.
+- **Offline meetings:** If you're recording an in-person conversation, make sure your meeting assistant works when you need it most. Choose tools that don't rely on internet connectivity for transcription and note-taking. Char runs entirely on your device using local AI models, so it works in basement conference rooms, on planes, or anywhere without WiFi.
+
+### 7. Meeting templates: stop starting from scratch every time
+
+You run the same types of meetings repeatedly: customer calls, team standups, strategy reviews, performance check-ins. Templates reduce cognitive load by giving you a proven framework.
+
+**How to create meeting templates:**
+
+Identify your recurring meeting types. For each, define the standard structure. Customer discovery might be: context questions (10 min), pain points (15 min), solution exploration (15 min), next steps (5 min). Weekly team updates might be: wins, blockers, priorities, action items.
+
+Char lets you create custom templates that automatically structure your AI-generated summaries. Set a default template in Settings, and every meeting gets summarized in that format automatically. Or select a specific template right after finishing a recording for one-off meetings.
+
+<Image src="/api/assets/blog/meeting-preparation-checklist/prep-4.png" alt="Preparation Checklist"/>
+
+To create a custom template, define your sections (the structure you want) and add system instructions (rules for the AI to follow). For example:
+
+- **For user interviews** -- "For every bullet point you write, attach the user's actual quote as a reference next to it." Now every interview summary comes with supporting evidence automatically.
+- **For sales calls** -- "Generate the summary in JSON format with fields: painPoints, budget, timeline, decisionMakers." Perfect if you're pushing data to a CRM.
+- **For therapy or coaching sessions** -- "Focus on the client's own words and emotional themes. Minimize interpretation."
+
+The more specific your instructions, the better the AI tailors notes to your needs.
+
+---
+
+These seven steps transform chaotic meeting prep into a structured process.
+
+## Use Char for productive meetings
+
+Meeting preparation is exhausting when you're doing it manually: searching through old emails, reconstructing context from memory, frantically taking notes while trying to stay present.
+
+Char eliminates that overhead.
+
+**Before the meeting:** Use Search (cmd + k) to instantly find relevant past conversations. Check Contacts View to see your complete history with each participant. Ask AI Chat questions like "What did we decide about the pricing model?" to pull specific context without digging through transcripts.
+
+**During the meeting:** Stop trying to be a human tape recorder. Char captures everything automatically—both what's said and what you're thinking. Everything is stored as plain markdown files with zero lock-in. You choose your AI stack, making it the right choice for sensitive conversations in healthcare, legal, and finance. You can stay fully present in the conversation instead of splitting focus between listening and documenting.
+
+**After the meeting:** Don't immediately process anything. Take an actual break. When you're ready, your AI-generated summary is waiting with your custom template already applied. Hover over any part to see the exact quote from the transcript. Ask AI Chat "What are my action items?" instead of hunting through notes. Search across all meetings to track themes and patterns.
+
+You spend your mental energy on thinking, not on reconstructing what happened or organizing information.
+
+[Download Char free](/) and have productive meetings with confidence
+
+<CtaCard/>

--- a/apps/web/content/articles/meeting-productivity-tools.mdx
+++ b/apps/web/content/articles/meeting-productivity-tools.mdx
@@ -1,0 +1,210 @@
+---
+meta_title: "The 5 Meeting Productivity Tools Worth Using in 2026"
+display_title: "Top 5 Software to Make Your Meetings Productive"
+meta_description: "A no-fluff guide to the tools that fix different parts of a broken meeting workflow - and where Char fits in."
+author:
+  - "John Jeong"
+featured: false
+category: "Comparisons"
+date: "2026-02-19"
+---
+
+Meetings are a category of problems that no single tool can solve. You need the right time to meet, a way to stay engaged during the meeting, a place to capture what was discussed, somewhere to ideate visually, and a calendar that isn't completely dominated by other people's priorities.
+
+Most "best tools for meetings" articles hand you a list of 25 apps and call it a day. This one doesn't. We picked five tools and focused on being honest about what each one actually does well and where it falls short.
+
+Here's what we're covering:
+
+- **Char**: for capturing what happens in meetings without giving up control of your data
+- **Calendly**: for scheduling meetings without the back-and-forth
+- **Grain**: for teams that need to record, share clips, and sync meeting insights to a CRM
+- **Miro**: for visual thinking and collaboration during and around meetings
+- **Reclaim.ai**: for protecting your calendar from being eaten alive
+
+Let's get into it.
+
+## 5 best **meeting productivity tools in 2026**
+
+### 1. Char: best AI notepad for meetings
+
+![](/api/assets/blog/articles/meeting-productivity-tools/image-1-3.png)
+
+Most AI meeting tools make the same trade: convenience in exchange for your data living in someone else's database, locked into their format, processed by their AI. Char doesn't make that trade.
+
+<u>[Char](https://char.com)</u> (formerly Hyprnote) is an open-source AI notepad for meetings, built for people who want complete control over their files, their AI stack, and what happens to their data. 
+
+Every meeting is saved as a plain .md file on your device. You choose which AI processes it. Nothing is locked behind Char's ecosystem.
+
+That design is deliberate. Engineers, developers, and privacy-conscious professionals in fields like law, healthcare, and finance don't want a SaaS tool deciding what happens to their meeting data.
+
+#### Key Features
+
+- **System audio capture** - no bots, no calendar access, works on Zoom, Teams, phone calls, and in-person conversations
+- **Real-time transcription** - live transcript as the meeting happens, so you can stay present instead of furiously typing
+- **AI summaries** - combines your notes and transcript into structured summaries with action items
+- **Your choice of AI stack** - use Char's managed cloud, bring your own API keys (OpenAI, Anthropic, Deepgram), or run fully local via Ollama or LM Studio
+- **Plain markdown files** - every meeting is a .md file on your computer; open it in Obsidian, VS Code, Notion, anywhere
+- **Custom templates** - reusable structures for recurring meeting types
+- **AI chat + semantic search** - query your transcripts after the fact, search across all past meetings
+- **Open source** - the code is auditable; IT and security teams can review before approving
+
+#### Pros
+
+- True data ownership - your files, on your device, not in someone's database
+- No lock-in of any kind: portable format, swappable AI providers, works with any editor
+- Works for any conversation - phone calls, in-person meetings, anything with audio, not just scheduled video calls
+- Fully local mode available for teams that can't send data to any external service
+- Open source builds trust with security teams; the code is there to inspect
+
+#### Cons
+
+- macOS only currently - Windows and Linux coming in Q2 2026
+- No mobile app, so in-person meetings away from your computer aren't captured
+- No video recording - notes and transcripts only
+
+#### Pricing
+
+Free with local transcription or bring-your-own API keys. Pro is $25/month for the managed cloud service.
+
+### 2. Calendly: best for scheduling without the email back-and-forth
+
+![](/api/assets/blog/articles/meeting-productivity-tools/image-2-3.png)
+
+You share a link, the other person picks a time, it lands on both calendars. That's the premise, and <u>[Calendly](https://calendly.com/)</u> executes it cleanly. 
+
+What makes it more than a booking page is how much complexity it absorbs underneath: multiple calendars, team routing, automated follow-ups, while the person booking sees nothing but a simple interface.
+
+For groups where no one shares a calendar - cross-company sessions, client kickoffs - Doodle is cleaner. 
+
+#### Key Features
+
+- **Calendar sync** - checks up to six calendars simultaneously to prevent double-bookings
+- **Event types** - different meeting templates, each with their own availability rules and buffer times
+- **Workflows** - automated reminders and follow-ups before and after meetings
+- **Team scheduling** - Round Robin routing and Collective scheduling for multi-host meetings
+- **Video conferencing integration** - auto-generates Zoom, Google Meet, or Teams links for every booking
+
+#### Pros
+
+- Once it's set up, scheduling just happens - the back-and-forth stops
+- Automatic timezone detection handles international meetings without anyone thinking about it
+- Free plan is genuinely usable for basic individual scheduling
+
+#### Cons
+
+- Core features like automated reminders and custom branding are locked behind paid tiers
+- Public links attract spam bookings
+
+#### Pricing
+
+Free plan with one event type. Standard is $12/user/month, Teams is $20/user/month.
+
+### 3. Grain: best for teams that need to share meeting clips
+
+![](/api/assets/blog/articles/meeting-productivity-tools/image-3-3.png)
+
+<u>[Grain](https://grain.com/)</u> is a video-first AI note-taker that joins your meetings as a bot, records the video, transcribes it, and gives you a summary with chapters and action items.
+
+#### Key Features
+
+- **Automatic recording and transcription** - bot joins Zoom, Google Meet, or Teams; speaker-labelled transcript with filler word removal
+- **AI summaries** - chapters, outcomes, and action items with assigned owners
+- **Video clips** - create shareable clips from any transcript moment; organize into playlists
+- **CRM sync** - notes and properties auto-sync to HubSpot and Salesforce; no manual data entry
+- **AI chat** - ask questions about the transcript after the meeting
+
+#### Pros
+
+- Video clips are genuinely useful - sharing a precise 90-second moment beats sending a full recording
+- CRM sync means the data entry that normally gets skipped actually happens
+- Free plan is generous: unlimited recordings with one Notetaker seat
+
+#### Cons
+
+- A bot joins the call and announces the recording - no discreet capture option
+- One meeting at a time - if you're double-booked, one call won't be captured
+- No mobile app for in-person recordings
+
+#### Pricing
+
+Free plan with unlimited recordings (one Notetaker seat). Starter is $19/user/month, Business is $39/user/month. 14-day trial available.
+
+### 4. Miro: best collaborative whiteboard for meetings and workshops
+
+![](/api/assets/blog/articles/meeting-productivity-tools/image-4-3.png)
+
+If you've ever watched someone share their screen, open a Google Doc, and spend 30 minutes trying to explain something that needed to be drawn, you understand what <u>[Miro](https://miro.com/)</u> solves. 
+
+It's an infinite collaborative canvas, and the most capable digital replacement for a physical whiteboard that exists right now.
+
+#### Key Features
+
+- **Infinite canvas** - unlimited space, zoomable, no page constraints
+- **2,000+ templates** - retrospectives, roadmaps, design sprints, user journey maps, and more
+- **Real-time and async collaboration** - edit simultaneously or let teammates contribute on their own time
+- **Facilitation tools** - timers, voting, and presenter controls for running structured workshops
+- **Interactive presentation mode** - present directly from the board while keeping full editing access
+
+#### Pros
+
+- Nothing else comes close for visual collaboration - the infinite canvas genuinely changes how teams think together
+- Strong for both live sessions and async work, which most tools aren't
+- Easy to get started; most people figure it out without a tutorial
+
+#### Cons
+
+- Large boards can get slow 
+- Free plan caps you at three editable boards, which runs out quickly
+- Needs a solid internet connection; offline use is limited
+
+#### Pricing
+
+Free plan with three editable boards and unlimited collaborators. Starter is $8/user/month billed annually.
+
+### 5. Reclaim.ai: best for protecting your calendar from everyone else
+
+![](/api/assets/blog/articles/meeting-productivity-tools/image-5-3.png)
+
+You can use every tool on this list correctly and still end up with a week that's wall-to-wall meetings and no time for actual work. That's where <u>[Reclaim](https://reclaim.ai/)</u> comes in. 
+
+It sits on top of your Google Calendar or Outlook as an intelligent layer - you tell it your priorities (focus time, lunch, recurring 1:1s), and it finds the best times, marks them appropriately, and reshuffles lower-priority blocks when something more important needs the slot. Your calendar ends up reflecting what you actually want your week to look like.
+
+#### Key Features
+
+- **Focus Time** - set a weekly deep work goal; Reclaim automatically defends that time around your existing commitments
+- **Habits** - flexible recurring blocks for routines that auto-reschedule when meetings move
+- **Smart Meetings** - recurring meetings that find the best time across everyone's calendars and adapt to conflicts and PTO
+- **Scheduling Links** - booking links that understand your priorities and offer availability over events you'd be willing to move
+- **Task scheduling** - integrates with Asana, Todoist, Jira, and others to put actual work on your calendar
+
+#### Pros
+
+- Once configured, your calendar reflects your priorities rather than just everyone else's requests
+- The priority system is smart - higher-priority items automatically overbook lower-priority ones
+- Free plan is genuinely useful, not just a trial
+
+#### Cons
+
+- No mobile app - a real gap for managing your schedule on the go
+- Works best for internal scheduling; less useful if most of your meetings are external
+- Takes a week or two of tuning before the scheduling logic really clicks
+
+#### Pricing
+
+Free Lite plan forever (no credit card required). Starter is $12/user/month.
+
+## Quick recap of the top 5 meeting productivity software
+
+These five tools solve different parts of the same problem:
+
+**Getting on the calendar without the email chain**: Calendly (or Doodle for group polls)
+
+**Capturing what was said and decided**: Char (zero lock-in, no bot, your AI stack) or Grain (team-first, video clips, CRM sync)
+
+**Thinking visually together**: Miro
+
+**Protecting time for actual work**: Reclaim.ai
+
+None of these replace each other. And none of them replace the part where you actually pay attention and do the work. But if you're losing hours every week to scheduling friction, forgotten decisions, or a calendar you feel like you have no control over - starting with even one of these changes the situation meaningfully.
+
+We're biased, but we'd start with Char. Not because it's ours, but because if you're not capturing what's actually happening in your meetings - on your terms - every other optimization sits on a leaky foundation.

--- a/apps/web/content/articles/meeting-productivity-tools.mdx
+++ b/apps/web/content/articles/meeting-productivity-tools.mdx
@@ -31,7 +31,7 @@ Let's get into it.
 
 Most AI meeting tools make the same trade: convenience in exchange for your data living in someone else's database, locked into their format, processed by their AI. Char doesn't make that trade.
 
-<u>[Char](https://char.com)</u> (formerly Hyprnote) is an open-source AI notepad for meetings, built for people who want complete control over their files, their AI stack, and what happens to their data. 
+<u>[Char](https://anarlog.so)</u> (formerly Hyprnote) is an open-source AI notepad for meetings, built for people who want complete control over their files, their AI stack, and what happens to their data. 
 
 Every meeting is saved as a plain .md file on your device. You choose which AI processes it. Nothing is locked behind Char's ecosystem.
 

--- a/apps/web/content/articles/mistral-api-key.mdx
+++ b/apps/web/content/articles/mistral-api-key.mdx
@@ -104,4 +104,4 @@ Everything else stays local. The audio file, the transcript, the summary are all
 
 Plus, all core features, local transcription, and BYOK stay completely free. You’re already paying for the API key, you shouldn’t have to pay twice. But if you want cloud services and don't want to manage keys at all, there is a $8/month plan you can check out. 
 
-To connect Mistral, open Char's settings, go to API Keys, paste your key, and that's it. Try it out for free now - [Download Char for macOS](https://char.com/download/).
+To connect Mistral, open Char's settings, go to API Keys, paste your key, and that's it. Try it out for free now - [Download Char for macOS](https://anarlog.so/download/).

--- a/apps/web/content/articles/mistral-api-key.mdx
+++ b/apps/web/content/articles/mistral-api-key.mdx
@@ -1,0 +1,107 @@
+---
+meta_title: "How to Get a Mistral API Key (Free, No Credit Card)"
+meta_description: "Step-by-step guide to getting a Mistral API key for free. No credit card needed. Covers rate limits, pricing, models, and how to use your key securely."
+author:
+  - "Harshika"
+featured: false
+category: "Engineering"
+date: "2026-03-06"
+---
+
+Mistral makes some of the best open-weight models available. Getting an API key takes about two minutes, and you don't need a credit card.
+
+## **What you need before getting started**
+
+You need:
+
+- An email address
+- A phone number that can receive SMS (for verification)
+
+No credit card required for the free Experiment plan.
+
+One thing worth knowing upfront: on the free Experiment plan, your API requests may be used to train Mistral's models. If you're working with sensitive data, you'll want to upgrade to a paid plan, which comes with data isolation.
+
+## **How to generate your Mistral API key (step by step)**
+
+1. Go to [console.mistral.ai](https://console.mistral.ai) and create an account
+2. Verify your phone number when prompted. This is how Mistral gates the free tier
+3. Once inside the console, navigate to **API Keys** in the left sidebar
+4. Click **Create new key**, give it a name, and hit confirm
+5. Copy the key immediately and store it somewhere safe. Mistral won't show it again
+
+## **Mistral API rate limits on the free plan**
+
+On the free Experiment plan, every model is capped at 500,000 tokens per minute and 1,000,000,000 tokens per month. That's a billion tokens a month, which sounds like a lot until you're running something in a loop.
+
+The per-minute limit is the one you'll actually hit. 500k tokens per minute works out to roughly 375,000 words per minute, which is fast, but easy to saturate if you're processing batches or running concurrent requests. If a request gets rate limited, the API returns a 429 and you'll need to retry with backoff.
+
+The monthly cap of 1B tokens is genuinely generous for individual use. At typical usage, most developers won't come close. If you're building something at scale or need guaranteed throughput, upgrading to the Scale plan removes these ceilings and adds data isolation.
+
+## **Mistral API pricing: how much does it cost**
+
+Mistral charges per million tokens, counting both input (what you send) and output (what comes back). There's no subscription fee on the API side. You pay for what you use.
+
+
+| &nbsp;            | &nbsp;           | &nbsp;           |
+| ----------------- | ---------------- | ---------------- |
+| **Model**         | **Input**        | **Output**       |
+| Mistral Small 3.2 | $0.10 / M tokens | $0.30 / M tokens |
+| Mistral Large 3   | $0.50 / M tokens | $1.50 / M tokens |
+
+
+To put those numbers in context: a million input tokens is roughly 750,000 words, or about 1,500 pages of text. At Mistral Small's rates, that costs ten cents. For most personal or small-team use, the monthly bill is negligible.
+
+If you're running batch jobs that don't need an immediate response, Mistral offers a 50% discount on batch API requests. Worth using if latency isn't a concern.
+
+## **Which Mistral model should you use**
+
+If you're not sure, use mistral-small-latest.
+
+It's fast, cheap, multimodal, multilingual, and Apache 2.0 licensed. The Apache 2.0 license matters if you're building something commercial. No usage restrictions, no license fees.
+
+Step up to mistral-large-latest if you need heavier reasoning: complex multi-step tasks, nuanced analysis, or anything where output quality is worth paying more for. It's five times the price of Small, so it's worth being deliberate about when you actually need it.
+
+## **How to use your Mistral API key in your project**
+
+Set it as an environment variable so it never gets hardcoded into your source files:
+
+```bash
+export MISTRAL_API_KEY="your-key-here"
+```
+
+Test it with a curl call:
+
+```bash
+curl https://api.mistral.ai/v1/chat/completions \
+  -H "Authorization: Bearer $MISTRAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "model": "mistral-small-latest", "messages": [{"role": "user", "content": "Hello"}] }'
+```
+
+If you get a JSON response with a choices array back, the key is working. If you get a 401, double-check that the environment variable is set correctly in your current session.
+
+For Python projects, the python-dotenv package is the standard way to load a .env file at runtime rather than setting variables manually each session:
+
+```python
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+api_key = os.getenv("MISTRAL_API_KEY")
+```
+
+## Use your Mistral API key in Char for AI meeting notes that stay on your device
+
+![](/api/assets/blog/articles/mistral-api-key/image-1.png)
+
+Getting your own API key is a deliberate choice. It means you want control over what AI you're using and what happens to the data you send it. Char works on the same principles. 
+
+It’s an open-source AI notepad for meetings that gives you complete control over your AI stack and your data. 
+
+The workflow is simple: record, transcribe locally, summarize with your own Mistral key. You choose which model runs. You can swap to Anthropic, OpenAI, or a local Ollama model any time without losing your files or your history.
+
+Everything else stays local. The audio file, the transcript, the summary are all saved as plain markdown files on your device, not on Char's servers. Char doesn't have servers storing your conversations. There's nothing to breach, no vendor to trust with your data.
+
+Plus, all core features, local transcription, and BYOK stay completely free. You’re already paying for the API key, you shouldn’t have to pay twice. But if you want cloud services and don't want to manage keys at all, there is a $8/month plan you can check out. 
+
+To connect Mistral, open Char's settings, go to API Keys, paste your key, and that's it. Try it out for free now - [Download Char for macOS](https://char.com/download/).

--- a/apps/web/content/articles/mistral-data-retention-policy.mdx
+++ b/apps/web/content/articles/mistral-data-retention-policy.mdx
@@ -1,0 +1,65 @@
+---
+meta_title: "Here's How Mistral Retains Your Data"
+meta_description: "Mistral is the only major EU-native AI provider in this series. That matters for GDPR compliance, data residency, and how your data is handled by default."
+author:
+  - "Harshika"
+featured: false
+category: "Guides"
+date: "2026-03-17"
+---
+
+We've been evaluating data retention policies of major AI providers and Mistral is the only provider headquartered in the European Union. That is not a minor detail. It means Mistral is natively subject to GDPR, stores your data in the EU by default, and was built from the ground up under stricter privacy regulation than any of the US-based alternatives.
+
+For teams evaluating AI providers on data governance grounds, that starting point matters.
+
+Here is how the policy works in practice.
+
+## What Mistral Stores by Default
+
+For API users, Mistral retains your inputs and outputs for 30 rolling days after the request is processed. This window exists for abuse monitoring. After 30 days, the data is deleted. It is not used to train Mistral's models unless you explicitly opt in.
+
+For free users of Le Chat, Mistral's consumer product, your conversations may be used for model improvement unless you opt out. You can do this by opening the Privacy menu in the Admin Console and disabling the toggle under Anonymous improvement data.
+
+Paid plans are handled differently. Users on Le Chat Team, Le Chat Enterprise, or any paid API plan have their data excluded from training by default. No opt-out required.
+
+Account metadata follows a separate schedule. Name and identity data is kept for 5 years after account termination. Email and phone number are retained for 1 year after account deletion. Technical data such as connection logs is kept for 1 rolling year.
+
+## Where Your Data Is Stored
+
+By default, all data is hosted within the European Union. Mistral [explicitly states](https://legal.mistral.ai/terms/privacy-policy) that it prioritizes EU-based infrastructure providers and applies GDPR-standard safeguards when any non-EU provider is involved.
+
+There is a US API endpoint available if you need it. Using it will route your data to US infrastructure. If EU residency matters for your use case, stick with the default endpoint and confirm with your Mistral account contact that your deployment is EU-only.
+
+## Is Zero Data Retention Applicable?
+
+ZDR is available on the API. When activated, Mistral does not retain your inputs or outputs beyond what is needed to return the result. The 30-day abuse monitoring window does not apply.
+
+One important limitation: Zero Data Retention is not available on Le Chat. Because the consumer product relies on stored conversation history to function, ZDR cannot be applied there. If ZDR is a requirement, you need to use the API directly.
+
+## Training Opt-Out in Plain Terms
+
+Free Le Chat users are opted in to training by default and can opt out via Privacy settings. Paid Le Chat and paid API users are opted out by default. ZDR API customers have no training risk because their data is never retained to begin with.
+
+If you are a paid API customer, you do not need to take any action to keep your data out of training pipelines. It is already excluded.
+
+## GDPR and Compliance
+
+As an EU company, Mistral operates under GDPR natively rather than as a compliance overlay. A Data Processing Addendum is available for all business customers. GDPR rights including access, correction, deletion, and portability can be exercised by contacting Mistral's privacy team directly.
+
+Mistral does not currently publish a HIPAA Business Associate Agreement. For US healthcare organizations that need HIPAA coverage, Mistral is not the right choice without confirming a BAA is available for your specific plan.
+
+## How Mistral Compares With Other AI Providers
+
+The structural difference between Mistral and the US-based providers is data residency by default. With [OpenAI](/blog/chatgpt-data-retention-policy/), [Anthropic](/blog/anthropic-data-retention-policy/), or Google, you are opting into EU data residency as an enterprise feature. With Mistral, EU residency is the baseline and US routing is the opt-in.
+
+For organizations in the EU or those operating under GDPR, that reversal is meaningful. It shifts the burden of compliance from your team to Mistral's default configuration.
+
+## Use Mistral API to Take Meeting Notes Through Char
+
+[Char](https://char.com) is an open-source AI notepad for meetings that supports Mistral as one of its AI provider options. When you bring your own Mistral API key, your meeting data is handled under Mistral's API policy: 30-day retention for abuse monitoring, not used for training, stored in the EU by default.
+
+If you activate ZDR on your Mistral API account, that protection applies to requests made through Char as well. Nothing is stored beyond the time needed to process the result.
+
+And if your data governance requirements change, or a different provider gets approved by your security team, you can switch inside Char without changing how your notes are stored or structured. Your files stay on your device regardless.
+
+[Download Char for macOS](https://char.com/download/apple-silicon) and use the AI provider your security team actually trusts.

--- a/apps/web/content/articles/mistral-data-retention-policy.mdx
+++ b/apps/web/content/articles/mistral-data-retention-policy.mdx
@@ -56,10 +56,10 @@ For organizations in the EU or those operating under GDPR, that reversal is mean
 
 ## Use Mistral API to Take Meeting Notes Through Char
 
-[Char](https://char.com) is an open-source AI notepad for meetings that supports Mistral as one of its AI provider options. When you bring your own Mistral API key, your meeting data is handled under Mistral's API policy: 30-day retention for abuse monitoring, not used for training, stored in the EU by default.
+[Char](https://anarlog.so) is an open-source AI notepad for meetings that supports Mistral as one of its AI provider options. When you bring your own Mistral API key, your meeting data is handled under Mistral's API policy: 30-day retention for abuse monitoring, not used for training, stored in the EU by default.
 
 If you activate ZDR on your Mistral API account, that protection applies to requests made through Char as well. Nothing is stored beyond the time needed to process the result.
 
 And if your data governance requirements change, or a different provider gets approved by your security team, you can switch inside Char without changing how your notes are stored or structured. Your files stay on your device regardless.
 
-[Download Char for macOS](https://char.com/download/apple-silicon) and use the AI provider your security team actually trusts.
+[Download Char for macOS](https://anarlog.so/download/apple-silicon) and use the AI provider your security team actually trusts.

--- a/apps/web/content/articles/notetakers-for-developers.mdx
+++ b/apps/web/content/articles/notetakers-for-developers.mdx
@@ -32,7 +32,7 @@ I tested and researched these five tools across developer forums, Hacker News th
 
 ### 1. Char[a]
 
-[Char](https://char.com) is an open-source AI meeting note-taker that captures system audio directly from your computer, with no bot joining the call and no calendar permissions required. You jot notes in a built-in notepad while it transcribes in the background, then the AI merges both into a structured summary. Everything is stored on your device, and you can bring your own LLM: Ollama, LM Studio, OpenAI, Anthropic, etc.
+[Char](https://anarlog.so) is an open-source AI meeting note-taker that captures system audio directly from your computer, with no bot joining the call and no calendar permissions required. You jot notes in a built-in notepad while it transcribes in the background, then the AI merges both into a structured summary. Everything is stored on your device, and you can bring your own LLM: Ollama, LM Studio, OpenAI, Anthropic, etc.
 
 #### Why devs love it
 
@@ -195,4 +195,4 @@ If your team needs shared documentation you actually control, Outline is the sel
 
 And if you're deep in the Claude ecosystem and want your notes to be part of that workflow natively, keep an eye on Novi Notes. It's early, but the MCP-first approach is worth watching.
 
-For meeting notes specifically, you can [download Char](https://char.com/download) and try it in your next meeting.
+For meeting notes specifically, you can [download Char](https://anarlog.so/download) and try it in your next meeting.

--- a/apps/web/content/articles/notetakers-for-developers.mdx
+++ b/apps/web/content/articles/notetakers-for-developers.mdx
@@ -1,0 +1,198 @@
+---
+meta_title: "7 Best Note-Taking Apps for Developers in 2026"
+meta_description: "An honest guide to note-taking tools for developers who grep their notes, version-control their ideas, and install everything through a terminal."
+author:
+  - "John Jeong"
+featured: true
+category: "Comparisons"
+date: "2026-04-08"
+---
+
+Most "best note-taking apps" articles are written for project managers and productivity influencers. They'll recommend Notion, show you a Kanban board screenshot, and call it a day. This isn't that article.
+
+If you install tools through Homebrew, keep your dotfiles in a Git repo, and care whether your notes are stored as plain markdown or a proprietary blob, you have different requirements. You want local files you can grep. You want version control that isn't "page history (30 days)." You want a tool that doesn't require an account just to write a thought down.
+
+I tested and researched these five tools across developer forums, Hacker News threads, Reddit discussions, and my own workflow. Each one covers a distinct use case. Here's what I found.
+
+## How These Note-Taking Apps for Developers Compare
+
+
+| Tool                     | Best For                                               | Pricing                                |
+| ------------------------ | ------------------------------------------------------ | -------------------------------------- |
+| Char                     | AI meeting notes with local files and your own LLM     | Free (BYOK) / Pro $25/mo               |
+| Obsidian                 | Building a linked knowledge base over months and years | Free / Sync $5–10/mo                   |
+| VS Code + Markdown + Git | Developers who refuse to install another app           | Free                                   |
+| Joplin                   | Encrypted, self-hosted, cross-platform notes           | Free / Cloud $5–10/mo                  |
+| Logseq                   | Outliner-style thinking with block-level linking       | Free / Sync $5/mo (beta)               |
+| Outline                  | Team wiki and internal documentation                   | Free (self-hosted) / Cloud from $10/mo |
+| Novi Notes               | Bonus: AI-native notes via MCP for Claude users        | Varies by region                       |
+
+
+## Best Note-Taking Apps for Developers in 2026
+
+### 1. Char[a]
+
+[Char](https://char.com) is an open-source AI meeting note-taker that captures system audio directly from your computer, with no bot joining the call and no calendar permissions required. You jot notes in a built-in notepad while it transcribes in the background, then the AI merges both into a structured summary. Everything is stored on your device, and you can bring your own LLM: Ollama, LM Studio, OpenAI, Anthropic, etc.
+
+#### Why devs love it
+
+- Install with brew install --cask fastrepl/fastrepl/char. There's a CLI. The repo is public on GitHub.
+- Nine speech-to-text providers including two local options (Parakeet V3 and Whisper Small via Cactus) for fully offline transcription.
+- Notes support code blocks, @mentions with backlinks, and the AI chat can edit your notes directly in place.
+- Export to Markdown, PDF (with a formatted cover page), JSON, VTT, and Org mode. You can point the storage directory at an Obsidian vault.
+- Record-only mode lets you capture audio now and transcribe it later. Meeting countdown auto-starts recording for calendar events.
+
+#### What’s the catch
+
+- macOS only right now. Windows and Linux builds are planned for Q2 2026.
+- No mobile app. If you need to record a call from your phone, Char can't help yet.
+- No built-in CRM integrations. Meeting notes stay in Char unless you export or sync manually.
+- Daily notes with automatic task carry-forward and calendar linking are in preview but not shipped as the default experience yet.
+
+#### Cost
+
+Free with no limits if you bring your own API key or run local models. The Pro plan at $25/month adds managed cloud transcription and summarization. A Lite plan was recently added as a middle tier. For a developer running Ollama locally, the free tier is genuinely unlimited.
+
+### 2. Obsidian
+
+![obsidian for developers](/api/assets/blog/articles/notetakers-for-developers/image-1.png "char-editor-width=80")
+
+[Obsidian](https://obsidian.md) is a markdown-based knowledge management app that stores all your notes as .md files in a local folder. You link notes together with [[double brackets]], and the graph view maps how your ideas connect. With 1,500+ community plugins, it bends into whatever shape your workflow needs.
+
+#### Why devs love it
+
+- Your notes are just .md files on disk. Claude Code, VS Code, and grep all work on them directly. No API, no MCP, no export step.
+- The plugin ecosystem is enormous: Kanban boards, spaced repetition, Mermaid diagrams, Dataview queries, Git integration, and Vim keybindings.
+- Backlinks and graph view build a map of how your ideas connect over time. You don't organize upfront. You write, link with [[brackets]], and the structure emerges.
+- Canvas mode lets you spatially arrange notes and images on an infinite board for brainstorming architecture or planning sprints.
+- The app is fast. Startup is near-instant even with thousands of notes, which is more than most Electron apps can say.
+
+#### What’s the catch
+
+- Syncing across devices costs extra. Obsidian Sync starts at $4/month. Many devs use iCloud or Dropbox as a free workaround, but conflict resolution isn't as clean.
+- No real-time collaboration. You can share a vault via Sync, but it's not designed for two people editing the same note simultaneously.
+- The learning curve is real. New users often spend their first week configuring plugins instead of writing notes. The community calls this "plugin paralysis."
+
+#### Cost
+
+The core app is free forever, no account required. Obsidian Sync runs $5–10/month depending on storage. Obsidian Publish is $8/month per site. Commercial use requires a $50/user/year license, though the app itself doesn't enforce it. There's a 40% discount for students and nonprofits on Sync and Publish.
+
+### 3. VS Code + Markdown + Git
+
+![how to use VS Code for notetaking](/api/assets/blog/articles/notetakers-for-developers/image-2.png "char-editor-width=80")
+
+This isn't a product. It's a setup. You create a folder of .md files, open it in VS Code, and version-control it with Git.And if your team needs those markdown files published as shared docs, [GitBook](https://www.gitbook.com) syncs directly with your Git repo and renders them as a polished documentation site. Edit in VS Code, push to GitHub, GitBook handles the rest.
+
+#### Why devs love it
+
+- Zero new apps. If you already live in VS Code, your muscle memory, keybindings, and extensions carry over.
+- Git gives you version history, branching, diff, and backup to a private GitHub repo. The GitDoc extension auto-commits every 30 seconds.
+- Markdown All in One (5M+ installs) adds TOC generation, list continuation, and formatting shortcuts. markdownlint keeps your files consistent.
+- Side-by-side preview with Cmd+K V. IntelliSense autocompletes file links and headings. Drag-and-drop images just work.
+
+#### What’s the catch
+
+- No mobile access. Your notes live on your laptop, period. Unless you set up something like GitHub Codespaces, you're stuck.
+- No backlinks, no graph view, no knowledge graph. Notes don't know about each other unless you manually link them in markdown.
+- Search is workspace-level keyword matching. If you forget the exact term, you're scrolling. No semantic or fuzzy search built in.
+
+#### Cost
+
+Free. VS Code is free. Git is free. A private GitHub repo is free. The only cost is the setup time and the discipline to commit regularly. Several devs automate the commit step with shell scripts or the GitDoc extension, which turns it into a fire-and-forget system.
+
+### 4. Joplin
+
+![Joplin for programmers](/api/assets/blog/articles/notetakers-for-developers/image-3.png "char-editor-width=80")
+
+[Joplin](https://joplinapp.org) is an open-source note-taking app with end-to-end encryption and sync across every platform: Windows, macOS, Linux, iOS, Android, and even a terminal client. If you're migrating from Evernote and want to actually own your data, this is where most people land.
+
+#### Why devs love it
+
+- End-to-end encryption is on by default. Your notes are encrypted before they leave your device, no matter which sync backend you choose.
+- Sync options include Joplin Cloud, Dropbox, OneDrive, S3, WebDAV, or a self-hosted Joplin Server. Full control over where your data lives.
+- The terminal app (joplin) lets you manage notes entirely from the command line. It's the only mainstream note app that ships a TUI.
+- Web clipper for Chrome and Firefox. Evernote import tool that actually works. Markdown with notebook and tag organization.
+
+#### What’s the catch
+
+- The desktop app is Electron and feels like it. It's functional, not fast. Opening a large notebook takes a noticeable beat compared to Obsidian or Apple Notes.
+- No real-time collaboration. Joplin is a single-player tool. Sharing a note means exporting it.
+- The UI is honest but dated. If you care about visual polish, Joplin will feel utilitarian. The community calls it "function over form."
+
+#### Cost
+
+The app is free and open-source with no feature gates. Joplin Cloud is $5/month for the basic plan (1GB, sync + E2EE) or $10/month for teams (10GB). If you self-host Joplin Server or sync through Dropbox, the entire stack is free. There's no commercial license requirement.
+
+### 5. Logseq
+
+![logseq for notetaking](/api/assets/blog/articles/notetakers-for-developers/image-4.png "char-editor-width=80")
+
+[Logseq](https://logseq.com) is an open-source, block-based outliner where every bullet point is a first-class object that can be linked, queried, and embedded anywhere in your knowledge graph. It stores notes as local Markdown or Org-mode files and uses daily journal pages as the main entry point. With 32,000+ GitHub stars and an AGPL license, it's one of the most actively developed PKM tools in the open-source ecosystem.
+
+#### Why devs love it
+
+- The outliner model fits how developers think. Instead of writing long documents, you write structured bullets and link them across your graph. Block references let you reuse content without duplicating it.
+- Datalog-powered queries let you build dynamic views: all TODOs from this week, all notes mentioning a specific API, all blocks tagged #architecture. It's SQL for your notes.
+- Built-in flashcards with spaced repetition. Add #card to any bullet and Logseq schedules reviews automatically. Useful for learning new frameworks or prepping for interviews.
+- PDF annotation with Zotero integration. Highlight a passage, and it links directly to your notes. Researchers and devs who read papers will recognize the value immediately.
+
+#### What’s the catch
+
+- Mobile apps are the weak point. The iOS app has a history of crashes and slow loading. It works for quick capture, but extended editing on a phone is frustrating.
+- Sync has been Logseq's biggest friction point. The official Logseq Sync is still in beta. Without it, you're wiring up iCloud, Dropbox, or Git, all of which can cause conflicts if you're not careful.
+- The learning curve is steeper than Obsidian. The query language, block references, and outliner model take a real investment to learn. The first week feels awkward before it clicks.
+
+#### Cost
+
+Completely free with no feature limits for local use. Logseq Sync is $5/month (beta, available to backers and sponsors). A Sponsors tier at $15/month gives access to experimental features and insider builds. The core app will remain free forever. They only plan to charge for server-dependent features like real-time collaboration.
+
+### 6. Outline
+
+![outline for dev teams](/api/assets/blog/articles/notetakers-for-developers/image-5.png "char-editor-width=80")
+
+[Outline](https://getoutline.com) is an open-source team knowledge base with real-time collaborative editing, markdown with slash commands, and blazing-fast search. Think of it as the self-hostable alternative to Notion or Confluence, but focused on doing one thing well: organizing team documentation without the bloat.
+
+#### Why devs love it
+
+- Real-time collaboration that actually works. Multiple people can edit the same document simultaneously, with comments, @mentions, and threads keeping conversations organized.
+- Self-hostable with Docker (Postgres + Redis). Your team's documentation lives on your infrastructure, not someone else's cloud. The BSL 1.1 license keeps the source open.
+- The editor is fast and modern: slash commands, nested collections, drag-and-drop, code blocks, embeds, and a clean reading experience that doesn't feel like a wiki from 2010.
+- REST API + webhooks + 20+ integrations including Slack, Zapier, and SSO via Google, Microsoft, or OIDC. If your team already has an identity provider, Outline slots right in.
+
+#### What’s not there yet
+
+- No mobile app. Outline works through a responsive web interface, which is functional but not the same as a native app for quick capture on the go.
+- Self-hosting requires Docker, Postgres, Redis, and an external auth provider (OIDC/OAuth). There's no built-in username/password login. If your team doesn't already run an identity provider, the setup is more involved.
+- It's a wiki, not an all-in-one workspace. No databases, no Kanban boards, no task management. Outline does documentation and does it well, but doesn't try to replace your project management stack.
+
+#### Cost
+
+Self-hosted is free (open-source). Outline's cloud service runs $10/month for teams up to 10, $79/month for 11–100, and $249/month for 101–200. There's a 30-day free trial on the cloud version and a 30% discount for nonprofits and education. For dev teams already running Docker in production, self-hosting is the obvious choice.
+
+### 7. Bonus: Novi Notes
+
+![](/api/assets/blog/articles/notetakers-for-developers/image-6.png "char-editor-width=80")
+
+[Novi Notes](https://rhcwlq89.github.io/en/novi-note/) is a local-first Mac note app built by a solo developer in Seoul. The hook: it's AI-native via MCP (Model Context Protocol). Install the app, open Claude Desktop, and Claude can read and write your notes directly. No plugins, no API keys, no configuration files. It launched on Product Hunt in March 2026, hit Product of the Day #10, and it's a one-time purchase with no subscription.
+
+It's early. Mac-only, Claude-only for AI features, no cloud sync. But the zero-config MCP integration is the kind of thing that feels obvious once you see it. If you use Claude as a daily tool and want your notes to be part of that conversation without any glue code, Novi Notes is worth watching.
+
+## Which Note-Taking App Is Right for You?
+
+There's no single tool that handles meeting transcription, knowledge management, team documentation, and daily journaling equally well. That's why this list covers seven distinct approaches instead of ranking them against each other.
+
+If your main problem is meeting notes and you want to own the transcript, Char captures system audio without a bot, stores everything locally, and lets you run any LLM you want. The tradeoff is macOS-only for now.
+
+If you're building a long-term knowledge base and want the richest ecosystem, Obsidian has 1,500 plugins and a community that's solved almost every workflow. The tradeoff is that sync costs extra and the setup time is real.
+
+If you refuse to install another app, VS Code + Markdown + Git gives you version-controlled notes in a tool you already know. The tradeoff is no mobile, no graph, no search beyond keywords.
+
+If privacy and encryption are non-negotiable, Joplin encrypts everything end-to-end and lets you self-host the sync server. The tradeoff is a dated UI and Electron performance.
+
+If you think in outlines and want every bullet to be a queryable, linkable object, Logseq is the most ambitious outliner in the open-source space. The tradeoff is a rough mobile experience and sync that's still in beta.
+
+If your team needs shared documentation you actually control, Outline is the self-hostable wiki with real-time collaboration that Confluence wishes it was. The tradeoff is Docker setup and no built-in auth.
+
+And if you're deep in the Claude ecosystem and want your notes to be part of that workflow natively, keep an eye on Novi Notes. It's early, but the MCP-first approach is worth watching.
+
+For meeting notes specifically, you can [download Char](https://char.com/download) and try it in your next meeting.

--- a/apps/web/content/articles/obsidian-meeting-notes.mdx
+++ b/apps/web/content/articles/obsidian-meeting-notes.mdx
@@ -257,4 +257,4 @@ Monday morning. You open Obsidian.
 4. Before your 1:1 with Sarah that afternoon, you open [[Sarah Chen]] and glance at backlinks. You can see every meeting she's been in this month, what she committed to, what's still open. You search task-todo:"Sarah Chen" and it shows rwo open items from last week.
 5. In the 1:1, you reference the specific thing she said in the sprint planning meeting. You know the exact phrasing because it's in the transcript. You're not guessing. You're not paraphrasing from memory. You're reading her words back from a file in your vault.
 
-That's the system. Templates give you structure. Links connect everything. Backlinks surface history. Search finds anything. Char fills the gap between what you typed and what was actually said. [Download Char now](https://char.com/download/apple-silicon) and try it on your next meeting.
+That's the system. Templates give you structure. Links connect everything. Backlinks surface history. Search finds anything. Char fills the gap between what you typed and what was actually said. [Download Char now](https://anarlog.so/download/apple-silicon) and try it on your next meeting.

--- a/apps/web/content/articles/obsidian-meeting-notes.mdx
+++ b/apps/web/content/articles/obsidian-meeting-notes.mdx
@@ -1,0 +1,260 @@
+---
+meta_title: "How to Use Obsidian for Meeting Notes"
+meta_description: "Step-by-step guide to building meeting notes in Obsidian with templates, person notes, backlinks, searchable action items, and local AI transcription via Char."
+author:
+  - "John Jeong"
+featured: true
+category: "Product"
+date: "2026-04-08"
+---
+
+# How to Use Obsidian to Take Meeting Notes?
+
+You're already in Obsidian. You have a vault with projects, people notes, maybe a daily notes practice. What you don't have is meeting notes that connect to any of it. That's the specific problem this guide solves: building a meeting notes system inside an existing Obsidian PKB, where notes actually link to projects and people.
+
+## What we're building
+
+By the end of this guide you'll have:
+
+- A meeting note template that auto-fills the date and drops your cursor where you start typing
+- A person note for each colleague that automatically shows every meeting they appeared in
+- Action items you can find across your entire vault in one search
+- A way to get full meeting transcripts and AI summaries into your vault without any copy-pasting — and without your data leaving your machine
+
+## Sources and credit
+
+This guide draws from Obsidian's official documentation and real workflows shared by the community. Worth reading on their own:
+
+- [Managing notes for meetings and one-on-ones effectively](https://forum.obsidian.md/t/managing-notes-for-meetings-and-one-on-ones-effectively/32049) — The 22k-view thread where the backlinks-as-CRM approach first clicked for a lot of people.
+- [What to do with processed meeting notes?](https://forum.obsidian.md/t/what-to-do-with-processed-meeting-notes/4480) — Decisions vs. raw notes. When to keep, when to extract, when to let go.
+- [Need Help with Dataview for Meeting Notes](https://forum.obsidian.md/t/need-help-with-obsidian-dataview-for-meeting-notes/90648) — Pulling meeting references into person notes automatically.
+- [Automate Base Fill-in for Meeting Notes](https://forum.obsidian.md/t/automate-base-fill-in-for-meeting-notes/103433) — Using Bases to auto-surface meetings in person notes.
+- [From Daily Note, Create a New Note with a Template](https://forum.obsidian.md/t/from-daily-note-create-a-new-note-with-a-template/87160) — One-click meeting note creation from your daily note using Meta Bind buttons.
+
+## How to Take Meeting Notes in Obsidian?
+
+### Step 1: Create the folder structure
+
+![Obsidian vault with Meetings and People folders](/api/assets/blog/articles/obsidian-meeting-notes/image-1-1.png "char-editor-width=80")
+
+Open your vault. Create two folders:
+
+```
+Meetings/
+People/
+```
+
+That's it. You don't need subfolders by month or year yet. If you end up with hundreds of meeting notes and want to organize by date later, Obsidian's search doesn't care about folder depth, it searches everything. Start flat.
+
+If you already have an established vault, just add these two folders alongside whatever you have.
+
+### Step 2: Create a person note
+
+![Person note in Obsidian with role, company, and tags properties](/api/assets/blog/articles/obsidian-meeting-notes/image-2-1.png "char-editor-width=80")
+
+Before you touch templates or meetings, create your first person note. In the `People/` folder, make a new note. Name it after someone you meet with regularly. Something like `Sarah Chen.md`.
+
+Add this to the note:
+
+```
+---
+role: Engineering Lead
+company: Acme
+tags:
+  - person
+---
+## About
+Engineering lead on the payments team. Reports to VP Eng.
+## Meeting history
+```
+
+That's a person note. The role and company properties are there so you can search for them later `— [company:Acme]` finds everyone at Acme. The `## Meeting history` section is going to fill itself. We'll get to that.
+
+Make a few of these for people you meet with often. They don't need to be detailed. A name and a role is enough to start.
+
+### Step 3: Build the meeting note template
+
+In your vault, create a `Templates/` folder if you don't have one. Inside it, create a file called `Meeting.md`:
+
+```
+---
+date: "{{date:YYYY-MM-DD}}"
+type: meeting
+attendees:
+tags:
+  - meeting
+---
+# {{title}}
+**Attendees:**
+## Notes
+## Decisions
+## Action items
+- [ ]
+```
+
+Now go to Settings > Core Plugins > Templates and set your template folder to Templates/.
+
+When you want to start a meeting note: create a new note in `Meetings/`, name it something like `2026-04-06 Product Sync`, then hit Cmd+P and type "Insert template" and select your Meeting template. The date fills itself. Your cursor is ready.
+
+### Step 4: Fill in a real meeting note
+
+Here's what a meeting note looks like after a meeting. The key habit: write names and topics as `[[wikilinks]]`.
+
+```
+---
+date: "2026-04-06"
+type: meeting
+attendees:
+  - "[[Sarah Chen]]"
+  - "[[James Park]]"
+tags:
+  - meeting
+  - payments
+---
+# 2026-04-06 Sprint Planning
+**Attendees:** [[Sarah Chen]], [[James Park]]
+## Notes
+- [[Sarah Chen]] walked through the payments migration timeline
+- Target is end of Q2, but dependent on the [[PCI audit]] completing first
+- [[James Park]] flagged that the staging environment won't be ready until May 15
+- Need to decide if we push the launch or run a parallel environment
+## Decisions
+- We're keeping the Q2 target but building a fallback plan for parallel environments
+- [[Sarah Chen]] owns the fallback proposal, due by Friday
+## Action items
+- [ ] [[Sarah Chen]] — Write up the parallel environment fallback plan by April 11
+- [ ] [[James Park]] — Get staging timeline confirmed with infra team by April 9
+- [ ] Follow up with [[Legal]] on PCI audit status
+```
+
+Look at what just happened:
+
+- [[Sarah Chen]] appears in multiple places. Her person note now shows this meeting in backlinks — with the surrounding context of what she said, what she decided, and what she owes.
+- [[PCI audit]] links to a topic note. If that note doesn't exist yet, that's fine. When the PCI audit becomes important enough to have its own page, every meeting that mentioned it is already connected.
+- The action items use - [ ] task syntax. Obsidian's search can find these directly, and you can narrow it to a specific person.
+
+### Step 5: Person notes fill themselves
+
+![Person note with backlinks panel showing linked meeting notes](/api/assets/blog/articles/obsidian-meeting-notes/image-3-1.png "char-editor-width=80")
+
+Open `Sarah Chen.md` in `People/`. Click the backlinks icon in the right sidebar. Every meeting where you wrote `[[Sarah Chen]]` shows up with surrounding context. You can see what was discussed, what she decided, what she owes — all without maintaining anything.
+
+This is the approach from the [Managing notes for meetings thread](https://forum.obsidian.md/t/managing-notes-for-meetings-and-one-on-ones-effectively/32049) that resonated with the most people. No plugins. No queries. Just links and backlinks doing the work.
+
+If you want a structured table view instead of backlinks, use a Base. The [Automate Base Fill-in](https://forum.obsidian.md/t/automate-base-fill-in-for-meeting-notes/103433) thread shows the exact filter:
+
+```
+filters:
+  and:
+    - file.hasLink(this.file.name)
+    - 'type = "meeting"'
+```
+
+Embed this Base in Sarah's person note and it renders a table of every meeting note that links to her, filterable and sortable. This uses Obsidian's built-in Bases feature — no community plugins needed.
+
+### Step 6: Create meeting notes fast from your daily note
+
+![Daily note with wikilinks to today's meeting notes](/api/assets/blog/articles/obsidian-meeting-notes/image-4-1.png "char-editor-width=80")
+
+If you use Obsidian's Daily Notes plugin, you probably want to create meeting notes from there. The [Daily Note to Meeting Note thread](https://forum.obsidian.md/t/from-daily-note-create-a-new-note-with-a-template/87160) shows how to set up a one-click button using Meta Bind and Templater that:
+
+1. Creates a new note in your `Meetings/` folder
+2. Applies your meeting template
+3. Renames it with today's date
+4. Opens it in a new tab
+
+Your daily note becomes a launchpad. Start of the day, you see your calendar, and for each meeting you click a button and you're ready.
+
+If that's too much setup, just do it manually: Cmd+N, type the name, insert template. It takes five seconds.
+
+### Step 7: Finding things later
+
+This is where the system pays off. Every query below has been tested in a live Obsidian vault.
+
+Sarah's open action items:
+
+![search results for open tasks in obsidian](/api/assets/blog/articles/obsidian-meeting-notes/image-5-1.png "char-editor-width=80")
+
+```
+task-todo:"Sarah Chen"
+```
+
+Finds every incomplete task across your vault that mentions Sarah by name. Returns the exact task text with context.
+
+All meetings tagged payments:
+
+![search filtering in obsidian](/api/assets/blog/articles/obsidian-meeting-notes/image-6-1.png "char-editor-width=80")
+
+```
+path:Meetings [tags:payments]
+```
+
+Finds meeting notes where the tags property includes "payments." Returns only files inside the Meetings folder.
+
+Every meeting where PCI audit came up:
+
+![Obsidian search for a topic across all meeting notes](/api/assets/blog/articles/obsidian-meeting-notes/image-7-1.png "char-editor-width=80")
+
+```
+path:Meetings "PCI audit"
+```
+
+Finds every mention of "PCI audit" across all meeting notes, with surrounding context so you can see what was said about it.
+
+All March meetings:
+
+![Obsidian search filtering notes by date property](/api/assets/blog/articles/obsidian-meeting-notes/image-8-1.png "char-editor-width=80")
+
+```
+[date:/2026-03/]
+```
+
+Uses regex on the date property to find all notes with a March 2026 date. Works for any month — change the pattern to match what you need.
+
+Everyone at a specific company:
+
+![Obsidian property search across person notes](/api/assets/blog/articles/obsidian-meeting-notes/image-9-1.png "char-editor-width=80")
+
+```
+[company:Acme]
+```
+
+Searches the `company` property across person notes. Useful when you're preparing for a client meeting and want to see all your contacts there.
+
+### Step 8: Add Char for real-time transcription and AI notes
+
+Everything up to this point relies on what you managed to type. In a 30-minute meeting, that's maybe 15% of what was said. The decision that was made at minute 22. The exact phrasing someone used when they pushed back on a deadline. The side comment that turns out to be the most important thing said all week. It's gone unless you happened to write it down.
+
+You need transcription. And if you're the kind of person who chose Obsidian — you chose it because your files live on your machine, in a format you control, with no lock-in — you need transcription that works the same way.
+
+Most meeting transcription tools don't. They store your data on their servers. They require monthly subscriptions. They join your call as a bot. They lock your transcripts in a proprietary format you can't move.
+
+This is exactly the problem Char solves.
+
+Char is an open-source AI notepad for meetings. Here's what it does and why it fits this system:
+
+![Char obsidian integration](/api/assets/blog/articles/obsidian-meeting-notes/image-10-1.png "char-editor-width=80")
+
+You point the output folder at your vault. This is the key. Set Char's output folder to your `Meetings/` folder (or a subfolder like `Meetings/Transcripts/`). When Char finishes processing a meeting, the transcript and summary appear in your vault. Obsidian indexes them instantly. They're searchable, linkable, part of your system. No export. No copy-paste.
+
+It records via system audio. No bot joins your Zoom. No calendar permissions. Char captures what your computer hears, which means it works with Zoom, Teams, Google Meet, phone calls, and in-person conversations with a mic. Nobody in the meeting knows it's running.
+
+It transcribes in real time and generates structured summaries. Char combines your notes with the full transcript and produces a summary using AI. The summary lands as a file on your computer.
+
+You choose the AI. Use Char's managed cloud service if you want simplicity. Bring your own API keys from OpenAI, Deepgram, or Anthropic if your company already has them. Run models locally through Ollama or LM Studio if nothing leaves your machine. Your security team can audit the code. You're not trusting a black box with your meeting recordings.
+
+There's no lock-in. Every file Char produces is a file on your computer. Stop using Char and every transcript is still there, in your vault, working. There's nothing to export because nothing was ever locked up.
+
+If you use Obsidian, you already made this choice once: files on your machine, open format, your control. Char is the same choice applied to meeting recordings.
+
+## Your Obsidian Meeting Notes Workflow
+
+Monday morning. You open Obsidian.
+
+1. You check your calendar and see three meetings today. From your daily note, you create a meeting note for the first one: `2026-04-07 Sprint Planning`.
+2. The meeting starts. You open Char. It starts recording system audio. You take notes in Obsidian: quick bullets, [[wikilinks]] for people and topics as they come up.
+3. The meeting ends. You stop Char. It processes the recording and drops a transcript and structured summary into your vault. You pull the key decisions and action items to the top of your meeting note.
+4. Before your 1:1 with Sarah that afternoon, you open [[Sarah Chen]] and glance at backlinks. You can see every meeting she's been in this month, what she committed to, what's still open. You search task-todo:"Sarah Chen" and it shows rwo open items from last week.
+5. In the 1:1, you reference the specific thing she said in the sprint planning meeting. You know the exact phrasing because it's in the transcript. You're not guessing. You're not paraphrasing from memory. You're reading her words back from a file in your vault.
+
+That's the system. Templates give you structure. Links connect everything. Backlinks surface history. Search finds anything. Char fills the gap between what you typed and what was actually said. [Download Char now](https://char.com/download/apple-silicon) and try it on your next meeting.

--- a/apps/web/content/articles/open-source-meeting-transcription-software.mdx
+++ b/apps/web/content/articles/open-source-meeting-transcription-software.mdx
@@ -1,0 +1,195 @@
+---
+meta_title: "Best Open Source Meeting Transcription Software in 2026"
+display_title: "Open Source Alternatives to Otter AI and Fireflies"
+meta_description: "Review of the best open source meeting transcription tools you can fork, self-host, and customize. Compare features, pricing, and deployment options."
+author:
+  - "Harshika"
+coverImage: "/api/assets/blog/open-source-meeting-transcription-software/cover.png"
+featured: true
+category: "Comparisons"
+date: "2025-10-23"
+---
+
+Looking for meeting transcription tools that you can fork, fix, and make your own? This article reviews three open-source options that give you complete control over your meeting data.
+
+We'll compare Char, Meetily, and Amical—the only three open-source meeting transcription tools that let you inspect every line of code, modify any component, and own your data forever.
+
+## What are the best open-source meeting transcription software?
+
+
+| Feature                | Char                                | Meetily                   | Amical                       |
+| ---------------------- | ----------------------------------- | ------------------------- | ---------------------------- |
+| **Best For**           | Control over data and AI stack      | Pure transcription needs  | Hands-free typing everywhere |
+| **Transcription**      | Real-time via Whisper               | Real-time via Whisper.cpp | Real-time via Whisper        |
+| **Platforms**          | macOS (Windows/Linux Q2 2026)       | Windows, macOS, Linux     | macOS (Windows in progress)  |
+| **License**            | MIT                                 | MIT                       | MIT                          |
+| **Meeting Support**    | All platforms, no bots              | All platforms, no bots    | Live meeting transcription   |
+| **Local Models**       | HyperLLM-V1, Whisper                | Whisper.cpp, Ollama       | Ollama support               |
+| **Cloud Options**      | OpenAI, Gemini, Claude, custom APIs | Claude, Groq, OpenAI      | OpenAI, custom APIs          |
+| **Individual Use**     | Free forever                        | Free (MIT license)        | Free (MIT license)           |
+| **Organization Plans** | Pro ($8), Enterprise (custom)       | Custom (2-100 users)      | None currently               |
+| **GitHub Stars**       | 6.4k+                               | 7.8k+                     | 96                           |
+
+
+## Top open-source meeting transcription software: detailed reviews
+
+### 1. Char
+
+[Char](/) is an open-source AI notepad for meetings that gives you complete control over your data and AI stack. Everything is stored as plain markdown files.
+
+The interface works like Apple Notes. You open it and start typing. No list of past meetings to navigate, no calendar integration. Just a blank canvas ready to use.
+
+While you're writing, Char listens to both your microphone and system audio. Once the meeting ends, it enhances your manual notes into actionable AI summaries based on your chosen template.
+
+**Available as:** Native Mac app (desktop application, Windows and Linux coming in Q2 2026)
+
+![Char](/api/assets/blog/open-source-meeting-transcription-software/hyprnote.webp)
+
+#### **Top Features**
+
+- Multiple deployment options: keep everything on your device, deploy on your own servers, or use the managed cloud service
+- Real-time transcription with no bots or calendar permissions required
+- Works with Zoom, Teams, Google Meet, and in-person meetings without any setup
+- Your choice of AI: managed cloud, bring your own API keys (OpenAI, Anthropic, Mistral, and others), or run local models via Ollama or LM Studio
+- AI chat to query your transcripts and search across your entire meeting history
+- Custom templates for different meeting types
+- Import existing recordings or transcripts
+- 45+ language support including English, Spanish, French, German, Japanese, and more
+- Floating panel and keyboard shortcuts for quick recording controls
+- Smart consent management for enterprises with options from simple pop-ups to verbal consent recognition
+
+**Pros**
+
+- Your choice of AI stack: managed cloud, bring your own keys, or run local models
+- Free forever for local transcription, BYOK, and all core features
+- Can work completely offline, suitable for air-gapped environments
+- Open source codebase allows for inspection, customization, and community contributions
+- Plain markdown files work with Obsidian, Notion, VS Code, or any text editor
+
+**Cons**
+
+- macOS only currently (Windows and Linux versions coming in Q2 2026)
+- No mobile app currently available
+
+#### Pricing
+
+Free forever for local transcription, BYOK, and all core features. Managed cloud service is $25/month for the easiest setup. Enterprise offers on-premises deployment.
+
+&nbsp;
+
+### 2. Meetily
+
+[Meetily](https://meetily.zackriya.com/) is a privacy-first AI meeting assistant that runs entirely on your local machine. Unlike Char, which combines note-taking with transcription, Meetily focuses on recording, transcribing, and summarizing meetings.
+
+**Available as:** Native apps for Windows, macOS, and Linux
+
+![Meetily](/api/assets/blog/open-source-meeting-transcription-software/meetily.webp)
+
+#### Top features
+
+- **Real-time transcription with Whisper.cpp** uses an optimized implementation that runs significantly faster than standard Python-based Whisper.
+- **AI-powered meeting summaries** generate summaries using local LLMs through Ollama or connect to cloud providers (Claude, Groq, OpenAI).
+- **Dual audio capture** records both microphone and system audio simultaneously with intelligent ducking and clipping prevention.
+- **GPU acceleration support** automatically detects and uses hardware acceleration: Metal/CoreML on macOS, CUDA for NVIDIA, Vulkan for AMD/Intel.
+- **Semantic search via ChromaDB** enables searching by concepts and related discussions, not just exact keywords.
+- **Universal meeting platform support** works with Zoom, Teams, Google Meet, Webex, and any platform without requiring bots.
+- **SQLite local storage** keeps all data locally in a lightweight database that's easy to back up and migrate.
+- **REST API access** exposes endpoints for integrating with other tools and workflows.
+
+#### Pros
+
+- Runs on all major operating systems (Windows, macOS, Linux)
+- Focused approach to transcription without extra complexity
+- Permissive MIT license for maximum flexibility
+
+#### Cons
+
+- Initial setup requires C++, CMake, and other development tools
+- Pre-built releases aren't notarized, causing security warnings
+- Summarization quality varies with smaller local models
+- No manual note-taking integration
+- No public pricing information for organizational tiers
+- Steeper learning curve than consumer-focused alternatives
+
+#### Pricing
+
+Free for individuals under MIT license. Organizational (2-100 users) and enterprise (100+ users) plans are available at custom pricing, but rates aren't publicly listed.
+
+### 3. Amical
+
+[Amical](https://amical.ai/) is an open-source AI dictation tool that transforms how you type across your computer. While it supports meeting transcription, its primary focus is hands-free typing with context-aware formatting that adapts to whatever application you're using.
+
+**Available as:** Mac app (desktop application, Windows support in progress)
+
+![Amical](/api/assets/blog/open-source-meeting-transcription-software/amical.webp)
+
+#### Top features
+
+- **Context-aware intelligent formatting** automatically adjusts tone and style based on the application -- professional for Gmail, casual for Instagram, conversational for Slack.
+- **Floating desktop widget** provides a small, positioned-anywhere widget for quick dictation access without leaving your active application.
+- **Custom hotkeys configuration** lets you create keyboard shortcuts for starting/stopping dictation and executing commands hands-free.
+- **Multi-language native support** transcribes in 50+ languages with native-level accuracy, including seamless mixed-language dictation.
+- **Custom vocabulary training** teaches Amical industry-specific terms, proper nouns, project names, and technical jargon for improved accuracy.
+- **Voice commands and shortcuts** let you create personalized voice commands to automate repetitive tasks completely hands-free.
+- **Meeting transcription capability** records live meetings with both mic and system audio, though this feature is still in development.
+- **Automatic grammar correction** fixes pronouns, adds contextual elements like emojis, and corrects grammar in real-time.
+- **Works system-wide** so you can dictate in any text field across all applications without switching tools.
+- **Transcription history** provides a searchable archive of all dictated text with export options (in development).
+
+#### Pros
+
+- Excellent multi-language support with seamless language switching
+- Completely free with no paid tiers or subscriptions
+- Custom vocabulary dramatically improves accuracy for specialized work
+- Hands-free workflow with voice commands and shortcuts
+- MIT licensed for maximum flexibility
+
+#### Cons
+
+- In active development toward first stable release—expect bugs
+- Meeting transcription features less mature than Char or Meetily
+- macOS is the primary focus; Windows support exists but less polished
+- App not notarized, causing security warnings
+- Smaller community and contributor base (96 GitHub stars vs 6k-8k for others)
+
+#### Pricing
+
+Completely free with no paid tiers.
+
+## Which open-source transcription tool should you choose?
+
+For most developers and privacy-conscious professionals, **Char** stands out. It delivers zero lock-in with complete control over your data and AI stack. Plain markdown files work with any tool, you choose your AI provider, and the manual note integration gives you control over what the AI focuses on.
+
+The code is open source under the MIT license, so you can verify exactly how your data is processed. Need enterprise deployment? Self-host it on your own infrastructure. Want to modify the summarization logic? Fork it and make it yours.
+
+Setup is straightforward. No complex configuration, no security warnings to bypass, no hidden dependencies.
+
+Ready to try it? [Download Char for macOS](/download) or [check out the source code on GitHub](https://github.com/fastrepl/char).
+
+## Frequently asked questions
+
+### 1. Are open-source transcription tools really free?
+
+Yes, all three are open source. Char and Amical are [free](/blog/free-transcription-software/) for all users. Char is free forever for local transcription and BYOK. The managed cloud service is $25/month, and Enterprise tier has custom pricing.
+
+Meetily is free for individual users under the MIT license. Organizations (2-100 users) and enterprises (100+ users) can request custom plans, but pricing isn't publicly listed.
+
+### 2. Do I need a powerful computer to run local transcription software?
+
+You need a reasonably modern machine. An M-series Mac works best for Char, though Intel Macs function with reduced performance. Meetily and Amical have similar requirements—at least 8GB RAM (16GB recommended) and a decent CPU. GPU acceleration helps but isn't required for basic use.
+
+### 3. Can I use these tools offline?
+
+Yes. All three can transcribe meetings completely offline using local AI models. You only need internet if you choose to use cloud AI providers for enhanced summaries.
+
+### 4. How accurate is the transcription?
+
+With larger Whisper models, accuracy typically reaches 90-95% for clear English audio. Accuracy drops with background noise, heavy accents, or specialized terminology. Custom vocabulary features (where available) can improve accuracy for industry-specific terms.
+
+### 5. What about HIPAA, GDPR, and compliance?
+
+Because processing happens locally by default, these tools simplify compliance significantly. Your data doesn't leave your device, so you're not transmitting protected information to third-party processors. This makes HIPAA, GDPR, SOC 2, and other frameworks much easier to satisfy.
+
+Organizations needing formal compliance documentation can use Char or Meetily's enterprise plans, which include dedicated support.
+
+&nbsp;

--- a/apps/web/content/articles/openrouter-data-retention-policy.mdx
+++ b/apps/web/content/articles/openrouter-data-retention-policy.mdx
@@ -38,7 +38,7 @@ This gives you granular control if you need it. For most use cases, simply not e
 
 This is where OpenRouter's data policy gets more complicated.
 
-When you send a request through OpenRouter, it routes that request to a provider. That provider processes your prompt under their own data retention policy. OpenRouter does not change what the provider stores. If your request goes to OpenAI's API, [OpenAI's 30-day abuse monitoring window](https://char.com/blog/chatgpt-data-retention-policy/) applies. If it goes to Anthropic's API, [Anthropic's 7-day window](https://char.com/blog/anthropic-data-retention-policy/) applies.
+When you send a request through OpenRouter, it routes that request to a provider. That provider processes your prompt under their own data retention policy. OpenRouter does not change what the provider stores. If your request goes to OpenAI's API, [OpenAI's 30-day abuse monitoring window](https://anarlog.so/blog/chatgpt-data-retention-policy/) applies. If it goes to Anthropic's API, [Anthropic's 7-day window](https://anarlog.so/blog/anthropic-data-retention-policy/) applies.
 
 OpenRouter displays the data retention policy for each provider endpoint in its interface. Before routing sensitive data through a model, check the provider policy shown for that endpoint.
 
@@ -72,4 +72,4 @@ If you configure OpenRouter with ZDR enabled and prompt logging off, those setti
 
 As with all Char integrations, your meeting notes are stored on your device. The AI provider processes your data to generate a summary, but the output lives locally. Switching from OpenRouter to a direct provider relationship, or to a local model, does not require any changes to how your notes are organized.
 
-[Download Char for MacOS](https://char.com/download) and use the AI provider your security team actually approves.
+[Download Char for MacOS](https://anarlog.so/download) and use the AI provider your security team actually approves.

--- a/apps/web/content/articles/openrouter-data-retention-policy.mdx
+++ b/apps/web/content/articles/openrouter-data-retention-policy.mdx
@@ -1,0 +1,75 @@
+---
+meta_title: "OpenRouter Data Retention Policy Across Providers"
+meta_description: "OpenRouter routes your requests across dozens of AI providers. That means two data retention questions, not one. Here's how to think about both."
+author:
+  - "Harshika"
+featured: false
+category: "Guides"
+date: "2026-03-20"
+---
+
+OpenRouter is an aggregator that routes your API requests to dozens of underlying providers, including OpenAI, Anthropic, Mistral, Google, and many others.
+
+That creates a data retention question with two layers. What does OpenRouter itself store? And what does the provider your request gets routed to store?
+
+Both matter. Here is how each works.
+
+## What OpenRouter Itself Keeps From Your Requests
+
+By default, OpenRouter does not log your prompts or completions. What it does store is request metadata: timestamps, the model you used, token counts, and latency. That information is retained for billing and operational purposes.
+
+Your actual conversation content is not retained by OpenRouter unless you specifically opt in to prompt logging.
+
+## Why You Should Never Enable Prompt Logging
+
+OpenRouter offers a 1% discount on usage costs in exchange for enabling prompt logging. If you turn this on, OpenRouter stores your prompts and completions.
+
+There is a significant term attached to this. [OpenRouter's privacy policy](https://openrouter.ai/privacy) states that enabling prompt logging grants OpenRouter an irrevocable right to commercial use of those inputs and outputs. That language is broader than most providers use. It means logged data could be used for purposes beyond just displaying your history in the dashboard.
+
+If you are evaluating OpenRouter for any use case involving confidential information, sensitive conversations, or regulated data, do not enable prompt logging. The 1% discount is not worth the data rights you are granting.
+
+## How to Make Sure OpenRouter Never Logs Your Requests
+
+OpenRouter supports ZDR at the request level. You can pass the zdr parameter in individual API calls to prevent OpenRouter from logging that specific request, regardless of your account-wide settings. It also works as an account-wide setting.
+
+This gives you granular control if you need it. For most use cases, simply not enabling prompt logging achieves the same result for OpenRouter's own data handling.
+
+## What OpenRouter's Underlying Provider Stores
+
+This is where OpenRouter's data policy gets more complicated.
+
+When you send a request through OpenRouter, it routes that request to a provider. That provider processes your prompt under their own data retention policy. OpenRouter does not change what the provider stores. If your request goes to OpenAI's API, [OpenAI's 30-day abuse monitoring window](https://char.com/blog/chatgpt-data-retention-policy/) applies. If it goes to Anthropic's API, [Anthropic's 7-day window](https://char.com/blog/anthropic-data-retention-policy/) applies.
+
+OpenRouter displays the data retention policy for each provider endpoint in its interface. Before routing sensitive data through a model, check the provider policy shown for that endpoint.
+
+By default, OpenRouter does not guarantee which specific provider instance handles your request. It selects based on availability, price, and performance. You can specify a preferred provider using routing parameters in your API call, but unless you do, the selection is automatic.
+
+## How to Keep Your Data in the EU
+
+For enterprise customers, OpenRouter supports EU in-region routing. When enabled, your prompts and completions are processed within the European Union and do not leave the EU. This is relevant for organizations operating under GDPR or with contractual data residency requirements.
+
+EU routing is not enabled by default and requires an enterprise account configuration. Contact OpenRouter's team to enable it.
+
+## Is OpenRouter Safe for Regulated Industries?
+
+OpenRouter does not publish a HIPAA Business Associate Agreement. If your use case involves protected health information, OpenRouter is not the right routing layer without a BAA in place. The same applies to other regulated data categories.
+
+For compliance-sensitive deployments, the multi-provider nature of OpenRouter adds complexity. You are not just evaluating OpenRouter's compliance posture but also the compliance posture of every provider your requests might be routed to. Unless you lock routing to a specific provider with known compliance certifications, the compliance surface is difficult to bound.
+
+## **When OpenRouter Works for Sensitive Work and When It Does Not**
+
+OpenRouter's value is flexibility and cost optimization across providers. For non-sensitive workloads where you want access to a broad model catalog, routing optimization, and fallback handling, it is a practical tool.
+
+For sensitive work, the two-layer data question requires more active management. You need to be specific about which provider your requests go to, verify that provider's data policy, confirm that OpenRouter ZDR is enabled, and ensure prompt logging is off. That is manageable, but it requires deliberate configuration rather than relying on defaults.
+
+The defaults at OpenRouter are reasonably privacy-conscious. Prompts are not logged out of the box. But the flexibility that makes OpenRouter useful also makes its data handling harder to audit than a direct provider relationship.
+
+## Use OpenRouter to Take AI Notes Through Char
+
+Char supports OpenRouter as an API provider option. When you bring your own OpenRouter API key, your meeting data routes through OpenRouter under your account settings.
+
+If you configure OpenRouter with ZDR enabled and prompt logging off, those settings apply to requests Char sends through your account. If you have locked routing to a specific provider within OpenRouter, requests from Char will follow that configuration.
+
+As with all Char integrations, your meeting notes are stored on your device. The AI provider processes your data to generate a summary, but the output lives locally. Switching from OpenRouter to a direct provider relationship, or to a local model, does not require any changes to how your notes are organized.
+
+[Download Char for MacOS](https://char.com/download) and use the AI provider your security team actually approves.

--- a/apps/web/content/articles/organize-meeting-notes.mdx
+++ b/apps/web/content/articles/organize-meeting-notes.mdx
@@ -1,0 +1,40 @@
+---
+meta_title: "How to Organize Meeting Notes So You Can Actually Find Them Later"
+display_title: "How to Organize Meeting Notes So You Can Actually Find Them Later"
+meta_description: "Most people capture meeting notes fine. Finding them three weeks later is the real problem. Here's how to keep your notes organized. "
+author:
+  - "Harshika"
+featured: false
+category: "Guides"
+date: "2026-02-22"
+---
+
+Most people capture meeting notes fine. Finding them three weeks later is the problem. This is fixable, whatever tool you use.
+
+## How to Organize Your Meeting Notes
+
+### **Use Your Meeting Assistant's Built-In Features**
+
+Before building any system on top, most people underuse what their note-taking app already gives them. Conversational search. Summaries that pull out decisions and action items. Templates for recurring meetings. Char, Otter, Granola, Fireflies - all of them have this to some degree.
+
+Start there. Search is good enough now that a lot of organizational overhead simply isn't necessary anymore. Most things you'd want to find are one query away.
+
+### **If You're Using Char, You're Already at an Advantage**
+
+With most meeting note-takers, you're renting space in their database. Switch tools and getting your notes out cleanly is harder than it should be.
+
+Char, on the other hand, saves your notes as plain markdown files on your own device. That one difference opens up a lot.
+
+Markdown files are just text. Any tool can read them, which means your meeting history isn't locked in a platform. The files travel with you and work with anything, regardless of what Char does in the future.
+
+In practice that means you can open your notes folder directly in Obsidian and start linking meetings to projects and people. Drop the same folder into Logseq if you prefer a more task-and-outline-focused workflow. Open it in VS Code and run search across hundreds of files in seconds. Point Claude at the folder to organize it how you'd like.
+
+None of that requires any setup beyond having the files on your computer. That's the point.
+
+### **If You're Taking Notes Manually**
+
+The organizational options are the same, with one extra step first: get your notes into a consistent place and a consistent format. A folder of plain text or markdown files, named by date and meeting, works fine.
+
+The format matters less than the habit. Get your notes somewhere consistent, and the rest becomes much easier.
+
+&nbsp;

--- a/apps/web/content/articles/otter-ai-alternatives.mdx
+++ b/apps/web/content/articles/otter-ai-alternatives.mdx
@@ -1,0 +1,473 @@
+---
+meta_title: "14 Best Otter.ai Alternatives & Competitors in 2026"
+meta_description: "Discover 14 Otter AI alternatives that solve privacy, language, and accuracy issues. Compare features and pricing to find your perfect meeting assistant."
+author: "John Jeong"
+coverImage: "/api/assets/blog/otter-ai-alternatives/cover.png"
+category: "Comparisons"
+date: "2025-08-11"
+---
+
+While [Otter.ai](/blog/otter-ai-review/) has established itself as a popular meeting transcription tool, teams that prioritize data privacy and security often find it unsuitable for their needs.
+
+If you need better accuracy, offline capabilities, or want to keep sensitive conversations off cloud servers, several alternatives are worth evaluating.
+
+This guide reviews 14 Otter AI alternatives, from zero-lock-in open-source solutions to enterprise platforms with advanced analytics.
+
+## Quick comparison: top Otter AI alternatives
+
+| Tool         | Best For                | Starting Price (monthly)                                           | Key Advantage                                     |
+| ------------ | ----------------------- | ------------------------------------------------------------------ | ------------------------------------------------- |
+| Char     | Zero lock-in, complete control | Free forever (local + BYOK). Managed cloud $25/month. | Open source. Plain markdown files. Your choice of AI. |
+| Fireflies.ai | Team collaboration      | $18/user/month                                                     | 69+ languages supported                           |
+| Rev          | High accuracy needs     | Pay-per-use: $0.25/min                                             | Human + AI transcription                          |
+| Fathom       | Sales teams             | $19/user/month                                                     | CRM integrations                                  |
+| Notta        | Multilingual teams      | $13.49/user/month                                                  | 58 languages supported                            |
+| MeetGeek     | Analytics focus         | $19/user/month                                                     | Advanced meeting insights                         |
+| Tactiq       | Chrome users            | $12/user/month                                                     | Browser extension                                 |
+| Dialpad      | Communication platforms | $27/user/month                                                     | Unified communications                            |
+| Avoma        | Revenue teams           | $29/user/month                                                     | Conversation intelligence                         |
+| Grain        | Video-first teams       | $19/user/month                                                     | Video highlights                                  |
+| Sembly AI    | Workflow Integration    | $15/user/month                                                     | AI task extraction                                |
+| Descript     | Content creators        | $24/user/month                                                     | Audio/video editing                               |
+| Jamie AI     | Bot-free EU teams       | €24/user/month                                                     | GDPR compliance & offline capability              |
+| tl;dv        | Video-first teams       | $29/user/month                                                     | Unlimited video recordings & clips                |
+
+## How we selected these alternatives
+
+We analyzed hundreds of user reviews on G2, Capterra, and Reddit, [conducted hands-on testing of leading AI notetakers](/blog/best-ai-meeting-assistant-for-taking-notes), and identified the most frequently cited limitations driving teams to seek alternatives.
+
+The most common pain points we found include:
+
+### 1. Privacy and data control concerns
+
+[Otter.ai's privacy policy](https://otter.ai/privacy-policy) indicates they transfer data across international borders to partners and service providers, subjecting conversations to different privacy laws and regulatory frameworks depending on where those partners operate.
+
+This creates compliance complexity: organizations must ensure adherence to privacy regulations across multiple countries rather than maintaining local control.
+
+Otter also shares data with third-party vendors and uses customer conversations for AI model training, even when de-identified.
+
+Also read about [Otter AI's recent class-action lawsuit and privacy concerns](/blog/is-otter-ai-safe).
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-1.webp" alt="Otter AI's Privacy Concerns"/>
+
+### 2. Bot dependence and intrusiveness
+
+Otter.ai requires meeting bots to join Zoom, Teams, or Google Meet calls to record and transcribe. Many users find this intrusive—especially in client-facing meetings where an unfamiliar "bot participant" suddenly appears.
+
+Bot-based assistants also create compliance hurdles in finance and healthcare, where explicit participant consent is mandatory.
+
+If your team prefers an invisible approach that runs locally or integrates directly into your workflow, see [our guide on bot-free AI meeting assistants](/blog/bot-free-ai-meeting-assistants).
+
+### 3. Restrictive free plan limitations
+
+The free plan caps usage at 300 minutes per month, 30 minutes per meeting, and allows only 3 lifetime file uploads.
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-2.webp" alt="otter ai free plan restriction"/>
+Source: [G2](https://www.g2.com/products/otter-ai/reviews/otter-ai-review-9860718)
+
+### 4. Language support gaps
+
+[International teams](https://cybernews.com/ai-tools/otter-ai-review/) report significant limitations with Otter AI's support for only English, Spanish, and French, compared to competitors offering 40+ languages. Global organizations with diverse linguistic needs find this restrictive.
+
+### 5. Internet dependency
+
+Teams working in locations with poor connectivity or needing offline capabilities find Otter AI's requirement for stable internet connection for live transcription limiting.
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-3.webp" alt="does otter ai work offline"/>
+Source: [G2](https://www.g2.com/products/otter-ai/reviews/otter-ai-review-10454595)
+
+### 6. Cost escalation for teams
+
+Advanced features are locked behind higher-tier subscriptions. Organizations with heavy usage requirements report costs escalating quickly.
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-4.webp" alt="otter ai cost"/>
+Source: [G2](https://www.g2.com/products/otter-ai/reviews/otter-ai-review-10454595)
+
+### 7. Accuracy and speaker identification issues
+
+Speaker identification accuracy issues become problematic in multi-speaker environments where precise attribution is critical for follow-up actions and accountability.
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-5.webp" alt="otter ai accuracy issues"/>
+Source: [G2](https://www.g2.com/products/otter-ai/reviews/otter-ai-review-10454595)
+
+## The 14 best Otter.ai alternatives
+
+### 1. Char - Best for Zero Lock-in and Complete Control
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-6.webp" alt="Char"/>
+
+#### How it compares to Otter AI:
+
+[Char](/) is an open-source AI notepad for meetings built for high-agency people who demand complete control over their data and AI stack.
+
+The interface resembles Apple Notes, and everything is stored as plain markdown files on your device—not in proprietary databases. No bots joining your calls, no vendor lock-in.
+
+Launch a meeting and the AI assistant transcribes speech in real-time. When the meeting ends, it presents a structured summary with key decisions, action items, and discussion themes automatically extracted.
+
+You choose your AI stack: use the managed cloud service, bring your own API keys (OpenAI, Deepgram, Anthropic), or run local models via Ollama. Otter AI locks you into their cloud with no way to switch.
+
+You trade Otter's real-time collaboration features for zero lock-in, true file ownership, and complete control over your workflow. Your notes work with any tool—Obsidian, Notion, VS Code—because they're just markdown files.
+
+#### Key advantages over Otter AI:
+
+- Zero lock-in vs. platform dependency
+- Plain markdown files vs. proprietary database
+- Your choice of AI stack vs. vendor-locked cloud processing
+- Open source vs. closed source
+- Bot-free recording vs. meeting bot intrusion
+- Free forever for local transcription and BYOK vs. limited 300 minutes/month
+
+#### Trade-offs:
+
+- Currently macOS only vs. Otter AI's cross-platform availability
+- No real-time collaboration vs. Otter AI's team features
+- Performance depends on local hardware vs. cloud processing power
+
+### 2. Fireflies - best for global team collaboration
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-7.webp" alt="fireflies"/>
+
+#### How it compares to Otter AI:
+
+[Fireflies](https://fireflies.ai/) addresses Otter.ai's language limitations. Otter AI supports only 3 languages, making it unsuitable for global organizations. Fireflies offers 69+ languages while also providing the advanced conversation intelligence that Otter AI lacks.
+
+Both tools use meeting bots, which may concern people preferring less intrusive AI assistants.
+
+#### Key advantages over Otter AI:
+
+- 69+ languages vs. 3 languages
+- Advanced conversation intelligence vs. basic summaries
+- Stronger CRM integrations vs. limited third-party connections
+- Automated workflows vs. manual post-meeting tasks
+- Sentiment analysis capabilities vs. text-only insights
+
+#### Trade-offs:
+
+- Meeting bots can be intrusive (similar to Otter AI)
+- Higher complexity vs. Otter's simplicity
+- Requires more setup vs. Otter's plug-and-play approach
+
+### 3. Rev - best for human + AI transcription
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-8.webp" alt="rev"/>
+
+#### How it compares to Otter AI:
+
+[Rev](https://www.rev.com/) solves Otter AI's accuracy limitations. While Otter relies solely on AI transcription with 85% accuracy, Rev offers both AI (96%+) and human transcription (99% accuracy) options.
+
+This matters for legal, healthcare, and journalism professionals who cannot tolerate transcription errors from Otter's AI-only approach.
+
+#### Key advantages over Otter AI:
+
+- Dual transcription options (AI + human) vs. AI-only
+- 99% human accuracy vs. 85% AI accuracy
+- Professional compliance (HIPAA, SOC 2, GDPR) vs. basic security
+- Pay-per-use flexibility vs. subscription-only
+- Specialized industry focus vs. general business meetings
+
+#### Trade-offs:
+
+- Higher cost for premium accuracy vs. Otter's affordable plans
+- Human transcription turnaround time vs. real-time processing
+- Complex feature set vs. Otter's user-friendly interface
+
+### 4. Tactiq - best Chrome extension
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-9.webp" alt="tactiq"/>
+
+#### How it compares to Otter AI:
+
+[Tactiq](https://tactiq.io/) works directly in your browser rather than as a separate app.
+
+This browser-first design eliminates the need to download additional software like Otter AI requires, but creates dependency on Chrome that limits flexibility.
+
+The privacy philosophy differs significantly—Tactiq transcribes without storing audio files, addressing privacy concerns some users have with Otter's comprehensive recording approach.
+
+This privacy-focused design means sacrificing Otter's ability to playback meetings or share recordings with absent team members.
+
+#### Key advantages over Otter AI:
+
+- Browser integration vs. separate app requirement
+- 60+ languages vs. 3 languages
+- Custom AI workflows vs. standard templates
+- No audio storage (privacy) vs. full recording
+- Advanced search filtering vs. basic search
+
+#### Trade-offs:
+
+- Chrome dependency vs. Otter AI's platform flexibility
+- Limited free plan vs. Otter's generous free tier
+- Accuracy issues with accents vs. Otter's speaker recognition
+- No offline capability vs. Otter's mobile app offline features
+
+### 5. Fathom - best free-to-enterprise alternative
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-10.webp" alt="fathom"/>
+
+#### How it compares to Otter AI:
+
+[Fathom](https://www.fathom.ai/) directly challenges Otter AI's freemium limitations. While Otter AI restricts free users to 300 minutes monthly and basic features, Fathom provides unlimited recording, transcription, and AI summaries at no cost.
+
+In its "Teams Edition," Fathom offers conversation intelligence features typically found in expensive tools like Gong. Otter AI remains focused on basic meeting documentation.
+
+#### Key advantages over Otter AI:
+
+- Unlimited free features vs. 300-minute monthly cap
+- Instant processing vs. standard processing time
+- Sales conversation intelligence vs. basic transcription
+- Deal tracking and coaching vs. simple meeting notes
+- CRM sync automation vs. manual export
+
+#### Trade-offs:
+
+- Sales-focused features vs. Otter AI's general meeting focus
+- Team features require paid plans vs. Otter's collaborative free tier
+- Less brand recognition vs. Otter's established market presence
+
+### 6. Notta - best for multilingual teams
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-11.webp" alt="notta"/>
+
+#### How it compares to Otter AI:
+
+[Notta](https://www.notta.ai/) solves Otter's language support limitation.
+
+Otter's three-language restriction makes it unsuitable for international organizations, while Notta supports 58 languages with real-time translation capabilities.
+
+The trade-off involves ecosystem maturity—Otter AI offers more established integrations and collaborative features, while Notta focuses on superior multilingual accuracy.
+
+#### Key advantages over Otter AI:
+
+- 58 languages vs. 3 languages
+- Real-time translation vs. single-language transcription
+- 98.86% accuracy vs. lower reported accuracy
+- Global team collaboration vs. English-speaking team focus
+- Cross-platform mobile apps vs. limited mobile functionality
+
+#### Trade-offs:
+
+- Some billing issues reported vs. Otter's stable billing
+- Advanced features require paid plans vs. Otter's feature-rich free tier
+- Less integration ecosystem vs. Otter's established partnerships
+
+### 7. MeetGeek - best for automated meeting workflows
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-12.webp" alt="meetgeek"/>
+
+#### How it compares to Otter AI:
+
+[MeetGeek](https://meetgeek.ai/) goes beyond Otter's basic transcription and summary by automatically understanding meeting context.
+
+Otter AI treats every meeting the same way. MeetGeek intelligently detects whether you're in a sales call, HR interview, or team standup, then applies appropriate templates and workflows.
+
+This contextual intelligence means less manual post-meeting work compared to Otter's generic output, though it requires more initial setup and learning to fully utilize advanced automation features.
+
+#### Key advantages over Otter AI:
+
+- Context-aware AI that understands different meeting types
+- Automated workflow distribution to relevant stakeholders
+- 100+ performance KPIs with coaching insights
+- Chrome recorder operates without platform restrictions
+- Intelligent meeting organization and knowledge base creation
+
+#### Trade-offs:
+
+- Steeper learning curve vs. Otter's simplicity
+- Complex feature set may overwhelm basic users
+- Higher-tier plans needed for advanced automation
+
+### 8. Dialpad - best unified communications
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-13.webp" alt="dialpad"/>
+
+#### How it compares to Otter AI:
+
+[Dialpad](https://www.dialpad.com/) positions transcription as part of a complete business communications platform. Otter AI focuses solely on meeting documentation.
+
+Dialpad users get unified voice, video, messaging, and contact center capabilities alongside transcription, but pay significantly more than Otter's meeting-focused pricing.
+
+For organizations already using multiple communication tools, Dialpad consolidates functionality that Otter AI cannot provide, though it may be overkill for teams only needing meeting transcription.
+
+#### Key advantages over Otter AI:
+
+- Complete communications platform integration
+- Real-time sentiment analysis during calls
+- Business phone system connectivity
+- Contact center capabilities with transcription
+- Unified platform approach eliminates tool switching
+
+#### Trade-offs:
+
+- Higher cost structure vs. meeting-focused pricing
+- Complex setup vs. plug-and-play simplicity
+- Communication platform lock-in vs. standalone flexibility
+
+### 9. Avoma - best for revenue teams
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-14.webp" alt="avoma"/>
+
+#### How it compares to Otter AI:
+
+[Avoma](https://www.avoma.com/) transforms meeting transcripts into revenue intelligence. Otter.ai stops at basic documentation.
+
+Otter AI provides generic summaries. Avoma automatically identifies objections, tracks deal progression, and generates sales coaching insights. This makes Avoma invaluable for revenue teams frustrated with Otter's inability to connect meeting content to business outcomes, though the specialized focus and higher pricing make it less suitable for general meeting documentation needs.
+
+#### Key advantages over Otter AI:
+
+- Revenue-focused conversation intelligence
+- Automatic objection and topic identification
+- Sales performance metrics and coaching
+- Deal risk assessment capabilities
+- Custom conversation scorecards for sales processes
+
+#### Trade-offs:
+
+- Significantly higher pricing vs. affordable plans
+- Sales-specialized features vs. general meeting utility
+- Complex feature set vs. straightforward transcription
+
+### 10. Grain - best for video highlights
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-15.webp" alt="grain"/>
+
+#### How it compares to Otter AI:
+
+[Grain](https://grain.com/) prioritizes video content creation over text transcription, making it ideal for teams who need to share meeting clips rather than read summaries.
+
+Otter AI focuses on searchable text and collaborative editing. Grain excels at creating shareable video highlights with timestamps for visual learners and content creators.
+
+This video-first approach trades some of Otter's text analysis capabilities for superior visual meeting documentation and clip sharing.
+
+#### Key advantages over Otter AI:
+
+- Video highlight creation and clip sharing
+- Timestamp-based video navigation
+- Visual meeting documentation approach
+- Collaborative video editing features
+- Content creation workflow optimization
+
+#### Trade-offs:
+
+- Limited text transcription features vs. comprehensive text analysis
+- Video storage requirements vs. lightweight text approach
+- No mobile app vs. cross-platform accessibility
+
+### 11. Sembly AI - best for task management
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-16.webp" alt="sembly ai"/>
+
+#### How it compares to Otter AI:
+
+Otter AI focuses primarily on transcription and basic note-taking. [Sembly AI](https://www.sembly.ai/) positions itself as a comprehensive meeting intelligence platform.
+
+Sembly analyzes deeper, creating structured insights, action items, and complex artifacts like project plans and requirements documents. Otter AI excels at accurate transcription but lacks Sembly's advanced document generation.
+
+#### Key advantages over Otter AI:
+
+- AI Artifacts generation (project plans, requirements, reports)
+- Multi-meeting trend analysis and insights across conversations
+- Advanced action item extraction with assignees and due dates
+- Enterprise-grade security (SOC 2 Type II, GDPR compliance)
+- Role-based meeting insights tailored to specific job functions and goals
+- Comprehensive CRM and project management integrations
+- Team analytics and workspace management features
+- 45+ language support with international data residency options
+
+#### Trade-offs:
+
+- Steeper learning curve vs. straightforward transcription interface
+- Enterprise focus vs. broader consumer appeal
+- Complex feature set vs. simple, intuitive note-taking experience
+
+### 12. Descript - best for content creators
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-17.webp" alt="descript"/>
+
+#### How it compares to Otter AI:
+
+[Descript](https://www.descript.com/) combines transcription with comprehensive audio and video editing tools. Otter focuses purely on meeting documentation. Descript works better for podcast creators, video producers, and content teams who need to edit their recordings, not just transcribe them.
+
+This expanded functionality comes with complexity and higher pricing that exceeds what most teams need for simple meeting notes—an area where Otter AI's focused approach provides better value.
+
+#### Key advantages over Otter AI:
+
+- Text-based audio and video editing capabilities
+- Collaborative content creation workspace
+- Screen recording with transcription integration
+- Professional content creator workflow tools
+- Multi-format export and publishing options
+
+#### Trade-offs:
+
+- Content creation focus vs. meeting-specific features
+- Higher complexity and learning curve vs. simple transcription
+- Premium pricing vs. meeting-focused affordability
+
+### 13. Jamie AI - best bot-free European alternative
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-18.webp" alt="jamie ai"/>
+
+#### How it compares to Otter AI:
+
+[Jamie AI](https://www.meetjamie.ai/) addresses privacy and compliance concerns that European organizations have with US-based tools like Otter AI.
+
+Otter processes data in the cloud and uses meeting bots that can feel intrusive. Jamie operates without bots and stores all data within EU servers in Frankfurt with strict GDPR compliance.
+
+Jamie works both online and offline, making it ideal for in-person meetings or areas with poor connectivity. Otter AI requires stable internet.
+
+The key trade-off is real-time collaboration—Otter AI offers live editing and team features, while Jamie focuses on post-meeting processing and individual productivity.
+
+#### Key advantages over Otter AI:
+
+- Complete bot-free operation vs. intrusive meeting bots
+- EU data hosting with GDPR compliance vs. international data transfers
+- Offline functionality for in-person meetings vs. internet dependency
+- Advanced accent recognition for 20+ languages vs. limited language support
+- Privacy-first approach with automatic audio deletion vs. cloud storage
+
+#### Trade-offs:
+
+- Post-meeting processing vs. real-time transcription
+- Individual focus vs. team collaboration features
+- Limited integrations vs. established ecosystem partnerships
+
+### 14. tl;dv - best video-first meeting assistant
+
+<Image src="/api/assets/blog/otter-ai-alternatives/otter-alt-19.webp" alt="tl;dv"/>
+
+#### How it compares to Otter AI:
+
+Otter only offers video recording on Enterprise plans. [tl;dv](https://tldv.io/) provides unlimited video recordings, transcriptions, and automated notes for free.
+
+tl;dv excels at creating video clips directly from transcripts and timestamped highlights. Otter AI requires users to upgrade to expensive enterprise tiers for basic video functionality.
+
+Otter offers better transcript editing capabilities and mobile functionality that tl;dv currently lacks.
+
+#### Key advantages over Otter AI:
+
+- Unlimited video recordings and transcripts on free plan vs. Enterprise-only video
+- Video clip creation directly from transcripts vs. no video editing
+- Advanced search filtering by deal stage, meeting type, attendance vs. basic search
+- 30+ language support with dialect recognition vs. 3 languages
+- Unlimited concurrent meeting recordings vs. 3-meeting limitation
+
+#### Trade-offs:
+
+- Limited mobile functionality vs. comprehensive mobile apps
+- Internet dependency for optimal performance vs. offline mobile recording
+- Less transcript editing capability vs. full transcript modification
+- Desktop-focused approach vs. cross-platform accessibility
+
+## Why Char stands out
+
+While each alternative has strengths, **Char** offers a unique value proposition: **zero lock-in and complete control**.
+
+✅ **Zero lock-in** - Plain markdown files, open source, portable format that works with any tool
+✅ **Complete control** - Choose your AI stack: managed cloud, bring your own keys, or run fully local
+✅ **True ownership** - Your files live on your device, not in someone's database
+✅ **Simple but powerful** - Complete control without complexity
+✅ **Cost-effective** - No recurring fees for basic functionality
+
+Whether you're an engineer who wants files over apps, a privacy-conscious professional in regulated industries, or someone whose company has banned cloud tools like Otter—Char gives you ownership at the foundational level.
+
+**Ready to take control?** [Download Char](/download) and experience meeting notes with zero lock-in.

--- a/apps/web/content/articles/otter-ai-review.mdx
+++ b/apps/web/content/articles/otter-ai-review.mdx
@@ -171,7 +171,7 @@ Organizations in regulated industries face particular risks. Individual employee
 
 Some IT security professionals have compared Otter's behavior to malware-like characteristics. Otter automatically sends workspace invitations to colleagues on users' behalf and shares meeting transcripts with external participants without explicit authorization. This can spread throughout organizations before users realize what's happening.
 
-For a detailed analysis of these security concerns and documented incidents, see <u>[Is Otter AI Safe: What You Need to Know](https://char.com/blog/is-otter-ai-safe/)</u>.
+For a detailed analysis of these security concerns and documented incidents, see <u>[Is Otter AI Safe: What You Need to Know](https://anarlog.so/blog/is-otter-ai-safe/)</u>.
 
 ## How much does Otter AI cost
 
@@ -304,7 +304,7 @@ Here's how Otter AI stacks up against competitors:
 | tl;dv            | Video-first teams                 | Free plan available. Paid from $29/user/month    | Unlimited video recordings & clips      |
 
 
-See <u>[detailed reviews of all Otter AI competitors](https://char.com/blog/otter-ai-alternatives/)</u>.
+See <u>[detailed reviews of all Otter AI competitors](https://anarlog.so/blog/otter-ai-alternatives/)</u>.
 
 ### What is the best Otter alternative?
 

--- a/apps/web/content/articles/otter-ai-review.mdx
+++ b/apps/web/content/articles/otter-ai-review.mdx
@@ -1,0 +1,339 @@
+---
+meta_title: "Otter AI Review: Is It Worth It in 2026?"
+meta_description: "Complete Otter AI review covering features, pricing, security concerns, and user feedback. Compare alternatives and find the best AI notetaker for your needs."
+author: "Harshika"
+coverImage: "/api/assets/blog/otter-ai-review/cover.png"
+featured: false
+category: "Comparisons"
+ready_for_review: true
+date: "2026-02-11"
+---
+
+After using Otter AI across 200+ meetings, including sensitive client calls and chaotic team standups, I've learned what the marketing materials won't tell you.
+
+Otter AI offers a free tier with significant limitations. Safety is complicated—there's a 2025 lawsuit and privacy concerns worth understanding. This review covers pricing (including hidden costs), features that actually work, transcription accuracy, privacy issues, and alternatives I've tested.
+
+## How does Otter AI work?
+
+1. You connect your calendar to Otter AI
+2. The Otter AI meeting bot automatically joins scheduled meetings
+3. It records everything and sends audio to Otter AI's cloud servers
+4. You get a transcript, summary, and action items 2 hours later
+
+I find bots intrusive. In practice, people become more guarded, speak less candidly, and conversation flows suffer.
+
+Beyond the social awkwardness is technical dependency. Otter AI's bot requires stable internet connectivity and proper permissions. I've seen it fail to join meetings due to calendar sync issues, get kicked out by overzealous hosts, or simply not work with certain enterprise meeting configurations. When the bot doesn't join, you have no transcript and no backup recording happening locally. This is why I prefer bot-free meeting assistants.
+
+## What platforms does Otter AI support?
+
+Otter AI works with:
+
+- Zoom (the most reliable in testing)
+- Google Meet (occasional connection issues)
+- Microsoft Teams (worked about 80% of the time)
+- Mobile apps for iOS/Android (requires internet)
+- Browser extensions
+
+Otter AI requires constant internet connectivity. During a venue walkthrough with spotty WiFi, it captured 12 minutes of a 45-minute conversation. There's no offline mode.
+
+## What languages does Otter support?
+
+Otter AI transcribes only 3 languages: English, Spanish, and French.
+
+For international teams, this becomes a dealbreaker. A weekly check-in with German partners means no Otter AI. A client call with Japanese stakeholders gets no transcription.
+
+## Otter meeting assistant features & how I would grade them
+
+
+| &nbsp;                    | &nbsp;    | &nbsp;                                       |
+| ------------------------- | --------- | -------------------------------------------- |
+| **Feature**               | **Grade** | **Key Takeaway**                             |
+| Real-Time Transcription   | B-        | Works but inaccurate with accents/noise      |
+| Meeting Summary           | B+        | Useful but generic for technical content     |
+| Slide/Screen Capture      | A-        | Brilliant feature, just watch your screen    |
+| Otter Chat / AI Assistant | C+        | Handles basics, fails at complexity          |
+| Speaker Identification    | D         | Consistently inaccurate, needs heavy editing |
+| Channels & Workspaces     | B         | Functional organization, nothing special     |
+| Third-Party Integrations  | B-        | Surface-level, not deep automation           |
+| Calendar Integration      | A         | Flawless auto-join functionality             |
+| Mobile App                | B-        | Functional but requires internet             |
+| Search & Playback         | B+        | Good core search, missing advanced filters   |
+| File Upload               | C+        | Artificial limits to push upgrades           |
+| Export Options            | B         | Covers basics, missing customization         |
+| Vocabulary Customization  | B         | Helps with jargon, should be smarter         |
+| Collaboration             | C+        | Basic comments, poor integration             |
+| Admin Controls            | B         | Standard features, nothing innovative        |
+
+
+### 1. Real-time transcription (Grade: B-)
+
+Live transcription appears within 2-3 seconds of speech, which helps when following fast-paced discussions. Accuracy drops to 60-70% with background noise. Technical terms are consistently wrong ("Kubernetes" becomes "communitas"). It fails completely with heavy accents.
+
+### 2. Meeting summary (Grade: B+)
+
+Otter.ai generates automated summaries broken into chapters with timestamps. Email summaries arrive within 2 hours (usually 45 minutes in my experience). The chapter breakdown makes long meetings navigable. Action item extraction catches about 70-80% of commitments.
+
+The frustration: summaries for technical discussions turn generic. "The team discussed system architecture" instead of actual details. Nuanced decisions in complex strategy calls get missed, and there's no way to customize summary format or depth.
+
+### 3. Slide and screen capture (Grade: A-)
+
+The automatic screenshot feature worked surprisingly well. During product demos, it captured 90% of slides without manual input. Visual context embedded in transcripts saved me hours when reviewing what was actually shown versus what was said.
+
+One caution: it captures everything on screen, including private Slack messages or emails if you forget to pause screen sharing. I almost leaked internal metrics to a client once.
+
+### 4. Otter Chat / AI assistant (Grade: C+)
+
+The AI assistant handles basic questions like "What were the main action items?" reasonably well. It struggled with technical terminology. "What did John say about API latency?" returned a generic response. Cross-meeting insights failed entirely. "How has our timeline changed over the past month?" couldn't be answered. When I asked it to draft an email about three specific action items, I got a generic template instead.
+
+### 5. Speaker identification (Grade: D)
+
+Speaker identification is Otter.ai's weakest feature. In a 10-person team meeting, it misidentified speakers 30% of the time and confused two people with similar voices throughout, requiring 15 minutes of manual correction afterward. Even in simple two-person calls, it occasionally attributed my words to the other person. For meeting minutes you'll actually share, plan on extensive editing.
+
+### 6. Otter channels & workspaces (Grade: B)
+
+Team collaboration features worked adequately for organizing meetings by project. I created separate channels for client work (private), internal strategy (public to team), and all-hands meetings (public). The permissions system is straightforward, though not as flexible as some Otter.ai alternatives.
+
+### 7. Third-party integrations (Grade: B-)
+
+Otter.ai connects with 20+ tools: Salesforce (worked, but sync delays), HubSpot (reliable CRM integration), Slack (good for sharing summaries), Notion (basic export only), and Asana (manual linking required).
+
+Alternatives like Fireflies offer deeper CRM integration and workflow automation.
+
+### 8. Calendar integration (Grade: A)
+
+Otter.ai nails calendar integration. It detected 98% of scheduled meetings, joined automatically without manual intervention, and updated meeting details if the calendar changed. Truly set-it-and-forget-it functionality.
+
+One minor issue: it occasionally joined recurring meetings I'd removed from the series.
+
+### 9. Mobile app recording (Grade: B-)
+
+Recording in-person meetings from phone works, and transcripts sync across devices. It requires an internet connection (can record offline but won't transcribe until online), causes significant battery drain during long recordings, and the UI feels cramped for editing transcripts. You'll want to review and edit on a desktop.
+
+### 10. Search & playback (Grade: B+)
+
+Keyword search across hundreds of meetings is fast. Clicking any word in the transcript jumps audio to that moment. Variable playback speed (1.5x-2x) saved tons of review time. Advanced search operators are limited. You can't search "phrase in quotes AND keyword," and there's no way to filter by meeting duration, participant count, or date range easily.
+
+### 11. File upload & transcription (Grade: C+)
+
+Upload pre-recorded audio or video files for transcription. The problem: the free plan gets 3 lifetime uploads (then done forever), the Pro plan gets 10 uploads per month, and unlimited is locked to the Business tier. Having "lifetime limits" on a free tier is absurd. Ten per month on a $17/month plan feels stingy. This should be unlimited on Pro.
+
+### 12. Export options (Grade: B)
+
+Exports to plain text, Word document, PDF, SRT subtitles, and JSON. PDF formatting is clean and professional. SRT files worked in Premiere and Final Cut.
+
+Missing: direct export to Google Docs, customization options (remove speakers, keep only summary), and bulk export capability.
+
+### 13. Vocabulary customization (Grade: B)
+
+Add custom words for better transcription accuracy with company names, product names, and technical terms. After adding "Kubernetes", "PostgreSQL", and "Supabase", accuracy improved 10-15% for jargon-heavy meetings.
+
+However, I had to manually add every term (no bulk upload), and it sometimes ignored custom vocabulary anyway.
+
+### 14. Live collaboration & comments (Grade: C+)
+
+Team members can comment on transcripts at specific timestamps and @mention others for follow-up. It works for basic collaboration, but comments don't integrate with task management tools, there's no way to mark comments as resolved, and notifications become overwhelming with active teams.
+
+### 15. Admin controls & analytics (Grade: B) (Business/Enterprise only)
+
+See who's using minutes to prevent overages, manage user permissions, and view usage reports by department. This catches power users and helps deactivate former employees' access.
+
+Analytics are superficial though (just usage, not meeting quality metrics), and you can't set per-user or per-team minute limits.
+
+## Is Otter AI safe?
+
+Otter AI's security became a major concern following a federal class-action lawsuit filed in August 2025 and multiple user incidents. The case, filed in the U.S. District Court for the Northern District of California, alleges that Otter "deceptively and surreptitiously" records private conversations without proper consent.
+
+### Legal and privacy concerns
+
+![](/api/assets/blog/articles/otter-ai-review/image-1.png)
+
+The lawsuit centers on allegations that Otter's bot automatically joins meetings without obtaining consent from participants. If a meeting host has integrated their calendar with Otter, the system may join meetings without alerting attendees that conversations are being recorded and shared with Otter for AI training.
+
+Real-world incidents have highlighted these privacy issues:
+
+- Corporate data leaks where sensitive VC meetings were inadvertently shared with external parties
+- Job interview recordings captured without candidate knowledge
+- Unauthorized access to confidential business discussions
+
+### Data collection and usage
+
+Otter's privacy policy reveals extensive data collection practices beyond simple transcription. The company admits to using customer data for AI training:
+
+*"We train our proprietary artificial intelligence technology on de-identified audio recordings. We also train our technology on transcriptions to provide more accurate services, which may contain Personal Information." - Otter AI*
+
+The service shares personal information with multiple third-party processors, including cloud service providers, data labeling services, and AI backend providers. This creates potential exposure points that many users may not realize they're accepting.
+
+### Enterprise security considerations
+
+![](/api/assets/blog/articles/otter-ai-review/image-2.png)
+
+Organizations in regulated industries face particular risks. Individual employee adoption of Otter can create company-wide data exposure. The service collects extensive metadata including usage patterns, device information, and location data, which may conflict with enterprise security policies.
+
+Some IT security professionals have compared Otter's behavior to malware-like characteristics. Otter automatically sends workspace invitations to colleagues on users' behalf and shares meeting transcripts with external participants without explicit authorization. This can spread throughout organizations before users realize what's happening.
+
+For a detailed analysis of these security concerns and documented incidents, see <u>[Is Otter AI Safe: What You Need to Know](https://char.com/blog/is-otter-ai-safe/)</u>.
+
+## How much does Otter AI cost
+
+Otter AI offers several pricing tiers:
+
+![Source](/api/assets/blog/otter-ai-review/otter-10.webp)
+
+### Otter AI free plan features:
+
+- 300 monthly transcription minutes (5 hours total)
+- 30 minutes per conversation maximum
+- 3 lifetime audio file imports
+- 25 most recent conversations stored
+- Basic speaker identification
+- AI Chat (20 queries/month)
+- Integration with Zoom, Teams, Meet, Slack
+
+After three weeks of daily meetings, I hit the 300-minute limit. I had to choose which meetings to transcribe for the rest of the month. The 30-minute per-conversation cap is particularly painful. Long strategy sessions required restarting the recording, breaking the transcript into chunks.
+
+Otter AI's free tier works only if you average 1-2 meetings per week. For daily meeting participants, you'll need to upgrade within a month.
+
+### Otter AI Pro plan
+
+**Price:** $16.99/month billed monthly, $8.33/month if annual commitment
+
+**What's included:**
+
+- 1,200 monthly minutes (20 hours)
+- 90 minutes per conversation
+- 10 monthly file imports
+- Advanced search
+- Export capabilities
+- Priority email support
+
+### Otter AI Business plan
+
+**Price:** $40/month billed monthly, $19.99/month if annual commitment
+
+**What changes:**
+
+- 6,000 monthly minutes (100 hours)
+- 4-hour conversation limits
+- Unlimited file imports
+- Usage analytics
+- Admin controls
+- Centralized billing
+
+For a 10-person team:
+
+- Monthly cost: $400/month ($4,800/year)
+- Annual commitment: $200/month ($2,400/year)
+
+### Otter AI Enterprise plan (Custom)
+
+**Price:** Contact sales for quote (for roughly 50 seats, expect around $25k annually)
+
+**What's included:**
+
+- Unlimited transcription
+- HIPAA compliance options
+- Advanced security
+- SSO
+- Dedicated support
+- Custom legal terms
+
+### How costs add up
+
+The pricing structure creates multiple pressure points. Heavy users quickly exhaust even the Business tier's 6,000-minute limit (100 hours/month). Teams face escalating per-user costs.
+
+The annual discount of 51% pressures users into longer commitments before they fully understand the service's privacy implications or workflow integration challenges.
+
+Enterprise pricing remains opaque with custom quotes. Organizations needing HIPAA compliance or advanced security features face potentially much higher rates than the published tiers suggest.
+
+## What users think about Otter AI?
+
+Based on reviews from G2, TrustPilot, Product Hunt, and Reddit:
+
+### What users love
+
+- **Hands-free meeting participation** - Users focus entirely on conversations without taking notes, leading to more engaging and productive discussions
+- **AI-powered insights** - The ability to ask questions about past conversations and generate follow-up emails or summaries from recorded content
+- **Single source of truth** - All meeting recordings and summaries in one organized, searchable location
+- **Time-saving features** - Automated slide capture, timestamped transcriptions, and playback speed controls for efficient review
+- **User-friendly interface** - Intuitive dashboard that's welcoming to new users with easy navigation and organization
+
+### What could be better
+
+![Source](/api/assets/blog/otter-ai-review/otter-11.webp)
+
+- **Transcription accuracy issues** - Frequent speaker misidentification even in simple two-person calls, struggles with accents, technical terms, and produces summaries requiring extensive manual editing
+
+![Source](/api/assets/blog/otter-ai-review/otter-12.webp)
+
+- **Unauthorized and invasive behavior** - Automatically sends workspace invitations to colleagues without permission, joins meetings without proper consent, and shares transcripts with external participants unexpectedly
+
+![Source](/api/assets/blog/otter-ai-review/otter-13.webp)
+
+- **Lacking customer support** - Extremely slow response times, rare issue resolution, no phone support, and unresponsive account management
+- **Account management nightmares** - Difficulty canceling subscriptions, fake account deletion (accounts remain active despite appearing deleted), unexpected billing charges, and unauthorized seat upgrades
+
+![Source](/api/assets/blog/otter-ai-review/otter-14.webp)
+
+- **Billing and subscription traps** - Misleading plan differences (Business plan removes features available in Pro), non-refundable policies even for legitimate complaints, and automatic renewals that are difficult to cancel
+
+![Source](/api/assets/blog/otter-ai-review/otter-15.webp)
+
+- **Internet dependency** - Requires constant connectivity. Slow speeds or outages cause delays and data loss if recordings drop. The service becomes completely unavailable offline when needed most.
+
+## Top Otter AI alternatives - quick comparison
+
+Here's how Otter AI stacks up against competitors:
+
+
+| &nbsp;           | &nbsp;                            | &nbsp;                                           | &nbsp;                                  |
+| ---------------- | --------------------------------- | ------------------------------------------------ | --------------------------------------- |
+| **Tool**         | **Best For**                      | **Starting Price (monthly)**                     | **Key Advantage**                       |
+| [Char](Char.com) | Zero lock-in, complete control    | Free forever (local + BYOK). Cloud $25/month     | Open source. Plain markdown. Your choice of AI. |
+| Fireflies.ai     | Team collaboration                | Free plan available. Paid from $10/user/month    | 69+ languages supported                 |
+| Rev              | High accuracy needs               | Pay-per-use: $0.25/min AI, $1.99/min human       | Human + AI transcription                |
+| Fathom           | Sales teams                       | Free plan available. Teams from $18/user/month   | CRM integrations                        |
+| Notta            | Multilingual teams                | Free plan available. Paid from $13.49/user/month | 58 languages supported                  |
+| MeetGeek         | Analytics focus                   | Free plan available. Paid from $15.99/user/month | Advanced meeting insights               |
+| Tactiq           | Chrome users                      | Free plan available. Paid from $20/user/month    | Browser extension                       |
+| Dialpad          | Communication platforms           | From $15/user/month                              | Unified communications                  |
+| Avoma            | Revenue teams                     | From $29/user/month                              | Conversation intelligence               |
+| Grain            | Video-first teams                 | Free plan available. Paid from $19/user/month    | Video highlights                        |
+| Sembly AI        | Task management                   | Free plan available. Paid from $17/user/month    | AI task extraction                      |
+| Descript         | Content creators                  | Free plan available. Paid from $16/user/month    | Audio/video editing                     |
+| Jamie AI         | Bot-free EU teams                 | Free plan available. Paid from €25/user/month    | GDPR compliance & offline capability    |
+| tl;dv            | Video-first teams                 | Free plan available. Paid from $29/user/month    | Unlimited video recordings & clips      |
+
+
+See <u>[detailed reviews of all Otter AI competitors](https://char.com/blog/otter-ai-alternatives/)</u>.
+
+### What is the best Otter alternative?
+
+Char is the best Otter AI alternative if you want zero lock-in and complete control. It's an open-source AI notepad that stores everything as plain markdown files and lets you choose your AI stack—managed cloud, bring your own keys, or run local models. Zero vendor lock-in, zero compromises.
+
+You get all the core AI note-taking features—transcription, summaries, search—without sacrificing control.
+
+## Frequently asked questions
+
+### 1. Is Otter.ai free or paid?
+
+Otter.ai offers a free plan with 300 monthly minutes (5 hours) and a 30-minute limit per conversation. For regular users, paid plans are necessary: Pro at $16.99/month ($8.33/month with annual commitment) includes 1,200 minutes. Business costs $30/month ($19.99/month with annual commitment) and includes 6,000 minutes.
+
+### 2. Does Otter.ai sell my data?
+
+Otter.ai doesn't explicitly "sell" data, but their privacy policy states they use customer conversations to train AI models and share data with third-party processors. For complete control over your data, consider open-source alternatives like Char.
+
+### 3. What are Otter.ai free plan features?
+
+The free plan includes 300 monthly minutes, 30-minute conversation limit, 3 lifetime file imports, live transcription, basic speaker identification, and AI Chat with 20 queries/month. You keep only your 25 most recent conversations—older ones disappear. For comparison, alternatives like Char and Fathom offer unlimited free transcription.
+
+### 4. Can Otter.ai transcribe in languages other than English?
+
+Otter.ai supports only 3 languages: English, Spanish, and French. This is a major limitation compared to competitors.
+
+### 5. What are the best alternatives to Otter.ai?
+
+Char (best for zero lock-in with complete control over data and AI), Fireflies (69+ languages for global teams), Fathom (unlimited free tier), Rev (99% human accuracy), and Jamie AI (offline + GDPR compliance).
+
+### 6. Is Otter.ai worth it for teams?
+
+Otter.ai works for basic English-language meeting documentation if you're comfortable with cloud processing. For a 10-person team, costs run $200-400/month. However, it offers only 3 languages, has significant privacy concerns, requires constant internet, and transcription accuracy needs editing.

--- a/apps/web/content/articles/plaud-ai-alternatives.mdx
+++ b/apps/web/content/articles/plaud-ai-alternatives.mdx
@@ -1,0 +1,391 @@
+---
+meta_title: "6 Better Alternatives to Plaud AI (Hardware & Software)"
+display_title: "6 Plaud AI Alternatives Worth Considering in 2026"
+meta_description: "Looking beyond Plaud? Compare 6 AI voice recorder alternatives. Hardware, software & specialized AI recorders reviewed."
+author:
+  - "Harshika"
+coverImage: "/api/assets/blog/plaud-ai-alternatives/cover.png"
+featured: false
+category: "Comparisons"
+date: "2025-10-27"
+---
+
+Plaud's credit card-sized recorder looked promising until you saw the subscription costs pile up. Or maybe you're tired of managing yet another piece of hardware. Perhaps you just want your meeting data to stay on your device instead of floating around in someone else's cloud.
+
+Whatever brought you here, you're looking for something different. This guide covers six alternatives that take different approaches to voice recording and AI transcription.
+
+We'll focus on what actually matters: how they work, what they cost, and whether they'll solve your specific problem better than Plaud.
+
+## Quick Plaud AI review
+
+Plaud is a hardware-first AI notetaking system built around physical voice recorders that sync with a mobile app for transcription and summarization.
+
+The lineup includes Plaud Note (a credit card-sized recorder at 0.12" thin), Plaud Note Pro (with four precision microphones for 16.4-foot pickup range), and Plaud NotePin (a wearable recorder you can clip, pin, or wear as a necklace).
+
+All devices use dual-mode recording, switching between phone call capture via vibration conduction and ambient recording for in-person conversations.
+
+The catch? After your 300 free minutes per month, you're paying $99.99/year for 1,200 minutes or $239.99/year for unlimited. Plus, there's the upfront hardware cost ($159-$179) and the fact that you need cloud processing for the AI features that make it useful.
+
+It works, but it's not for everyone. Let's look at what else is out there.
+
+## Comparison table: Plaud vs alternatives
+
+Here's how six AI transcription and note-taking tools compare with Plaud:
+
+
+| Tool                       | Best For                     | Type                           | Key Advantage               | Main Limitation             | Starting Price              |
+| -------------------------- | ---------------------------- | ------------------------------ | --------------------------- | --------------------------- | --------------------------- |
+| Plaud                      | Portable recording anywhere  | Hardware recorder + app        | Portable & discreet         | Cloud dependency for AI     | $159 hardware + $99.99/year |
+| Char                       | Privacy-focused Mac users    | Desktop software (macOS)       | Zero cloud dependency       | macOS only                  | Free                        |
+| iFLYTEK Smart Recorder Pro | Professional field recording | Standalone hardware device     | Standalone with touchscreen | Bulky form factor           | $329.99 one-time            |
+| Mobvoi TicNote             | Casual wearable recording    | Wearable hardware + app        | Wearable convenience        | Limited battery life        | $169 + $8.99/month          |
+| Notta Memo                 | Budget-conscious users       | Pocket hardware + app          | Affordable entry point      | Requires phone for features | $69 + $13.49/month          |
+| Deepscribe                 | Healthcare providers only    | Healthcare AI scribe (iOS app) | Clinical documentation      | Healthcare-only             | $400-500/month per provider |
+| Avoma                      | Sales & revenue teams        | Cloud-based software           | Sales intelligence          | Bot visibility              | $29/user/month              |
+
+
+Continue reading for detailed reviews of each of these tools.
+
+## Plaud AI alternatives: detailed reviews
+
+### 1. Char
+
+[Char](/) is an open-source AI notepad for meetings that gives you complete control over your data, AI stack, and workflow. Everything is stored as plain Markdown files on your device and not in proprietary databases or cloud servers.
+
+You can inspect the code, customize functionality, and choose which AI processes your data. Zero lock-in, zero compromises.
+
+![Char](/api/assets/blog/plaud-ai-alternatives/hyprnote.webp)
+
+#### How it works
+
+Char sits quietly on your computer and captures audio directly from your system without bots joining your calls. While you're in a meeting, it generates a live transcript as you take your own notes alongside it.
+
+When the meeting ends, it combines your notes with the transcript and uses AI to produce a structured summary. 
+
+You choose which AI processes that data — our managed service, your own API keys (OpenAI, Anthropic, etc.), or a fully local model running on your machine via Ollama or LM Studio.
+
+Everything gets saved as plain markdown files on your device. Nothing goes to Char's servers. You can open those files in Obsidian, VS Code, Notion, or any text editor; they're just files you own.
+
+#### Key features
+
+- **Live note-taking:** Take your own notes alongside the transcript as the meeting happens
+- **AI-powered summaries:** Combines your notes + transcript into structured, actionable output
+- **Your choice of AI stack:** Managed cloud service, bring your own API keys (OpenAI, Anthropic, Deepgram), or run fully local models via Ollama or LM Studio
+- **Plain markdown files:** Stored locally on your device, works with any tool (Obsidian, Notion, VS Code)
+- **AI chat:** Query your transcripts conversationally after the meeting
+- **Search across all meetings:** Find anything across your entire meeting history
+- **Custom templates:** Set up different note structures for different meeting types
+- **Import support:** Bring in existing recordings or transcripts
+- **45+ language support:** English, Spanish, French, German, Japanese, Portuguese, Italian, Dutch, Korean, Chinese, and more
+
+#### Pros vs Plaud
+
+- No subscription required for core features (vs Plaud's $99-239/year after free minutes run out)
+- Zero lock-in—plain markdown files, open source, switch AI providers anytime (vs Plaud's closed system)
+- No hardware to carry, charge, or remember
+- Your choice of AI stack (vs Plaud requiring their cloud)
+- True file ownership (vs Plaud's proprietary app)
+
+#### Cons
+
+- macOS only, requires Sonoma 14.2+ and works best on M-series chips (Plaud works with any phone)
+- Manual speaker tagging needed for group meetings (Plaud has automatic speaker labels)
+- No app for field recording away from your computer (Plaud's main strength)
+- Fewer integrations currently—Obsidian and Attio vs Plaud's broader ecosystem
+
+#### Pricing
+
+Char is free forever for local transcription, BYOK, and all core features. No artificial caps, no trial that expires.
+
+The managed cloud service is $25/month for those who want the easiest setup without managing API keys. Most people never need to pay—the free plan handles meeting notes completely.
+
+Enterprise pricing applies when you need on-prem deployment, SSO, consent management, or admin controls for compliance-sensitive environments. [Contact sales](/founders) for custom quotes.
+
+### 2. iFLYTEK Smart Recorder Pro
+
+[iFLYTEK Smart Recorder Pro](https://www.iflytek.com/en/products/recorder/smart-recorder-pro.html) is a standalone hardware recorder with built-in touchscreen that transcribes offline.
+
+![iFLYTEK](/api/assets/blog/plaud-ai-alternatives/iflytek.webp)
+
+#### How it works
+
+iFLYTEK takes a self-contained approach. The device packs eight microphones (two directional, six omnidirectional) that capture audio from up to 15 meters away, along with an octa-core processor that handles real-time transcription directly on the device. No phone or internet required during recording.
+
+The 3.5-inch touchscreen lets you see transcriptions appear as you record, switch between four recording modes (intelligent, conference, interview, speech), and mark important moments with bookmarks.
+
+Unlike Plaud's sync-and-process model, iFLYTEK transcribes as you record using on-device AI. The transcription happens locally for privacy, though you can connect to WiFi or insert a 4G SIM card for cloud syncing.
+
+Files export to PDF, Word, or TXT, and you can transfer them via USB or access through their web portal at cloud.iflytekrecord.com.
+
+#### Key features
+
+- **Offline transcription**: Real-time speech-to-text without internet connection, processing happens on-device
+- **Professional microphone array**: 8 mics (2 directional + 6 omnidirectional) with 15-meter range and 360-degree pickup
+- **Built-in 3.5-inch touchscreen**: Review transcripts immediately, no phone required
+- **Four recording modes**: Customized microphone positioning and noise reduction for different scenarios (meetings, interviews, speeches, lectures)
+- **Multilingual support**: Transcribes 8 languages including English, Chinese, Japanese, Korean, French, German, Spanish, Hungarian
+- **Massive battery**: 2500mAh provides extended recording sessions
+- **32GB storage**: Holds approximately 175 hours of recordings, plus 5GB cloud storage (valid 3 years)
+- **8MP camera**: Integrated for real-time subtitle generation on video
+
+#### Pros vs Plaud
+
+- Completely standalone device with touchscreen (vs Plaud requiring your phone to see transcriptions)
+- True offline transcription during recording (vs Plaud's cloud-only processing)
+- Much longer microphone range at 15 meters (vs Plaud's close-proximity design)
+- Larger battery at 2500mAh (vs Plaud's 400mAh)
+- Can work with 4G SIM card for connectivity anywhere
+- More storage at 32GB (vs Plaud's 64GB, but iFLYTEK doesn't count against monthly limits)
+
+#### Cons
+
+- Significantly larger and heavier than Plaud's credit card form factor
+- More expensive upfront with no clear ongoing subscription model
+- Fewer supported languages at 8 (vs Plaud's 112)
+- Cloud storage expires after 3 years with no announced renewal option
+- Transfer to Mac requires Android File Transfer software
+
+#### Pricing
+
+iFLYTEK's pricing reflects its position as a professional-grade tool rather than a consumer gadget. The Smart Recorder Pro currently lists at $329.99 (reduced from $369.99), while the standard Smart Recorder runs $199.99.
+
+There's no monthly subscription or transcription minute limits. You buy the hardware once, get 5GB of cloud storage valid for three years, and transcribe as much as you want offline.
+
+After three years, the cloud storage expires, but they haven't announced what happens next—presumably a renewal fee or you just keep using local storage.
+
+### 3. Mobvoi TicNote
+
+[Mobvoi TicNote](https://www.mobvoi.com/us/pages/mobvoiticnote) is a credit card-sized recorder with an integrated AI agent called Shadow that learns your work patterns and surfaces insights automatically.
+
+![Mobvoi TicNote](/api/assets/blog/plaud-ai-alternatives/ticknote.webp)
+
+#### How it works
+
+TicNote takes Plaud's magnetic attachment approach but adds an AI agent layer that changes things.
+
+The hardware captures audio through three MEMS microphones with dual modes (phone calls via vibration conduction, ambient recording for meetings), then uploads to the cloud where Shadow, powered by GPT-4o, GPT-4o-mini, and DeepSeek-R1, handles transcription in 120+ languages.
+
+The key difference is Shadow's project-centric approach. Instead of treating each recording separately, you organize files into projects. Shadow builds contextual knowledge across everything in a project, so when you ask it questions or request research, it pulls from your entire conversation history within that project.
+
+The more you use it, the smarter Shadow gets at connecting dots and surfacing insights you didn't explicitly ask for.
+
+#### Key features
+
+- **Shadow AI agent**: Flash Chat, Deep Think, Random Thought capture, and Deep Research across project files
+- **Project-based organization**: AI builds contextual understanding across all recordings in a project for smarter insights
+- **MagSafe compatible**: Credit card form factor (3.4" x 2.2" x 0.118") with magnetic attachment for phones
+- **Dual recording modes**: Toggle between phone call capture and environmental recording
+- **Small OLED display**: Shows battery, recording status, and Bluetooth connectivity at a glance
+- **Massive storage**: 64GB internal (434 hours) plus unlimited cloud storage
+- **25-hour battery life**: 470mAh battery with 20+ days standby
+- **120+ languages**: Transcription and translation across extensive language support
+- **Multimodal input**: Add photos and notes during recording that integrate into AI summaries
+- **AI Podcast creation**: Convert recordings into shareable podcasts with voice effects
+
+#### Pros vs Plaud
+
+- AI agent that learns and surfaces insights automatically (vs Plaud's static processing)
+- Double the free credits at 600 minutes/month (vs Plaud's 300 minutes)
+- Project-based intelligence connects conversations contextually (vs Plaud's isolated recordings)
+- More languages at 120+ (vs Plaud's 112)
+- Slightly longer battery life at 25 hours (vs Plaud's 30 hours continuous)
+- Can add photos and notes in real-time during recording
+
+#### Cons
+
+- Requires cloud processing for all AI features, no offline transcription (unlike iFLYTEK)
+- Credit-based pricing can be confusing compared to minute-based systems
+- Heavier at 71 grams vs Plaud's 29 grams (though still pocket-friendly)
+- AI agent features only work well if you heavily use the project organization system
+- U.S.-based cloud storage might concern international users
+
+#### Pricing
+
+TicNote costs $159.99 for hardware—matching Plaud's entry point.
+
+The free tier gives 300 transcription minutes monthly (same as Plaud) but includes AI agent features Plaud doesn't offer.
+
+Pro runs $79/year for 2,000 minutes versus Plaud's $99/year for 1,200 minutes, making it better value if you need the extra capacity.
+
+Business tier ($239/year) delivers 6,000 minutes with unlimited audio imports and AI Speech Enhancement.
+
+The real differentiator is Shadow's contextual intelligence. If you organize work into projects and want an AI that connects dots across conversations, TicNote's pricing makes sense. If you just need straightforward transcription, you're paying extra for features you won't use.
+
+&nbsp;
+
+### 4. Notta Memo
+
+Notta Memo is a Japanese AI company's entry into hardware. An ultra-lightweight recorder (under 1 ounce) with a five-platform ecosystem connecting web, mobile, Chrome extension, and hardware.
+
+![Nota Memo](/api/assets/blog/plaud-ai-alternatives/notta.webp)
+
+#### How it works
+
+The device weighs just 28 grams with four MEMS microphones plus one bone conduction mic for phone calls. Toggle between live mode (ambient recording) and call mode (phone recording via vibration detection), then recordings automatically sync via Bluetooth or WiFi to Notta's cloud platform.
+
+The differentiator is the mature software ecosystem behind it. Your recordings flow across web interface, iOS app, Android app, Chrome extension, and the device itself with AI context maintained throughout.
+
+Start recording on hardware, edit on mobile, analyze on web, share via browser extension. The platform handles transcription in 58 languages, then generates summaries, mind maps, and integrates with 30+ templates.
+
+#### Key features
+
+- **Five-platform ecosystem**: Seamless sync across hardware, web, iOS, Android, and Chrome extension with maintained AI context
+- **Ultra-lightweight**: 28 grams (under 1 ounce), 3.5mm thick credit card design
+- **Bone conduction technology**: Captures both sides of phone calls clearly via vibration detection
+- **MagSafe compatible**: Magnetic case attaches to phone or any metal surface
+- **Massive local storage**: 32GB holds approximately 2,000 hours of recordings
+- **30-hour battery life**: 470mAh with 28-day standby, 1.5-hour charge time
+- **58 language support**: Transcription and translation across major languages
+- **Small display**: Shows recording mode, battery, Bluetooth status at a glance
+- **Enterprise security**: SOC 2, GDPR, ISO 27001 compliant with data hosted on AWS
+- **Zapier integration**: Connects to hundreds of productivity apps for workflow automation
+
+#### Pros vs Plaud
+
+- Backed by proven enterprise platform (10M users) rather than hardware-first startup
+- Five-platform ecosystem vs Plaud's hardware + mobile app approach
+- Lighter at 28 grams (vs Plaud's 29 grams—technically wins by ounces)
+- Better local storage value at 2,000 hours vs Plaud's 480 hours (32GB vs 64GB)
+- More mature software with workflow automation via Zapier
+- Enterprise customers already trust the brand (68% of Japan's Nikkei 225)
+
+#### Cons
+
+- Fewer supported languages at 58 (vs Plaud's 112)
+- Comparable battery at 30 hours (actually similar to Plaud's 30 hours continuous)
+- Requires cloud processing, no offline AI (like Plaud)
+- Free plan only shows first 3 minutes of transcripts unless upgraded
+- Some users report transcription accuracy varies significantly by language
+- Limited to 10-foot optimal recording distance
+
+#### Pricing
+
+Notta Memo costs $149 for the hardware. This gets you the device plus a "Starter Plan" with 300 minutes monthly transcription, same as Plaud's free tier.
+
+Notta's software pricing sits between basic and premium. Pro plan runs $13.49/month, giving unlimited transcription minutes with a 200 uploaded file monthly cap. Business plan starts at $27.99/user/month with unlimited transcription and uploaded files.
+
+Compare this to Plaud's $99.99/year Pro (1,200 minutes/month) or $239.99/year Unlimited. If you need truly unlimited transcription, Notta's annual Pro delivers better value than Plaud's $99 plan that still caps you at 1,200 minutes monthly. But if 1,200 minutes covers your needs, Plaud's Pro is slightly cheaper.
+
+### 5. Deepscribe
+
+Deepscribe is an enterprise-grade AI medical scribe built specifically for healthcare. It captures patient conversations and generates clinical documentation directly in EHR systems, not a general-purpose recorder.
+
+![Deepscribe](/api/assets/blog/plaud-ai-alternatives/deepscribe.webp)
+
+#### How it works
+
+Physicians use an iOS app during patient visits, and the AI—trained on data from over 2 million patient encounters—listens to natural doctor-patient conversations, extracts medically relevant information, and automatically populates discrete EHR fields with complete, billable documentation.
+
+It integrates deeply with major EHR systems (Epic, athenaOne, eClinicalWorks, DrChrono) and includes AI pre-charting that pulls forward patient history, labs, imaging, medications, and diagnoses for context. The AI learns individual physician styles and continuously adapts to their documentation preferences.
+
+#### Key features
+
+- **Ambient capture**: Records patient visits in background without disrupting clinical workflow
+- **EHR-ready documentation**: Generates complete SOAP notes directly in EHR systems with proper field mapping
+- **AI pre-charting**: Automatically summarizes patient history, labs, imaging, prior visits before appointments
+- **Specialty templates**: Customizable note formats for different medical specialties and workflows
+- **AI coding**: Automated medical coding with real-time insights and audit-ready documentation
+- **Trained on clinical data**: 2 million+ real patient encounters, not generic conversations
+- **Enterprise security**: HIPAA compliant, end-to-end AES-256 encryption, de-identified patient data
+- **Telehealth compatible**: Works for virtual and in-person visits
+- **Multiple EHR integrations**: Epic, athenaOne, eClinicalWorks, DrChrono, AdvancedMD, Veradigm
+
+#### Pros vs Plaud
+
+- Purpose-built for healthcare vs. general recording (completely different use cases)
+- Generates billable EHR documentation vs. basic transcripts
+- HIPAA compliant with healthcare-specific security vs. general cloud storage
+- Reduces documentation time by 75% (clinically validated) vs. just transcription
+- Trained on actual clinical conversations vs. generic speech models
+
+#### Cons
+
+- Healthcare-only solution, not usable for business meetings or general recording
+- Requires sales consultation and custom quote, no transparent pricing
+- Much more expensive than consumer recorders
+- iOS only, no Android support
+- Requires EHR integration, can't work standalone
+- Not portable hardware, relies on phone/tablet during patient visits
+- Setup complexity higher than consumer tools
+
+#### Pricing
+
+Deepscribe doesn't list prices publicly—you have to request a demo for custom quotes. Based on third-party sources and industry reports, pricing runs approximately $400-500 per provider per month for EHR-integrated plans, with some estimates suggesting $8,000+ annually per clinician. Non-integrated plans may start around $250-400/month.
+
+Compare this to Plaud's $159 hardware + $99-239/year software, and you're looking at 20-40x higher annual cost for Deepscribe. That comparison misses the point entirely: Deepscribe generates billable clinical documentation that meets regulatory standards and integrates with practice management systems. Plaud gives you meeting transcripts. These solve completely different problems for completely different users.
+
+### 6. Avoma
+
+Avoma is a cloud-based AI meeting assistant built specifically for revenue teams, combining transcription with conversation intelligence and sales coaching features.
+
+![Avoma](/api/assets/blog/plaud-ai-alternatives/avoma.webp)
+
+#### How it works
+
+Avoma operates as a bot-based meeting assistant that joins your Zoom, Teams, or Google Meet calls to record and transcribe conversations in real-time across 75+ languages.
+
+During meetings, you can live-bookmark key moments by clicking categories like "Pain Points" or "Next Steps", and Avoma automatically organizes these under time-stamped sections.
+
+After the call, AI generates human-like notes using custom templates (MEDDIC, SPICED, SPIN, etc.) and automatically extracts topics like Business Need, Objections, and Pricing Discussions into smart chapters.
+
+The platform then pushes this data directly to your CRM, updating custom fields, logging activities, and syncing action items without manual data entry.
+
+#### Key features
+
+- **AI meeting assistant**: Automatic recording, real-time transcription in 75+ languages, custom AI note templates, AI-generated follow-up emails
+- **Smart chapters**: Auto-categorizes conversations into topics (pain points, next steps, business needs) with timestamps for quick navigation
+- **Auto CRM updates**: Syncs notes and automatically fills custom CRM fields in Salesforce, HubSpot, Zoho, Pipedrive, Copper
+- **Conversation Intelligence (add-on)**: AI call scoring, coaching recommendations, real-time answer assistant, talk pattern analysis, keyword tracking
+- **Revenue Intelligence (add-on)**: Deal risk alerts, sales methodology tracking, pipeline inspection, forecasting, AI win-loss analysis
+- **Scheduler & Lead Router (add-on)**: Group/round-robin scheduling, lead routing rules, inbound form qualification, SDR-to-AE handoff
+- **Ask Avoma AI copilot**: Query individual meetings, search across all conversations, or analyze at deal/account level
+- **Smart playlists**: Auto-curate call recordings based on rules for coaching and review
+
+#### Pros vs Plaud
+
+- Software-based, no hardware to carry or charge (vs Plaud's physical device dependency)
+- Works across all meeting platforms as a bot (vs Plaud requiring close proximity to conversations)
+- Deep sales features like CRM automation and deal intelligence (vs Plaud's basic transcription/summary)
+- Unlimited transcription with no monthly minute caps on any paid plan (vs Plaud's 300-minute limit on free tier)
+- Free viewer/collaborator seats for managers and non-recording team members
+- Integrates with 6,000+ apps through native connections and Zapier
+
+#### Cons
+
+- Cloud-only with bot visibility that can affect conversation dynamics (vs Plaud's discreet recording)
+- Add-on costs stack up quickly—conversation and revenue intelligence each cost $35/user/month extra
+- Designed for sales teams, potentially overkill if you just need simple meeting notes
+- Requires annual billing for Enterprise features (SSO, HIPAA, advanced security)
+- Minimum seat requirements on higher tiers
+
+#### Pricing
+
+Avoma's pricing looks straightforward until you realize the good features cost extra. The base Organization plan starts at $29/user/month (billed annually) and includes unlimited transcription, AI notes, CRM automation, and scheduling. This handles core meeting needs without artificial limits.
+
+But to unlock conversation intelligence features like call scoring, coaching insights, and keyword tracking, add another $29/user/month. Want revenue intelligence with deal risk alerts and pipeline tracking? That's another $29/user/month. Need advanced lead routing? Add $19/user/month for the Scheduler add-on.
+
+For teams that actually need the full revenue intelligence stack, Avoma delivers legitimate ROI by replacing multiple tools. But if you're just looking for meeting transcription, this is expensive overkill.
+
+## Which Plaud alternative should you choose?
+
+The right tool depends on what matters most to you:
+
+**Choose Char** if you're on a Mac and privacy is non-negotiable. It's the only option here that keeps everything local—no cloud, no subscriptions, no data leaving your device. This works for healthcare professionals, lawyers, consultants, or anyone in compliance-sensitive roles who needs unlimited meeting notes without worrying about data storage.
+
+**Choose iFLYTEK Smart Recorder Pro** if you need professional-grade field recording with a standalone device. The built-in touchscreen and 15-meter microphone range make it ideal for journalists, researchers, or anyone recording lectures and conferences where you can't rely on your phone or laptop.
+
+**Choose Mobvoi TicNote** if you want hands-free recording without carrying a separate device. The wearable form factor works for casual note-taking, but the limited battery and cloud dependency make it less suitable for all-day use.
+
+**Choose Notta Memo** if you're looking for the most affordable hardware option with decent transcription. At $69 plus subscription, it's the cheapest entry point for hardware recording, though you'll need your phone nearby to unlock most features.
+
+**Choose Deepscribe** if you're a physician drowning in EHR documentation. This isn't a meeting recorder—it's a clinical documentation tool that generates billable notes. The price reflects that: 20-40x more expensive than consumer tools, but it solves a completely different problem.
+
+**Choose Avoma** if you're on a sales team and need more than transcription. The CRM automation, deal intelligence, and coaching features justify the cost if you're already using multiple tools for revenue operations. But if you just want meeting notes, this is overkill.
+
+### Try Char for free
+
+Ready to take meeting notes without the cloud dependency or subscription treadmill? Char gives you unlimited transcription and AI summaries completely free—no credit card, no trials that expire, no catch.
+
+**[Download Char for macOS](/download)** and start recording your first meeting in under 2 minutes. Your data stays yours, on your device, forever.
+
+&nbsp;

--- a/apps/web/content/articles/read-ai-alternatives.mdx
+++ b/apps/web/content/articles/read-ai-alternatives.mdx
@@ -36,7 +36,7 @@ The first four are bot-free meeting tools for people whose primary use was trans
 
 ![Char vs Read AI](/api/assets/blog/Char%20pros%20and%20cons "char-editor-width=80")
 
-[Char](https://char.com) is open-source and approaches the problem differently from everything else here. It captures system audio without joining your call or requesting calendar permissions. There's no OAuth grant that can propagate through your organization. Everything is stored  on your device, which means your notes are readable by any tool you already use: Obsidian, VS Code, Notion, a plain text editor.
+[Char](https://anarlog.so) is open-source and approaches the problem differently from everything else here. It captures system audio without joining your call or requesting calendar permissions. There's no OAuth grant that can propagate through your organization. Everything is stored  on your device, which means your notes are readable by any tool you already use: Obsidian, VS Code, Notion, a plain text editor.
 
 You can take notes during a meeting in Char's built-in notepad while it transcribes in the background, and the AI combines both into structured output after the call. Or you can skip the manual notes entirely and let it generate summaries from the transcript alone. 
 
@@ -120,4 +120,4 @@ If you came to Read AI for meeting notes and the bot was the problem, Char gives
 
 If you actually use the email and messaging features, Microsoft Copilot covers the full scope for organizations already on M365, at a cost that adds up fast. Slack AI handles the messaging summary and search side for teams on Business+ or higher, and you may already be paying for it.
 
-Char is free for unlimited local transcription. [Download it for free](https://char.com/download/apple-silicon) and try it on your next call. No account required, no calendar permissions, no data leaves your machine unless you want it to.
+Char is free for unlimited local transcription. [Download it for free](https://anarlog.so/download/apple-silicon) and try it on your next call. No account required, no calendar permissions, no data leaves your machine unless you want it to.

--- a/apps/web/content/articles/read-ai-alternatives.mdx
+++ b/apps/web/content/articles/read-ai-alternatives.mdx
@@ -1,0 +1,123 @@
+---
+meta_title: "6 Best Read AI Alternatives in 2026"
+meta_description: "Read AI bundles meeting notes, email summaries, Slack search, and a Digital Twin into one subscription. Most people use one of those. Here are six tools that handle the parts you actually need."
+author:
+  - "Harshika"
+featured: false
+category: "Comparisons"
+date: "2026-04-01"
+---
+
+Most users came to Read AI for meeting notes and ended up paying for email summaries, a Slack integration, and an AI assistant they never asked for. And then there's the bot: Read AI joins every call as a visible participant, spreads through organizations via OAuth, and records people who never consented. 
+
+A security architect at Crayon called it *"a case study in viral Shadow IT"* in [a widely shared post](https://agderinthe.cloud/2026/01/19/read-ai-the-meeting-assistant-you-didnt-invite/) after it propagated through a client's Microsoft 365 tenant. IT teams across [Microsoft's own forums](https://learn.microsoft.com/en-us/answers/questions/4419430/read-ai) have been asking how to block it. Read AI recently shipped a botless integration for Google Meet, but on Zoom and Teams the bot remains the default.
+
+So if you're in the market for Read AI alternatives, I've covered six tools in this article that are worth a look. 
+
+The first four are bot-free meeting tools for people whose primary use was transcription and summaries. The last two, Microsoft Copilot and Slack AI, are platform-level alternatives that cover the broader feature set: email, messaging, and cross-channel search. Nobody replaces the full bundle in one product. But most people don't need the full bundle.
+
+## **How These Read AI Alternatives Compare**
+
+
+|                       |                                                                                                        |                                          |
+| --------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
+| **Tool**              | **Best For**                                                                                           | **Pricing**                              |
+| **Char**              | Open-source, bot-free, fully offline capable. Plain markdown files on your device, your choice of AI   | Free (unlimited local); Pro $25/mo       |
+| **Jamie**             | Closest feature-match to Read AI among bot-free tools: CRM sync, speaker memory, enterprise compliance | Free (10 meetings); Pro €47/mo           |
+| **Tactiq**            | Cheapest bot-free option: Chrome extension with real-time transcription and CRM workflow automations   | Free (10 transcripts); Pro $8/mo         |
+| **Granola**           | Notepad-first approach for client calls where discretion matters most                                  | Free (25 meetings); Business $14/user/mo |
+| **Microsoft Copilot** | Full-scope alternative if your org runs Microsoft 365: meetings, email, messaging, search              | $30/user/mo add-on (requires M365)       |
+| **Slack AI**          | Messaging summaries, enterprise search, and huddle transcription you may already be paying for         | Included in Business+ ($15/user/mo)      |
+
+
+## Best Read AI Alternatives in 2026
+
+### 1. Char
+
+![Char vs Read AI](/api/assets/blog/Char%20pros%20and%20cons "char-editor-width=80")
+
+[Char](https://char.com) is open-source and approaches the problem differently from everything else here. It captures system audio without joining your call or requesting calendar permissions. There's no OAuth grant that can propagate through your organization. Everything is stored  on your device, which means your notes are readable by any tool you already use: Obsidian, VS Code, Notion, a plain text editor.
+
+You can take notes during a meeting in Char's built-in notepad while it transcribes in the background, and the AI combines both into structured output after the call. Or you can skip the manual notes entirely and let it generate summaries from the transcript alone. 
+
+The AI stack is yours to pick: Char's managed cloud service, your own API keys from OpenAI, Anthropic, or Deepgram, or fully local models through Ollama. That last option means the entire pipeline can run offline, on your machine, with nothing leaving your network. 
+
+For companies that blocked Read AI over data residency, Char is one of the few tools where "local-first" means exactly what it says, because you can read the source code to verify it.
+
+It runs on macOS and Linux. Windows support isn't here yet, and there's no mobile app, no built-in CRM sync, no engagement scoring. Char focuses on transcription, notes, and AI summaries with complete data ownership. Free for unlimited local transcription or BYOK setups. Pro is $25/month for managed cloud. 45+ languages.
+
+### 2. Jamie
+
+![jamie vs read ai](/api/assets/blog/Jamie%20pros%20and%20cons "char-editor-width=80")
+
+Where Char gives you raw ownership and flexibility, [Jamie](https://meetjamie.ai/) packages the bot-free experience into a more conventional product. It's a desktop app for Mac and Windows (plus an iOS app) that captures audio from your device and generates summaries with speaker recognition, action items, and custom templates. 
+
+The feature set is the closest match to Read AI among bot-free tools: HubSpot and Salesforce integrations, 100+ languages with automatic detection, in-person meeting support, and an "Ask Jamie" semantic search that lets you query across all your recorded meetings.
+
+The privacy credentials are built around European compliance: EU-hosted infrastructure, GDPR compliant, ISO 27001 certified. Audio gets deleted after transcription and customer data is never used for model training. 
+
+For companies in Europe where Read AI's US-based data handling was the dealbreaker, Jamie was designed for that exact use case. The tradeoff against Char is that Jamie is closed-source and stores data on their servers (EU servers, but still theirs).
+
+[Pro runs €47/month](https://www.meetjamie.ai/pricing) for unlimited meetings. The free plan gives you 10 meetings with a 30-minute limit per session. There's no live transcription during the call (summaries arrive after) and CRM integrations require the higher tiers.
+
+### 3. Tactiq
+
+![Tactiq vs Read AI](/api/assets/blog/Tactiq%20pros%20and%20cons "char-editor-width=80")
+
+Char and Jamie are desktop apps. [Tactiq](https://tactiq.com/) lives entirely in the browser as a Chrome extension, which changes the dynamic. 
+
+You install it, join a call in your browser, and it transcribes in real time with [over a million users and a 4.8-star rating](https://chromewebstore.google.com/detail/tactiq-chatgpt-meeting-su/fggkaccpbmombhnjkjokndojfgagejfb) on the Chrome Web Store. No bot joins the meeting. The transcript shows up live as people speak, so you can highlight and tag moments during the call rather than reviewing everything after.
+
+The workflow automations are where Tactiq earns its keep. One-click summaries, action item extraction, follow-up email drafting, and reusable prompt templates that push to Slack, Notion, HubSpot, Pipedrive, and Linear. Security is stronger than you'd expect from a browser extension: SOC 2 Type II, GDPR, ISO 27001, HIPAA. No audio is recorded or stored.
+
+[Pro starts at $8/month](https://tactiq.io/buy) (annual) with unlimited transcripts, which makes it the cheapest option on this list by a wide margin. Free gives 10 transcripts and 5 AI credits per month. 
+
+The limitation is that it only works in the browser. If your team uses native desktop apps for Zoom or Teams, Tactiq can't capture those calls. No in-person meeting support either, which is where Char and Jamie have the edge.
+
+### 4. Granola
+
+![Granola vs read ai](/api/assets/blog/Granola%20pros%20and%20cons "char-editor-width=80")
+
+[Granola](https://www.granola.ai/) shares the same core mechanic as Char's notepad mode: you type rough notes during the call while it captures audio in the background, and the AI merges both into structured output when the meeting ends. 
+
+The difference is that Granola leans harder into the notepad-as-interface idea. It's designed to feel like you're just writing in a doc, and the AI enhances what you wrote rather than generating a separate summary. For people who want to stay engaged by typing rather than passively letting a tool record, that workflow clicks.
+
+The company raised $125 million in March 2026 at a $1.5 billion valuation. That same month, they encrypted their local database, which broke every agent workflow that had been reading notes from the local cache. 
+
+Speaker identification is weak in multi-person calls and there's no audio playback or CRM integration. The free plan covers 25 meetings lifetime (not monthly). Business is $14/user/month. Available on Mac, Windows, and iOS.
+
+### 5. Microsoft 365 Copilot
+
+![Copilot vs read ai](/api/assets/blog/Copilot%20pros%20and%20cons "char-editor-width=80")
+
+[Microsoft 365 Copilot](https://www.microsoft.com/en-us/microsoft-365/copilot/pricing) is the closest full-scope alternative to Read AI. It operates across Microsoft's entire suite, which means if your organization already runs M365, most of what Read AI does is available without adding another vendor's bot to your meetings.
+
+Wave 3 shipped in March 2026 with model choice (Claude alongside OpenAI), Copilot Cowork for multi-step tasks, and deeper integration into Teams meetings including a [Facilitator AI agent](https://summarizemeeting.com/en/app-reviews/microsoft-teams) that manages agendas, captures notes, and tracks time. Meeting transcription in Teams doesn't require a bot joining from outside your org. It's native. That alone eliminates the shadow IT problem that drives people away from Read AI.
+
+The cost is significant. Copilot Business is $21/user/month as an add-on to your existing M365 subscription ($12.50-22/user/month), bringing the total to $33-43/user/month. Enterprise plans go higher. 
+
+If your organization doesn't already run Microsoft 365, this isn't a realistic option. But if you do, it covers meetings, email, messaging, and search in one licensing line item, with no third-party bots and no separate vendor handling your data.
+
+### 6. Slack AI
+
+![slack vs read ai](/api/assets/blog/Slack%20ai%20pros%20and%20cons "char-editor-width=80")
+
+If your team uses Slack and you were paying Read AI mainly for the messaging summaries or cross-channel search, check what your Slack plan already includes. 
+
+[Slack bundled AI into all paid plans in mid-2025](https://share.pricingsaas.com/1772731424/slack-pricing-report-2026-03.html), removing the old standalone add-on. Basic AI (conversation summaries, AI search, daily recaps) is now part of every paid tier, including Pro at $7.25/user/month. Advanced AI on Business+ ($15/user/month) adds Slackbot as a personal AI agent, file summaries, translations, and workflow generation.
+
+Slackbot was [rebuilt in January 2026](https://slack.com/blog/news/slackbot-context-aware-ai-agent-for-work) as a context-aware AI agent that drafts emails, schedules meetings, searches across your workspace and connected apps, and just got 30 more features in March including reusable AI skills and MCP client support. 
+
+Enterprise search on Enterprise+ connects Google Drive, Salesforce, and other tools into one searchable index. Huddle transcription covers the meeting piece for teams that use Slack calls.
+
+Slack AI doesn't replace Read AI's engagement scoring, speaker coaching, or meeting analytics. And if your meetings happen on Zoom or Teams rather than Slack huddles, it won't transcribe those calls. But for the messaging summary and enterprise search features that Read AI charges $19.75/month for, your Slack subscription might already cover it.
+
+## Which Read AI Alternative Is Right for You?
+
+Read AI bundles five things into one subscription: meeting notes, email summaries, messaging summaries, cross-channel search, and engagement analytics. Most people use one, maybe two of those. The question isn't which tool replaces all of Read AI. It's which parts you actually need.
+
+If you came to Read AI for meeting notes and the bot was the problem, Char gives you complete ownership: open-source, local files, your AI provider, nothing touching your org's OAuth. Jamie packages the bot-free experience with CRM integrations and EU compliance at a higher price point. Tactiq is the budget pick at $8/month if your meetings happen in the browser. Granola works for client-facing calls where the notepad workflow fits, though the database encryption incident and lifetime meeting cap on free are worth weighing.
+
+If you actually use the email and messaging features, Microsoft Copilot covers the full scope for organizations already on M365, at a cost that adds up fast. Slack AI handles the messaging summary and search side for teams on Business+ or higher, and you may already be paying for it.
+
+Char is free for unlimited local transcription. [Download it for free](https://char.com/download/apple-silicon) and try it on your next call. No account required, no calendar permissions, no data leaves your machine unless you want it to.

--- a/apps/web/content/articles/see-zoom-meeting-history.mdx
+++ b/apps/web/content/articles/see-zoom-meeting-history.mdx
@@ -1,0 +1,133 @@
+---
+meta_title: "How to View Zoom Meeting History (Updated 2026)"
+display_title: "How to See Your Zoom Meeting History (And Actually Make It Useful)"
+meta_description: "Step-by-step guide to viewing Zoom meeting history. See what Zoom shows (and what it doesn't), plus how to make your meeting history actually searchable."
+author: "John Jeong"
+coverImage: "/api/assets/blog/see-zoom-meeting-history/cover.png"
+category: "Guides"
+date: "2025-11-05"
+---
+
+Need to find a past Zoom meeting? Whether you're tracking attendance, checking when a call happened, or looking up a meeting ID, Zoom's meeting history can help. Here's how to access it.
+
+## How to access your Zoom meeting history
+
+Zoom offers a few ways to view your meeting history, depending on whether you hosted or joined the meeting.
+
+### For meetings you hosted
+
+<Image src="/api/assets/blog/see-zoom-meeting-history/zoom-1.png" alt="Zoom dashboard" />
+
+If you're the meeting host, accessing your history is straightforward:
+
+1. Sign in to the [Zoom web portal](https://zoom.us/)
+2. Click **Meetings** in the navigation menu, then select **Previous**
+3. Use the date range filters if you're looking for something specific
+
+Your account admin and owner can also see this information. If a meeting ID has expired (which happens based on [Zoom's expiration rules](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0060761)), it won't show up in your list anymore.
+
+### For meetings you joined
+
+You can only see meetings you've joined through the Zoom desktop app, with significant limitations:
+
+1. Open the Zoom desktop app
+2. Click **Join**
+3. Click the dropdown arrow in the Meeting ID field
+
+You'll see your last 10 meetings with a partial meeting topic and the meeting ID. There are no full details, no reliable timestamps, and this list doesn't sync across devices. If you joined a meeting on your laptop, you won't see it in your phone's history.
+
+### Using Zoom reporting for advanced history
+
+If you're on a Pro, Business, Enterprise, or Education account, you can access Zoom's reporting features. Account owners and admins can generate reports showing:
+
+- Active meetings during specific time ranges (up to one month)
+- Meeting minutes and participant lists
+- User activity reports
+
+These reports can go back 12 months, which helps with compliance or attendance tracking. Meetings must be hosted by a paid account, and upgrading your account won't retroactively create reports for past meetings.
+
+## What information does Zoom meeting history actually show?
+
+Zoom's meeting history tells you when meetings happened, who attended, how long they lasted, and the meeting IDs and basic settings.
+
+It doesn't tell you what was actually discussed, what decisions were made, what action items came up, or the context of any conversation.
+
+You can see that you had a meeting with Sarah on October 15th at 2 PM, but unless you took detailed notes during the call, you have no way to remember what was discussed. Meeting history shows proof that a meeting occurred—metadata—but not what actually happened in it.
+
+Zoom was designed to help admins track usage and generate compliance reports. It wasn't designed to help you remember meeting content. If you spend hours in meetings every day—in customer success, sales, consulting, recruiting, or similar roles—you need more than proof of meetings. You need to remember what was actually said. This is where [AI note-takers for Zoom](/blog/best-ai-notetaker-for-zoom), like Char, can help.
+
+<CtaCard/>
+
+## How Char changes meeting history
+
+Char is an open-source [AI notepad](/) for meetings that gives you complete control over your data and AI stack. Instead of just logging when meetings happened, it captures what actually occurred—stored as plain markdown files with zero lock-in.
+
+### 1. Search through actual conversations
+
+<Image src="/api/assets/blog/see-zoom-meeting-history/zoom-2.png" alt="Search" />
+
+With Char, you can search for any keyword and find it within your meeting transcripts. Press `cmd + k` to open the search palette and type anything—a person's name, a project code, a specific topic.
+
+The search shows you the actual context: what was said, by whom, and when in the conversation. You can filter by person to see all meetings with a specific colleague or client.
+
+If you search for "budget," you're not getting a list of 47 meetings that might have mentioned budget somewhere. You're getting the exact moments where budget was discussed, with full context around each mention.
+
+### 2. Ask questions about your meetings
+
+<Image src="/api/assets/blog/see-zoom-meeting-history/zoom-3.png" alt="Chat" />
+
+Sometimes you don't know the exact keyword to search for. You just have a vague memory that someone said something important.
+
+Char's AI Chat lets you ask natural language questions like:
+
+- "What are my action items from this week's meetings?"
+- "What did Richard say about installing more servers?"
+- "Bring up notes related to the product launch"
+
+The AI searches through your transcripts and summaries to answer. You can mention specific people or notes using "@" to pull them into context.
+
+### 3. Visual meeting organization
+
+Char's Finder feature includes three views:
+
+**Calendar View:** See your meetings laid out visually by date, just like your calendar app. Click any event to see the full note and transcript.
+
+<Image src="/api/assets/blog/see-zoom-meeting-history/zoom-4.png" alt="Calendar" />
+
+**Table View:** A spreadsheet-style layout for scanning through large amounts of meeting data quickly.
+
+<Image src="/api/assets/blog/see-zoom-meeting-history/zoom-5.png" alt="Table" />
+
+**Contacts View:** See all your contacts and filter meetings by organization. Want to see every conversation you've had with a particular company? It's all there.
+
+<Image src="/api/assets/blog/see-zoom-meeting-history/zoom-6.png" alt="Contacts" />
+
+Each view gives you a different way to approach your conversation history: by time, by relationship, or by project.
+
+### 4. Verify what was actually said
+
+<Image src="/api/assets/blog/see-zoom-meeting-history/zoom-7.webp" alt="Annotation" />
+
+Ever read an AI summary and wonder if someone really said that? Char's Source Analysis feature lets you hover over any part of your meeting summary to see the exact quote from the transcript.
+
+This matters for client meetings where you need to quote exact requirements, negotiations where precise wording matters, or compliance situations where you need to verify what was discussed. You get AI summarization with the accuracy of checking the source.
+
+## How Char works with Zoom (and every other platform)
+
+Char runs entirely on your Mac, capturing audio from both your microphone and your system audio. This means it works with Zoom, Teams, Google Meet, or any other platform without bots or meeting interruptions.
+
+During your meeting, real-time transcription powered by Whisper models captures everything being said. When the meeting ends, Char generates a structured summary with action items, key decisions, and discussion points using our custom HyperLLM-V1 model. Everything stays local on your device—no audio uploaded, no transcripts sent to external servers, no compliance concerns about where your data lives.
+
+Key features for Zoom users:
+
+- **Bot-free recording** works silently in the background without joining your meeting as a participant
+- **Universal compatibility** captures both virtual Zoom calls and in-person meetings
+- **Offline capable** -- Transcription and summarization work even without internet connection
+- **Privacy-first** -- Makes HIPAA, GDPR, SOC 2 compliance simple by eliminating cloud dependencies
+- **Flexible AI options** -- Go fully local, connect to OpenAI/Mistral/Ollama, or use custom endpoints
+
+For organizations in healthcare, legal, finance, or any compliance-sensitive industry, this approach matters. You can have AI-powered meeting intelligence while meeting regulatory requirements. For everyone else, you get meeting history that actually works the way your brain works—by content and context.
+
+[Download Char](/download) and start building meeting history that's actually useful.
+
+<CtaCard/>

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -30,7 +30,7 @@ If you don't want your meeting audio on someone else's servers, these are your o
 
 ![Char review](/api/assets/blog/blog/char-summary.png "char-editor-width=80")
 
-[Char](https://char.com/) is the only tool on this list that handles the full meeting workflow in one app — capture, transcription, note-taking, summarization, and structured export. 
+[Char](https://anarlog.so/) is the only tool on this list that handles the full meeting workflow in one app — capture, transcription, note-taking, summarization, and structured export. 
 
 It ships with a built-in notepad where you write during the meeting, and the AI merges your manual notes with the transcript into structured output using your template. Notes are plain Markdown files on disk. Open them in Obsidian, VS Code, whatever.
 
@@ -201,4 +201,4 @@ It depends on what you're optimizing for.
 - If you just need fast, reliable file transcription on your desktop, Vibe is the simplest path.
 - If you're building a custom pipeline and need word-level timestamps with speaker diarization, WhisperX gives you the research-grade engine to wire into your own stack.
 
-For most users who want privacy-first meeting notes that just work, start with [Char](https://char.com/download/apple-silicon). Free for fully local use, no account required.
+For most users who want privacy-first meeting notes that just work, start with [Char](https://anarlog.so/download/apple-silicon). Free for fully local use, no account required.

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -1,0 +1,204 @@
+---
+meta_title: "Best Self-Hosted AI Notetakers in 2026"
+meta_description: "Six open-source AI meeting notetakers you can self-host — from full meeting workspaces to raw transcription pipelines. Covers Char, Meetily, Scriberr, Vibe, Whishper, and WhisperX."
+author:
+  - "Harshika"
+featured: false
+category: "Comparisons"
+date: "2026-04-20"
+---
+
+If you don't want your meeting audio on someone else's servers, these are your options. Six tools, from full note-taking apps to raw transcription pipelines. All of them are self-hostable and open-source.
+
+## Self-Hosted AI Notetaker Comparison
+
+
+|              |             |                 |                                               |                    |                                |
+| ------------ | ----------- | --------------- | --------------------------------------------- | ------------------ | ------------------------------ |
+| **Tool**     | **License** | **Platform**    | **Local STT**                                 | **Local LLM**      | **Pricing**                    |
+| **Char**     | MIT         | macOS           | Parakeet V3, Whisper Small (Cactus) + 7 cloud | Ollama / LM Studio | Free (local) · $8–$25/mo cloud |
+| **Meetily**  | MIT         | Windows, macOS  | Whisper, Parakeet                             | Ollama             | Free · $10/mo Pro              |
+| **Scriberr** | MIT         | Docker (web)    | Whisper.cpp                                   | Ollama             | Free                           |
+| **Vibe**     | MIT         | Win, Mac, Linux | Whisper.cpp                                   | No built-in        | Free                           |
+| **Whishper** | MIT         | Docker (web)    | Whisper                                       | No                 | Free                           |
+| **WhisperX** | BSD-4       | CLI / Docker    | Whisper-based                                 | No                 | Free                           |
+
+
+### 6 Best Self-Hosted AI Notetakers
+
+### 1. Char
+
+![Char review](/api/assets/blog/blog/char-summary.png "char-editor-width=80")
+
+[Char](https://char.com/) is the only tool on this list that handles the full meeting workflow in one app — capture, transcription, note-taking, summarization, and structured export. 
+
+It ships with a built-in notepad where you write during the meeting, and the AI merges your manual notes with the transcript into structured output using your template. Notes are plain Markdown files on disk. Open them in Obsidian, VS Code, whatever.
+
+#### Setup
+
+**Install:** brew install char, or clone the [MIT-licensed repo](https://github.com/fastrepl/char) and build from source.
+
+**Transcription:** Pick from 9 STT providers in Preferences. Two are fully on-device - Parakeet V3 (Apple Neural Engine via Cactus) and Whisper Small (also Cactus). The other seven are cloud BYOK: paste your API key, audio goes to that provider, Char never touches it.
+
+**Summarization:** Configured separately. Point it at Ollama or LM Studio for offline, or add a key for OpenAI, Anthropic, or Gemini.
+
+**Storage:** Local filesystem
+
+#### What else
+
+Calendar integration (Apple, Google, Outlook) with auto-record on event start. AI chat over your transcripts. Code blocks, @mentions with backlinks. Export to Markdown, PDF, JSON, VTT, Org mode. 45+ languages. 
+
+#### Limitations
+
+- On-device transcription quality scales with hardware. The older Macs without a Neural Engine won't get Parakeet V3 acceleration.
+- Single-user desktop app. No web UI for team sharing yet.
+
+#### Pricing
+
+Free for fully local use (on-device STT + local LLM). Cloud features available at $8–$25/month.
+
+### 2. Meetily
+
+![Meetily review](https://github.com/Zackriya-Solutions/meetily/raw/main/docs/home.png "char-editor-width=80")
+
+[Meetily](https://meetily.ai/) captures system audio and mic input in real time, transcribes locally using Whisper or Parakeet, and summarizes through your choice of AI provider. 
+
+It covers the full record → transcribe → summarize pipeline without leaving the app, and works with any conferencing platform that produces audio on your machine.
+
+#### Setup
+
+**Install:** Download the desktop app for Windows or macOS from GitHub releases. Linux is supported but requires building from source.
+
+**Transcription:** Whisper or Parakeet, running locally. GPU acceleration is automatic — Metal/CoreML on Apple Silicon, CUDA for NVIDIA, Vulkan for AMD/Intel.
+
+**Summarization:** Pluggable. Use Ollama for fully local processing, or bring your own API key for Claude, Groq, OpenRouter, or OpenAI.
+
+**Storage:** Local SQLite database on disk.
+
+#### Limitations
+
+- No rich editor or note-taking interface — it's a transcription and summarization tool, not a writing workspace.
+- Linux requires building from source; no prebuilt installer.
+- Speaker diarization not yet available in the Community Edition.
+- Auto-meeting detection and calendar integration are Pro-only features.
+
+#### Pricing
+
+Free and open source (MIT) for the Community Edition. Pro is $120/year ($10/month billed annually) and runs on a separate codebase with enhanced accuracy and additional features. Enterprise pricing is custom.
+
+### 3. Scriberr
+
+![scribber review](/api/assets/blog/blog/telegram-cloud-photo-size-5-6282995305728905641-w.jpg "char-editor-width=80")
+
+[Scriberr](https://github.com/rishikanthc/Scriberr) is a team transcription service you deploy with Docker. Upload recordings through the browser, get transcripts back from Whisper.cpp on your server. Optional Ollama sidecar for summarization. 
+
+Useful when you want one shared interface and don't need anything installed on individual machines.
+
+#### Setup
+
+**Deploy:** Docker Compose. One container for the web UI, one for Whisper.cpp, optional Ollama sidecar.
+
+**GPU:** CUDA acceleration supported for Whisper.cpp.
+
+**Storage:** Host filesystem + SQLite. 
+
+**Access control:** Basic auth or reverse proxy. Share the URL with your team.
+
+#### Limitations
+
+- Upload-only workflow. You record elsewhere, then drop the file in.
+- Development is currently paused by the sole maintainer. The project works and is not abandoned, but expect slower updates and limited support in the near term.
+
+#### Pricing
+
+Free and open-source (MIT). Self-host only.
+
+### 4. Vibe
+
+![vibe review](/api/assets/blog/blog/telegram-cloud-photo-size-5-6282995305728905642-y.jpg "char-editor-width=80")
+
+[Vibe](https://thewh1teagle.github.io/vibe/) does one thing: transcribe audio and video files using Whisper.cpp. Cross-platform desktop app with a clean UI. It also exposes a local API, which makes it useful as a transcription backend you can wire into other tools. 
+
+If you don't need summarization, note-taking, or real-time capture, this is the simplest path.
+
+#### Setup
+
+**Install:** Download the desktop app for Windows, macOS, or Linux. No Docker, no server.
+
+**Models:** Whisper.cpp with automatic model download. GPU acceleration on all platforms.
+
+**API mode:** Run as a local transcription server. POST audio, get transcripts back (TXT, SRT, VTT).
+
+#### Limitations
+
+- Transcription only.
+- Single-user. No collaboration or sharing features.
+
+#### Pricing
+
+Free and open-source (MIT).
+
+### 5. Whishper
+
+![](/api/assets/blog/blog/Screenshot-2026-04-20-at-1.55.51-PM.png "char-editor-width=80")
+
+[Whishper](https://github.com/pluja/whishper) is another Docker-deployed web UI for Whisper with drag-and-drop upload and subtitle generation (SRT, VTT). 
+
+It's built for teams that need a transcription service without any setup complexity. Automatic language detection across 90+ languages. 
+
+No summarization, no post-processing — you get the transcript and take it elsewhere.
+
+#### Setup
+
+**Deploy:** Docker Compose. Pull the image, set your Whisper model size (tiny through large-v3), start.
+
+**Interface:** Browser-based drag-and-drop. Share the URL with your team.
+
+**Storage:** Host filesystem via Docker volumes.
+
+#### Limitations
+
+- No editing or formatting tools — you get raw transcript output.
+- Less configurable than Scriberr if you need GPU tuning or Ollama integration.
+
+#### Pricing
+
+Free and open-source (MIT). Self-host only.
+
+### 6. WhisperX
+
+![whisperx review](/api/assets/blog/blog/Screenshot-2026-04-20-at-12.53.00-PM-1.png "char-editor-width=80")
+
+[WhisperX](https://github.com/m-bain/whisperX) is a research-grade transcription pipeline. It extends Whisper with forced alignment (word-level timestamps via wav2vec2) and speaker diarization (pyannote.audio). 
+
+It's the only tool on this list that tells you exactly who said what and when, down to the word. If you're building a custom meeting intelligence stack, this is the engine.
+
+#### Setup
+
+**Install:** pip install or Docker. Requires Python and a CUDA GPU for reasonable performance.
+
+**Diarization:** pyannote.audio models. It requires accepting license terms on Hugging Face and providing a token.
+
+**I/O:** CLI-driven. Pipe audio in, get JSON/SRT/VTT out.
+
+#### Limitations
+
+- No UI. You build any interface yourself.
+- GPU effectively required because the CPU inference is impractically slow for long recordings.
+- BSD-4-Clause license has an advertising clause some legal teams flag.
+
+#### Pricing
+
+Free and open-source (BSD-4-Clause).
+
+## Which Self-Hosted AI Notetaker Should You Use?
+
+It depends on what you're optimizing for.
+
+- If you want a full meeting workspace, Char is the most complete option on this list. 
+- If you're on Windows and need real-time capture with local transcription and summarization, go for Meetily.
+- If you need a shared transcription service for a team, deploy Scriberr or Whishper via Docker and give everyone a browser-based upload interface.
+- If you just need fast, reliable file transcription on your desktop, Vibe is the simplest path.
+- If you're building a custom pipeline and need word-level timestamps with speaker diarization, WhisperX gives you the research-grade engine to wire into your own stack.
+
+For most users who want privacy-first meeting notes that just work, start with [Char](https://char.com/download/apple-silicon). Free for fully local use, no account required.

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -227,4 +227,4 @@ Free (limited); Pro $13.49/user/month; Business $27.99/user/month.
 
 **Notta** is the strongest option for multilingual teams that need transcription and translation accuracy across dozens of languages.
 
-If you want prefer the local-first approach, [download Char](https://char.com/download/apple-silicon) and try it on your next meeting.
+If you want prefer the local-first approach, [download Char](https://anarlog.so/download/apple-silicon) and try it on your next meeting.

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -1,0 +1,230 @@
+---
+meta_title: "7 Best Tactiq Alternatives in 2026"
+meta_description: "For anyone whose workflow has outgrown a Chrome extension: the best alternatives to Tactiq for meeting transcription, AI notes, and real ownership of your data."
+author:
+  - "John Jeong"
+featured: false
+category: "Comparisons"
+date: "2026-04-02"
+---
+
+Tactiq is one of the lighter, smarter approaches to meeting transcription. It runs as a Chrome extension, captures live captions from Google Meet, Zoom, or Teams without sending a bot into the call, and generates AI summaries from the text. Over a million people use it weekly, and for a browser-based tool, it handles the basics well.
+
+But the Chrome dependency is also its ceiling. You have to join meetings through the browser, not the Zoom desktop app or Teams client. 
+
+I spent weeks testing alternatives that remove that ceiling in different ways. Here are seven tools worth a look.
+
+## List of the Best Tactiq Alternatives
+
+
+|                  |                      |                                                                           |                                         |
+| ---------------- | -------------------- | ------------------------------------------------------------------------- | --------------------------------------- |
+| **Tool**         | **Chrome extension** | **Best For**                                                              | **Pricing**                             |
+| **Char**         | No                   | Developers and tech founder who want control over their data and AI stack | Free (local/BYOK); Pro $25/mo           |
+| **Otter.ai**     | Yes                  | Teams that need cross-meeting search and a mature knowledge base          | Free (300 min/mo); Pro $16.99/mo        |
+| **Granola**      | No                   | Individuals who want a notepad-first workflow without a meeting bot       | ~$14/mo (Business)                      |
+| **Fathom**       | Yes                  | Solo users who want unlimited free transcription with fast summaries      | Free (unlimited); Team from $32/user/mo |
+| **Fireflies.ai** | Yes                  | Sales teams that need deep CRM sync and conversation analytics            | Free (800 min/mo); Pro $10/user/mo      |
+| **tl;dv**        | Yes                  | Distributed teams sharing async video clips from meetings                 | Free (unlimited); Pro $29/user/mo       |
+| **Notta**        | Yes                  | International teams needing multilingual transcription and translation    | Free (limited); Pro $13.49/user/mo      |
+
+
+## Best Tactiq Alternatives for Meeting Transcription in 2026
+
+### 1. Char
+
+![char vs tactiq](/api/assets/blog/blog/char-summary.png "char-editor-width=80")
+
+[Char](char.com) is an open-source AI notepad for meetings, built for people who want to own their data. 
+
+Where Tactiq captures text inside Chrome, Char is a desktop app that records system audio from any meeting platform: Zoom, Teams, phone calls, even in-person conversations. 
+
+It transcribes in real time while you take notes in a built-in editor, then combines both into a structured summary after the call. No bot joins your meeting and no calendar permissions are required.
+
+#### What works
+
+- Save your notes in your desired folder. If Char disappeared tomorrow, your data would still be exactly where you left it.
+- You choose your own AI stack: Char's managed cloud, your own API keys (OpenAI, Anthropic, Deepgram), or fully local models through Ollama or LM Studio for offline operation.
+- System audio capture means it works with any meeting platform without a bot or calendar permissions. For teams whose companies have banned cloud-based tools like Otter or Granola, this is the only option that keeps everything on-device without compromise.
+- Open-source codebase. Your security team can audit exactly how data is handled.
+- The notepad mode lets you take your own notes during the call. The AI combines your notes with the transcript into structured output, so summaries reflect what you thought was important, not just what the AI picked up.
+
+#### What doesn't
+
+- macOS and Linux only. No Windows client yet.
+- No mobile app, no video recording.
+- No built-in CRM integrations yet.
+
+#### Pricing
+
+Free with on-device transcription and bring-your-own keys; Lite at $8/month adds cloud transcription and speaker ID; Pro at $25/month adds sync, integrations, and shareable links.
+
+### 2. Otter.ai
+
+![Otter ai vs tactiq](https://help.otter.ai/hc/article_attachments/8775272002967 "char-editor-width=80")
+
+[Otter](otter.ai) is the most established name in AI meeting transcription, with over 25 million users. Its OtterPilot bot auto-joins your scheduled meetings on Zoom, Meet, or Teams, transcribes everything, and generates AI summaries with action items. Unlike Tactiq, Otter is a standalone app that works outside the browser.
+
+#### What works
+
+- Cross-meeting search is the standout feature. You can ask "What did Sarah say about the Q4 budget?" and get an answer pulled from months of recordings. No other tool on this list does this as well.
+- OtterPilot auto-joins scheduled meetings with zero manual effort.
+- Mature collaboration features: shared notes, highlights, comments, team workspace with usage analytics.
+- Speaker identification works reliably after initial voice training.
+
+#### What doesn't
+
+- A federal class-action lawsuit filed in August 2025 accuses Otter of "deceptively and surreptitiously" recording private conversations and using them to train its AI without consent from all meeting participants. The suit alleges the bot records everyone in a call, including people who never signed up for the service.
+- The bot ("Otter.ai") joins meetings as a visible participant. Clients notice.
+- AI transcription only works in English, French, and Spanish. Significant gap for international teams.
+- Free tier burns through fast: 300 minutes per month with a 30-minute cap per conversation.
+
+#### Pricing
+
+Free (300 min/mo, 30-min cap); Pro $16.99/month ($8.33 annually); Business $30/user/month.
+
+### 3. Granola
+
+![Granola vs tactiq](/api/assets/blog/blog/image-13.png "char-editor-width=80")
+
+[Granola](granola.ai) is a desktop app that, like Char, captures system audio and skips the bot. You take notes during the meeting in Granola's notepad, and the AI fills in everything you missed using the transcript. The calendar sync works out of the box, and the note quality is consistently strong.
+
+#### What works
+
+- No bot joins your call. No awkward notifications for other participants.
+- Templates for different meeting types (standup, 1:1, client call) produce well-structured output with minimal setup.
+- Calendar integration is fully automatic. Granola detects meetings and is ready before you are.
+- Works on macOS and Windows, which gives it broader reach than Char's macOS/Linux support.
+
+#### What doesn't
+
+- In March 2026, Granola encrypted its local database, [breaking every agent workflow and third-party tool](https://weekinvoiceai.substack.com/p/week-in-voice-ai12-granola-scramble) that had been reading notes directly from the file system.
+- A [security researcher discovered in May 2025](https://josephthacker.com/hacking/2025/05/08/reverse-engineering-granola-notes.html) that Granola's beta had shipped with a hard-coded AssemblyAI API key, potentially exposing user transcripts. Fixed before public release, but it raised questions about security practices.
+- Requires a Google account to sign up, which excludes Microsoft-only organizations.
+- Data training is on by default. You have to find and toggle an opt-out in settings.
+- No mobile app. No full transcript bulk export until recently.
+
+#### Pricing
+
+Business plan at ~$14/month; requires a Google account to sign up.
+
+### 4. Fathom
+
+![Fathom vs tactiq](/api/assets/blog/blog/image-14.png "char-editor-width=80")
+
+[Fathom](fathom.ai) has disrupted the pricing model of this entire category by offering unlimited free transcription for individual users. No credit card, no time limits, no catch. 
+
+It sends a bot into your Zoom, Meet, or Teams call, records everything, and produces AI summaries that are often ready before the meeting ends. 
+
+The interface is clean and uncluttered, and the highlight clip feature lets you share short video moments with teammates who missed the call.
+
+#### What works
+
+- Unlimited free transcription for individuals is unmatched in this category.
+- Summary speed is the fastest I tested. Usable notes appeared consistently before Otter or Fireflies finished processing.
+- CRM integration pushes notes directly to HubSpot or Salesforce after each call.
+- Highlight clips let you mark key moments during a call and share short video excerpts.
+
+#### What doesn't
+
+- The free tier is individual only. Team features start at $32/user/month (Standard) or $39/user/month (Pro), which is significantly more than Fireflies or Otter at scale.
+- Bot is visible to all meeting participants. For external or client-facing calls, this matters.
+- No offline mode, no local storage. Everything lives in Fathom's cloud.
+- Limited value outside of meeting transcription. No conversation analytics, no sentiment tracking.
+
+#### Pricing
+
+Free (unlimited individual); Team Standard $32/user/month, Team Pro $39/user/month.
+
+### 5. Fireflies.ai
+
+![Fireflies vs tactiq](/api/assets/blog/blog/image-15.png "char-editor-width=80")
+
+[Fireflies](fireflies.ai) is built for revenue teams. Where other tools stop at transcription, Fireflies layers on conversation analytics: talk-to-listen ratios, sentiment analysis, topic tracking, and custom vocabulary for industry-specific terminology. 
+
+The CRM integrations are the deepest I have tested. After connecting HubSpot, every client call automatically logged notes, action items, and summaries to the correct contact record without any manual work.
+
+#### What works
+
+- Native auto-sync with Salesforce, HubSpot, Pipedrive, and Zoho.
+- Conversation analytics (sentiment, talk ratio, topic detection) are genuinely useful for sales coaching and pipeline reviews.
+- Most generous free tier among bot-based tools: 800 minutes per month of storage.
+- Works across Zoom, Meet, Teams, and Webex. Broader platform coverage than most competitors.
+
+#### What doesn't
+
+- Facing two class-action lawsuits under Illinois' BIPA. The first, [Cruz v. Fireflies.AI Corp.](https://www.jdsupra.com/legalnews/lawsuit-alleges-fireflies-ai-corp-8472044), filed December 2025, alleges the bot collected voiceprints from a participant who never created an account. The second, [Fricker v. Fireflies.AI Corp.](https://topclassactions.com/lawsuit-settlements/lawsuit-news/fireflies-ai-sued-over-alleged-unlawful-data-collection-from-meeting-participants/), followed in March 2026 with the same pattern. Both claim the speaker recognition feature creates biometric identifiers without the written consent BIPA requires.
+- Bot ("Fireflies.ai Notetaker") joins every meeting as a visible participant.
+- Dashboard can feel overwhelming. The feature density that makes it great for sales teams makes it noisy for everyone else.
+- Advanced analytics locked behind the Business tier at $19/user/month.
+
+#### Pricing
+
+Free (800 min/mo storage); Pro $10/user/month; Business $19/user/month.
+
+### 6. tl;dv
+
+![tl;dv vs tactiq](/api/assets/blog/blog/image-16.png "char-editor-width=80")
+
+[tl;dv](tldv.io) takes a different angle than the other tools on this list. The core idea is that most people do not need a full transcript or even a summary. They need the one moment that matters, packaged in a way they can send to someone who was not on the call. 
+
+tl;dv records your meeting, transcribes it, and lets you create timestamped video clips shareable via Slack, Notion, or a direct link. It is built for async-first teams more than for documentation.
+
+#### What works
+
+- Unlimited free recordings and transcriptions with no time cap. One of the most generous free tiers available.
+- Timestamped video clips are the fastest way to share a specific meeting moment with someone who was not there.
+- AI-powered search finds specific moments across all recordings, not just keywords in transcripts.
+- Integrates with Slack, Notion, HubSpot, and project management tools for clip distribution.
+
+#### What doesn't
+
+- Bot joins your call visibly, same friction as Otter and Fireflies.
+- AI summaries are limited on the free plan. You get the recordings but not the intelligence without paying.
+- Pro plan at $29/user/month is steep for small teams, especially when the core value (clips) is available for free.
+- 30+ languages supported, which is solid but behind Notta's 58. No offline mode, no local storage.
+
+#### Pricing
+
+Free (unlimited recordings and transcriptions); Pro $29/user/month.
+
+### 7. Notta
+
+![Notta vs tactiq](/api/assets/blog/blog/image-18.png "char-editor-width=80")
+
+[Notta's](notta.ai) strongest card is language coverage. It supports 58 languages for transcription and real-time translation for over 50, which is more than any other tool on this list. Tactiq claims 60+ languages for captions, but accuracy drops noticeably with accents and non-native speakers in practice. 
+
+#### What works
+
+- 58 languages for transcription with real-time translation for 50+. Best-in-class for international and multilingual teams.
+- Actually records audio and video, so you can replay meetings, verify exact wording, and export files. Essential for compliance-sensitive industries.
+- Exports to DOCX, PDF, SRT, and other formats. Good data portability compared to tools that lock notes in proprietary views.
+- Works on desktop, mobile, and browser. The broadest device coverage on this list.
+
+#### What doesn't
+
+- Bot joins calls visibly, same as Otter and Fireflies.
+- Free plan is limited: 120 transcription minutes per month, 10 AI summaries per month.
+- AI summary quality is decent but not as sharp as Fathom's or Granola's in my testing.
+
+#### Pricing
+
+Free (limited); Pro $13.49/user/month; Business $27.99/user/month.
+
+## Which Tactiq Alternative Is Right for You?
+
+**Char** is the pick if data ownership is non-negotiable: plain markdown files, your choice of AI, fully offline capable. 
+
+**Otter.ai** has the most mature search and knowledge base, but the ongoing consent lawsuit and visible bot make it a harder sell for client-facing work. 
+
+**Granola** produces excellent notes without a bot, though the recent database encryption incident should give pause to anyone who builds agent workflows around direct file access. 
+
+**Fathom** is unbeatable for individuals on a budget: unlimited, free, fast. The team pricing is where it gets expensive. 
+
+**Fireflies.ai** earns its place for sales teams through CRM depth and analytics, but the BIPA lawsuits are a real consideration for organizations with Illinois-based participants. 
+
+**tl;dv** works best when you need to share moments, not documents, with teammates who were not on the call. And 
+
+**Notta** is the strongest option for multilingual teams that need transcription and translation accuracy across dozens of languages.
+
+If you want prefer the local-first approach, [download Char](https://char.com/download/apple-silicon) and try it on your next meeting.

--- a/apps/web/content/articles/tldv-alternatives.mdx
+++ b/apps/web/content/articles/tldv-alternatives.mdx
@@ -1,0 +1,296 @@
+---
+meta_title: "7 Best tl;dv Alternatives in 2026"
+meta_description: "Looking for tl;dv alternatives? Compare 7 AI meeting assistants with better pricing, no bots, and free plans that don't run out after 10 uses."
+author: "Harshika"
+category: "Comparisons"
+date: "2026-02-27"
+---
+
+tl;dv does a lot well but at $29/month, you're paying for sales coaching and multi-meeting intelligence you may never use. Add a visible bot in every call and no HIPAA compliance, and the cracks start to show for a lot of teams. (We covered this in detail in our [tl;dv review](/blog/tldv-review).)
+
+So, if you're in the market for a tl;dv alternative, I have compiled the best options in this article.
+
+## Top tl;dv Competitors for Specific Use Cases
+
+| Tool         | Best for                                      | Pricing                                   | Bot-free? |
+| ------------ | --------------------------------------------- | ----------------------------------------- | --------- |
+| Char         | Data ownership, privacy, offline use          | Free (local + BYOK). Cloud: $25/mo        | Yes       |
+| Fathom       | Free unlimited recording, small teams         | Free. Premium: $19/mo                     | No        |
+| Grain        | Video clips and customer highlights           | Free (5 recordings). Starter: $15/mo      | No        |
+| Fireflies    | Conversation analytics at a lower price       | Free (limited). Pro: $18/mo               | No        |
+| Tactiq       | Bot-free recording via Chrome                 | Free (10 meetings/mo). Pro: $12/mo        | Yes       |
+| MeetGeek     | Smart meeting categorization and workflows    | Free (3 hours/mo). Pro: $19/mo            | No        |
+| Supernormal  | AI agents for agencies                        | Free. Pro: $10/mo                         | Yes       |
+
+## 7 Best tl;dv Alternatives: Detailed Reviews
+
+### 1. Char
+
+[Char](/) is an open-source AI notepad for meetings that stores everything as plain markdown files on your device. No proprietary database, no cloud dependency.
+
+It looks like Apple Notes with AI superpowers, capturing audio from any meeting platform without joining as a bot.
+
+#### How it compares to tl;dv
+
+tl;dv sends your audio to their servers, then to Anthropic for processing. You get video clips and sales coaching in return.
+
+Char skips the video entirely and gives you text-based meeting intelligence with complete data ownership.
+
+tl;dv Pro is $29/month. Char is free for local transcription and BYOK, or $25/month for managed cloud. If you left tl;dv over pricing or privacy, the gap here is still meaningful.
+
+#### Top Features
+
+- Plain markdown files stored locally that work with any tool (Obsidian, Notion, VS Code)
+- Your choice of AI stack: managed cloud, bring your own keys, or run local models
+- Open source with full transparency into the codebase
+- Customizable templates for different meeting types (therapy, legal, interviews)
+- AI Chat with source quotes from the exact transcript line
+- Calendar integration with notification system
+- Conversational search across all meeting history
+- Works offline and with in-person meetings
+
+#### Pros
+
+- Zero vendor lock-in. You can switch AI providers anytime, export your files anywhere
+- No meeting bots to disrupt conversations
+- Free forever for local transcription, BYOK, and all core features
+- Works with any meeting platform or in-person discussions
+
+#### Cons
+
+- Currently macOS only (Windows and Linux coming in Q2 2026)
+- No video recording by design for maximum privacy
+- No direct CRM sync
+
+#### Pricing
+
+Free forever for local transcription, BYOK, and all core features. Managed cloud is $25/month.
+
+<CtaCard title="Try Char for free" description="Open-source meeting notes. Your data stays on your device." buttonText="Download Char" buttonUrl="/download" />
+
+### 2. Fathom
+
+[Fathom](https://fathom.video/) is built for sales and customer-facing teams who need meeting notes to automatically flow into their CRM without any manual input.
+
+#### How it compares to tl;dv
+
+The overlap with tl;dv is real: both record video, both let you clip and share moments, both generate AI summaries. Where they diverge is depth. tl;dv built toward multi-meeting intelligence, coaching playbooks, and trend tracking across calls. Fathom went deeper on CRM automation and sales workflow.
+
+If you used tl;dv mainly for clipping moments and sharing them with your team, Fathom is a fair switch. If you relied on the cross-meeting analytics or sales coaching features, Fathom doesn't cover that.
+
+#### Top Features
+
+- Unlimited free recording and transcription with no lifetime limits
+- "Ask Fathom" AI assistant for querying past meetings
+- CRM sync with Salesforce and HubSpot
+- Video highlights for sharing moments from calls
+- Instant post-meeting processing
+
+#### Pros
+
+- Free plan that resets monthly instead of running out
+- CRM integrations work smoothly and save manual data entry
+- Handles multiple speakers and accents reasonably well
+- Fast setup with calendar integration
+
+#### Cons
+
+- Bot joins meetings visibly, same as tl;dv
+- Team features require paid plans
+- Works best on Zoom; other platforms feel secondary
+- Trains AI on your meetings unless you opt out manually
+- No offline capability
+
+#### Pricing
+
+Free unlimited recording. Premium at $20/month to unlock advanced summaries and AI search. CRM sync available on $29 Business plan.
+
+Also check: [Fathom AI alternatives](/blog/fathom-ai-alternatives)
+
+### 3. Grain
+
+If you're leaving tl;dv but actually used the video clip features, [Grain](https://grain.com/) does that part better and cheaper. It's built around the same idea—record meetings, create shareable video highlights—but starts at $15/month instead of $29.
+
+#### How it compares to tl;dv
+
+Grain's clip creation and highlight reels are more polished than tl;dv's. The interface for browsing and sharing moments is cleaner. What you lose is tl;dv's multi-meeting analytics and sales coaching. If you used those, Grain isn't the right move. If you mostly made clips and shared them with your team, it is.
+
+#### Top Features
+
+- Video highlight reels from meeting moments
+- Shareable clips with one click
+- CRM integrations (Salesforce, HubSpot)
+- Team library for organizing recordings
+- Smart chapters for navigation
+- 25 language transcription
+
+#### Pros
+
+- Best-in-class video clip creation and sharing
+- Clean interface for browsing meeting moments
+- Good CRM integrations for sales teams
+- Affordable compared to tl;dv for similar video features
+
+#### Cons
+
+- Bot records meetings, same visibility issue
+- Only 5 free recordings (more limited than tl;dv's free tier)
+- Video-centric design is overkill if you just want text notes
+- No offline or local processing
+
+#### Pricing
+
+Free with 5 recordings. Starter at $19/month. Business at $39/month.
+
+### 4. Fireflies
+
+[Fireflies.ai](https://fireflies.ai/) is a conversation intelligence platform that matches most of what tl;dv does at $18/month instead of $29. Speaker analytics, sentiment analysis, topic tracking, keyword monitoring across calls.
+
+#### How it compares to tl;dv
+
+The conversation intelligence that tl;dv locks behind Pro and Business tiers, Fireflies includes at a lower price point. Where Fireflies falls short: no video clip creation, and the sales coaching playbooks aren't as developed. Where it wins: 69 languages (tl;dv has 30), unlimited free transcription, and a larger integration ecosystem.
+
+#### Top Features
+
+- AskFred AI assistant for querying across meetings
+- Speaker analytics, sentiment analysis, topic tracking
+- 69 languages with auto-detection
+- Unlimited free transcription (tl;dv caps AI summaries at 10)
+- Collections for grouping related meetings
+
+#### Pros
+
+- Broader language support than almost any competitor
+- Strong conversation analytics at a lower price
+- AskFred works well for searching across months of calls
+- Large integration ecosystem
+
+#### Cons
+
+- Bot records meetings visibly
+- Some users report confusing billing and trial cancellation
+- Accuracy drops outside English despite claiming 69 languages
+- AI credits add hidden cost on top of subscription
+
+#### Pricing
+
+Free unlimited transcription with limited storage. Pro at $18/month. Business at $29/month.
+
+Also check: [Fireflies AI alternatives](/blog/fireflies-ai-alternatives)
+
+### 5. Tactiq
+
+[Tactiq](https://tactiq.io/) runs as a Chrome extension. No bot joins your call. No one in the meeting knows you're transcribing unless you tell them. If the bot was your main problem with tl;dv, this solves it directly.
+
+#### How it compares to tl;dv
+
+Unlike tl;dv's bot-based approach, Tactiq works invisibly in your browser and shows the transcript live during the meeting. tl;dv doesn't offer that real-time view. The trade-off: Chrome only, no video recording, and limited to three meeting platforms.
+
+#### Top Features
+
+- Live transcription visible during calls
+- 60 languages with auto-detection
+- Custom AI workflows and reusable prompts
+- Integrations with Slack, HubSpot, Jira, Linear
+- No audio storage (privacy-friendly)
+
+#### Pros
+
+- No meeting bot disruption
+- See transcripts while the meeting is happening
+- Fast setup—works immediately after installing the extension
+- Custom prompts for specific meeting outputs
+
+#### Cons
+
+- Chrome only. No Firefox, Safari, Arc, or desktop app.
+- No video recording or clips
+- Accuracy issues with accents
+- Can't record in-person meetings
+
+#### Pricing
+
+Free with 10 meetings/month and 5 AI credits. Pro at $12/month.
+
+### 6. MeetGeek
+
+[MeetGeek](https://meetgeek.ai/) auto-detects whether you're in a sales call, team standup, or client review, then applies the right template and workflow.
+
+#### How it compares to tl;dv
+
+MeetGeek has analytics, but it's more about meeting health than revenue coaching. If you used tl;dv primarily for its cross-meeting AI reports or sales coaching, MeetGeek isn't a straight swap.
+
+If you used it for solid transcription, summaries, and workflow integrations across a broader team, MeetGeek is a strong and cheaper alternative. MeetGeek also offers HIPAA compliance, which tl;dv doesn't.
+
+#### Top Features
+
+- Automatic meeting type detection with context-aware summaries
+- Conversation analytics and engagement metrics
+- Workflow automation to Slack, Notion, CRM
+- 50 languages
+- HIPAA compliance available
+- Meeting KPI tracking
+
+#### Pros
+
+- Automatic categorization saves setup time
+- HIPAA compliance for healthcare and legal teams
+- Good multilingual support for international teams
+- Strong analytics and coaching insights
+
+#### Cons
+
+- Bot records meetings visibly
+- Free plan is only 3 hours/month (about 3-4 meetings)
+- Auto-categorization isn't always right
+- No offline or local processing
+
+#### Pricing
+
+Free with 3 hours/month. Pro at $19/month. Business at $29/month.
+
+### 7. Supernormal
+
+[Supernormal](https://www.supernormal.com/) is AI for agencies. It pulls context from your meetings, emails, and docs to complete actual client work, such as creating slide decks, project briefs, research reports, follow-up emails, and mood boards.
+
+#### How it compares to tl;dv
+
+Supernormal starts from meeting capture and goes further into actually completing the work that comes out of those meetings.
+
+If you used tl;dv mainly as a notetaker with CRM sync or sales coaching, Supernormal isn't the right swap. But if you left tl;dv wishing it would just do the post-meeting work for you, especially in an agency context where every client call produces deliverables, Supernormal is worth a serious look.
+
+#### Top Features
+
+- Bot-free capture via desktop app
+- AI agents that produce deliverables: decks, briefs, emails, spreadsheets
+- Context memory across meetings, emails, and docs
+- Real-time AI chat during live meetings
+- Group meetings into projects for shared context
+- Integrations with Slack, Gmail, HubSpot, Salesforce, Notion, and more
+
+#### Pros
+
+- Cheapest paid option on this list
+- Pre-meeting context is a unique time-saver
+- Covers daily meeting needs without extra complexity
+- Clean, simple interface
+
+#### Cons
+
+- Limited language support
+- Bot joins meetings by default
+- No multi-meeting analytics or coaching features
+- Transcript accuracy varies
+- Smaller ecosystem than established competitors
+
+#### Pricing
+
+Free plan available. Pro at $10/month.
+
+## Our top recommendation
+
+Char is worth trying if you value both functionality and control.
+
+You get AI-powered features without giving up ownership of your data. You get enterprise-grade functionality without vendor lock-in. You get ease of use without sacrificing flexibility.
+
+You can [try the tool out for free](/download). If it's not for you, you can walk away and your notes stay yours.

--- a/apps/web/content/articles/tldv-review.mdx
+++ b/apps/web/content/articles/tldv-review.mdx
@@ -1,0 +1,221 @@
+---
+meta_title: "tl;dv meeting notes software review 2026"
+display_title: "I Tested tl;dv So You Don't Have To [2026 Review]"
+meta_description: "Is tl;dv worth it? Complete 2026 review with pricing, feature tests, user complaints, and honest pros & cons to help you decide."
+author: "Harshika"
+coverImage: "/api/assets/blog/tldv-review/cover.png"
+category: "Comparisons"
+date: "2025-10-17"
+---
+
+If you're considering tl;dv to handle your meeting notes and summaries automatically, you'll find a detailed breakdown here.
+
+I've tested the platform, analyzed dozens of user reviews, and compared it against [top alternatives](/blog/tldv-alternatives/).
+
+## What is tl;dv and how does it work?
+
+[tl;dv](https://tldv.io) (yes, lowercase, it stands for "too long; didn't view") is a cloud-based AI note-taker designed primarily for virtual meetings on Zoom, Google Meet, and Microsoft Teams. A bot joins your meeting, records everything, transcribes the conversation in real-time, and generates AI summaries once the call ends.
+
+The platform has attracted over 2 million users worldwide, including teams at Fortune 500 companies like Cloudflare, Forbes, and Salesforce. It's particularly popular among sales and customer success teams who need to track conversations, coach reps, and push insights into their CRMs.
+
+tl;dv is entirely cloud-based and bot-dependent. Your data goes to their servers for processing, then to Anthropic (their AI partner) for generating summaries and insights. This architecture shapes both its strengths and limitations.
+
+## tl;dv's top features and my verdict on them
+
+### 1. Real-time transcription
+
+tl;dv delivers live transcription as people speak during meetings. The claimed accuracy is 96% for clear English audio, and you can watch the transcript appear in real-time.
+
+After the meeting, you get a full searchable transcript with timestamps. The transcription supports 30+ languages including Spanish, Portuguese, German, Japanese, and Korean.
+
+**Verdict:** Works well for native English speakers with good audio quality. But struggles significantly with accents—[particularly Indian English and mixed vernacular conversations](https://www.g2.com/products/tl-dv/reviews/tl-dv-review-11077932)—and completely falls apart with technical jargon.
+
+The biggest problem is the lack of custom vocabulary options. Teams in biotech, fintech, or specialized fields spend considerable time manually correcting transcripts after every meeting.
+
+<Image src="/api/assets/blog/tldv-review/tldv-1.webp" alt="tl;dv real-time transcription interface" />
+Source: [G2](https://www.g2.com/products/tl-dv/reviews/tl-dv-review-11538783)
+
+### 2. Automatic speaker recognition
+
+The platform automatically identifies who's speaking and labels them in the transcript. You can rename speakers afterward to keep things organized.
+
+**Verdict:** Works great for one-on-one calls or structured meetings where people take turns. Falls apart when multiple people talk quickly, interrupt, or overlap. Manual cleanup is necessary for fast-paced team discussions.
+
+### 3. AI summaries with custom templates
+
+After each meeting, tl;dv generates an AI summary that includes key discussion points, action items, decisions made, and next steps.
+
+You can customize these summaries using templates. Built-in frameworks include MEDDIC and BANT for sales teams, or you can create your own format using custom prompts.
+
+**Verdict:** Saves time for getting the gist quickly, but misses nuances and context regularly. Users report having to prompt the AI multiple times to capture all action items correctly. Consider it a smart first draft that needs review rather than a finished product you can trust blindly.
+
+<Image src="/api/assets/blog/tldv-review/tldv-2.webp" alt="tl;dv AI-generated meeting summary example" />
+Source: [G2](https://www.g2.com/products/tl-dv/reviews/tl-dv-review-11529251)
+
+### 4. Clip creation and video highlights
+
+You can highlight any part of the transcript and instantly generate a short video clip of that exact moment. You can combine multiple clips into "Reels" to share highlights with stakeholders without forcing them to watch full recordings.
+
+**Verdict:** This is one of tl;dv's standout features. Being able to grab exact customer feedback or important decisions and share them instantly proves useful in practice. Users consistently praise this capability, and it works well with no complaints.
+
+### 5. Multi-meeting conversational intelligence
+
+You can ask questions across multiple meetings, track topics automatically with keyword alerts, analyze sentiment, get automated weekly reports of trends, and evaluate sales performance with coaching scorecards.
+
+**Verdict:** Powerful for sales managers, CS leaders, and product people who need insights from many customer conversations. Much less valuable if you only need occasional meeting notes.
+
+However, users note the analytics lack depth. You get qualitative insights but limited quantitative metrics. Tools like Avoma offer more detailed statistical analysis if you need it.
+
+<Image src="/api/assets/blog/tldv-review/tldv-3.webp" alt="tl;dv multi-meeting conversational intelligence dashboard" />
+Source: [G2](https://www.g2.com/products/tl-dv/reviews/tl-dv-review-11621640)
+
+### 6. Sales coaching and playbooks
+
+For sales teams, tl;dv offers coaching features that evaluate how well reps follow your methodology. You can compare actual responses against ideal rebuttals, track which reps need coaching, and identify performance patterns. The platform includes frameworks like BANT and MEDDIC built-in.
+
+**Verdict:** Well-designed for sales teams that want to scale coaching across reps. This differentiates tl;dv if you're managing a sales org. Less relevant for other use cases.
+
+### 7. Integrations
+
+tl;dv integrates with major CRMs like Salesforce and HubSpot. You can map your AI summary template to CRM fields, and the system will automatically update records after calls. The platform claims integration with 6,000+ tools via Zapier.
+
+**Verdict:** The 6,000+ number is misleading—most require Zapier, adding another tool to your stack. Even the native integrations have problems. Multiple users reported broken or limited HubSpot and Slack integrations, with some giving harsh reviews entirely due to integration failures and poor support.
+
+<Image src="/api/assets/blog/tldv-review/tldv-4.webp" alt="tl;dv CRM and tool integrations" />
+Source: [G2](https://www.g2.com/products/tl-dv/reviews/tl-dv-review-11405083)
+
+### 8. Collaboration features
+
+You can comment on specific meeting moments, tag teammates, share clips and highlights, and auto-share summaries to team channels. The platform also lets you take manual notes with timestamps during or after calls.
+
+**Verdict:** Async collaboration works well. You can't collaborate in real-time during a meeting, but post-meeting sharing and commenting function properly. Useful for distributed teams that need to circulate insights after calls.
+
+### 9. Search and discovery
+
+Keyword search across all your transcripts makes it easy to find past discussions. You can search by speaker, topic, or specific phrases, then jump directly to relevant moments. Filtering by domain, date, and meeting status narrows results.
+
+**Verdict:** The search functionality is hit or miss. While it works for straightforward keyword matches, it sometimes returns meetings that don't actually contain the searched keywords.
+
+### 10. Download and export
+
+On the Pro plan, you get unlimited downloads of meetings as .mp4 video files. You can download full recordings or just clips, then upload them to other platforms or save them to internal storage.
+
+**Verdict:** Works as advertised. Being able to grab recordings offline or move them to your own storage is useful. The catch is it requires the Pro plan. Free users face a 3+ day wait to access older videos.
+
+## Where tl;dv falls short
+
+Despite an impressive feature set, tl;dv has some notable gaps:
+
+### 1. No custom vocabulary
+
+You cannot add custom terms, product names, or industry jargon to improve transcription accuracy. For teams in biotech, fintech, legal, or healthcare, this means constant manual corrections of technical terms that the AI misunderstands.
+
+### 2. No offline capability
+
+tl;dv is entirely cloud-dependent. No internet means no recording, no transcription, no access to past meetings. If you travel frequently or work in areas with spotty connectivity, this becomes a real problem.
+
+### 3. Virtual meetings only
+
+The platform only works with Zoom, Google Meet, and Microsoft Teams. In-person meetings, phone calls, and conversations on other platforms like Discord or Slack cannot be captured.
+
+### 4. No seamless manual note-taking experience
+
+While you can add timestamped notes, there's no true notepad experience where you can actively type alongside live transcription in a unified interface. It functions more as an annotation tool than an integrated note-taking workspace.
+
+## tl;dv pros and cons
+
+**Pros**
+
+- Excellent clip creation feature for sharing specific moments
+- Multi-meeting insights valuable for sales and CS teams
+- Good sales coaching features with playbook tracking
+- Strong CRM integration for automating post-call admin work
+- Custom summary templates let you control output format
+- Competitive pricing compared to expensive tools like Gong
+
+**Cons**
+
+- Bot-based approach creates friction with privacy-conscious clients
+- Free plan limitations - 3+ day wait to access older videos
+- UI has a learning curve
+- Customer support problems - users report slow, unhelpful responses
+- AI summaries miss nuances and require manual review
+- No custom vocabulary for technical or specialized terms
+- Speaker identification fails with overlapping or fast-paced conversation
+- Integration quality issues - HubSpot and Slack specifically called out
+- Cloud dependency - no offline capability
+- Platform limited to Zoom, Meet, and Teams
+
+<CtaCard/>
+
+## How much does tl;dv cost?
+
+tl;dv operates on a freemium model with four tiers: Free Forever ($0), Pro ($29/seat/month), Business ($98/seat/month), and custom Enterprise pricing.
+
+<Image src="/api/assets/blog/tldv-review/tldv-5.webp" alt="tl;dv pricing breakdown" />
+
+The free plan offers unlimited meetings, basic AI summaries, and transcription without a credit card. You're capped at 20 AI multi-meeting reports, which heavily restricts conversational intelligence features. You'll outgrow this quickly for anything beyond basic transcription.
+
+Pro at $29/month is expensive compared to the competition. Fireflies offers similar multi-meeting insights at $18/month. Otter charges $16.99/month. MeetGeek and Avoma both start at $19/month with comparable analytics. Read AI comes in at $19.75/month and offers unified search across meetings and emails.
+
+If you're just looking for meeting highlights and basic video clips, you're overpaying.
+
+The value proposition only makes sense if you specifically need tl;dv's sales coaching features, locked behind the Business plan at $98/month. That's a $69/month jump from Pro.
+
+Enterprise offers custom pricing for organizations needing privately hosted AI, advanced security, and dedicated support.
+
+## Final verdict: is tl;dv worth it?
+
+tl;dv is a capable meeting assistant with genuinely useful features, particularly for sales and customer success teams. The clip creation works well, multi-meeting intelligence delivers value when analyzing dozens of conversations, and the sales coaching tools are sophisticated.
+
+But tl;dv is priced at a premium without offering premium features until you hit the expensive Business tier.
+
+**Choose tl;dv if you:**
+
+- Run a sales or CS team that specifically needs coaching scorecards and playbook monitoring
+- Use Zoom, Google Meet, or Teams exclusively
+- Are comfortable with cloud tools, bot-based recording, and data leaving your device
+- Speak standard English without heavy accents and don't work in technical fields requiring custom vocabulary
+- Don't need offline capability or in-person meeting capture
+
+**Look elsewhere if you:**
+
+- Work in healthcare, legal, finance, or other privacy-sensitive fields where bot visibility and cloud processing create compliance issues. Char might be worth exploring.
+- Need to capture in-person meetings, use diverse platforms beyond the big three, or require offline functionality.
+- Want better value. At $29/month for Pro, you're paying 50-70% more than competitors like Char ($8), Fireflies ($18), Otter ($16.99), or MeetGeek ($19) for similar conversation intelligence.
+- Work in technical fields needing custom vocabulary or have multilingual teams with strong accents.
+- Just need basic transcription and highlights. Fathom offers this completely free.
+
+## How Char compares with tl;dv
+
+Char doesn't record meeting video, so it's not a one-to-one tl;dv alternative. But if you're looking for an AI meeting assistant that captures meeting audio to deliver real-time transcription and instant AI summaries, it's worth considering.
+
+**Core advantages over tl;dv:**
+
+- **Local-first privacy.** Everything processes on your device using on-device AI models. Your conversations never touch the cloud unless you explicitly connect an external LLM provider of your choice.
+- **Bot-free recording.** Captures system audio and microphone directly. No visible bot in your meetings, no client discomfort, no disruption.
+- **Universal platform support.** Works with any meeting software—Zoom, Meet, Teams, Discord, Slack—and captures in-person conversations.
+- **Offline capability.** Record, transcribe, and summarize meetings anywhere without internet. Perfect for travel, secure environments, or unreliable connectivity.
+- **No vendor lock-in.** Choose your own AI providers—OpenAI, Anthropic, Gemini, Ollama, or custom endpoints.
+- **Open source.** Inspect the code, audit security, and customize for your organization's needs.
+- **Better pricing.** Free forever for local transcription, BYOK, and all core features. Managed cloud is $25/month versus tl;dv's $29/month.
+
+<Image src="/api/assets/blog/tldv-review/tldv-6.webp" alt="Char vs tl;dv comparison" />
+
+**Char's note-taking and summary features:**
+
+- **Familiar notepad interface.** Feels like Apple Notes with powerful AI running locally in the background. A true notepad experience rather than an annotation tool.
+- **Custom templates for any meeting type.** Tailored formats for therapy sessions, legal consultations, sales calls, team standups, or casual conversations.
+- **Real-time transcription.** Live captions appear as people speak, without sending data to the cloud.
+- **AI chat for instant answers.** Ask "What did Sarah say about the budget?" or "List all action items from this week" and get immediate responses.
+- **Control over AI involvement.** Choose how much AI restructures your notes—from minimal touch-ups to complete reformatting.
+- **Source verification.** Hover over any AI-generated summary point to see the exact transcript quote.
+- **Multiple export formats.** Markdown, PDF, or Rich Text to fit your workflow.
+
+**Bottom line:** If you're a sales team needing video recording and coaching features, tl;dv makes more sense.
+
+If privacy matters, you need bot-free recording, or you want offline capability, Char delivers better value at a fraction of the cost while keeping your data completely under your control.
+
+Download Char for macOS or explore our full comparison of AI meeting summary tools to see how other alternatives stack up.
+
+<CtaCard/>

--- a/apps/web/content/articles/transcription-software-mac.mdx
+++ b/apps/web/content/articles/transcription-software-mac.mdx
@@ -1,0 +1,270 @@
+---
+meta_title: "Best Transcription Software for Mac in 2026: Complete Guide"
+display_title: "Best Transcription Software for Mac in 2026"
+meta_description: "Find the best transcription software for Mac in 2026. Compare open-source tools like Char and MacWhisper with cloud options like Otter, Notta, and Descript."
+author: "John Jeong"
+category: "Comparisons"
+date: "2025-10-07"
+---
+
+Finding transcription software that works well on Mac isn't as simple as it should be. Many popular tools are Windows-first ports, web apps that drain your battery, or subscription services that send your audio to the cloud.
+
+This guide covers transcription software built for macOS, whether you need real-time meeting transcription, batch file processing, or podcast editing with built-in transcription.
+
+## Best transcription software for Mac: quick comparison
+
+| Tool       | Best For                   | Processing | Real-Time | Starting Price   | Offline |
+| ---------- | -------------------------- | ---------- | --------- | ---------------- | ------- |
+| Char   | Privacy & meetings         | Local      | Yes       | Free             | Yes     |
+| MacWhisper | Simple file transcription  | Local      | No        | Free             | Yes     |
+| Descript   | Podcast/video editing      | Cloud      | No        | Free (1hr/mo)    | No      |
+| Otter.ai   | Meeting automation         | Cloud      | Yes       | Free (300min/mo) | No      |
+| Notta      | Multi-language             | Cloud      | Yes       | Free (120min/mo) | No      |
+| Rev        | Human accuracy option      | Cloud      | Yes       | $0.25/min AI     | No      |
+| Sonix      | Multi-language + subtitles | Cloud      | No        | $10/hr           | No      |
+
+## How we evaluated these tools
+
+We tested each tool on M1, M2, and Intel Macs to assess:
+
+- **Native Mac experience**: Does it feel like a Mac app or a web wrapper?
+- **Apple Silicon optimization**: Does it leverage M-series chips for faster processing?
+- **Privacy and data handling**: Where does your audio go?
+- **Transcription accuracy**: How well does it handle accents, technical terms, and multiple speakers?
+- **Real-world usability**: [Free tier](/blog/free-transcription-software/) limitations, export options, and workflow integration
+
+## Best transcription software for Mac: detailed reviews
+
+### 1. Char: best for privacy and unlimited local transcription
+
+[Char](/) is an open-source AI notepad for meetings built for Mac. Everything is stored as plain markdown files on your device. You choose your AI stack: managed cloud, BYOK, or run local models. Zero lock-in.
+
+It works as both a real-time meeting assistant and a file transcription tool. Connect it to any meeting platform (Zoom, Teams, Meet, or in-person conversations), and it transcribes while you focus on the conversation.
+
+#### What makes it stand out on Mac
+
+- **Apple Silicon optimized**: Runs Whisper models efficiently on M1/M2/M3 chips
+- **Native macOS app**: Feels like a proper Mac application, not a web wrapper
+- **Works offline**: Transcribe anywhere without internet dependency
+- **Open source**: Full transparency about how your data is handled
+
+#### What's free
+
+- Unlimited transcription with no monthly caps
+- Real-time transcription during meetings
+- AI-powered meeting summaries
+- Export as Markdown, PDF, or Rich Text
+- Custom vocabulary support
+
+#### Managed Cloud ($25/month)
+
+- Unlimited AI chat with your transcripts
+- Custom template building
+- Advanced search capabilities
+
+**Best for**: Professionals handling sensitive conversations who need unlimited, private transcription.
+
+<CtaCard/>
+
+### 2. MacWhisper: best for simple file transcription
+
+[MacWhisper](https://goodsnooze.gumroad.com/l/macwhisper) wraps OpenAI's Whisper technology in a simple drag-and-drop interface built specifically for Mac. If you just need to transcribe audio files without the complexity of a full meeting assistant, MacWhisper delivers.
+
+The app processes everything locally on your Mac. Drop in an audio file, select a model size based on accuracy versus speed needs, and get your transcript with synced audio playback.
+
+#### Performance on Mac
+
+Performance depends on your hardware. Apple Silicon Macs handle transcription smoothly, processing files at roughly 15x real-time speed. A 27-minute video with three speakers transcribes in about 2 minutes on an M2 Max.
+
+Intel Macs work but run significantly slower, especially with larger models that require more than 8GB RAM.
+
+#### MacWhisper 12 update (2025)
+
+The latest version adds automatic speaker recognition, making it the first Mac app to offer this feature locally on-device. When you transcribe conversations, MacWhisper automatically detects different speakers and groups their speech.
+
+#### What's free
+
+- Unlimited transcriptions
+- Tiny, Base, and Small Whisper models
+- Zero lock-in, plain markdown files
+- 100+ language support
+- Export as SRT, VTT, or TXT
+
+#### When you'll need Pro ($29-79 one-time)
+
+- Medium, Large, and Large-V3 models for better accuracy
+- Batch processing for multiple files
+- Speaker identification
+- System audio capture for Zoom/Teams meetings
+- Word, PDF, and HTML exports
+
+**Best for**: Users who need straightforward file transcription without subscriptions.
+
+### 3. Descript: best for podcast and video editing
+
+[Descript](https://www.descript.com) isn't just transcription software. It's an audio/video editor that uses transcription as its core editing interface. Edit your podcast or video by editing the text transcript.
+
+Delete a sentence from the transcript, and it removes that audio from your recording. This text-based approach eliminates timeline scrubbing.
+
+#### Mac-specific considerations
+
+Descript runs as a native Mac app with decent Apple Silicon support, though it's more resource-intensive than simpler transcription tools. Expect it to use significant CPU and RAM during editing sessions.
+
+#### What's free
+
+- 1 hour of transcription per month
+- Basic editing features
+- Screen recording
+- 720p video export (watermarked)
+- 5GB cloud storage
+
+#### Paid plans
+
+- **Hobbyist** ($12/month): 10 hours transcription, 1080p export
+- **Creator** ($24/month): 30 hours transcription, 4K export, filler word removal
+- **Business** ($40/month): Everything in Creator plus team features
+
+**Best for**: Podcasters and video creators who want to edit by editing text.
+
+### 4. Otter.ai: best for automated meeting transcription
+
+[Otter.ai](https://otter.ai) is one of the most popular meeting transcription tools. Its bot (OtterPilot) automatically joins your Zoom, Teams, and Google Meet calls based on your calendar, records everything, and shares notes afterward.
+
+The trade-off is clear: you gain convenience by sending all conversations to Otter's cloud servers for processing.
+
+#### Mac experience
+
+Otter works primarily through their web app and browser extensions. The Mac app is essentially a web wrapper. Don't expect native macOS feel or Apple Silicon optimization.
+
+#### What's free
+
+- 300 minutes per month
+- 30-minute max per conversation
+- Live transcription in English, Spanish, French
+- Automatic meeting bot
+- 25 most recent conversations stored
+
+#### When you'll need to pay
+
+- **Pro** ($16.99/month): 1,200 minutes, 90-minute conversations
+- **Business** ($30/month): 6,000 minutes, 4-hour meetings, CRM integrations
+
+**Best for**: Teams who want automated meeting capture and don't mind cloud processing.
+
+**Also read**: [Otter AI Review](/blog/otter-ai-review) | [Is Otter AI Safe?](/blog/is-otter-ai-safe)
+
+### 5. Notta: best for multi-language transcription
+
+[Notta](https://www.notta.ai) supports 58 languages for transcription and 42 for translation, making it the strongest choice for multilingual teams. Like Otter, it uses a meeting bot to automatically join and transcribe calls.
+
+#### Mac experience
+
+Notta offers a Mac app alongside their web interface. The app is functional but not particularly Mac-native in feel. Processing happens in the cloud.
+
+#### What's free
+
+- 120 minutes per month
+- 3-minute max per recording (severely limiting)
+- 50 file uploads per month
+- Live transcription for Zoom, Teams, Meet, Webex
+
+#### When you'll need to pay
+
+- **Pro** ($13.49/month): 1,800 minutes, 5-hour recordings, translation features
+- **Business** ($27.99/month): Unlimited transcription, CRM integrations
+
+**Best for**: Teams working across multiple languages who need translation alongside transcription.
+
+### 6. Rev: best for human transcription accuracy
+
+[Rev](https://www.rev.com) offers something unique: the option to have humans transcribe your audio for 99% accuracy. Their AI transcription is also available at lower cost, but the human option sets them apart.
+
+#### Pricing model
+
+Rev uses a different pricing structure than most competitors:
+
+- **AI transcription**: $0.25/minute
+- **Human transcription**: $1.99/minute (99% accuracy, 24-hour turnaround)
+- **Subscription**: $29.99/month for 20 hours of AI transcription
+
+#### Mac experience
+
+Rev is primarily web-based. Upload files through their website, and download transcripts when ready. No native Mac app.
+
+**Best for**: Legal, medical, or other professionals who need guaranteed accuracy and can't risk AI errors.
+
+### 7. Sonix: best for subtitles and translation
+
+[Sonix](https://sonix.ai) focuses on transcription plus automated subtitles and translation. It supports 53+ languages for transcription and can translate into 54+ languages.
+
+The platform is popular with video producers who need subtitles in multiple languages without hiring translators for each version.
+
+#### Mac experience
+
+Sonix is entirely web-based. All editing happens in their browser-based editor, which works fine on Mac but isn't a native experience.
+
+#### Pricing
+
+- 30-minute free trial (one-time, not monthly)
+- $10/hour pay-as-you-go
+- $22/month subscription includes 2 hours
+
+**Best for**: Video producers who need automated subtitles in multiple languages.
+
+## Local vs cloud: what's the real difference?
+
+The biggest decision when choosing Mac transcription software is where your audio gets processed.
+
+### Local processing (Char, MacWhisper)
+
+**Pros:**
+- Complete privacy (audio never leaves your device)
+- Works offline
+- No ongoing subscription required
+- No data used for AI training
+- Simpler compliance for sensitive industries
+
+**Cons:**
+- Requires capable hardware (Apple Silicon recommended)
+- Model downloads can be large (1-6GB)
+- Speaker identification is harder locally
+
+### Cloud processing (Otter, Notta, Descript, Rev, Sonix)
+
+**Pros:**
+- Works on any hardware
+- Often includes collaboration features
+- Speaker identification is generally better
+- Continuous model improvements without updates
+
+**Cons:**
+- Requires internet connection
+- Audio sent to third-party servers
+- Ongoing subscription costs
+- Privacy policies vary (some use data for training)
+
+## Which transcription software should you choose?
+
+**Char** works best if you handle sensitive conversations, want unlimited local transcription, and prefer open-source transparency. The Mac-native experience and Apple Silicon optimization make it feel like it belongs on your Mac.
+
+**MacWhisper** suits you if you need simple file transcription without meeting assistant features. The one-time payment model beats subscription fatigue.
+
+**Descript** is right for editing podcasts or videos through text. The transcription serves the editing workflow.
+
+**Otter** makes sense if you live in scheduled meetings and want automatic capture without thinking about it. Accept that your conversations go to the cloud.
+
+**Notta** fits teams working across multiple languages that need both transcription and translation.
+
+**Rev** works for legal, medical, or other critical transcripts where guaranteed accuracy matters. The human option justifies the premium.
+
+**Sonix** suits video producers who need subtitles in multiple languages.
+
+## Our recommendation
+
+For most Mac users who care about privacy and want a tool that actually feels like a Mac app, **Char** offers the best combination of unlimited local transcription, real-time meeting support, and native macOS experience.
+
+If you just need occasional file transcription without meeting features, **MacWhisper** is solid with its one-time payment.
+
+For teams who prioritize automation over privacy, **Otter** or **Notta** provide the meeting bot experience, though all conversations go to the cloud.
+
+<CtaCard/>

--- a/apps/web/content/articles/what-makes-reliable-ai-note-taker.mdx
+++ b/apps/web/content/articles/what-makes-reliable-ai-note-taker.mdx
@@ -1,0 +1,107 @@
+---
+meta_title: "What Makes a Reliable AI-powered Note Taker?"
+display_title: "The Reliable AI Note-Taker Checklist"
+meta_description: "How to choose an AI notetaker? Use this guide to assess the 5 dependency risks in any AI note-taker before you commit to a platform."
+author:
+  - "John Jeong"
+coverImage: "/api/assets/blog/what-makes-reliable-ai-note-taker/cover.png"
+featured: false
+category: "Comparisons"
+date: "2025-10-25"
+---
+
+When we started building Char, we knew what we were up against. Otter, Fireflies, Granola—the space was already crowded with well-funded players offering impressive features.
+
+We could have tried to out-feature them. More integrations. Shinier interfaces. Flashier AI capabilities. Instead, we made reliability our north star.
+
+IT teams were banning existing tools. Users worried about data privacy. Most options didn't work without internet. The market needed an AI notetaker that worked anywhere, reliably, offline.
+
+We haven't built a perfect platform yet. But we've learned what makes an AI notetaker reliable, and what makes one fail.
+
+If you're evaluating note-taking tools, here's what matters.
+
+## Measuring reliability in AI notetakers
+
+In system design, reliability scales with the number of dependencies your tool needs to function. The fewer external services required, the more reliable it is.
+
+Most AI notetakers today depend on multiple layers. Understanding those dependencies helps you decide which vulnerabilities you can live with and which ones break your workflow.
+
+AI notetakers typically introduce dependencies in five places:
+
+### 1. Network dependency
+
+Most AI notetakers require internet to function. Not just to sync notes, but to process them in real time. Transcription happens in the cloud. AI runs on remote servers. No internet means no tool.
+
+This shows up in basements where WiFi doesn't reach. Client sites with restricted networks. Airports. Rural locations. Government facilities. Hospitals with compliance-driven restrictions.
+
+These aren't edge cases. They're where important conversations actually happen. When your notetaker requires connectivity, it fails when you need it most.
+
+See [best AI notetakers for in-person meetings](/blog/best-ai-notetaker-for-in-person-meetings) or meetings without stable internet.
+
+### 2. Vendor dependency
+
+Cloud-based AI notetakers need specific services running. OpenAI's API. Azure's infrastructure. AWS endpoints. When those vendors go down, every tool built on them stops working.
+
+OpenAI had outages in March 2023 and June 2024. Every dependent tool went offline until the vendor recovered. Your product quality didn't matter. Your users' payments didn't matter.
+
+Vendor dependencies also mean inheriting their business decisions. Pricing changes. Service deprecations. Geographic restrictions. You're subject to their roadmap, not yours.
+
+&nbsp;
+
+### 3. Platform dependency
+
+Many AI notetakers work as bots that join your meetings. They need Zoom, Teams, or Google Meet to grant access to the audio. This creates platform dependency.
+
+Platforms change their rules. Zoom updates bot policies regularly. IT administrators block bots. Enterprise security teams restrict third-party integrations. When this happens, your notetaker stops working.
+
+API deprecation is another failure mode. Platforms update their systems. Older integrations break. You're not in control of the timeline for fixes.
+
+Bots also create user friction. They show up in participant lists. People ask what they are. Some clients won't allow them. Some conversations are too sensitive. The dependency is social, not just technical.
+
+Check out [bot-free AI notetakers](/blog/bot-free-ai-meeting-assistants) that solve this problem.
+
+### 4. Economic dependency
+
+Usage-based pricing scales your costs with your usage. Per-minute charges work until they don't.
+
+SaaS pricing has increased dramatically across the industry. Tools affordable at 10 meetings per month become expensive at 50. Features move from basic tiers to enterprise plans. Free tiers get restricted.
+
+Usage caps create the same problem. You get 100 minutes per month, then you're blocked. Or unlimited meetings but limited AI features. The tool works until you cross a threshold.
+
+Cloud processing costs money. If a vendor's unit economics fail, they raise prices or shut down. You inherit this risk. You build workflows around a tool, then it becomes unaffordable or disappears.
+
+### 5. Compliance dependency
+
+For doctors, lawyers, therapists, and financial advisors, using an AI notetaker isn't just about features. It's about compliance. HIPAA for healthcare. Attorney-client privilege for legal. SOC 2 for enterprise. GDPR for European operations.
+
+Cloud-based tools create compliance dependencies because data leaves your device. It gets processed on someone else's servers. It might cross geographic boundaries. It might live in multi-tenant databases.
+
+Can you prove where the data was processed? Can you guarantee it wasn't used for training? Can you delete it completely? With cloud tools, you're trusting the vendor's compliance, not ensuring your own.
+
+## Choosing an AI notetaker
+
+Start with architecture, not features.
+
+Ask: What does this tool need to function? Does it need internet? Does it depend on external services? Does it require platform permissions? Does it charge based on usage? Does it send data off your device?
+
+Each requirement is an architectural dependency. Each dependency is a trade-off. Decide which trade-offs matter for your use case.
+
+## How we're building Char
+
+We're designing Char around dependency thinking.
+
+The tool works without anything external if you want it to. No internet. No cloud services. No platform permissions. No usage limits. But you can add capabilities as optional layers, such as, cloud AI, integrations, and exports, when they suit your workflow. You decide what the tool depends on, not us.
+
+**Your choice of AI stack.** Char works fully offline out of the box, but you're not locked into local-only. Use the managed cloud service for the easiest setup, bring your own API keys (OpenAI, Anthropic, Mistral, and others), or run local models via Ollama or LM Studio. Switch anytime. No lock-in.
+
+**Deployment flexibility.** Char is open-source, so you're not tied to our infrastructure. Run it on your device, self-host on your own servers, or deploy to your private cloud. The architecture supports all three.
+
+**Direct audio capture.** Char captures system audio and microphone input directly at the OS level. No bots. No platform permissions. No dependency on Zoom or Teams policies. Works for all meeting platforms and in-person conversations.
+
+**Forever free, unlimited.** Local transcription, BYOK, and all core features are free forever. No per-meeting charges. No per-minute charges. No artificial caps.
+
+**Compliance by architecture.** When data stays on your device, you control the compliance surface. HIPAA requirements? Patient data stays on your machine. Attorney-client privilege? Conversations never leave your device. GDPR data residency? You decide where data lives. SOC 2? Self-host and manage your own security.
+
+[Download Char for macOS](/download).
+
+&nbsp;

--- a/apps/web/content/articles/zoom-ai-companion-review.mdx
+++ b/apps/web/content/articles/zoom-ai-companion-review.mdx
@@ -1,0 +1,200 @@
+---
+meta_title: "Zoom AI Companion Review: Is It Worth It in 2026?"
+meta_description: "Zoom AI Companion 2026 review: We tested features, analyzed user feedback, and compared costs. Find out when it works and when you should look for an alternative."
+author:
+  - "Harshika"
+coverImage: "/api/assets/blog/zoom-ai-companion-review/cover.png"
+featured: false
+category: "Comparisons"
+date: "2025-09-19"
+---
+
+The AI meeting assistant market has exploded with promises of effortless note-taking and perfect meeting summaries. Zoom, the platform where millions spend their workday, launched AI Companion to compete directly with specialized tools.
+
+After analyzing hundreds of real user reviews, community discussions, and hands-on testing, the picture is far more complex than Zoom's marketing suggests.
+
+## What Is Zoom AI Companion? The Complete Feature Breakdown
+
+[Zoom AI Companion](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0057623) is a generative AI assistant built directly into the Zoom Workplace platform, not a separate app. The feature set spans across virtually every Zoom product, from meetings to team chat to phone calls.
+
+### What are Zoom AI Companion's Meeting Features?
+
+- **Meeting Summaries** generate post-meeting overviews with key points and action items using your audio transcript, screen-shared content (via OCR), and chat messages. These summaries require cloud processing through third-party AI models from companies like Anthropic and OpenAI.
+- **Smart Recording** breaks cloud recordings into chapters, highlights important sections, and extracts next steps. This only works with cloud recordings, raising immediate privacy concerns for sensitive meetings.
+- **In-Meeting Questions** let you ask the AI what you missed without interrupting the conversation. Users report that the feature often provides inaccurate or irrelevant responses.
+- **Voice Recorder** creates meeting summaries for in-person meetings, but requires manual setup and doesn't offer real-time transcription like specialized tools.
+- **Agentic Capabilities** proactively suggest which meetings to skip, automatically detect and track action items across the platform, and provide meeting preparation assistance.
+- **Cross-Platform Note-Taking** across Google Meet and Microsoft Teams through the Custom AI Companion add-on ($12/user/month). The AI joins meetings on these platforms as a visible bot participant that must be invited to each meeting.
+
+Beyond meetings, AI Companion extends to **Chat Compose** for drafting Team Chat messages, **Email Compose** for Zoom Mail, and **Sentence Completion** across text fields. There's also **Whiteboard Content Generation** for brainstorming and **Virtual Background Generation** for custom meeting backdrops.
+
+Some features, like real-time voice translation and photorealistic AI avatars, are on the product roadmap.
+
+The breadth is impressive, but this wide scope comes at the cost of depth and reliability in core use cases.
+
+## Is Zoom AI Companion Free?
+
+Zoom markets the AI Companion as "included at no additional cost" with paid plans, but this framing obscures the true expense.
+
+- **Base requirements** -- You need a Zoom Pro, Business, or Enterprise account starting at $16.99 per user per month. The free Zoom Basic plan doesn't include any AI features.
+- **Custom AI Companion add-on** -- For meaningful customization, custom agents, or third-party integrations, you'll pay an additional $12 per user per month—bringing your total to nearly $30 per user monthly.
+- **Hidden limitations** -- Many features are disabled by default and require admin activation. Some advanced capabilities aren't available in certain regions or industry verticals due to compliance restrictions.
+
+## How Does Zoom AI Companion Handle Your Data?
+
+According to [Zoom's official documentation](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0057861), here's how Zoom AI Companion processes your sensitive meeting data.
+
+![How Does Zoom AI Companion Handle Data](/api/assets/blog/zoom-ai-companion-review/zoom-alt-1.webp)
+
+### 1. Your Data Leaves Your Device
+
+AI Companion processes audio transcripts, screen-shared content via OCR, chat messages, and user prompts through external AI models. Your confidential conversations are sent to and processed by third-party companies, including Anthropic and OpenAI.
+
+### 2. Multi-Vendor Processing
+
+Zoom uses a "federated approach" to AI, dynamically routing your data to different AI providers based on the task. While this may improve results, your sensitive information touches multiple external systems, each with its own security practices and potential vulnerabilities.
+
+### 3. Compliance Implications
+
+Zoom AI Companion's cloud processing creates serious problems for compliance-sensitive organizations. Major institutions are actively blocking these features or creating separate HIPAA-compliant instances without AI capabilities.
+
+UC Irvine explicitly states that "Zoom AI Companion is not available for any users under the UCI-HIPAA Zoom instance" and warns it "should never be used in any meeting involving discussion of sensitive or protected information." For healthcare providers, legal firms, and financial services companies, this makes AI Companion unusable for their most important meetings.
+
+&nbsp;
+
+## Is Zoom AI Companion Actually Worth Using?
+
+We analyzed hundreds of user reviews across Zoom's community forums, Reddit, G2, and Gartner Peer Insights, plus tested it ourselves across different types of meetings.
+
+### 1. Accuracy Problems
+
+![Zoom ai companion review](/api/assets/blog/zoom-ai-companion-review/zoom-alt-2.webp)
+
+ Source: [Zoom](https://community.zoom.com/t5/Zoom-AI-Companion/Why-is-the-AI-Meeting-Summary-So-Inaccurate/m-p/162719)
+
+Meeting summaries frequently misinterpret context and change the meaning of what was actually discussed. The AI often elevates minor side comments to major discussion points while completely missing critical decisions that determine project outcomes.
+
+In technical discussions or meetings with industry-specific terminology, the system struggles significantly with complex subject matter. Summaries shared with stakeholders who weren't present can contain fundamentally incorrect information about what was decided.
+
+### 2. Reliability Remains Inconsistent
+
+![zoom ai companion feedback](/api/assets/blog/zoom-ai-companion-review/zoom-alt-3.webp)
+
+ Source: [Zoom](https://community.zoom.com/t5/Zoom-AI-Companion/Inconsistent-performance-of-AI-Companion-Features/m-p/233318)
+
+Even when AI Companion functions properly, users cannot depend on consistent performance. Important meetings sometimes generate no summary at all, with no error message or explanation.
+
+Teams must assign multiple people to save transcripts manually because data is regularly lost if meetings close before manual intervention. This unpredictability makes the tool unreliable for business-critical meetings.
+
+### 3. No Offline Functionality
+
+![does zoom ai work offline](/api/assets/blog/zoom-ai-companion-review/zoom-alt-4.webp)
+
+ Source: [G2](https://www.g2.com/products/zoom-ai-companion/reviews/zoom-ai-companion-review-3955518)
+
+Zoom AI Companion requires constant internet connectivity and cloud processing. This creates significant limitations for users in areas with unreliable internet, secure environments that restrict external connections, or traveling professionals who need meeting intelligence regardless of connectivity status.
+
+### 4. No Real-Time Transcription
+
+![zoom ai transcription](/api/assets/blog/zoom-ai-companion-review/zoom-alt-5.webp)
+
+Unlike dedicated meeting assistants, AI Companion lacks live transcription during meetings. Users cannot catch important names, technical terms, or key decisions as they happen. The post-meeting summary approach leaves room for error in fast-moving or complex discussions where context matters most.
+
+Read more about [how to transcribe Zoom calls automatically](/blog/how-to-transcribe-zoom-calls).
+
+### 5. Multi-lingual Performance Issues
+
+![is zoom ai multi lingual](/api/assets/blog/zoom-ai-companion-review/zoom-alt-6.webp)
+
+ Source: [G2](https://www.g2.com/products/zoom-ai-companion/reviews/zoom-ai-companion-review-10924080)
+
+While Zoom supports transcription in multiple languages, AI Companion's summarization quality degrades significantly with non-English content. Teams conducting mixed-language conversations or working in international environments report substantially reduced accuracy and utility.
+
+### 6. Inconsistent Action Item Extraction
+
+![is zoom ai accurate](/api/assets/blog/zoom-ai-companion-review/zoom-alt-7.webp)
+
+ Source: [Zoom](https://community.zoom.com/t5/Zoom-AI-Companion/Why-is-the-AI-Meeting-Summary-So-Inaccurate/m-p/178437/highlight/true#M1207)
+
+Action item identification frequently misses genuine tasks while flagging irrelevant comments as actionable items. The AI sometimes creates entirely fictional action items that could lead to confusion or wasted effort if team members attempt to follow through on non-existent assignments.
+
+### 7. No Custom Vocabulary Training
+
+![zoom ai companion accuracy](/api/assets/blog/zoom-ai-companion-review/zoom-alt-8.webp)
+
+ Source: [G2](https://www.g2.com/products/zoom-ai-companion/reviews/zoom-ai-companion-review-4223031)
+
+AI Companion cannot learn company-specific terminology or industry jargon, leading to consistent transcription errors in technical meetings. Users remain stuck with generic AI that misunderstands their professional context.
+
+### 8. License and Cost Management Complexity
+
+![zoom ai companion pricing](/api/assets/blog/zoom-ai-companion-review/zoom-alt-9.webp)
+
+Managing the AI Companion across teams becomes cumbersome quickly. Since features require paid Zoom accounts, organizations must track which users have access, manage license allocations, and deal with cost escalation as teams grow. Adding the Custom AI Companion for cross-platform functionality potentially doubles the per-user cost to nearly $30/month, making it expensive for larger teams compared to dedicated alternatives that offer flat-rate or free options.
+
+Want to see how other AI notetakers stack up on pricing? Check out our [detailed comparison guide](/blog/best-ai-notetaker-for-zoom).
+
+&nbsp;
+
+## Looking for a Better Zoom AI Companion Alternative? Meet Char
+
+Char is an open-source AI notepad for meetings that gives you complete control over your data and AI stack. Here's why it's a superior alternative for most users seeking reliable AI meeting assistance.
+
+### 1. Complete Data Control
+
+![Char Local AI](/api/assets/blog/zoom-ai-companion-review/zoom-alt-10.webp)
+
+Unlike Zoom's cloud processing, Char stores everything as plain markdown files on your device and lets you choose your AI stack—managed cloud, bring your own keys, or run local models. Zero lock-in means your files work with any tool, and you can switch AI providers anytime.
+
+### 2. Superior Accuracy and Reliability
+
+Char offers flexible AI model options—you can use the custom HyperLLM-V1 model for faster local processing, connect to your preferred cloud providers like OpenAI or Anthropic, or run other local models through Ollama.
+
+![Char custom AI](/api/assets/blog/zoom-ai-companion-review/zoom-alt-11.webp)
+
+With AI Autonomy controls, you can fine-tune exactly how much the AI enhances your notes—from conservative edits that preserve your original structure to full autonomy that completely transforms raw notes into polished summaries.
+
+### 3. Universal Platform Support Without Bots
+
+Char captures audio from any meeting platform—Zoom, Teams, Google Meet, or in-person conversations—without joining as a participant. You're not locked into a single vendor's ecosystem, and there's no disruption to meeting dynamics.
+
+### 4. No Latency Model
+
+![Char pricing](/api/assets/blog/zoom-ai-companion-review/zoom-alt-12.webp)
+
+Char provides live transcription during meetings and can generate instant summaries and action items once the meeting ends. You can also use AI chat to ask natural language questions like "What are my action items?" or "What exactly did Sarah say about the budget?" and get instant answers without scrolling through pages of text.
+
+### 5. Enterprise-Ready
+
+For organizations needing on-premise deployment, private cloud options, or hybrid setups, Char's Enterprise plan provides complete deployment flexibility alongside SSO integration and smart consent management features. You get complete control without vendor lock-in or cloud processing risks.
+
+### 6. Exceptional Value
+
+Unlike Zoom's paid-plan requirement, Char is free forever for local transcription, BYOK, and all core features—including calendar integration, meeting search, and basic AI chat.
+
+The managed cloud service at $25/month adds the easiest setup without managing API keys, plus unlimited chat with your notes, custom templates, and advanced features.
+
+For enterprises, Char provides custom pricing with 24/7 priority support, secure team sharing, SSO/MFA authentication, smart consent management, customizable UI, and custom workflow builders—features that would cost hundreds per user with other enterprise AI platforms.
+
+## Final Recommendation: Should You Use Zoom AI Companion?
+
+### Use Zoom AI Companion if:
+
+- Your meetings involve simple, straightforward conversations
+- You're comfortable with cloud-based data processing
+- Basic post-meeting summaries meet your needs
+- Your team operates entirely within the Zoom ecosystem
+
+### Choose an Alternative Like Char if:
+
+- You need meeting intelligence that works offline or in secure environments
+- You want to avoid bots disrupting client meetings or sensitive conversations
+- You're tired of paying per-user fees that escalate quickly across teams
+- You need custom AI models or want control over which AI processes your data
+- Your meetings involve technical terminology that generic AI consistently misunderstands
+- You require on-premise deployment or hybrid cloud setups for compliance
+- You want real-time transcription instead of waiting for post-meeting summaries
+
+[Download Char for macOS](/download) to experience meeting intelligence that costs nothing and compromises nothing (Windows and Linux versions coming in Q2 2026).
+
+&nbsp;


### PR DESCRIPTION
Restores 57 of 72 blog articles deleted in 4172cbfc0 ("cleanup web", Apr 21). Blog routes still ship but content was nuked → empty blog page.

## What's in

**57 articles kept** — all the ones that reinforce anarlog's manifesto (zero lock-in, files over apps, AI on your terms, open source):

- All competitor alternatives + reviews (Granola, Otter, Fireflies, Fathom, tldv, Plaud, Read, Tactiq, Zoom AI, Meetily) — these are the SEO funnels that map directly onto anarlog's "alternative to X" positioning
- All data-retention exposés (ChatGPT, Gemini, Anthropic, Mistral, Azure OpenAI, OpenRouter) — these *are* the anarlog argument
- All local/oss/self-hosted/markdown/file-based posts
- `filesystem-is-coretex` — the manifesto piece
- `char-is-now-anarlog` — the rebrand announcement
- Meeting practice guides
- BYO-key enablement (`mistral-api-key`)

## What's out

**15 dropped** for conflicting with content/AGENTS.md positioning:

| Article | Why |
|---|---|
| chatgpt-for-meeting-notes | Recommends cloud SaaS AI for notetaking — opposite of anarlog's thesis |
| hyprnote-is-now-char | Superseded by char-is-now-anarlog (double-rebrand is confusing) |
| krisp-alternatives | Krisp is noise cancellation, not a notetaker |
| sales-ai-note-takers | Sales/CRM framing, off-thesis (target is privacy/individual) |
| company-handbook-in-public | Char-as-company meta, not anarlog product story |
| slack-is-the-best-ide, devin-ai-review | Off-narrative founder dev posts |
| choosing-a-cms, dont-use-a-cms, why-our-cms-is-github, publishing-stack, using-ide-for-writing, how-we-build-with-ai, developer-documentation-tools, building-editorial-workflow-github-slack | Meta blog-ops content about how Char publishes |

## Follow-up needed (NOT in this PR)

Every restored article predates the Char → Anarlog rename. They still call the product "Char" inline and frame it as the SaaS notetaker. Needs a brand pass — search/replace + light rewrites — but that's a separate scope.

`pnpm exec dprint fmt` ran clean. `pnpm -F @hypr/web typecheck` shows the same pre-existing content-collections errors as origin/main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to adding/restoring MDX article content and a minor copy tweak, with no runtime code changes beyond what the content pipeline already supports.
> 
> **Overview**
> Restores/adds a large set of blog article MDX files under `apps/web/content/articles`, covering meeting assistant comparisons (e.g., Zoom/Teams/Google Meet, bot-free tools, in-person tools) and multiple AI provider data-retention policy guides.
> 
> Also makes a small copy edit in `char-is-now-anarlog.mdx` (removing an inline link wrapper), with no functional changes to the web app code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79773c40a1de9015d90dcf33f59df62f2f0b6ca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->