### PR TITLE
fix(content): author rendering as J, o, h, n, J, e, o, n, g on mac-productivity-apps

### DIFF
--- a/apps/web/content/articles/mac-productivity-apps.mdx
+++ b/apps/web/content/articles/mac-productivity-apps.mdx
@@ -1,17 +1,7 @@
 ---
 meta_title: "9 Best Mac Productivity Apps for 2026"
 meta_description: "Discover the best Mac productivity apps for 2026. A vetted list of tools for AI meeting notes, file management, and automation."
-author:
-  - "J"
-  - "o"
-  - "h"
-  - "n"
-  - " "
-  - "J"
-  - "e"
-  - "o"
-  - "n"
-  - "g"
+author: "John Jeong"
 featured: true
 category: "Guides"
 date: "2026-02-13"


### PR DESCRIPTION
Frontmatter on `mac-productivity-apps.mdx` had the author field serialized character-by-character as a YAML list of 10 single-char strings:

```yaml
author:
  - "J"
  - "o"
  - "h"
  - "n"
  - " "
  - "J"
  - "e"
  - "o"
  - "n"
  - "g"
```

Zod's `z.array(z.string())` accepted it as valid, and the page renderer joined them with commas — producing 'J, o, h, n,  , J, e, o, n, g' as the visible byline.

Replaced with the scalar `author: "John Jeong"`. Audited the other 56 articles; this was the only one affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Edits a single article’s frontmatter to fix a display-only byline issue; no application logic changes.
> 
> **Overview**
> Fixes `mac-productivity-apps.mdx` frontmatter by replacing the `author` field from a YAML list of single characters to a single scalar string (`"John Jeong"`), preventing the byline from rendering as `J, o, h, n, ...`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ce8d72980a0c4466ee074302694171cedd14c34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->