### PR TITLE
fix(desktop): allow background session processing

### DIFF
--- a/apps/desktop/src/session/components/floating/listen.tsx
+++ b/apps/desktop/src/session/components/floating/listen.tsx
@@ -21,7 +21,9 @@ export function ListenButton({
   tab: Extract<Tab, { type: "sessions" }>;
 }) {
   const { shouldRender } = useListenButtonState(tab.id);
-  const loading = useListener((state) => state.live.loading);
+  const loading = useListener(
+    (state) => state.live.loading && state.live.sessionId === tab.id,
+  );
   const remote = useRemoteMeeting(tab.id);
   const countdown = useEventCountdown(tab.id);
 

--- a/apps/desktop/src/session/components/listen-action.tsx
+++ b/apps/desktop/src/session/components/listen-action.tsx
@@ -14,7 +14,7 @@ export function ListenActionButton({ sessionId }: { sessionId: string }) {
   const { shouldRender, isDisabled, warningMessage } =
     useListenButtonState(sessionId);
   const { loading, stop } = useListener((state) => ({
-    loading: state.live.loading,
+    loading: state.live.loading && state.live.sessionId === sessionId,
     stop: state.stop,
   }));
   const startListening = useStartListening(sessionId);

--- a/apps/desktop/src/session/components/shared.tsx
+++ b/apps/desktop/src/session/components/shared.tsx
@@ -4,9 +4,7 @@ import { Button } from "@hypr/ui/components/ui/button";
 
 import { computeCurrentNoteTab } from "./compute-note-tab";
 
-import { useAITaskTask } from "~/ai/hooks";
 import * as main from "~/store/tinybase/store/main";
-import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 import type { Tab } from "~/store/zustand/tabs/schema";
 import { type EditorView } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
@@ -57,11 +55,7 @@ export function useListenButtonState(sessionId: string) {
   const active = sessionMode === "active" || sessionMode === "finalizing";
   const batching = sessionMode === "running_batch";
 
-  const taskId = createTaskId(sessionId, "enhance");
-  const { status } = useAITaskTask(taskId, "enhance");
-  const generating = status === "generating";
-
-  const shouldRender = !active && !generating;
+  const shouldRender = !active;
   const isDisabled = batching;
 
   let warningMessage = "";

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -110,7 +110,10 @@ export function TabContentNote({
 }: {
   tab: Extract<Tab, { type: "sessions" }>;
 }) {
-  const listenerStatus = useListener((state) => state.live.status);
+  const sessionMode = useListener((state) => state.getSessionMode(tab.id));
+  const canStartLiveSession = useListener((state) =>
+    state.canStartLiveSession(tab.id),
+  );
   const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
   const { conn } = useSTTConnection();
   const startListening = useStartListening(tab.id);
@@ -126,7 +129,7 @@ export function TabContentNote({
       return;
     }
 
-    if (listenerStatus !== "inactive") {
+    if (!canStartLiveSession) {
       return;
     }
 
@@ -141,14 +144,14 @@ export function TabContentNote({
     tab.id,
     tab.state,
     tab.state.autoStart,
-    listenerStatus,
+    canStartLiveSession,
     conn,
     startListening,
     updateSessionTabState,
   ]);
 
   const { data: audioUrl } = useQuery({
-    enabled: listenerStatus === "inactive",
+    enabled: sessionMode !== "active" && sessionMode !== "finalizing",
     queryKey: ["audio", tab.id, "url"],
     queryFn: () => fsSyncCommands.audioPath(tab.id),
     select: (result) => {

--- a/apps/desktop/src/shared/useNewNote.ts
+++ b/apps/desktop/src/shared/useNewNote.ts
@@ -68,7 +68,7 @@ export function useNewNoteAndListen({
   }));
 
   const handler = useCallback(() => {
-    if ((status === "active" || status === "finalizing") && liveSessionId) {
+    if (status === "active" && liveSessionId) {
       const ff = behavior === "new" ? openNew : openCurrent;
       ff({ type: "sessions", id: liveSessionId });
       return;

--- a/apps/desktop/src/store/zustand/listener/general-live.ts
+++ b/apps/desktop/src/store/zustand/listener/general-live.ts
@@ -135,7 +135,9 @@ const createSessionEventHandlers = <T extends LiveStore>(
 
     const currentLive = get().live;
     const stoppedSeconds =
-      currentLive.sessionId === targetSessionId ? currentLive.seconds : 0;
+      currentLive.sessionId === targetSessionId
+        ? currentLive.seconds
+        : (currentLive.finalizingBySession[targetSessionId]?.seconds ?? 0);
     const onStopped = get().takeOnStopped(targetSessionId);
     const unlisteners = currentLive.eventUnlistenersBySession[targetSessionId];
 
@@ -170,6 +172,10 @@ const createSessionEventHandlers = <T extends LiveStore>(
       return;
     }
 
+    if (get().live.sessionId !== targetSessionId) {
+      return;
+    }
+
     setLiveState(set, (live) => {
       updateLiveProgress(live, payload);
     });
@@ -180,6 +186,10 @@ const createSessionEventHandlers = <T extends LiveStore>(
     }
 
     if (payload.type === "audio_amplitude") {
+      if (get().live.sessionId !== targetSessionId) {
+        return;
+      }
+
       setLiveState(set, (live) => {
         updateLiveAmplitude(live, payload.mic, payload.speaker);
       });
@@ -190,11 +200,16 @@ const createSessionEventHandlers = <T extends LiveStore>(
       get().handleTranscriptDelta(
         targetSessionId,
         payload.delta as unknown as LiveTranscriptDelta,
+        { updateLivePreview: get().live.sessionId === targetSessionId },
       );
       return;
     }
 
     if (payload.type === "transcript_segment_delta") {
+      if (get().live.sessionId !== targetSessionId) {
+        return;
+      }
+
       get().handleTranscriptSegmentDelta(
         payload.delta as unknown as LiveTranscriptSegmentDelta,
       );
@@ -202,6 +217,10 @@ const createSessionEventHandlers = <T extends LiveStore>(
     }
 
     if (payload.type === "mic_muted") {
+      if (get().live.sessionId !== targetSessionId) {
+        return;
+      }
+
       setLiveState(set, (live) => {
         live.muted = payload.value;
       });

--- a/apps/desktop/src/store/zustand/listener/general-shared.ts
+++ b/apps/desktop/src/store/zustand/listener/general-shared.ts
@@ -17,6 +17,12 @@ export type LoadingPhase =
   | "connecting"
   | "connected";
 
+export type LiveStartBlockReason =
+  | "session_active"
+  | "session_finalizing"
+  | "another_session_active"
+  | "start_in_progress";
+
 export type LiveIntervalId = ReturnType<typeof setInterval>;
 
 export type GeneralState = {
@@ -35,7 +41,10 @@ export type GeneralState = {
     degraded: DegradedError | null;
     requestedLiveTranscription: boolean | null;
     liveTranscriptionActive: boolean | null;
-    finalizingBySession: Record<string, { startedAtMs: number }>;
+    finalizingBySession: Record<
+      string,
+      { startedAtMs: number; seconds: number }
+    >;
     triggerAppIds: string[] | null;
   };
 };
@@ -62,6 +71,40 @@ const initialLiveState: LiveState = {
 
 export const initialGeneralState: GeneralState = {
   live: initialLiveState,
+};
+
+export const getLiveStartBlockReason = (
+  live: Pick<
+    LiveState,
+    "status" | "loading" | "sessionId" | "finalizingBySession"
+  >,
+  targetSessionId: string,
+): LiveStartBlockReason | null => {
+  if (live.sessionId === targetSessionId) {
+    if (live.status === "active") {
+      return "session_active";
+    }
+    if (live.status === "finalizing") {
+      return "session_finalizing";
+    }
+    if (live.loading) {
+      return "start_in_progress";
+    }
+  }
+
+  if (live.finalizingBySession[targetSessionId]) {
+    return "session_finalizing";
+  }
+
+  if (live.status === "active") {
+    return "another_session_active";
+  }
+
+  if (live.status === "inactive" && live.loading) {
+    return "start_in_progress";
+  }
+
+  return null;
 };
 
 export const setLiveState = <T extends GeneralState>(
@@ -103,12 +146,13 @@ export const markLiveActive = (
 };
 
 export const markLiveFinalizing = (live: LiveState, sessionId: string) => {
+  const seconds = live.sessionId === sessionId ? live.seconds : 0;
   if (live.sessionId === sessionId) {
     live.status = "finalizing";
     live.loading = true;
     live.intervalId = undefined;
   }
-  live.finalizingBySession[sessionId] = { startedAtMs: Date.now() };
+  live.finalizingBySession[sessionId] = { startedAtMs: Date.now(), seconds };
 };
 
 export const markLiveInactive = (live: LiveState, error: string | null) => {

--- a/apps/desktop/src/store/zustand/listener/general.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general.test.ts
@@ -220,11 +220,42 @@ describe("General Listener Slice", () => {
     test("getSessionMode returns finalizing for non-active finalizing sessions", () => {
       store.setState((state) =>
         mutate(state, (draft) => {
-          draft.live.finalizingBySession["session-a"] = { startedAtMs: 123 };
+          draft.live.finalizingBySession["session-a"] = {
+            startedAtMs: 123,
+            seconds: 0,
+          };
         }),
       );
 
       expect(store.getState().getSessionMode("session-a")).toBe("finalizing");
+    });
+
+    test("canStartLiveSession allows new sessions while another session is finalizing", () => {
+      store.setState((state) =>
+        mutate(state, (draft) => {
+          draft.live.status = "finalizing";
+          draft.live.loading = true;
+          draft.live.sessionId = "session-a";
+          draft.live.finalizingBySession["session-a"] = {
+            startedAtMs: 123,
+            seconds: 0,
+          };
+        }),
+      );
+
+      expect(store.getState().canStartLiveSession("session-b")).toBe(true);
+      expect(store.getState().canStartLiveSession("session-a")).toBe(false);
+    });
+
+    test("canStartLiveSession blocks new sessions while another session is active", () => {
+      store.setState((state) =>
+        mutate(state, (draft) => {
+          draft.live.status = "active";
+          draft.live.sessionId = "session-a";
+        }),
+      );
+
+      expect(store.getState().canStartLiveSession("session-b")).toBe(false);
     });
 
     test("startTranscription rejects when the session is already running batch", async () => {

--- a/apps/desktop/src/store/zustand/listener/general.ts
+++ b/apps/desktop/src/store/zustand/listener/general.ts
@@ -13,6 +13,7 @@ import { startLiveSession, stopLiveSession } from "./general-live";
 import {
   type GeneralState,
   type SessionMode,
+  getLiveStartBlockReason,
   initialGeneralState,
   markLiveStartRequested,
   setLiveState,
@@ -43,6 +44,7 @@ export type GeneralActions = {
     options?: { handlePersist?: BatchPersistCallback },
   ) => Promise<void>;
   stopTranscription: (sessionId: string) => Promise<void>;
+  canStartLiveSession: (sessionId: string) => boolean;
   getSessionMode: (sessionId: string) => SessionMode;
 };
 
@@ -74,11 +76,9 @@ export const createGeneralSlice = <
       return false;
     }
 
-    const currentLive = get().live;
-    if (currentLive.loading || currentLive.status !== "inactive") {
-      console.warn(
-        "[listener] cannot start live session while another session is running",
-      );
+    const blockReason = getLiveStartBlockReason(get().live, targetSessionId);
+    if (blockReason) {
+      console.warn(`[listener] cannot start live session: ${blockReason}`);
       return false;
     }
 
@@ -155,6 +155,17 @@ export const createGeneralSlice = <
     }
 
     await listenerCommands.stopTranscription(sessionId).catch(console.error);
+  },
+  canStartLiveSession: (sessionId) => {
+    if (!sessionId) {
+      return false;
+    }
+
+    if (get().getSessionMode(sessionId) === "running_batch") {
+      return false;
+    }
+
+    return getLiveStartBlockReason(get().live, sessionId) === null;
   },
   getSessionMode: (sessionId) => {
     if (!sessionId) {

--- a/apps/desktop/src/store/zustand/listener/transcript.test.ts
+++ b/apps/desktop/src/store/zustand/listener/transcript.test.ts
@@ -115,6 +115,37 @@ describe("transcript slice", () => {
     expect(store.getState().partialHintsByChannel).toEqual({});
   });
 
+  test("can persist deltas without replacing the active live preview", () => {
+    const persist = vi.fn();
+    store.getState().setTranscriptPersist("session-1", persist);
+    store.getState().handleTranscriptDelta("active-session", createDelta());
+
+    const delta: LiveTranscriptDelta = {
+      new_words: [
+        {
+          id: "word-1",
+          text: " background",
+          start_ms: 0,
+          end_ms: 100,
+          channel: 0,
+          state: "final",
+          speaker_index: null,
+        },
+      ],
+      replaced_ids: [],
+      partials: [],
+    };
+
+    store.getState().handleTranscriptDelta("session-1", delta, {
+      updateLivePreview: false,
+    });
+
+    expect(persist).toHaveBeenCalledWith(delta);
+    expect(
+      store.getState().partialWordsByChannel[0]?.map((word) => word.text),
+    ).toEqual([" hello"]);
+  });
+
   test("resetTranscript clears partial state and callbacks", () => {
     store.getState().setTranscriptPersist("session-1", vi.fn());
     store.getState().setOnStopped("session-1", vi.fn());

--- a/apps/desktop/src/store/zustand/listener/transcript.ts
+++ b/apps/desktop/src/store/zustand/listener/transcript.ts
@@ -48,6 +48,7 @@ export type TranscriptActions = {
   handleTranscriptDelta: (
     sessionId: string,
     delta: LiveTranscriptDelta,
+    options?: { updateLivePreview?: boolean },
   ) => void;
   handleTranscriptSegmentDelta: (delta: LiveTranscriptSegmentDelta) => void;
   takeOnStopped: (sessionId: string) => OnStoppedCallback | undefined;
@@ -92,18 +93,20 @@ export const createTranscriptSlice = <
       }),
     );
   },
-  handleTranscriptDelta: (sessionId, delta) => {
+  handleTranscriptDelta: (sessionId, delta, options) => {
     const handlePersist = get().handlePersistBySession[sessionId];
     const { wordsByChannel, hintsByChannel } = groupPartialsByChannel(
       delta.partials,
     );
 
-    set((state) =>
-      mutate(state, (draft) => {
-        draft.partialWordsByChannel = wordsByChannel;
-        draft.partialHintsByChannel = hintsByChannel;
-      }),
-    );
+    if (options?.updateLivePreview !== false) {
+      set((state) =>
+        mutate(state, (draft) => {
+          draft.partialWordsByChannel = wordsByChannel;
+          draft.partialHintsByChannel = hintsByChannel;
+        }),
+      );
+    }
 
     if (delta.new_words.length === 0 && delta.replaced_ids.length === 0) {
       return;


### PR DESCRIPTION
Allow a new live session to start while another session finalizes, keep prior transcript events from clobbering the active live preview, and avoid hiding listening actions during summary generation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the live-listener state machine and event handling; mistakes could block starting sessions or show incorrect live preview/amplitude while sessions overlap in finalizing state.
> 
> **Overview**
> Enables **overlapping session workflows** by allowing a new live capture to start while a previous session is *finalizing*, via new `getLiveStartBlockReason`/`canStartLiveSession` gating and tracking finalize duration per session.
> 
> Hardens live event routing so progress/amplitude/segment updates only apply to the currently active session, while `transcript_delta` can still persist in the background without clobbering the active live preview (`handleTranscriptDelta(..., { updateLivePreview })`).
> 
> Adjusts UI behavior to scope `loading` to the current session (so other tabs don’t show spinners) and keeps listen actions visible during summary/enhance generation by removing the AI-task-based hide condition; also tightens “new note and listen” to only jump to an existing session when status is `active` (not `finalizing`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ebfbd0cf952c96493c893cd11d526c38d356285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->