### PR TITLE
fix(desktop): auto-generate empty summaries after batch

### DIFF
--- a/apps/desktop/src/services/enhancer/index.test.ts
+++ b/apps/desktop/src/services/enhancer/index.test.ts
@@ -25,7 +25,10 @@ type Tables = Record<string, Record<string, Record<string, any>>>;
 
 function createTables(data?: {
   transcripts?: Record<string, { session_id: string; words: string }>;
-  enhanced_notes?: Record<string, { session_id: string; template_id?: string }>;
+  enhanced_notes?: Record<
+    string,
+    { session_id: string; template_id?: string; content?: string }
+  >;
   sessions?: Record<string, { title: string }>;
 }): Tables {
   return {
@@ -180,6 +183,7 @@ describe("EnhancerService", () => {
           "note-1": {
             session_id: "session-1",
             template_id: undefined as any,
+            content: "Generated summary",
           },
         },
       });
@@ -206,6 +210,7 @@ describe("EnhancerService", () => {
           "note-1": {
             session_id: "session-1",
             template_id: undefined as any,
+            content: "Generated summary",
           },
         },
       });
@@ -224,6 +229,91 @@ describe("EnhancerService", () => {
       const result = service.enhance("session-1");
       expect(result).toEqual({ type: "already_active", noteId: "note-1" });
       expect(aiTaskStore.getState().generate).not.toHaveBeenCalled();
+    });
+
+    it("starts generation when a succeeded task has empty summary content", () => {
+      const tables = createTables({
+        enhanced_notes: {
+          "note-1": {
+            session_id: "session-1",
+            template_id: undefined as any,
+            content: JSON.stringify({ type: "doc", content: [] }),
+          },
+        },
+      });
+      const aiTaskStore = createMockAITaskStore();
+      aiTaskStore.getState.mockReturnValue({
+        generate: vi.fn(),
+        getState: vi.fn().mockReturnValue({ status: "success" }),
+      });
+      const deps = createDeps({
+        mainStore: createMockStore(tables),
+        indexes: createMockIndexes(tables),
+        aiTaskStore,
+      });
+      const service = new EnhancerService(deps);
+
+      const result = service.enhance("session-1");
+      expect(result).toEqual({ type: "started", noteId: "note-1" });
+      expect(aiTaskStore.getState().generate).toHaveBeenCalled();
+    });
+  });
+
+  describe("queueAutoEnhanceIfSummaryEmpty()", () => {
+    it("skips auto-enhance when the matching summary already has content", () => {
+      const tables = createTables({
+        enhanced_notes: {
+          "note-1": {
+            session_id: "session-1",
+            template_id: undefined as any,
+            content: "Generated summary",
+          },
+        },
+      });
+      const aiTaskStore = createMockAITaskStore();
+      const deps = createDeps({
+        mainStore: createMockStore(tables),
+        indexes: createMockIndexes(tables),
+        aiTaskStore,
+      });
+      const service = new EnhancerService(deps);
+
+      const result = service.queueAutoEnhanceIfSummaryEmpty("session-1");
+      expect(result).toEqual({ type: "summary_exists", noteId: "note-1" });
+      expect(aiTaskStore.getState().generate).not.toHaveBeenCalled();
+      expect((service as any).activeAutoEnhance.has("session-1")).toBe(false);
+    });
+
+    it("queues auto-enhance when the matching summary is empty", () => {
+      const words = Array.from({ length: 10 }, (_, i) => ({
+        text: `word${i}`,
+      }));
+      const tables = createTables({
+        transcripts: {
+          "t-1": {
+            session_id: "session-1",
+            words: JSON.stringify(words),
+          },
+        },
+        enhanced_notes: {
+          "note-1": {
+            session_id: "session-1",
+            template_id: undefined as any,
+            content: "",
+          },
+        },
+      });
+      const aiTaskStore = createMockAITaskStore();
+      const deps = createDeps({
+        mainStore: createMockStore(tables),
+        indexes: createMockIndexes(tables),
+        aiTaskStore,
+      });
+      const service = new EnhancerService(deps);
+
+      const result = service.queueAutoEnhanceIfSummaryEmpty("session-1");
+      expect(result).toEqual({ type: "queued" });
+      expect(aiTaskStore.getState().generate).toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/services/enhancer/index.ts
+++ b/apps/desktop/src/services/enhancer/index.ts
@@ -16,6 +16,10 @@ type EnhanceResult =
   | { type: "already_active"; noteId: string }
   | { type: "no_model" };
 
+type QueueEmptySummaryResult =
+  | { type: "queued" }
+  | { type: "summary_exists"; noteId: string };
+
 type EnhanceOpts = {
   isAuto?: boolean;
   templateId?: string;
@@ -40,6 +44,48 @@ type EnhancerDeps = {
 const UUID_TITLE_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const ISO_TITLE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
+
+type TiptapNode = {
+  content?: TiptapNode[];
+  text?: string;
+};
+
+function hasTiptapText(node: TiptapNode): boolean {
+  if (typeof node.text === "string" && node.text.trim()) {
+    return true;
+  }
+
+  return node.content?.some(hasTiptapText) ?? false;
+}
+
+function hasSummaryContent(value: unknown): boolean {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  if (!trimmed.startsWith("{")) {
+    return true;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      (parsed as { type?: unknown }).type === "doc"
+    ) {
+      return hasTiptapText(parsed);
+    }
+    return true;
+  } catch {
+    return true;
+  }
+}
 
 function shouldHydrateTemplateTitle(
   currentTitle: string | null | undefined,
@@ -124,6 +170,21 @@ export class EnhancerService {
     this.tryAutoEnhance(sessionId, 0);
   }
 
+  queueAutoEnhanceIfSummaryEmpty(sessionId: string): QueueEmptySummaryResult {
+    const templateId = this.deps.getSelectedTemplateId();
+    const existingNoteId = this.getMatchingEnhancedNoteId(
+      sessionId,
+      templateId,
+    );
+
+    if (existingNoteId && this.hasEnhancedNoteContent(existingNoteId)) {
+      return { type: "summary_exists", noteId: existingNoteId };
+    }
+
+    this.queueAutoEnhance(sessionId);
+    return { type: "queued" };
+  }
+
   private tryAutoEnhance(sessionId: string, attempt: number) {
     const eligibility = this.checkEligibility(sessionId);
     if (!eligibility.eligible) {
@@ -190,9 +251,12 @@ export class EnhancerService {
     const enhancedNoteId = this.ensureNote(sessionId, templateId);
     const enhanceTaskId = createTaskId(enhancedNoteId, "enhance");
     const existingTask = aiTaskStore.getState().getState(enhanceTaskId);
+    if (existingTask?.status === "generating") {
+      return { type: "already_active", noteId: enhancedNoteId };
+    }
     if (
-      existingTask?.status === "generating" ||
-      existingTask?.status === "success"
+      existingTask?.status === "success" &&
+      this.hasEnhancedNoteContent(enhancedNoteId)
     ) {
       return { type: "already_active", noteId: enhancedNoteId };
     }
@@ -234,12 +298,10 @@ export class EnhancerService {
     const normalizedTemplateId = templateId || undefined;
 
     const existingIds = this.getEnhancedNoteIds(sessionId);
-    const existingId = existingIds.find((id) => {
-      const tid = store.getCell("enhanced_notes", id, "template_id") as
-        | string
-        | undefined;
-      return (tid || undefined) === normalizedTemplateId;
-    });
+    const existingId = this.getMatchingEnhancedNoteId(
+      sessionId,
+      normalizedTemplateId,
+    );
     if (existingId) {
       if (normalizedTemplateId) {
         void this.hydrateTemplateTitle(existingId, normalizedTemplateId);
@@ -266,6 +328,27 @@ export class EnhancerService {
     }
 
     return enhancedNoteId;
+  }
+
+  private getMatchingEnhancedNoteId(
+    sessionId: string,
+    templateId?: string,
+  ): string | undefined {
+    const normalizedTemplateId = templateId || undefined;
+    const store = this.deps.mainStore;
+
+    return this.getEnhancedNoteIds(sessionId).find((id) => {
+      const tid = store.getCell("enhanced_notes", id, "template_id") as
+        | string
+        | undefined;
+      return (tid || undefined) === normalizedTemplateId;
+    });
+  }
+
+  private hasEnhancedNoteContent(enhancedNoteId: string): boolean {
+    return hasSummaryContent(
+      this.deps.mainStore.getCell("enhanced_notes", enhancedNoteId, "content"),
+    );
   }
 
   private async hydrateTemplateTitle(

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -18,6 +18,7 @@ import {
 import { cn } from "@hypr/utils";
 
 import * as AudioPlayer from "~/audio-player";
+import { getEnhancerService } from "~/services/enhancer";
 import { Transcript } from "~/session/components/note-input/transcript";
 import { useTranscriptScreen } from "~/session/components/note-input/transcript/state";
 import { useListener } from "~/stt/contexts";
@@ -129,6 +130,7 @@ function useRegenerateTranscript(sessionId: string) {
 
     try {
       await runBatch(audioPath);
+      getEnhancerService()?.queueAutoEnhanceIfSummaryEmpty(sessionId);
     } catch (error) {
       if (isStoppedTranscriptionError(error)) {
         return;

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -5,7 +5,7 @@ import { getPostCaptureAction } from "./useStartListening";
 import { useStartListening } from "./useStartListening";
 
 const {
-  queueAutoEnhanceMock,
+  queueAutoEnhanceIfSummaryEmptyMock,
   startMock,
   runBatchMock,
   useListenerMock,
@@ -14,7 +14,7 @@ const {
   useIndexesMock,
   useConfigValueMock,
 } = vi.hoisted(() => ({
-  queueAutoEnhanceMock: vi.fn(),
+  queueAutoEnhanceIfSummaryEmptyMock: vi.fn(),
   startMock: vi.fn(),
   runBatchMock: vi.fn(),
   useListenerMock: vi.fn(),
@@ -56,7 +56,7 @@ vi.mock("./useSTTConnection", () => ({
 
 vi.mock("~/services/enhancer", () => ({
   getEnhancerService: vi.fn(() => ({
-    queueAutoEnhance: queueAutoEnhanceMock,
+    queueAutoEnhanceIfSummaryEmpty: queueAutoEnhanceIfSummaryEmptyMock,
   })),
 }));
 
@@ -177,6 +177,8 @@ describe("useStartListening", () => {
     });
 
     expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav");
-    expect(queueAutoEnhanceMock).toHaveBeenCalledWith("session-1");
+    expect(queueAutoEnhanceIfSummaryEmptyMock).toHaveBeenCalledWith(
+      "session-1",
+    );
   });
 });

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -93,7 +93,7 @@ export function useStartListening(sessionId: string) {
         return;
       }
 
-      getEnhancerService()?.queueAutoEnhance(sessionId);
+      getEnhancerService()?.queueAutoEnhanceIfSummaryEmpty(sessionId);
     };
 
     const handlePersist: LiveTranscriptPersistCallback = (delta) => {

--- a/apps/desktop/src/stt/useUploadFile.ts
+++ b/apps/desktop/src/stt/useUploadFile.ts
@@ -57,6 +57,10 @@ export function useUploadFile(sessionId: string) {
     }
   }, [sessionId, sessionTab, updateSessionTabState]);
 
+  const triggerEnhanceIfSummaryEmpty = useCallback(() => {
+    getEnhancerService()?.queueAutoEnhanceIfSummaryEmpty(sessionId);
+  }, [sessionId]);
+
   const applyEstimatedAudioNoteDate = useCallback(
     async (filePath: string) => {
       try {
@@ -222,7 +226,7 @@ export function useUploadFile(sessionId: string) {
             catch: (error) => error,
           }),
         ),
-        Effect.tap(() => Effect.sync(() => triggerEnhance())),
+        Effect.tap(() => Effect.sync(() => triggerEnhanceIfSummaryEmpty())),
         Effect.catchAll((error: unknown) =>
           Effect.sync(() => {
             if (isStoppedTranscriptionError(error)) {
@@ -249,6 +253,7 @@ export function useUploadFile(sessionId: string) {
       sessionTab,
       store,
       triggerEnhance,
+      triggerEnhanceIfSummaryEmpty,
       applyEstimatedAudioNoteDate,
       updateSessionTabState,
       user_id,


### PR DESCRIPTION
Queue summary generation after completed batch transcription when the selected summary is empty, and allow empty successful summary tasks to rerun.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when/if summary generation is triggered after transcription and when a previously successful enhance task is considered skippable, which could lead to unexpected extra or missing generations if content detection is wrong.
> 
> **Overview**
> **Auto-enhance is now gated on whether the selected summary actually has content.** A new `queueAutoEnhanceIfSummaryEmpty()` API checks the existing enhanced note for the selected template and only queues auto-enhance when the summary is empty.
> 
> **Empty “successful” enhance tasks can rerun.** `enhance()` now treats `success` as *already active* only when the note has non-empty content (including handling empty Tiptap `doc` JSON), allowing regeneration when the stored summary is effectively blank.
> 
> Call sites after batch transcription (post-session regenerate, `useStartListening`, and audio upload flow) are updated to use the new empty-summary queueing behavior, with tests added/updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b91ebed8a71f64bc822b5f5ae38aa7d76c8daddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->