### PR TITLE
fix(desktop): remove support actions

### DIFF
--- a/apps/desktop/src/shared/control.tsx
+++ b/apps/desktop/src/shared/control.tsx
@@ -4,30 +4,14 @@ import {
   NotFoundRouteComponent,
   useNavigate,
 } from "@tanstack/react-router";
-import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
-import { arch, version as osVersion, platform } from "@tauri-apps/plugin-os";
 import { relaunch } from "@tauri-apps/plugin-process";
-import {
-  AlertTriangle,
-  Bug,
-  Home,
-  Loader2,
-  RotateCw,
-  Search,
-} from "lucide-react";
+import { AlertTriangle, Home, RotateCw, Search } from "lucide-react";
 import { motion } from "motion/react";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
-import { commands as miscCommands } from "@hypr/plugin-misc";
-import { commands as openerCommands } from "@hypr/plugin-opener2";
-import { commands as tracingCommands } from "@hypr/plugin-tracing";
 import { Button } from "@hypr/ui/components/ui/button";
 
-import { env } from "~/env";
-
 export const ErrorComponent: ErrorRouteComponent = ({ error }) => {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
   useEffect(() => {
     Sentry.captureException(error);
   }, [error]);
@@ -37,69 +21,6 @@ export const ErrorComponent: ErrorRouteComponent = ({ error }) => {
       await relaunch();
     } catch (err) {
       console.error("Failed to restart app:", err);
-    }
-  };
-
-  const handleReportIssue = async () => {
-    if (isSubmitting) return;
-
-    setIsSubmitting(true);
-
-    try {
-      const gitHashResult = await miscCommands.getGitHash();
-      const gitHash =
-        gitHashResult.status === "ok" ? gitHashResult.data : "unknown";
-
-      let logs: string | undefined;
-      const logsResult = await tracingCommands.logContent();
-      if (logsResult.status === "ok" && logsResult.data) {
-        logs = logsResult.data.slice(-10000);
-      }
-
-      const errorDetails = [
-        `**Error Message:** ${error.message || "Unknown error"}`,
-        error.stack ? `**Stack Trace:**\n\`\`\`\n${error.stack}\n\`\`\`` : "",
-      ]
-        .filter(Boolean)
-        .join("\n\n");
-
-      const description = `## Error Details\n${errorDetails}`;
-
-      const response = await tauriFetch(`${env.VITE_API_URL}/feedback/submit`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          type: "bug",
-          description,
-          logs,
-          deviceInfo: {
-            platform: platform(),
-            arch: arch(),
-            osVersion: osVersion(),
-            appVersion: env.VITE_APP_VERSION ?? "unknown",
-            gitHash,
-          },
-        }),
-      });
-
-      const data = (await response.json()) as {
-        success: boolean;
-        issueUrl?: string;
-        error?: string;
-      };
-
-      if (data.success && data.issueUrl) {
-        await openerCommands.openUrl(data.issueUrl, null);
-      } else {
-        console.error("Failed to submit error report:", data.error);
-      }
-    } catch (err) {
-      console.error(
-        "Failed to submit error report:",
-        err instanceof Error ? err.message : String(err),
-      );
-    } finally {
-      setIsSubmitting(false);
     }
   };
 
@@ -141,28 +62,10 @@ export const ErrorComponent: ErrorRouteComponent = ({ error }) => {
                 </p>
               </div>
 
-              <div className="flex gap-2 pt-2">
+              <div className="pt-2">
                 <Button size="sm" onClick={handleRestart}>
                   <RotateCw className="mr-1.5 h-3.5 w-3.5" />
                   Restart App
-                </Button>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={handleReportIssue}
-                  disabled={isSubmitting}
-                >
-                  {isSubmitting ? (
-                    <>
-                      <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                      Submitting...
-                    </>
-                  ) : (
-                    <>
-                      <Bug className="mr-1.5 h-3.5 w-3.5" />
-                      Report Issue
-                    </>
-                  )}
                 </Button>
               </div>
             </div>

--- a/apps/desktop/src/sidebar/profile/index.tsx
+++ b/apps/desktop/src/sidebar/profile/index.tsx
@@ -2,7 +2,6 @@ import { useQuery } from "@tanstack/react-query";
 import {
   CalendarIcon,
   ChevronUpIcon,
-  CircleHelp,
   FolderOpenIcon,
   SettingsIcon,
   UsersIcon,
@@ -11,7 +10,6 @@ import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useResizeObserver } from "usehooks-ts";
 
-import { commands as openerCommands } from "@hypr/plugin-opener2";
 import { Kbd } from "@hypr/ui/components/ui/kbd";
 import { cn } from "@hypr/utils";
 
@@ -120,11 +118,6 @@ export function ProfileSection({ onExpandChange }: ProfileSectionProps = {}) {
     setCurrentView("main");
   }, []);
 
-  const handleClickHelp = useCallback(() => {
-    void openerCommands.openUrl("https://char.com/discord", null);
-    closeMenu();
-  }, [closeMenu]);
-
   // const handleClickData = useCallback(() => {
   //   openNew({ type: "data" });
   //   closeMenu();
@@ -144,6 +137,7 @@ export function ProfileSection({ onExpandChange }: ProfileSectionProps = {}) {
             label: "Folders",
             onClick: handleClickFolders,
             badge: <Kbd className={kbdClass}>⌘ ⇧ L</Kbd>,
+            sectionBreakAfter: false,
           },
         ]
       : []),
@@ -152,23 +146,21 @@ export function ProfileSection({ onExpandChange }: ProfileSectionProps = {}) {
       label: "Contacts",
       onClick: handleClickContacts,
       badge: <Kbd className={kbdClass}>⌘ ⇧ O</Kbd>,
+      sectionBreakAfter: false,
     },
     {
       icon: CalendarIcon,
       label: "Calendar",
       onClick: handleClickCalendar,
       badge: <Kbd className={kbdClass}>⌘ ⇧ C</Kbd>,
+      sectionBreakAfter: isPro,
     },
     {
       icon: SettingsIcon,
       label: "Settings",
       onClick: handleClickSettings,
       badge: <Kbd className={kbdClass}>⌘ ,</Kbd>,
-    },
-    {
-      icon: CircleHelp,
-      label: "Help",
-      onClick: handleClickHelp,
+      sectionBreakAfter: !isAuthenticated,
     },
   ];
 
@@ -202,10 +194,10 @@ export function ProfileSection({ onExpandChange }: ProfileSectionProps = {}) {
                         onClick={handleClickNotifications}
                       />*/}
 
-                      {menuItems.map((item, index) => (
+                      {menuItems.map(({ sectionBreakAfter, ...item }) => (
                         <div key={item.label}>
                           <MenuItem {...item} />
-                          {(index === 2 || index === 4) && (
+                          {sectionBreakAfter && (
                             <div className="my-1 border-t border-neutral-100" />
                           )}
                         </div>


### PR DESCRIPTION
Remove the profile Help entry and error-screen Report Issue action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI simplification that deletes support/feedback wiring (URL opening, log collection, feedback API call) without affecting core app flows.
> 
> **Overview**
> Removes the error-screen **"Report Issue"** flow, including log/device info collection and the `POST /feedback/submit` request, leaving only Sentry capture plus a **Restart App** action.
> 
> Removes the profile menu **Help** entry (Discord link) and simplifies menu divider rendering by switching from index-based breaks to an explicit `sectionBreakAfter` flag per item.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 099dc0b3e5af0ac83e6ba9ed3472ea46b2180240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->