### PR TITLE
fix(desktop): polish pro trial dialogs

### DIFF
--- a/apps/desktop/src/billing/trial-dialog-icon.tsx
+++ b/apps/desktop/src/billing/trial-dialog-icon.tsx
@@ -8,40 +8,52 @@ export function TrialDialogIcon({ state }: { state: "started" | "ended" }) {
   return (
     <div
       className={cn([
-        "relative mb-2 flex size-12 items-center justify-center overflow-hidden rounded-[14px]",
+        "relative flex size-[76px] items-center justify-center overflow-visible",
+        isStarted
+          ? "drop-shadow-[0_14px_22px_rgba(180,83,9,0.22)]"
+          : "drop-shadow-[0_14px_22px_rgba(0,0,0,0.18)]",
       ])}
     >
-      <img
-        src={ANARLOG_ICON_SRC}
-        alt=""
+      <div
         aria-hidden="true"
         className={cn([
-          "size-12 object-contain object-center",
-          isStarted
-            ? "drop-shadow-[0_0_10px_rgba(245,158,11,0.45)]"
-            : "opacity-75 brightness-[0.58] grayscale",
+          "absolute inset-2.5 rounded-[22px] blur-md",
+          isStarted ? "bg-amber-200/55" : "bg-neutral-400/30",
         ])}
       />
-      {isStarted ? (
-        <span
+      <div
+        className={cn([
+          "relative size-14 rounded-[18px]",
+          "shadow-[0_1px_0_rgba(255,255,255,0.75),0_10px_24px_-10px_rgba(0,0,0,0.58)]",
+        ])}
+      >
+        <img
+          src={ANARLOG_ICON_SRC}
+          alt=""
           aria-hidden="true"
           className={cn([
-            "absolute inset-0 -translate-x-full",
-            "animate-shimmer bg-linear-to-r from-transparent via-white/70 to-transparent",
+            "size-full rounded-[18px] object-cover object-center",
+            isStarted
+              ? "drop-shadow-[0_0_10px_rgba(245,158,11,0.35)]"
+              : "opacity-58 brightness-[0.54] grayscale",
           ])}
         />
-      ) : (
-        <>
-          <div
-            aria-hidden="true"
-            className="absolute inset-0 bg-linear-to-b from-white/20 via-neutral-700/10 to-black/35"
-          />
-          <div
-            aria-hidden="true"
-            className="absolute inset-x-1 bottom-1 h-1/2 rounded-b-[12px] bg-black/15 blur-sm"
-          />
-        </>
-      )}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 overflow-hidden rounded-[18px]"
+        >
+          {isStarted ? (
+            <span
+              className={cn([
+                "absolute inset-0 -translate-x-full",
+                "animate-shimmer bg-linear-to-r from-transparent via-white/70 to-transparent",
+              ])}
+            />
+          ) : (
+            <div className="absolute inset-0 bg-linear-to-b from-neutral-900/5 via-neutral-900/20 to-black/42" />
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/billing/trial-ended-dialog.tsx
+++ b/apps/desktop/src/billing/trial-ended-dialog.tsx
@@ -23,21 +23,28 @@ export function TrialEndedDialog({
 }: TrialEndedDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
+      <DialogContent className="w-[calc(100vw-48px)] max-w-[320px] gap-0 overflow-hidden rounded-[26px] border-white/45 bg-neutral-200/95 p-0 shadow-[0_24px_70px_rgba(0,0,0,0.32)] backdrop-blur-xl sm:rounded-[26px] [&>button:last-child]:hidden">
+        <DialogHeader className="items-center gap-2 px-5 pt-7 text-center sm:text-center">
           <TrialDialogIcon state="ended" />
-          <DialogTitle>Your Pro trial has ended</DialogTitle>
-          <DialogDescription>
+          <DialogTitle className="text-[13px] leading-5 font-semibold tracking-normal text-neutral-900">
+            Your Pro trial has ended
+          </DialogTitle>
+          <DialogDescription className="max-w-[260px] text-center text-[13px] leading-[1.36] text-neutral-800">
             You're back on the free plan. Your notes and recordings are safe —
             you can still capture and edit them locally. Upgrade to Pro to keep
             cloud AI, longer recordings, and premium templates.
           </DialogDescription>
         </DialogHeader>
-        <DialogFooter>
-          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+        <DialogFooter className="grid grid-cols-2 gap-2 px-4 pt-4 pb-4 sm:grid-cols-2 sm:justify-normal">
+          <Button
+            variant="ghost"
+            className="h-8 rounded-full bg-neutral-300/80 px-4 text-xs font-medium text-neutral-800 shadow-none hover:bg-neutral-300 hover:text-neutral-900"
+            onClick={() => onOpenChange(false)}
+          >
             Maybe later
           </Button>
           <Button
+            className="h-8 rounded-full bg-linear-to-t from-stone-600 to-stone-500 px-4 text-xs font-medium text-white shadow-sm hover:from-stone-500 hover:to-stone-500 hover:text-white"
             onClick={() => {
               onUpgrade();
               onOpenChange(false);

--- a/apps/desktop/src/billing/trial-started-dialog.tsx
+++ b/apps/desktop/src/billing/trial-started-dialog.tsx
@@ -25,18 +25,25 @@ export function TrialStartedDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
+      <DialogContent className="w-[calc(100vw-48px)] max-w-[320px] gap-0 overflow-hidden rounded-[26px] border-white/45 bg-neutral-200/95 p-0 shadow-[0_24px_70px_rgba(0,0,0,0.32)] backdrop-blur-xl sm:rounded-[26px] [&>button:last-child]:hidden">
+        <DialogHeader className="items-center gap-2 px-5 pt-7 text-center sm:text-center">
           <TrialDialogIcon state="started" />
-          <DialogTitle>Your Pro trial just started</DialogTitle>
-          <DialogDescription>
+          <DialogTitle className="text-[13px] leading-5 font-semibold tracking-normal text-neutral-900">
+            Your Pro trial just started
+          </DialogTitle>
+          <DialogDescription className="max-w-[260px] text-center text-[13px] leading-[1.36] text-neutral-800">
             You have {days} {days === 1 ? "day" : "days"} of full Pro access —
             unlimited cloud AI, longer recordings, and every premium template.
             No payment needed during the trial.
           </DialogDescription>
         </DialogHeader>
-        <DialogFooter>
-          <Button onClick={() => onOpenChange(false)}>Got it</Button>
+        <DialogFooter className="px-4 pt-4 pb-4 sm:justify-center">
+          <Button
+            className="h-8 w-full rounded-full bg-linear-to-t from-stone-600 to-stone-500 px-4 text-xs font-medium text-white shadow-sm hover:from-stone-500 hover:to-stone-500 hover:text-white"
+            onClick={() => onOpenChange(false)}
+          >
+            Got it
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
Restyle the trial started and ended dialogs with a compact native-alert layout, centered icon and title, and charcoal CTA buttons.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Styling-only changes to the desktop trial dialogs and icon; low risk aside from potential minor visual/layout regressions across breakpoints.
> 
> **Overview**
> Restyles the Pro trial `started` and `ended` dialogs to a compact, centered layout with custom `DialogContent` sizing, rounded corners, backdrop blur, and updated typography.
> 
> Updates the footer actions to match the new visual design (full-width primary on start; two-column *Maybe later* / *Upgrade* on end) with new charcoal gradient button styles.
> 
> Reworks `TrialDialogIcon` to a larger, layered icon treatment with glow/blur background, refined shadows, and state-specific shimmer vs. muted overlay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eb6e1084c625c6b2feb372fdb7a3c6b19fa40bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->