### PR TITLE
fix(desktop): polish live transcript footer

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
@@ -1,0 +1,180 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DuringSessionAccessory } from "./during-session";
+
+import type { Segment } from "~/stt/live-segment";
+
+const { useListenerMock, useQueryMock, useStoreMock } = vi.hoisted(() => ({
+  useListenerMock: vi.fn(),
+  useQueryMock: vi.fn(),
+  useStoreMock: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: useQueryMock,
+}));
+
+vi.mock("~/store/tinybase/store/main", () => ({
+  STORE_ID: "main",
+  INDEXES: {
+    transcriptBySession: "transcriptBySession",
+  },
+  UI: {
+    useSliceRowIds: vi.fn(() => []),
+    useStore: useStoreMock,
+    useTable: vi.fn(() => ({})),
+    useValue: vi.fn(() => undefined),
+  },
+}));
+
+vi.mock("~/stt/contexts", () => ({
+  useListener: useListenerMock,
+}));
+
+describe("DuringSessionAccessory", () => {
+  let liveSegments: Segment[];
+  let scrollHeight: number;
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    liveSegments = [segment("All right, let's see.", 0)];
+    scrollHeight = 480;
+
+    useQueryMock.mockReturnValue({ data: [] });
+    useStoreMock.mockReturnValue(null);
+    useListenerMock.mockImplementation((selector) =>
+      selector({
+        live: {
+          requestedLiveTranscription: true,
+          liveTranscriptionActive: true,
+        },
+        liveSegments,
+      }),
+    );
+
+    Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+  });
+
+  it("lets manual scrolling override expanded live transcript bottom pinning", () => {
+    const view = render(
+      <DuringSessionAccessory sessionId="session-1" isExpanded />,
+    );
+
+    const viewport = getLiveTranscriptScrollViewport();
+    expect(viewport.scrollTop).toBe(480);
+
+    viewport.scrollTop = 10;
+    fireEvent.scroll(viewport);
+    expect(viewport.scrollTop).toBe(10);
+
+    scrollHeight = 640;
+    liveSegments = [
+      liveSegments[0]!,
+      segment("I'm going to leave that alone.", 500),
+    ];
+    view.rerender(<DuringSessionAccessory sessionId="session-1" isExpanded />);
+
+    expect(screen.getByText("I'm going to leave that alone.")).toBeTruthy();
+    expect(getLiveTranscriptScrollViewport().scrollTop).toBe(10);
+  });
+
+  it("resumes expanded live transcript bottom pinning after scrolling back down", () => {
+    const view = render(
+      <DuringSessionAccessory sessionId="session-1" isExpanded />,
+    );
+
+    const viewport = getLiveTranscriptScrollViewport();
+    expect(viewport.scrollTop).toBe(480);
+
+    viewport.scrollTop = 10;
+    fireEvent.scroll(viewport);
+
+    scrollHeight = 640;
+    liveSegments = [
+      liveSegments[0]!,
+      segment("I'm going to leave that alone.", 500),
+    ];
+    view.rerender(<DuringSessionAccessory sessionId="session-1" isExpanded />);
+    expect(getLiveTranscriptScrollViewport().scrollTop).toBe(10);
+
+    viewport.scrollTop = 640;
+    fireEvent.scroll(viewport);
+
+    scrollHeight = 800;
+    liveSegments = [
+      liveSegments[0]!,
+      liveSegments[1]!,
+      segment("Pin new words after I return to the bottom.", 1000),
+    ];
+    view.rerender(<DuringSessionAccessory sessionId="session-1" isExpanded />);
+
+    expect(
+      screen.getByText("Pin new words after I return to the bottom."),
+    ).toBeTruthy();
+    expect(getLiveTranscriptScrollViewport().scrollTop).toBe(800);
+  });
+
+  it("truncates long speaker labels inside the chip", () => {
+    const label = "Alexandria Catherine Montgomery";
+
+    useStoreMock.mockReturnValue({
+      getValue: vi.fn(() => undefined),
+      getRow: vi.fn((tableId: string, rowId: string) =>
+        tableId === "humans" && rowId === "human-1" ? { name: label } : {},
+      ),
+    });
+    liveSegments = [
+      segment("This label should not resize the transcript row.", 0, {
+        channel: "RemoteParty",
+        speaker_human_id: "human-1",
+      }),
+    ];
+
+    render(<DuringSessionAccessory sessionId="session-1" isExpanded />);
+
+    const chip = screen.getByTitle(label);
+    expect(chip.className).toContain("max-w-full");
+    expect(chip.className).toContain("min-w-0");
+    expect(screen.getByText(label).className).toContain("truncate");
+  });
+});
+
+function getLiveTranscriptScrollViewport() {
+  const viewport = document.querySelector<HTMLDivElement>(
+    "[data-live-transcript-scroll]",
+  );
+  expect(viewport).not.toBeNull();
+  return viewport!;
+}
+
+function segment(
+  text: string,
+  startMs: number,
+  key: Partial<Segment["key"]> = {},
+): Segment {
+  return {
+    key: {
+      channel: "DirectMic",
+      speaker_index: null,
+      speaker_human_id: null,
+      ...key,
+    },
+    start_ms: startMs,
+    end_ms: startMs + 300,
+    words: [
+      {
+        id: `word-${startMs}`,
+        text,
+        start_ms: startMs,
+        end_ms: startMs + 300,
+      },
+    ],
+  } as Segment;
+}

--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useMemo, useRef } from "react";
+import { useLayoutEffect, useMemo, useRef } from "react";
 
 import { cn } from "@hypr/utils";
 
@@ -19,10 +19,12 @@ import {
 
 export function DuringSessionAccessory({
   sessionId,
+  fillHeight = false,
   isFinalizing = false,
   isExpanded = false,
 }: {
   sessionId: string;
+  fillHeight?: boolean;
   isFinalizing?: boolean;
   isExpanded?: boolean;
 }) {
@@ -40,14 +42,22 @@ export function DuringSessionAccessory({
     );
   }
 
-  return <LiveTranscriptFooter sessionId={sessionId} isExpanded={isExpanded} />;
+  return (
+    <LiveTranscriptFooter
+      sessionId={sessionId}
+      fillHeight={fillHeight}
+      isExpanded={isExpanded}
+    />
+  );
 }
 
 function LiveTranscriptFooter({
   sessionId,
+  fillHeight,
   isExpanded = false,
 }: {
   sessionId: string;
+  fillHeight: boolean;
   isExpanded?: boolean;
 }) {
   const store = main.UI.useStore(main.STORE_ID);
@@ -86,12 +96,18 @@ function LiveTranscriptFooter({
   const previewText = useMemo(() => getTranscriptPreview(segments), [segments]);
 
   return (
-    <div className="w-full select-none">
-      <div className="rounded-xl bg-neutral-50">
+    <div className={cn(["w-full select-none", fillHeight && "h-full min-h-0"])}>
+      <div
+        className={cn([
+          "rounded-xl bg-neutral-50",
+          fillHeight && "h-full min-h-0",
+        ])}
+      >
         {mode.kind === "record_only" ? (
           <RecordOnlyFooter isFallbackFromLive={mode.isFallbackFromLive} />
         ) : (
           <LiveTranscriptContent
+            fillHeight={fillHeight}
             isExpanded={isExpanded}
             previewText={previewText}
             scrollRef={scrollRef}
@@ -122,6 +138,7 @@ function RecordOnlyFooter({
 }
 
 function LiveTranscriptContent({
+  fillHeight,
   isExpanded,
   previewText,
   scrollRef,
@@ -129,6 +146,7 @@ function LiveTranscriptContent({
   labelContext,
   speakerLabelManager,
 }: {
+  fillHeight: boolean;
   isExpanded: boolean;
   previewText: string | null;
   scrollRef: React.RefObject<HTMLDivElement | null>;
@@ -136,6 +154,20 @@ function LiveTranscriptContent({
   labelContext: ReturnType<typeof defaultRenderLabelContext> | undefined;
   speakerLabelManager: SpeakerLabelManager;
 }) {
+  const scrollKey = getLiveTranscriptScrollKey(segments);
+  const shouldPinToBottomRef = useRef(true);
+
+  useLayoutEffect(() => {
+    if (!isExpanded) {
+      shouldPinToBottomRef.current = true;
+      return;
+    }
+
+    if (shouldPinToBottomRef.current) {
+      pinLiveTranscriptToBottom(scrollRef);
+    }
+  }, [isExpanded, scrollKey, scrollRef]);
+
   if (!isExpanded) {
     return <CollapsedFooterMessage message={previewText ?? "Listening..."} />;
   }
@@ -143,7 +175,19 @@ function LiveTranscriptContent({
   return (
     <div
       ref={scrollRef}
-      className="flex max-h-[180px] flex-col gap-1 overflow-y-auto px-3 pt-2 pb-2.5"
+      data-live-transcript-scroll
+      onScroll={() => {
+        const element = scrollRef.current;
+        if (!element) {
+          return;
+        }
+
+        shouldPinToBottomRef.current = isLiveTranscriptPinnedToBottom(element);
+      }}
+      className={cn([
+        "flex flex-col gap-1 overflow-y-auto px-3 pt-2 pb-2.5",
+        fillHeight ? "h-full min-h-0" : "max-h-[180px]",
+      ])}
     >
       {segments.length === 0 ? (
         <span className="py-4 text-center text-xs text-neutral-400">
@@ -163,6 +207,26 @@ function LiveTranscriptContent({
         ))
       )}
     </div>
+  );
+}
+
+function pinLiveTranscriptToBottom(
+  scrollRef: React.RefObject<HTMLDivElement | null>,
+) {
+  const element = scrollRef.current;
+  if (!element) {
+    return;
+  }
+
+  element.scrollTop = element.scrollHeight;
+}
+
+const LIVE_TRANSCRIPT_BOTTOM_THRESHOLD_PX = 24;
+
+function isLiveTranscriptPinnedToBottom(element: HTMLDivElement) {
+  return (
+    element.scrollHeight - element.clientHeight - element.scrollTop <=
+    LIVE_TRANSCRIPT_BOTTOM_THRESHOLD_PX
   );
 }
 
@@ -232,6 +296,24 @@ function useLiveTranscriptSegments(sessionId: string): Segment[] {
   }, [liveSegments, renderedSegments]);
 }
 
+function getLiveTranscriptScrollKey(segments: Segment[]): string {
+  const lastSegment = segments[segments.length - 1];
+  const lastWord = lastSegment?.words[lastSegment.words.length - 1];
+
+  if (!lastSegment || !lastWord) {
+    return String(segments.length);
+  }
+
+  return [
+    segments.length,
+    lastSegment.words.length,
+    getSegmentIdentity(lastSegment, segments.length - 1),
+    lastWord.id ?? "",
+    lastWord.text,
+    lastWord.end_ms,
+  ].join(":");
+}
+
 function getSegmentIdentity(segment: Segment, fallbackIndex: number): string {
   const firstWord = segment.words[0];
   const lastWord = segment.words[segment.words.length - 1];
@@ -280,15 +362,16 @@ function TranscriptSegmentRow({
   const color = getSegmentColor(segment.key);
 
   return (
-    <div className="grid min-w-0 grid-cols-[92px_1fr] items-start gap-x-3">
+    <div className="grid min-w-0 grid-cols-[92px_minmax(0,1fr)] items-start gap-x-3">
       <span
-        className="mt-0.5 inline-flex min-h-5 items-center justify-start rounded-full px-2 text-[11px] font-medium whitespace-nowrap"
+        className="mt-0.5 flex min-h-5 max-w-full min-w-0 items-center justify-start rounded-full px-2 text-[11px] font-medium"
+        title={label}
         style={{
           backgroundColor: `${color}1A`,
           color,
         }}
       >
-        {label}
+        <span className="min-w-0 truncate">{label}</span>
       </span>
       <span className="min-w-0 text-xs leading-5 text-neutral-700">
         {getSegmentText(segment)}

--- a/apps/desktop/src/session/components/bottom-accessory/expand-toggle.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/expand-toggle.tsx
@@ -8,12 +8,14 @@ export function ExpandToggle({
   label,
   showExpandedCloseIcon = false,
   collapsedClassName,
+  expandedClassName,
 }: {
   isExpanded: boolean;
   onToggle: () => void;
   label?: string;
   showExpandedCloseIcon?: boolean;
   collapsedClassName?: string;
+  expandedClassName?: string;
 }) {
   const hasLabel = Boolean(label);
 
@@ -27,7 +29,9 @@ export function ExpandToggle({
         hasLabel ? "px-3" : "w-10",
         "rounded-t-[10px] rounded-b-none border-x border-t border-neutral-200",
         "text-neutral-400",
-        isExpanded ? "bg-white" : (collapsedClassName ?? "bg-white"),
+        isExpanded
+          ? (expandedClassName ?? "bg-white")
+          : (collapsedClassName ?? "bg-white"),
         "transition-colors hover:bg-neutral-100 hover:text-neutral-600",
         "hover:cursor-pointer",
       ])}

--- a/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.test.tsx
@@ -146,4 +146,63 @@ describe("useSessionBottomAccessory", () => {
     });
     expect(hoisted.hotkeys.get("esc")?.options?.enabled).toBe(false);
   });
+
+  it("keeps the playback accessory mounted while the transcript panel is collapsed", () => {
+    const { result } = renderHook(() =>
+      useSessionBottomAccessory({
+        sessionId: "session-1",
+        sessionMode: "inactive",
+        audioUrl: "file:///session.wav",
+        hasTranscript: true,
+      }),
+    );
+
+    expect(result.current.bottomAccessoryState).toEqual({
+      mode: "playback",
+      expanded: false,
+    });
+    expect(result.current.bottomAccessory).not.toBeNull();
+  });
+
+  it("keeps the expanded live handle on neutral 50", () => {
+    const { result } = renderHook(() =>
+      useSessionBottomAccessory({
+        sessionId: "session-1",
+        sessionMode: "active",
+        audioUrl: null,
+        hasTranscript: false,
+      }),
+    );
+
+    const toggle = result.current.bottomBorderHandle;
+    expect(
+      isValidElement<{
+        expandedClassName?: string;
+        isExpanded: boolean;
+        label?: string;
+        onToggle: () => void;
+      }>(toggle),
+    ).toBe(true);
+    if (
+      !isValidElement<{
+        expandedClassName?: string;
+        label?: string;
+        onToggle: () => void;
+      }>(toggle)
+    ) {
+      return;
+    }
+
+    expect(toggle.props.label).toBe("Live");
+    expect(toggle.props.expandedClassName).toBe("bg-neutral-50");
+
+    act(() => {
+      toggle.props.onToggle();
+    });
+
+    expect(result.current.bottomAccessoryState).toEqual({
+      mode: "live",
+      expanded: true,
+    });
+  });
 });

--- a/apps/desktop/src/session/components/bottom-accessory/index.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/index.tsx
@@ -96,6 +96,7 @@ export function useSessionBottomAccessory({
           sessionId={sessionId}
           isFinalizing={isFinalizing}
           isExpanded={effectiveExpanded}
+          fillHeight={effectiveExpanded && !isFinalizing}
         />
       ),
       bottomBorderHandle:
@@ -105,6 +106,7 @@ export function useSessionBottomAccessory({
             onToggle={() => setIsExpanded((v) => !v)}
             label="Live"
             collapsedClassName="bg-neutral-50"
+            expandedClassName="bg-neutral-50"
           />
         ) : null,
       bottomAccessoryState,
@@ -112,7 +114,7 @@ export function useSessionBottomAccessory({
   }
 
   if (showPostSession) {
-    const hasAccessoryContent = isExpanded || isBatching;
+    const hasAccessoryContent = isExpanded || isBatching || hasAudio;
     return {
       bottomAccessory: hasAccessoryContent ? (
         <PostSessionAccessory
@@ -120,6 +122,7 @@ export function useSessionBottomAccessory({
           hasAudio={hasAudio}
           hasTranscript={hasTranscript}
           isTranscriptExpanded={isExpanded}
+          fillHeight={isExpanded}
         />
       ) : null,
       bottomBorderHandle: (

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PostSessionAccessory } from "./post-session";
@@ -95,6 +101,7 @@ vi.mock("~/stt/useUploadFile", () => ({
 
 describe("PostSessionAccessory", () => {
   beforeEach(() => {
+    cleanup();
     vi.clearAllMocks();
 
     audioPathMock.mockResolvedValue({
@@ -162,5 +169,36 @@ describe("PostSessionAccessory", () => {
     await waitFor(() => {
       expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav");
     });
+  });
+
+  it("keeps the audio timeline visible while the transcript panel is collapsed", () => {
+    render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        hasAudio
+        hasTranscript
+        isTranscriptExpanded={false}
+      />,
+    );
+
+    expect(screen.getByTestId("timeline")).toBeTruthy();
+    expect(screen.queryByTestId("transcript")).toBeNull();
+  });
+
+  it("lets expanded transcript content fill the resizable bottom panel", () => {
+    render(
+      <PostSessionAccessory
+        sessionId="session-1"
+        hasAudio
+        hasTranscript
+        isTranscriptExpanded
+        fillHeight
+      />,
+    );
+
+    const scrollArea = screen.getByTestId("transcript").parentElement;
+    expect(scrollArea?.className).toContain("flex-1");
+    expect(scrollArea?.className).not.toContain("h-[300px]");
+    expect(scrollArea?.parentElement?.className).toContain("flex-1");
   });
 });

--- a/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/post-session.tsx
@@ -30,17 +30,19 @@ export function PostSessionAccessory({
   hasAudio,
   hasTranscript,
   isTranscriptExpanded,
+  fillHeight = false,
 }: {
   sessionId: string;
   hasAudio: boolean;
   hasTranscript: boolean;
   isTranscriptExpanded: boolean;
+  fillHeight?: boolean;
 }) {
   const screen = useTranscriptScreen({ sessionId });
   const isBatching = screen.kind === "running_batch";
   const timeline = isBatching ? (
     <BatchProgressTimeline sessionId={sessionId} screen={screen} />
-  ) : hasAudio && isTranscriptExpanded ? (
+  ) : hasAudio ? (
     <AudioPlayer.Timeline />
   ) : null;
 
@@ -54,7 +56,8 @@ export function PostSessionAccessory({
   return (
     <div
       className={cn([
-        "flex flex-col",
+        "flex min-h-0 flex-col",
+        fillHeight && "h-full",
         isTranscriptExpanded && "gap-1",
         shouldBalanceCollapsedTimeline && "relative -mt-[6px] pb-1",
       ])}
@@ -72,6 +75,7 @@ export function PostSessionAccessory({
           hasAudio={hasAudio}
           hasTranscript={hasTranscript}
           isExpanded={isTranscriptExpanded}
+          fillHeight={fillHeight}
         />
       ) : null}
       {timeline}
@@ -85,12 +89,14 @@ function TranscriptPanel({
   hasAudio,
   hasTranscript,
   isExpanded,
+  fillHeight,
 }: {
   sessionId: string;
   screen: ReturnType<typeof useTranscriptScreen>;
   hasAudio: boolean;
   hasTranscript: boolean;
   isExpanded: boolean;
+  fillHeight: boolean;
 }) {
   if (screen.kind === "running_batch") {
     return (
@@ -99,13 +105,18 @@ function TranscriptPanel({
         screen={screen}
         hasTranscript={hasTranscript}
         isExpanded={isExpanded}
+        fillHeight={fillHeight}
       />
     );
   }
 
   if (hasTranscript) {
     return (
-      <TranscriptReadyPanel sessionId={sessionId} isExpanded={isExpanded} />
+      <TranscriptReadyPanel
+        sessionId={sessionId}
+        isExpanded={isExpanded}
+        fillHeight={fillHeight}
+      />
     );
   }
 
@@ -114,6 +125,7 @@ function TranscriptPanel({
       sessionId={sessionId}
       hasAudio={hasAudio}
       isExpanded={isExpanded}
+      fillHeight={fillHeight}
     />
   );
 }
@@ -146,6 +158,7 @@ function BatchingTranscriptPanel({
   screen,
   hasTranscript,
   isExpanded,
+  fillHeight,
 }: {
   sessionId: string;
   screen: {
@@ -155,6 +168,7 @@ function BatchingTranscriptPanel({
   };
   hasTranscript: boolean;
   isExpanded: boolean;
+  fillHeight: boolean;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const stopTranscription = useListener((state) => state.stopTranscription);
@@ -170,8 +184,8 @@ function BatchingTranscriptPanel({
   }
 
   return (
-    <TranscriptCard>
-      <div className="flex items-center justify-between px-3 py-1.5">
+    <TranscriptCard fillHeight={fillHeight}>
+      <div className="flex shrink-0 items-center justify-between px-3 py-1.5">
         <span className="text-xs font-medium text-neutral-500">Transcript</span>
         <div className="flex items-center gap-1 px-1 py-0.5">
           <Spinner size={10} />
@@ -190,11 +204,16 @@ function BatchingTranscriptPanel({
       </div>
 
       {hasTranscript ? (
-        <div className="h-[300px] overflow-y-auto px-3">
+        <TranscriptScrollArea fillHeight={fillHeight}>
           <Transcript sessionId={sessionId} scrollRef={scrollRef} />
-        </div>
+        </TranscriptScrollArea>
       ) : (
-        <div className="flex h-[120px] flex-col items-center justify-center gap-2">
+        <div
+          className={cn([
+            "flex flex-col items-center justify-center gap-2",
+            fillHeight ? "min-h-0 flex-1" : "h-[120px]",
+          ])}
+        >
           <Spinner size={24} />
           {typeof percentage === "number" && percentage > 0 && (
             <p className="text-xl font-medium text-neutral-500 tabular-nums">
@@ -305,9 +324,11 @@ function StopTranscriptionButton({
 function TranscriptReadyPanel({
   sessionId,
   isExpanded,
+  fillHeight,
 }: {
   sessionId: string;
   isExpanded: boolean;
+  fillHeight: boolean;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const regenerate = useRegenerateTranscript(sessionId);
@@ -319,8 +340,8 @@ function TranscriptReadyPanel({
   }
 
   return (
-    <TranscriptCard>
-      <div className="flex items-center justify-between px-3 py-1.5">
+    <TranscriptCard fillHeight={fillHeight}>
+      <div className="flex shrink-0 items-center justify-between px-3 py-1.5">
         <div className="flex items-center gap-1">
           <Tooltip>
             <TooltipTrigger asChild>
@@ -376,9 +397,9 @@ function TranscriptReadyPanel({
         ) : null}
       </div>
 
-      <div className="h-[300px] overflow-y-auto px-3">
+      <TranscriptScrollArea fillHeight={fillHeight}>
         <Transcript sessionId={sessionId} scrollRef={scrollRef} />
-      </div>
+      </TranscriptScrollArea>
     </TranscriptCard>
   );
 }
@@ -387,10 +408,12 @@ function TranscriptEmptyPanel({
   sessionId,
   hasAudio,
   isExpanded,
+  fillHeight,
 }: {
   sessionId: string;
   hasAudio: boolean;
   isExpanded: boolean;
+  fillHeight: boolean;
 }) {
   const screen = useTranscriptScreen({ sessionId });
   const { uploadAudio } = useUploadFile(sessionId);
@@ -403,8 +426,8 @@ function TranscriptEmptyPanel({
   }
 
   return (
-    <TranscriptCard>
-      <div className="flex items-center justify-between px-4 py-3">
+    <TranscriptCard fillHeight={fillHeight}>
+      <div className="flex min-h-0 flex-1 items-center justify-between px-4 py-3">
         {error ? (
           <span className="text-xs text-red-500">{error}</span>
         ) : (
@@ -437,9 +460,39 @@ function TranscriptEmptyPanel({
   );
 }
 
-function TranscriptCard({ children }: { children: ReactNode }) {
+function TranscriptScrollArea({
+  children,
+  fillHeight,
+}: {
+  children: ReactNode;
+  fillHeight: boolean;
+}) {
   return (
-    <div className="overflow-hidden rounded-b-xl border-x border-b border-neutral-200 bg-white">
+    <div
+      className={cn([
+        "overflow-y-auto px-3",
+        fillHeight ? "min-h-0 flex-1" : "h-[300px]",
+      ])}
+    >
+      {children}
+    </div>
+  );
+}
+
+function TranscriptCard({
+  children,
+  fillHeight = false,
+}: {
+  children: ReactNode;
+  fillHeight?: boolean;
+}) {
+  return (
+    <div
+      className={cn([
+        "overflow-hidden rounded-b-xl border-x border-b border-neutral-200 bg-white",
+        fillHeight && "flex min-h-0 flex-1 flex-col",
+      ])}
+    >
       {children}
     </div>
   );

--- a/apps/desktop/src/session/components/session-surface.tsx
+++ b/apps/desktop/src/session/components/session-surface.tsx
@@ -5,6 +5,8 @@ export function SessionSurface({
   title,
   children,
   afterBorder,
+  afterBorderExpanded,
+  afterBorderResizable,
   bottomBorderHandle,
   floatingButton,
   mergeAfterBorder,
@@ -13,6 +15,8 @@ export function SessionSurface({
   title?: React.ReactNode;
   children: React.ReactNode;
   afterBorder?: React.ReactNode;
+  afterBorderExpanded?: boolean;
+  afterBorderResizable?: boolean;
   bottomBorderHandle?: React.ReactNode;
   floatingButton?: React.ReactNode;
   mergeAfterBorder?: boolean;
@@ -20,6 +24,8 @@ export function SessionSurface({
   return (
     <StandardTabWrapper
       afterBorder={afterBorder}
+      afterBorderExpanded={afterBorderExpanded}
+      afterBorderResizable={afterBorderResizable}
       bottomBorderHandle={bottomBorderHandle}
       floatingButton={floatingButton}
       mergeAfterBorder={mergeAfterBorder}

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -234,6 +234,12 @@ function TabContentNoteInner({
     bottomAccessoryState?.expanded === true &&
     (bottomAccessoryState.mode === "playback" ||
       bottomAccessoryState.mode === "transcript_only");
+  const canResizeTranscriptSurface =
+    bottomAccessoryState?.mode === "live" ||
+    bottomAccessoryState?.mode === "playback" ||
+    bottomAccessoryState?.mode === "transcript_only";
+  const resizeTranscriptSurface =
+    bottomAccessoryState?.expanded === true && canResizeTranscriptSurface;
 
   return (
     <SessionSurface
@@ -249,6 +255,8 @@ function TabContentNoteInner({
         />
       }
       afterBorder={bottomAccessory}
+      afterBorderExpanded={resizeTranscriptSurface}
+      afterBorderResizable={canResizeTranscriptSurface}
       bottomBorderHandle={bottomBorderHandle}
       mergeAfterBorder={mergeTranscriptSurface}
       floatingButton={<FloatingActionButton tab={tab} />}

--- a/apps/desktop/src/shared/main/index.test.tsx
+++ b/apps/desktop/src/shared/main/index.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
+import * as React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { resizeMock } = vi.hoisted(() => ({
@@ -98,9 +99,50 @@ describe("StandardTabWrapper", () => {
       </StandardTabWrapper>,
     );
 
-    expect(screen.queryByTestId("panel-group")).toBeNull();
+    expect(screen.getByTestId("panel-group").dataset.direction).toBe(
+      "vertical",
+    );
     expect(screen.queryByTestId("resize-handle")).toBeNull();
+    expect(screen.getAllByTestId("panel")).toHaveLength(1);
+    expect(screen.getByTestId("panel").dataset.defaultSize).toBe("100");
     expect(screen.getByTestId("bottom-area")).toBeTruthy();
     expect(resizeMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps main content mounted when expandable bottom content toggles", () => {
+    const mountMock = vi.fn();
+
+    class MainArea extends React.Component {
+      componentDidMount() {
+        mountMock();
+      }
+
+      render() {
+        return <div data-testid="main-area" />;
+      }
+    }
+
+    const { rerender } = render(
+      <StandardTabWrapper
+        afterBorder={<div data-testid="bottom-area" />}
+        afterBorderResizable
+        bottomBorderHandle={<button>Live</button>}
+      >
+        <MainArea />
+      </StandardTabWrapper>,
+    );
+
+    rerender(
+      <StandardTabWrapper
+        afterBorder={<div data-testid="bottom-area" />}
+        afterBorderExpanded
+        afterBorderResizable
+        bottomBorderHandle={<button>Live</button>}
+      >
+        <MainArea />
+      </StandardTabWrapper>,
+    );
+
+    expect(mountMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/shared/main/index.test.tsx
+++ b/apps/desktop/src/shared/main/index.test.tsx
@@ -1,0 +1,106 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { resizeMock } = vi.hoisted(() => ({
+  resizeMock: vi.fn(),
+}));
+
+vi.mock("@hypr/ui/components/ui/resizable", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    ResizablePanelGroup: ({
+      children,
+      direction,
+    }: {
+      children: React.ReactNode;
+      direction: string;
+    }) => (
+      <div data-direction={direction} data-testid="panel-group">
+        {children}
+      </div>
+    ),
+    ResizablePanel: React.forwardRef<
+      { resize: (size: number) => void },
+      {
+        children: React.ReactNode;
+        defaultSize?: number;
+        maxSize?: number;
+        minSize?: number;
+      }
+    >(function ResizablePanel(
+      { children, defaultSize, maxSize, minSize },
+      ref,
+    ) {
+      React.useImperativeHandle(ref, () => ({
+        resize: resizeMock,
+      }));
+
+      return (
+        <div
+          data-default-size={defaultSize}
+          data-max-size={maxSize}
+          data-min-size={minSize}
+          data-testid="panel"
+        >
+          {children}
+        </div>
+      );
+    }),
+    ResizableHandle: ({ disabled }: { disabled?: boolean }) => (
+      <div
+        data-disabled={disabled ? "true" : "false"}
+        data-testid="resize-handle"
+      />
+    ),
+  };
+});
+
+import { StandardTabWrapper } from "./index";
+
+describe("StandardTabWrapper", () => {
+  beforeEach(() => {
+    cleanup();
+    resizeMock.mockClear();
+  });
+
+  it("renders a vertical resizable split for expandable bottom content", () => {
+    render(
+      <StandardTabWrapper
+        afterBorder={<div data-testid="bottom-area" />}
+        afterBorderExpanded
+        afterBorderResizable
+        bottomBorderHandle={<button>Live</button>}
+      >
+        <div data-testid="main-area" />
+      </StandardTabWrapper>,
+    );
+
+    expect(screen.getByTestId("panel-group").dataset.direction).toBe(
+      "vertical",
+    );
+    expect(screen.getByTestId("resize-handle").dataset.disabled).toBe("false");
+
+    const panels = screen.getAllByTestId("panel");
+    expect(panels[0]?.dataset.defaultSize).toBe("78");
+    expect(panels[1]?.dataset.defaultSize).toBe("22");
+    expect(panels[1]?.dataset.maxSize).toBe("60");
+    expect(resizeMock).toHaveBeenCalledWith(22);
+  });
+
+  it("sizes collapsed bottom content to its row instead of reserving split space", () => {
+    render(
+      <StandardTabWrapper
+        afterBorder={<div data-testid="bottom-area" />}
+        afterBorderResizable
+        bottomBorderHandle={<button>Live</button>}
+      >
+        <div data-testid="main-area" />
+      </StandardTabWrapper>,
+    );
+
+    expect(screen.queryByTestId("panel-group")).toBeNull();
+    expect(screen.queryByTestId("resize-handle")).toBeNull();
+    expect(screen.getByTestId("bottom-area")).toBeTruthy();
+    expect(resizeMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -82,7 +82,7 @@ export function StandardTabWrapper({
             <ResizableHandle
               disabled={!afterBorderExpanded}
               className={cn([
-                "z-10 bg-transparent",
+                "z-10 !bg-transparent",
                 !afterBorderExpanded && "pointer-events-none",
               ])}
             />

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -1,4 +1,14 @@
+import { useLayoutEffect, useRef } from "react";
+
+import {
+  type ImperativePanelHandle,
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@hypr/ui/components/ui/resizable";
 import { cn } from "@hypr/utils";
+
+const RESIZABLE_AFTER_BORDER_EXPANDED_SIZE = 22;
 
 export { MainShellBodyFrame } from "./body-frame";
 export { MainChatPanels } from "./chat-panels";
@@ -17,6 +27,8 @@ export function StandardTabWrapper({
   children,
   afterBorder,
   bottomBorderHandle,
+  afterBorderResizable = false,
+  afterBorderExpanded = false,
   floatingButton,
   mergeAfterBorder = false,
   noBorder = false,
@@ -24,46 +36,158 @@ export function StandardTabWrapper({
   children: React.ReactNode;
   afterBorder?: React.ReactNode;
   bottomBorderHandle?: React.ReactNode;
+  afterBorderResizable?: boolean;
+  afterBorderExpanded?: boolean;
   floatingButton?: React.ReactNode;
   mergeAfterBorder?: boolean;
   noBorder?: boolean;
 }) {
+  const afterBorderPanelRef = useRef<ImperativePanelHandle>(null);
+  const afterBorderSize = RESIZABLE_AFTER_BORDER_EXPANDED_SIZE;
+  const hasAfterBorder = Boolean(afterBorder);
+  const useResizableAfterBorder =
+    hasAfterBorder && afterBorderResizable && afterBorderExpanded;
+
+  useLayoutEffect(() => {
+    if (useResizableAfterBorder) {
+      afterBorderPanelRef.current?.resize(afterBorderSize);
+    }
+  }, [afterBorderSize, useResizableAfterBorder]);
+
+  const mainPanel = (
+    <MainPanel
+      bottomBorderHandle={bottomBorderHandle}
+      fill={useResizableAfterBorder}
+      floatingButton={floatingButton}
+      mergeAfterBorder={mergeAfterBorder}
+      noBorder={noBorder}
+      afterBorder={afterBorder}
+    >
+      {children}
+    </MainPanel>
+  );
+
+  if (useResizableAfterBorder) {
+    return (
+      <ResizablePanelGroup direction="vertical" className="h-full">
+        <ResizablePanel
+          defaultSize={100 - afterBorderSize}
+          minSize={35}
+          className="min-h-0"
+        >
+          {mainPanel}
+        </ResizablePanel>
+        <ResizableHandle
+          disabled={!afterBorderExpanded}
+          className={cn([
+            "z-10 bg-transparent",
+            !afterBorderExpanded && "pointer-events-none",
+          ])}
+        />
+        <ResizablePanel
+          ref={afterBorderPanelRef}
+          defaultSize={afterBorderSize}
+          minSize={afterBorderExpanded ? 10 : 6}
+          maxSize={60}
+          className="min-h-0 overflow-hidden"
+        >
+          <AfterBorderContent
+            bottomBorderHandle={bottomBorderHandle}
+            fill={afterBorderExpanded}
+            mergeAfterBorder={mergeAfterBorder}
+          >
+            {afterBorder}
+          </AfterBorderContent>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    );
+  }
+
   return (
     <div className="flex h-full flex-col">
-      <div className="relative flex min-h-0 flex-1 flex-col">
-        <div
-          data-chat-floating-anchor
-          className={cn([
-            "relative flex min-h-0 flex-1 flex-col overflow-hidden bg-white",
-            mergeAfterBorder && afterBorder
-              ? "rounded-t-xl rounded-b-none"
-              : "rounded-xl",
-            !noBorder &&
-              (mergeAfterBorder && afterBorder
-                ? "border border-b-0 border-neutral-200"
-                : "border border-neutral-200"),
-          ])}
-        >
-          {children}
-          {floatingButton}
-        </div>
-        {bottomBorderHandle ? (
-          <div className="pointer-events-none absolute right-0 bottom-0 left-0 z-20">
-            <div className="pointer-events-auto relative">
-              {bottomBorderHandle}
-            </div>
-          </div>
-        ) : null}
-      </div>
+      {mainPanel}
       {afterBorder ? (
-        <div
-          className={cn([
-            !mergeAfterBorder && (bottomBorderHandle ? "pt-[10px]" : "mt-1"),
-          ])}
+        <AfterBorderContent
+          bottomBorderHandle={bottomBorderHandle}
+          mergeAfterBorder={mergeAfterBorder}
         >
           {afterBorder}
+        </AfterBorderContent>
+      ) : null}
+    </div>
+  );
+}
+
+function MainPanel({
+  children,
+  afterBorder,
+  bottomBorderHandle,
+  fill,
+  floatingButton,
+  mergeAfterBorder,
+  noBorder,
+}: {
+  children: React.ReactNode;
+  afterBorder?: React.ReactNode;
+  bottomBorderHandle?: React.ReactNode;
+  fill: boolean;
+  floatingButton?: React.ReactNode;
+  mergeAfterBorder: boolean;
+  noBorder: boolean;
+}) {
+  return (
+    <div
+      className={cn([
+        "relative flex min-h-0 flex-1 flex-col",
+        fill && "h-full",
+      ])}
+    >
+      <div
+        data-chat-floating-anchor
+        className={cn([
+          "relative flex min-h-0 flex-1 flex-col overflow-hidden bg-white",
+          mergeAfterBorder && afterBorder
+            ? "rounded-t-xl rounded-b-none"
+            : "rounded-xl",
+          !noBorder &&
+            (mergeAfterBorder && afterBorder
+              ? "border border-b-0 border-neutral-200"
+              : "border border-neutral-200"),
+        ])}
+      >
+        {children}
+        {floatingButton}
+      </div>
+      {bottomBorderHandle ? (
+        <div className="pointer-events-none absolute right-0 bottom-0 left-0 z-20">
+          <div className="pointer-events-auto relative">
+            {bottomBorderHandle}
+          </div>
         </div>
       ) : null}
+    </div>
+  );
+}
+
+function AfterBorderContent({
+  children,
+  bottomBorderHandle,
+  fill = false,
+  mergeAfterBorder,
+}: {
+  children: React.ReactNode;
+  bottomBorderHandle?: React.ReactNode;
+  fill?: boolean;
+  mergeAfterBorder: boolean;
+}) {
+  return (
+    <div
+      className={cn([
+        !mergeAfterBorder && (bottomBorderHandle ? "pt-[10px]" : "mt-1"),
+        fill && "flex h-full min-h-0 flex-col overflow-hidden",
+      ])}
+    >
+      {children}
     </div>
   );
 }

--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -57,7 +57,7 @@ export function StandardTabWrapper({
   const mainPanel = (
     <MainPanel
       bottomBorderHandle={bottomBorderHandle}
-      fill={useResizableAfterBorder}
+      fill
       floatingButton={floatingButton}
       mergeAfterBorder={mergeAfterBorder}
       noBorder={noBorder}
@@ -67,46 +67,44 @@ export function StandardTabWrapper({
     </MainPanel>
   );
 
-  if (useResizableAfterBorder) {
-    return (
-      <ResizablePanelGroup direction="vertical" className="h-full">
+  return (
+    <div className="flex h-full flex-col">
+      <ResizablePanelGroup direction="vertical" className="min-h-0 flex-1">
         <ResizablePanel
-          defaultSize={100 - afterBorderSize}
+          defaultSize={useResizableAfterBorder ? 100 - afterBorderSize : 100}
           minSize={35}
           className="min-h-0"
         >
           {mainPanel}
         </ResizablePanel>
-        <ResizableHandle
-          disabled={!afterBorderExpanded}
-          className={cn([
-            "z-10 bg-transparent",
-            !afterBorderExpanded && "pointer-events-none",
-          ])}
-        />
-        <ResizablePanel
-          ref={afterBorderPanelRef}
-          defaultSize={afterBorderSize}
-          minSize={afterBorderExpanded ? 10 : 6}
-          maxSize={60}
-          className="min-h-0 overflow-hidden"
-        >
-          <AfterBorderContent
-            bottomBorderHandle={bottomBorderHandle}
-            fill={afterBorderExpanded}
-            mergeAfterBorder={mergeAfterBorder}
-          >
-            {afterBorder}
-          </AfterBorderContent>
-        </ResizablePanel>
+        {useResizableAfterBorder ? (
+          <>
+            <ResizableHandle
+              disabled={!afterBorderExpanded}
+              className={cn([
+                "z-10 bg-transparent",
+                !afterBorderExpanded && "pointer-events-none",
+              ])}
+            />
+            <ResizablePanel
+              ref={afterBorderPanelRef}
+              defaultSize={afterBorderSize}
+              minSize={afterBorderExpanded ? 10 : 6}
+              maxSize={60}
+              className="min-h-0 overflow-hidden"
+            >
+              <AfterBorderContent
+                bottomBorderHandle={bottomBorderHandle}
+                fill={afterBorderExpanded}
+                mergeAfterBorder={mergeAfterBorder}
+              >
+                {afterBorder}
+              </AfterBorderContent>
+            </ResizablePanel>
+          </>
+        ) : null}
       </ResizablePanelGroup>
-    );
-  }
-
-  return (
-    <div className="flex h-full flex-col">
-      {mainPanel}
-      {afterBorder ? (
+      {afterBorder && !useResizableAfterBorder ? (
         <AfterBorderContent
           bottomBorderHandle={bottomBorderHandle}
           mergeAfterBorder={mergeAfterBorder}


### PR DESCRIPTION
Keep the expanded Live handle neutral-50, pin live transcript scrolling to the newest rows, truncate long speaker chips, and make the expanded live footer resizable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: refactors `StandardTabWrapper` layout to use a resizable split and changes live transcript auto-scrolling behavior, which could introduce regressions in session UI sizing/mounting and scroll interactions.
> 
> **Overview**
> Improves the session bottom accessory UX by making the expanded live/transcript footer **resizable** and able to **fill available height** via new `afterBorderExpanded/afterBorderResizable` plumbing from `SessionSurface`/`session/index.tsx` into `StandardTabWrapper` (now a vertical `ResizablePanelGroup`).
> 
> Polishes the live transcript footer: it now **pins to bottom** only while the user is already at the bottom (manual scrolling disables pinning until scrolled back), adds a stable `scrollKey` trigger, and **truncates long speaker labels** to prevent layout stretching. Post-session playback is kept mounted so the **audio timeline stays visible** when the transcript panel is collapsed, and the live expand handle keeps its `bg-neutral-50` styling.
> 
> Adds/updates Vitest coverage for the new scroll pinning, label truncation, resizable split behavior, and collapsed playback/timeline cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13c58ea265256669394de59241b20c38f70eeb58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->