### PR TITLE
fix(desktop): clean up post-meeting summary state

### DIFF
--- a/apps/desktop/src/services/enhancer/index.ts
+++ b/apps/desktop/src/services/enhancer/index.ts
@@ -355,7 +355,14 @@ export class EnhancerService {
     enhancedNoteId: string,
     templateId: string,
   ): Promise<void> {
-    const template = await getTemplateById(templateId);
+    let template: Awaited<ReturnType<typeof getTemplateById>>;
+    try {
+      template = await getTemplateById(templateId);
+    } catch (error) {
+      console.error("[enhancer] failed to hydrate template title", error);
+      return;
+    }
+
     const title = template?.title?.trim();
     if (!title) {
       return;

--- a/apps/desktop/src/session/components/outer-header/listen.tsx
+++ b/apps/desktop/src/session/components/outer-header/listen.tsx
@@ -1,89 +1,19 @@
 import { MicOff } from "lucide-react";
-import { useCallback } from "react";
 
 import { DancingSticks } from "@hypr/ui/components/ui/dancing-sticks";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@hypr/ui/components/ui/tooltip";
 import { cn } from "@hypr/utils";
 
-import {
-  ActionableTooltipContent,
-  RecordingIcon,
-  useHasTranscript,
-  useListenButtonState,
-} from "~/session/components/shared";
-import { useTabs } from "~/store/zustand/tabs";
+import { useListenButtonState } from "~/session/components/shared";
 import { useListener } from "~/stt/contexts";
-import { useStartListening } from "~/stt/useStartListening";
 
 export function ListenButton({ sessionId }: { sessionId: string }) {
   const { shouldRender } = useListenButtonState(sessionId);
-  const hasTranscript = useHasTranscript(sessionId);
 
   if (!shouldRender) {
     return <InMeetingIndicator sessionId={sessionId} />;
   }
 
-  if (hasTranscript) {
-    return <StartButton sessionId={sessionId} />;
-  }
-
   return null;
-}
-
-function StartButton({ sessionId }: { sessionId: string }) {
-  const { isDisabled, warningMessage } = useListenButtonState(sessionId);
-  const handleClick = useStartListening(sessionId);
-  const openNew = useTabs((state) => state.openNew);
-
-  const handleConfigureAction = useCallback(() => {
-    openNew({ type: "settings", state: { tab: "transcription" } });
-  }, [openNew]);
-
-  const button = (
-    <button
-      type="button"
-      onClick={handleClick}
-      disabled={isDisabled}
-      className={cn([
-        "inline-flex items-center justify-center rounded-md text-xs font-medium",
-        "text-neutral-900",
-        "hover:bg-neutral-100/80",
-        "gap-1.5",
-        "h-7 px-2",
-        "disabled:pointer-events-none disabled:opacity-50",
-      ])}
-    >
-      <span className="flex items-center gap-1.5 whitespace-nowrap">
-        <RecordingIcon />
-        <span>Resume listening</span>
-      </span>
-    </button>
-  );
-
-  if (!warningMessage) {
-    return button;
-  }
-
-  return (
-    <Tooltip delayDuration={0}>
-      <TooltipTrigger asChild>
-        <span className="inline-block">{button}</span>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">
-        <ActionableTooltipContent
-          message={warningMessage}
-          action={{
-            label: "Configure",
-            handleClick: handleConfigureAction,
-          }}
-        />
-      </TooltipContent>
-    </Tooltip>
-  );
 }
 
 function InMeetingIndicator({ sessionId }: { sessionId: string }) {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-transform.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-transform.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { enhanceTransform } from "./enhance-transform";
+
+const getTemplateByIdMock = vi.hoisted(() => vi.fn());
+
+vi.mock("~/templates/queries", () => ({
+  getTemplateById: getTemplateByIdMock,
+}));
+
+function createStore() {
+  return {
+    forEachRow: vi.fn(),
+    getCell: vi.fn((tableId: string, _rowId: string, cellId: string) => {
+      if (tableId === "sessions" && cellId === "title") {
+        return "Weekly Review";
+      }
+
+      return "";
+    }),
+    getRow: vi.fn((tableId: string) => {
+      if (tableId === "sessions") {
+        return { title: "Weekly Review" };
+      }
+
+      return undefined;
+    }),
+  } as any;
+}
+
+function createSettingsStore() {
+  return {
+    getValue: vi.fn(() => "en"),
+  } as any;
+}
+
+describe("enhanceTransform.transformArgs", () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getTemplateByIdMock.mockResolvedValue(null);
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it("uses the selected template when it can be loaded", async () => {
+    getTemplateByIdMock.mockResolvedValue({
+      title: "Standup",
+      description: "Daily sync",
+      sections: [{ title: "Updates", description: null }],
+    });
+
+    const result = await enhanceTransform.transformArgs(
+      {
+        sessionId: "session-1",
+        enhancedNoteId: "note-1",
+        templateId: "template-1",
+      },
+      createStore(),
+      createSettingsStore(),
+    );
+
+    expect(result.template).toEqual({
+      title: "Standup",
+      description: "Daily sync",
+      sections: [{ title: "Updates", description: null }],
+    });
+  });
+
+  it("falls back to generic enhancement when template loading fails", async () => {
+    getTemplateByIdMock.mockRejectedValue(new Error("Failed query"));
+
+    const result = await enhanceTransform.transformArgs(
+      {
+        sessionId: "session-1",
+        enhancedNoteId: "note-1",
+        templateId: "template-1",
+      },
+      createStore(),
+      createSettingsStore(),
+    );
+
+    expect(result.template).toBeNull();
+    expect(result.session.title).toBe("Weekly Review");
+    expect(consoleError).toHaveBeenCalledWith(
+      "[enhance] failed to load template",
+      expect.any(Error),
+    );
+  });
+});

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-transform.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-transform.ts
@@ -43,7 +43,7 @@ async function transformArgs(
   const { sessionId, templateId } = args;
 
   const sessionContext = getSessionContext(sessionId, store);
-  const templateRecord = templateId ? await getTemplateById(templateId) : null;
+  const templateRecord = await loadTemplate(templateId);
   const template = templateRecord
     ? {
         title: templateRecord.title,
@@ -66,6 +66,19 @@ async function transformArgs(
     postMeetingMemo: sessionContext.postMeetingMemo,
     transcripts: formatTranscripts(segments, sessionContext.transcriptsMeta),
   };
+}
+
+async function loadTemplate(templateId: string | undefined) {
+  if (!templateId) {
+    return null;
+  }
+
+  try {
+    return await getTemplateById(templateId);
+  } catch (error) {
+    console.error("[enhance] failed to load template", error);
+    return null;
+  }
 }
 
 function formatTranscripts(


### PR DESCRIPTION
Hide the inactive header resume CTA and let enhancement fall back when optional template lookup fails.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly adds defensive error handling around optional template loading and removes an inactive header CTA; behavior changes are localized to enhancement/template selection and header rendering.
> 
> **Overview**
> Improves robustness of enhancement when a selected template can’t be fetched: both the enhancer’s `hydrateTemplateTitle` and `enhanceTransform.transformArgs` now catch `getTemplateById` errors, log them, and fall back to generic enhancement (no template).
> 
> Cleans up the outer header listen UI by removing the “Resume listening” CTA/tooltip branch, leaving only the in-meeting indicator/stop control, and adds a focused unit test to assert the template-load fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08e1d59b5644a692a10663a62d3ac826da2ad176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->