### PR TITLE
fix(desktop): use chat icon for chat CTA

### DIFF
--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -1,3 +1,5 @@
+import { MessageCircle } from "lucide-react";
+
 import { useShell } from "~/contexts/shell";
 
 export function ChatCTA({
@@ -27,11 +29,7 @@ export function ChatCTA({
       onClick={handleClick}
       className="flex items-center gap-2 rounded-full border-2 border-stone-600 bg-stone-800 px-4 py-2 text-sm text-white shadow-[0_4px_14px_rgba(87,83,78,0.4)] transition-colors hover:bg-stone-700"
     >
-      <img
-        src="/assets/anarlog-icon.png"
-        alt=""
-        className="size-4 shrink-0 object-contain object-center"
-      />
+      <MessageCircle className="size-4 shrink-0" aria-hidden="true" />
       <span>{label}</span>
     </button>
   );


### PR DESCRIPTION
Replace the Anarlog glyph in shared ChatCTA with the Lucide chat icon for session and task floating actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that swaps the CTA icon; no behavior, state, or data-handling logic is modified.
> 
> **Overview**
> Updates the shared `ChatCTA` button to render a `lucide-react` `MessageCircle` icon instead of the bundled `/assets/anarlog-icon.png` image, keeping the CTA behavior and styling otherwise unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb0d48c05a2d23930a96331795f25247c585f478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->