### PR TITLE
fix(desktop): widen settings dropdowns

### DIFF
--- a/apps/desktop/src/settings/general/main-language.tsx
+++ b/apps/desktop/src/settings/general/main-language.tsx
@@ -54,7 +54,7 @@ export function MainLanguageView({
         options={options}
         placeholder="Select language"
         searchPlaceholder="Search language..."
-        className="w-40"
+        className="w-48"
       />
     </div>
   );

--- a/apps/desktop/src/settings/general/searchable-select.tsx
+++ b/apps/desktop/src/settings/general/searchable-select.tsx
@@ -32,6 +32,7 @@ interface SearchableSelectProps {
   searchPlaceholder?: string;
   emptyMessage?: string;
   className?: string;
+  dropdownClassName?: string;
 }
 
 const filterFunction = (value: string, search: string) => {
@@ -51,6 +52,7 @@ export function SearchableSelect({
   searchPlaceholder = "Search...",
   emptyMessage = "No results found.",
   className,
+  dropdownClassName,
 }: SearchableSelectProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -96,7 +98,12 @@ export function SearchableSelect({
       <PopoverContent
         variant="app"
         align="start"
-        style={{ width: "var(--radix-popover-trigger-width)" }}
+        className={dropdownClassName}
+        style={{
+          width: dropdownClassName
+            ? undefined
+            : "var(--radix-popover-trigger-width)",
+        }}
       >
         <AppFloatingPanel className="overflow-hidden">
           <Command

--- a/apps/desktop/src/settings/general/timezone.tsx
+++ b/apps/desktop/src/settings/general/timezone.tsx
@@ -68,7 +68,8 @@ export function TimezoneSelector() {
         options={options}
         placeholder="Select timezone"
         searchPlaceholder="Search timezone..."
-        className="w-40"
+        className="w-48"
+        dropdownClassName="w-72"
       />
     </div>
   );


### PR DESCRIPTION
Set the language and timezone selectors to 192px so labels and search placeholders have more room.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only sizing changes; behavior is unchanged aside from allowing an optional custom dropdown width.
> 
> **Overview**
> Settings language and timezone selectors are widened (`w-40` → `w-48`) to better fit labels/placeholders.
> 
> `SearchableSelect` now supports an optional `dropdownClassName` to override `PopoverContent` sizing; when provided (used by timezone as `w-72`), it skips the default trigger-width style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cfb82886836e46eea9c269f786adfb5335a13d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->