### PR TITLE
fix(desktop): move data settings into own menu

### DIFF
--- a/apps/desktop/src/settings/general/index.tsx
+++ b/apps/desktop/src/settings/general/index.tsx
@@ -169,13 +169,16 @@ export function SettingsApp() {
           </form.Field>
         </div>
       </div>
+    </div>
+  );
+}
 
+export function SettingsData() {
+  return (
+    <div className="flex flex-col gap-8">
+      <SettingsPageTitle title="Data" />
       <StorageSettingsView />
-
-      <div>
-        <h2 className="mb-4 font-serif text-lg font-semibold">Data</h2>
-        <Data />
-      </div>
+      <Data />
     </div>
   );
 }

--- a/apps/desktop/src/settings/index.tsx
+++ b/apps/desktop/src/settings/index.tsx
@@ -5,6 +5,7 @@ import { cn } from "@hypr/utils";
 import {
   SettingsAccount,
   SettingsApp,
+  SettingsData,
   SettingsNotifications,
   SettingsPermissions,
 } from "./general";
@@ -65,6 +66,8 @@ function SettingsView({ tab }: { tab: Extract<Tab, { type: "settings" }> }) {
         return <SettingsAccount />;
       case "app":
         return <SettingsApp />;
+      case "data":
+        return <SettingsData />;
       case "notifications":
         return <SettingsNotifications />;
       case "permissions":

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -1,5 +1,3 @@
-import { useQuery } from "@tanstack/react-query";
-import { getIdentifier } from "@tauri-apps/api/app";
 import { platform } from "@tauri-apps/plugin-os";
 import {
   AudioLinesIcon,
@@ -7,7 +5,7 @@ import {
   BellIcon,
   BookText,
   CalendarIcon,
-  FlaskConical,
+  DatabaseIcon,
   LockIcon,
   SmartphoneIcon,
   SparklesIcon,
@@ -29,7 +27,7 @@ type SettingsNavItem =
 
 type SettingsNavGroup = { label: string; items: SettingsNavItem[] };
 
-function getBaseGroups(showLab: boolean): SettingsNavGroup[] {
+function getBaseGroups(): SettingsNavGroup[] {
   const aiItems: SettingsNavItem[] = [
     { id: "transcription", label: "Transcription", icon: AudioLinesIcon },
     { id: "intelligence", label: "Intelligence", icon: SparklesIcon },
@@ -40,11 +38,12 @@ function getBaseGroups(showLab: boolean): SettingsNavGroup[] {
     },
   ];
 
-  const groups: SettingsNavGroup[] = [
+  return [
     {
       label: "General",
       items: [
         { id: "app", label: "App", icon: SmartphoneIcon },
+        { id: "data", label: "Data", icon: DatabaseIcon },
         { id: "account", label: "Account", icon: UserIcon },
         { id: "notifications", label: "Notifications", icon: BellIcon },
       ],
@@ -54,15 +53,6 @@ function getBaseGroups(showLab: boolean): SettingsNavGroup[] {
       items: aiItems,
     },
   ];
-
-  if (showLab) {
-    groups.push({
-      label: "Lab",
-      items: [{ id: "lab", label: "Preview", icon: FlaskConical }],
-    });
-  }
-
-  return groups;
 }
 
 export function SettingsNav() {
@@ -92,15 +82,7 @@ export function SettingsNav() {
     openNew({ type: "calendar" });
   }, [openNew]);
 
-  const identifierQuery = useQuery({
-    queryKey: ["app-identifier"],
-    queryFn: () => getIdentifier(),
-    staleTime: Infinity,
-  });
-
-  const showLab = identifierQuery.data !== "com.hyprnote.stable";
-
-  const groups = getBaseGroups(showLab);
+  const groups = getBaseGroups();
   const isMacos = platform() === "macos";
   if (isMacos) {
     groups[0].items.push({

--- a/apps/desktop/src/store/zustand/tabs/schema.ts
+++ b/apps/desktop/src/store/zustand/tabs/schema.ts
@@ -29,6 +29,7 @@ export const isTabInputSupported = (tab: WindowsTabInput): tab is TabInput => {
 export type SettingsTab =
   | "account"
   | "app"
+  | "data"
   | "notifications"
   | "permissions"
   | "lab"
@@ -41,6 +42,7 @@ export const normalizeSettingsTab = (
 ): Exclude<SettingsTab, "account"> => {
   switch (tab) {
     case "app":
+    case "data":
     case "notifications":
     case "permissions":
     case "lab":


### PR DESCRIPTION
Add a Data settings tab and sidebar item while removing the import section from App settings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/navigation refactor; main risk is misrouting or hiding/showing settings tabs (notably `lab`) due to sidebar and tab-schema changes.
> 
> **Overview**
> Introduces a new **Data** settings section: adds `SettingsData` and routes the `data` subtab in `settings/index.tsx`, and adds a **Data** item to the Settings sidebar.
> 
> Moves the existing data/storage UI (`StorageSettingsView` and `Data`) out of the App settings page into this new tab, and updates the tabs schema (`SettingsTab`/`normalizeSettingsTab`) to recognize `data`. Also removes the stable-build check that previously conditionally hid the `Lab` group from the settings sidebar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50ad3d279a333e9bbcc2270b56a888a83ce49023. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->