### PR TITLE
fix(desktop): make template creation reachable

### DIFF
--- a/apps/desktop/src/templates/details.tsx
+++ b/apps/desktop/src/templates/details.tsx
@@ -1,4 +1,4 @@
-import { HeartIcon, MoreHorizontalIcon } from "lucide-react";
+import { HeartIcon, MoreHorizontalIcon, PlusIcon } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@hypr/ui/components/ui/button";
@@ -26,6 +26,7 @@ export function TemplateDetailsColumn({
   isWebMode,
   selectedMineTemplate,
   selectedWebTemplate,
+  handleCreateTemplate,
   handleDeleteTemplate,
   handleDuplicateTemplate,
   handleCloneTemplate,
@@ -35,6 +36,7 @@ export function TemplateDetailsColumn({
   isWebMode: boolean;
   selectedMineTemplate: UserTemplate | null;
   selectedWebTemplate: WebTemplate | null;
+  handleCreateTemplate: () => void;
   handleDeleteTemplate: (id: string) => void;
   handleDuplicateTemplate: (id: string) => void;
   handleCloneTemplate: (template: UserTemplateDraft) => void;
@@ -56,7 +58,7 @@ export function TemplateDetailsColumn({
   }
 
   if (!selectedMineTemplate) {
-    return <ResourceDetailEmpty message="No templates yet" />;
+    return <TemplateDetailEmpty onCreate={handleCreateTemplate} />;
   }
 
   return (
@@ -66,6 +68,24 @@ export function TemplateDetailsColumn({
       handleDeleteTemplate={handleDeleteTemplate}
       handleDuplicateTemplate={handleDuplicateTemplate}
     />
+  );
+}
+
+function TemplateDetailEmpty({ onCreate }: { onCreate: () => void }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3">
+      <p className="text-sm text-neutral-500">No templates yet</p>
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        onClick={onCreate}
+        className="gap-2"
+      >
+        <PlusIcon className="size-4" />
+        Create template
+      </Button>
+    </div>
   );
 }
 

--- a/apps/desktop/src/templates/queries.test.tsx
+++ b/apps/desktop/src/templates/queries.test.tsx
@@ -1,9 +1,16 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { executeProxy, subscribe } from "@hypr/plugin-db";
 
-import { getTemplateById, useUserTemplate, useUserTemplates } from "./queries";
+import {
+  getTemplateById,
+  useCreateTemplate,
+  useUserTemplate,
+  useUserTemplates,
+} from "./queries";
 
 type SubscribeOptions<T> = {
   onData: (rows: T[]) => void;
@@ -13,6 +20,23 @@ type SubscribeOptions<T> = {
 describe("template queries", () => {
   const executeProxyMock = vi.mocked(executeProxy);
   const subscribeMock = vi.mocked(subscribe);
+
+  function createWrapper() {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        mutations: { retry: false },
+        queries: { retry: false },
+      },
+    });
+
+    return function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      );
+    };
+  }
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -111,5 +135,32 @@ describe("template queries", () => {
       targets: ["engineering"],
       sections: [{ title: "Notes", description: "Capture updates" }],
     });
+  });
+
+  it("creates a template row through the SQLite proxy", async () => {
+    const { result } = renderHook(() => useCreateTemplate(), {
+      wrapper: createWrapper(),
+    });
+
+    let createdId: string | undefined;
+    await act(async () => {
+      createdId = await result.current({
+        title: "New Template",
+        description: "",
+        sections: [],
+      });
+    });
+
+    expect(createdId).toEqual(expect.any(String));
+    expect(executeProxyMock).toHaveBeenCalledWith(
+      expect.stringContaining('insert into "templates"'),
+      [createdId, "New Template", "", 0, null, "[]"],
+      "run",
+    );
+    expect(executeProxyMock).toHaveBeenCalledWith(
+      expect.stringContaining("strftime('%Y-%m-%dT%H:%M:%SZ', 'now')"),
+      expect.any(Array),
+      "run",
+    );
   });
 });

--- a/apps/desktop/src/templates/template-body.tsx
+++ b/apps/desktop/src/templates/template-body.tsx
@@ -19,6 +19,7 @@ export function TemplateView({
     selectedWebTemplate,
     setSelectedMineId,
     createTemplate,
+    createDefaultTemplate,
     deleteTemplate,
     toggleTemplateFavorite,
   } = useTemplateTab(tab);
@@ -96,6 +97,7 @@ export function TemplateView({
         isWebMode={isWebMode}
         selectedMineTemplate={selectedMineTemplate}
         selectedWebTemplate={selectedWebTemplate}
+        handleCreateTemplate={createDefaultTemplate}
         handleDeleteTemplate={handleDeleteTemplate}
         handleDuplicateTemplate={handleDuplicateTemplate}
         handleCloneTemplate={handleCloneTemplate}

--- a/apps/desktop/src/templates/template-sidebar.tsx
+++ b/apps/desktop/src/templates/template-sidebar.tsx
@@ -39,21 +39,10 @@ export function TemplatesSidebarContent({
     setSelectedMineId,
     setSelectedWebIndex,
     createTemplate,
+    createDefaultTemplate,
     deleteTemplate,
     toggleTemplateFavorite,
   } = useTemplateTab(tab);
-
-  const handleCreateTemplate = useCallback(async () => {
-    const id = await createTemplate({
-      title: "New Template",
-      description: "",
-      sections: [],
-    });
-
-    if (id) {
-      setSelectedMineId(id);
-    }
-  }, [createTemplate, setSelectedMineId]);
 
   const handleDuplicateTemplate = useCallback(
     async (template: UserTemplate) => {
@@ -338,7 +327,7 @@ export function TemplatesSidebarContent({
               size="icon"
               variant="ghost"
               className="text-neutral-600 hover:text-black"
-              onClick={handleCreateTemplate}
+              onClick={createDefaultTemplate}
             >
               <Plus size={16} />
             </Button>
@@ -394,7 +383,7 @@ export function TemplatesSidebarContent({
             </p>
             {!search && (
               <button
-                onClick={handleCreateTemplate}
+                onClick={createDefaultTemplate}
                 className="mt-3 text-sm text-neutral-600 underline hover:text-neutral-800"
               >
                 Create my first template

--- a/apps/desktop/src/templates/utils.test.ts
+++ b/apps/desktop/src/templates/utils.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import type { WebTemplate } from "./codec";
+import type { UserTemplate } from "./queries";
+import { resolveTemplateTabSelection } from "./utils";
+
+const userTemplate: UserTemplate = {
+  id: "template-1",
+  title: "Standup",
+  description: "",
+  pinned: false,
+  sections: [],
+};
+
+const webTemplate: WebTemplate = {
+  slug: "community-standup",
+  title: "Community Standup",
+  description: "",
+  category: "",
+  sections: [],
+};
+
+describe("resolveTemplateTabSelection", () => {
+  it("keeps an empty tab in local template mode when there are no community templates", () => {
+    expect(
+      resolveTemplateTabSelection({
+        isWebMode: true,
+        selectedMineId: null,
+        selectedWebIndex: null,
+        userTemplates: [],
+        webTemplates: [],
+      }),
+    ).toEqual({
+      isWebMode: false,
+      selectedMineId: null,
+      selectedWebIndex: null,
+      selectedWebTemplate: null,
+    });
+  });
+
+  it("defaults to community mode only when community templates exist without local templates", () => {
+    expect(
+      resolveTemplateTabSelection({
+        isWebMode: null,
+        selectedMineId: null,
+        selectedWebIndex: null,
+        userTemplates: [],
+        webTemplates: [webTemplate],
+      }),
+    ).toEqual({
+      isWebMode: true,
+      selectedMineId: null,
+      selectedWebIndex: 0,
+      selectedWebTemplate: webTemplate,
+    });
+  });
+
+  it("selects the first local template when mine mode has no explicit selection", () => {
+    expect(
+      resolveTemplateTabSelection({
+        isWebMode: false,
+        selectedMineId: null,
+        selectedWebIndex: null,
+        userTemplates: [userTemplate],
+        webTemplates: [webTemplate],
+      }),
+    ).toEqual({
+      isWebMode: false,
+      selectedMineId: "template-1",
+      selectedWebIndex: null,
+      selectedWebTemplate: null,
+    });
+  });
+});

--- a/apps/desktop/src/templates/utils.ts
+++ b/apps/desktop/src/templates/utils.ts
@@ -29,9 +29,9 @@ export function resolveTemplateTabSelection({
   const hasUserTemplates = userTemplates.length > 0;
   const hasWebTemplates = webTemplates.length > 0;
 
-  let effectiveIsWebMode = isWebMode ?? !hasUserTemplates;
+  let effectiveIsWebMode = isWebMode ?? (hasWebTemplates && !hasUserTemplates);
 
-  if (effectiveIsWebMode && !hasWebTemplates && hasUserTemplates) {
+  if (effectiveIsWebMode && !hasWebTemplates) {
     effectiveIsWebMode = false;
   }
 
@@ -140,6 +140,20 @@ export function useTemplateTab(tab: Extract<Tab, { type: "templates" }>) {
     [updateTabState, tab],
   );
 
+  const createDefaultTemplate = useCallback(async () => {
+    const id = await createTemplate({
+      title: "New Template",
+      description: "",
+      sections: [],
+    });
+
+    if (id) {
+      setSelectedMineId(id);
+    }
+
+    return id;
+  }, [createTemplate, setSelectedMineId]);
+
   return {
     userTemplates,
     webTemplates,
@@ -151,6 +165,7 @@ export function useTemplateTab(tab: Extract<Tab, { type: "templates" }>) {
     setSelectedMineId,
     setSelectedWebIndex,
     createTemplate,
+    createDefaultTemplate,
     deleteTemplate,
     toggleTemplateFavorite,
   };


### PR DESCRIPTION
Keep empty template tabs in local mode, add an empty-state create action, and cover template creation plus selection behavior with tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state changes limited to template tab selection defaults and wiring a shared create action, with added unit tests covering the new behavior.
> 
> **Overview**
> Fixes template tab behavior so an *empty* templates tab stays in local mode unless community templates actually exist, preventing users from landing in an unusable community view.
> 
> Adds a consistent `createDefaultTemplate` action (used by sidebar and details empty state) and updates the details pane to show an empty-state **Create template** button when no local template is selected. Adds tests for the new selection rules and for `useCreateTemplate` inserting rows via the SQLite proxy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0d45251476a1bcf00cb7e92a86741ce06ccf694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->