### PR TITLE
fix(desktop): simplify language selection

### DIFF
--- a/apps/desktop/src/settings/general/language.ts
+++ b/apps/desktop/src/settings/general/language.ts
@@ -1,12 +1,12 @@
 const displayNames = new Intl.DisplayNames(["en"], { type: "language" });
 
-export function getLanguageDisplayName(code: string): string {
-  return displayNames.of(code) ?? code;
-}
-
 export function getBaseLanguageDisplayName(code: string): string {
   const { language } = parseLocale(code);
   return displayNames.of(language) ?? code;
+}
+
+export function getBaseLanguageCode(code: string): string {
+  return parseLocale(code).language;
 }
 
 export function parseLocale(code: string): {

--- a/apps/desktop/src/settings/general/spoken-languages.tsx
+++ b/apps/desktop/src/settings/general/spoken-languages.tsx
@@ -5,35 +5,7 @@ import { Badge } from "@hypr/ui/components/ui/badge";
 import { Button } from "@hypr/ui/components/ui/button";
 import { cn } from "@hypr/utils";
 
-import { getLanguageDisplayName } from "./language";
-
-function hasRegionVariant(langCode: string): boolean {
-  return langCode.includes("-");
-}
-
-function getBaseLanguage(langCode: string): string {
-  return langCode.split("-")[0];
-}
-
-function isLanguageDisabled(
-  langCode: string,
-  selectedLanguages: string[],
-): boolean {
-  const base = getBaseLanguage(langCode);
-  const isVariant = hasRegionVariant(langCode);
-
-  for (const selected of selectedLanguages) {
-    const selectedBase = getBaseLanguage(selected);
-    if (selectedBase !== base) continue;
-
-    if (isVariant) {
-      return selected === base || hasRegionVariant(selected);
-    } else {
-      return hasRegionVariant(selected);
-    }
-  }
-  return false;
-}
+import { getBaseLanguageCode, getBaseLanguageDisplayName } from "./language";
 
 interface SpokenLanguagesViewProps {
   value: string[];
@@ -50,23 +22,54 @@ export function SpokenLanguagesView({
   const [languageInputFocused, setLanguageInputFocused] = useState(false);
   const [languageSelectedIndex, setLanguageSelectedIndex] = useState(-1);
 
+  const supportedLanguageCodes = useMemo(() => {
+    const seen = new Set<string>();
+    const codes: string[] = [];
+
+    for (const langCode of supportedLanguages) {
+      const baseCode = getBaseLanguageCode(langCode);
+      if (seen.has(baseCode)) continue;
+      seen.add(baseCode);
+      codes.push(baseCode);
+    }
+
+    return codes;
+  }, [supportedLanguages]);
+
+  const selectedLanguageCodes = useMemo(() => {
+    const seen = new Set<string>();
+    const codes: string[] = [];
+
+    for (const langCode of value) {
+      const baseCode = getBaseLanguageCode(langCode);
+      if (seen.has(baseCode)) continue;
+      seen.add(baseCode);
+      codes.push(baseCode);
+    }
+
+    return codes;
+  }, [value]);
+
   const filteredLanguages = useMemo(() => {
     if (!languageSearchQuery.trim()) {
       return [];
     }
     const query = languageSearchQuery.toLowerCase();
-    return supportedLanguages.filter((langCode) => {
-      if (value.includes(langCode)) return false;
-      if (isLanguageDisabled(langCode, value)) return false;
-      const langName = getLanguageDisplayName(langCode);
+    return supportedLanguageCodes.filter((langCode) => {
+      if (selectedLanguageCodes.includes(langCode)) return false;
+      const langName = getBaseLanguageDisplayName(langCode);
       return langName.toLowerCase().includes(query);
     });
-  }, [languageSearchQuery, value, supportedLanguages]);
+  }, [languageSearchQuery, selectedLanguageCodes, supportedLanguageCodes]);
 
   const handleLanguageKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Backspace" && !languageSearchQuery && value.length > 0) {
+    if (
+      e.key === "Backspace" &&
+      !languageSearchQuery &&
+      selectedLanguageCodes.length > 0
+    ) {
       e.preventDefault();
-      onChange(value.slice(0, -1));
+      onChange(selectedLanguageCodes.slice(0, -1));
       return;
     }
 
@@ -89,7 +92,7 @@ export function SpokenLanguagesView({
         languageSelectedIndex < filteredLanguages.length
       ) {
         const selectedCode = filteredLanguages[languageSelectedIndex];
-        onChange([...value, selectedCode]);
+        onChange([...selectedLanguageCodes, selectedCode]);
         setLanguageSearchQuery("");
         setLanguageSelectedIndex(-1);
       }
@@ -116,13 +119,13 @@ export function SpokenLanguagesView({
             document.getElementById("language-search-input")?.focus()
           }
         >
-          {value.map((code) => (
+          {selectedLanguageCodes.map((code) => (
             <Badge
               key={code}
               variant="secondary"
               className="bg-muted flex items-center gap-1 px-2 py-0.5 text-xs"
             >
-              {getLanguageDisplayName(code)}
+              {getBaseLanguageDisplayName(code)}
               <Button
                 type="button"
                 variant="ghost"
@@ -130,14 +133,14 @@ export function SpokenLanguagesView({
                 className="ml-0.5 h-3 w-3 p-0 hover:bg-transparent"
                 onClick={(e) => {
                   e.stopPropagation();
-                  onChange(value.filter((c) => c !== code));
+                  onChange(selectedLanguageCodes.filter((c) => c !== code));
                 }}
               >
                 <X className="h-2.5 w-2.5" />
               </Button>
             </Badge>
           ))}
-          {value.length === 0 && (
+          {selectedLanguageCodes.length === 0 && (
             <Search className="size-4 shrink-0 text-neutral-700" />
           )}
           <input
@@ -161,7 +164,9 @@ export function SpokenLanguagesView({
                 : undefined
             }
             aria-label="Add spoken language"
-            placeholder={value.length === 0 ? "Add language" : ""}
+            placeholder={
+              selectedLanguageCodes.length === 0 ? "Add language" : ""
+            }
             className="min-w-[120px] flex-1 bg-transparent text-sm placeholder:text-neutral-500 focus:outline-hidden"
           />
         </div>
@@ -181,7 +186,7 @@ export function SpokenLanguagesView({
                   role="option"
                   aria-selected={languageSelectedIndex === index}
                   onClick={() => {
-                    onChange([...value, langCode]);
+                    onChange([...selectedLanguageCodes, langCode]);
                     setLanguageSearchQuery("");
                     setLanguageSelectedIndex(-1);
                   }}
@@ -195,7 +200,7 @@ export function SpokenLanguagesView({
                   ])}
                 >
                   <span className="truncate font-medium">
-                    {getLanguageDisplayName(langCode)}
+                    {getBaseLanguageDisplayName(langCode)}
                   </span>
                 </button>
               ))

--- a/crates/owhisper-client/src/adapter/mod.rs
+++ b/crates/owhisper-client/src/adapter/mod.rs
@@ -44,6 +44,7 @@ use std::collections::{BTreeSet, HashSet};
 use std::future::Future;
 use std::path::Path;
 use std::pin::Pin;
+use std::str::FromStr;
 
 use hypr_ws_client::client::Message;
 use owhisper_interface::ListenParams;
@@ -64,35 +65,60 @@ pub type StreamingBatchEvent = BatchStreamEvent;
 pub type StreamingBatchStream =
     Pin<Box<dyn futures_util::Stream<Item = Result<BatchStreamEvent, Error>> + Send>>;
 
+fn canonical_menu_language_code(code: &str) -> Option<String> {
+    let language = code
+        .split(['-', '_'])
+        .next()
+        .filter(|part| !part.is_empty())?
+        .to_lowercase();
+    let language = match language.as_str() {
+        "jw" => "jv",
+        _ => language.as_str(),
+    };
+
+    hypr_language::ISO639::from_str(language)
+        .ok()
+        .map(|code| code.code().to_string())
+}
+
+fn simple_documented_language_codes(codes: impl IntoIterator<Item = &'static str>) -> Vec<String> {
+    let set: BTreeSet<String> = codes
+        .into_iter()
+        .filter_map(canonical_menu_language_code)
+        .collect();
+
+    set.into_iter().collect()
+}
+
 pub fn documented_language_codes_live() -> Vec<String> {
-    let mut set: BTreeSet<&'static str> = BTreeSet::new();
+    let mut codes = Vec::new();
 
-    set.extend(deepgram::documented_language_codes());
-    set.extend(soniox::documented_language_codes().iter().copied());
-    set.extend(gladia::documented_language_codes().iter().copied());
-    set.extend(assemblyai::documented_language_codes_live().iter().copied());
-    set.extend(elevenlabs::documented_language_codes());
-    set.extend(argmax::PARAKEET_V3_LANGS.iter().copied());
+    codes.extend(deepgram::documented_language_codes());
+    codes.extend(soniox::documented_language_codes().iter().copied());
+    codes.extend(gladia::documented_language_codes().iter().copied());
+    codes.extend(assemblyai::documented_language_codes_live().iter().copied());
+    codes.extend(elevenlabs::documented_language_codes());
+    codes.extend(argmax::PARAKEET_V3_LANGS.iter().copied());
 
-    set.into_iter().map(str::to_string).collect()
+    simple_documented_language_codes(codes)
 }
 
 pub fn documented_language_codes_batch() -> Vec<String> {
-    let mut set: BTreeSet<&'static str> = BTreeSet::new();
+    let mut codes = Vec::new();
 
-    set.extend(deepgram::documented_language_codes());
-    set.extend(soniox::documented_language_codes().iter().copied());
-    set.extend(gladia::documented_language_codes().iter().copied());
-    set.extend(
+    codes.extend(deepgram::documented_language_codes());
+    codes.extend(soniox::documented_language_codes().iter().copied());
+    codes.extend(gladia::documented_language_codes().iter().copied());
+    codes.extend(
         assemblyai::documented_language_codes_batch()
             .iter()
             .copied(),
     );
-    set.extend(elevenlabs::documented_language_codes());
-    set.extend(argmax::PARAKEET_V3_LANGS.iter().copied());
-    set.extend(pyannote::documented_language_codes());
+    codes.extend(elevenlabs::documented_language_codes());
+    codes.extend(argmax::PARAKEET_V3_LANGS.iter().copied());
+    codes.extend(pyannote::documented_language_codes());
 
-    set.into_iter().map(str::to_string).collect()
+    simple_documented_language_codes(codes)
 }
 
 pub trait RealtimeSttAdapter: Clone + Default + Send + Sync + 'static {
@@ -604,6 +630,30 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].iso639(), ISO639::En);
         assert_eq!(result[0].region(), None);
+    }
+
+    #[test]
+    fn test_simple_documented_language_codes_collapses_variants() {
+        let result = simple_documented_language_codes(["zh", "zh-CN", "zh-Hans", "en-US", "en-GB"]);
+
+        assert_eq!(result, vec!["en".to_string(), "zh".to_string()]);
+    }
+
+    #[test]
+    fn test_simple_documented_language_codes_canonicalizes_aliases() {
+        let result = simple_documented_language_codes(["jw", "jv"]);
+
+        assert_eq!(result, vec!["jv".to_string()]);
+    }
+
+    #[test]
+    fn test_documented_language_codes_are_menu_safe() {
+        let result = documented_language_codes_live();
+
+        assert!(result.contains(&"en".to_string()));
+        assert!(result.contains(&"zh".to_string()));
+        assert!(result.iter().all(|code| !code.contains("-")));
+        assert!(!result.contains(&"jw".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
Show canonical base languages in settings and return menu-safe language codes from transcription language metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how spoken language selections are deduped/stored (collapsing regional variants) and how documented STT language codes are normalized, which could affect persisted settings and language availability in menus.
> 
> **Overview**
> Desktop settings now *collapse regional/variant locales to base language codes* for spoken-language selection: the picker dedupes `supportedLanguages`/selected values by base code, displays base-language names, and removes the previous variant-disabling logic.
> 
> `owhisper-client` now returns *menu-safe documented language codes* by canonicalizing provider language metadata to ISO639 base codes (stripping `-`/`_` variants and mapping aliases like `jw`→`jv`), with new unit tests ensuring variant collapse and alias handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d19d657d9477d38548fe923105be4612def3dd8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->