### PR TITLE
fix(desktop): brand chat assistant as Anarlog AI

### DIFF
--- a/apps/desktop/src/chat/components/body/empty.tsx
+++ b/apps/desktop/src/chat/components/body/empty.tsx
@@ -1,6 +1,7 @@
 import {
   ListChecksIcon,
   MailIcon,
+  MessageCircleIcon,
   SearchIcon,
   SparklesIcon,
 } from "lucide-react";
@@ -60,18 +61,15 @@ export function ChatBodyEmpty({
       <div className="flex justify-start py-2 pb-1">
         <div className="flex w-full flex-col">
           <div className="mb-2 flex items-center gap-2">
-            <img
-              src="/assets/anarlog-icon.png"
-              alt="Anarlog"
-              className="size-4 object-contain object-center"
-            />
+            <MessageCircleIcon className="size-4 text-neutral-500" />
             <span className="text-sm font-medium text-neutral-800">
-              Charlie
+              Anarlog AI
             </span>
             <BetaChip />
           </div>
           <p className="mb-2 text-sm text-neutral-700">
-            Hi, I'm Charlie. Set up a language model and I'll be ready to help.
+            Hi, I'm Anarlog AI. Set up a language model and I'll be ready to
+            help.
           </p>
           <button
             onClick={handleGoToSettings}
@@ -92,17 +90,15 @@ export function ChatBodyEmpty({
     <div className="flex justify-start pb-1">
       <div className="flex w-full flex-col">
         <div className="mb-2 flex items-center gap-2">
-          <img
-            src="/assets/anarlog-icon.png"
-            alt="Anarlog"
-            className="size-4 object-contain object-center"
-          />
-          <span className="text-sm font-medium text-neutral-800">Charlie</span>
+          <MessageCircleIcon className="size-4 text-neutral-500" />
+          <span className="text-sm font-medium text-neutral-800">
+            Anarlog AI
+          </span>
           <BetaChip />
         </div>
         <p className="mb-2 text-sm text-neutral-700">
-          Hi, I'm Charlie. I can help you pull context from your notes, find key
-          decisions, and draft what comes next.
+          Hi, I'm Anarlog AI. I can help you pull context from your notes, find
+          key decisions, and draft what comes next.
         </p>
         {hasContext && (
           <div className="flex flex-wrap gap-1.5">

--- a/apps/desktop/src/chat/components/chat-panel.tsx
+++ b/apps/desktop/src/chat/components/chat-panel.tsx
@@ -1,3 +1,4 @@
+import { platform } from "@tauri-apps/plugin-os";
 import { useCallback } from "react";
 
 import { cn } from "@hypr/utils";
@@ -16,6 +17,8 @@ import * as main from "~/store/tinybase/store/main";
 export function ChatView() {
   const { chat } = useShell();
   const { groupId, sessionId, setGroupId } = chat;
+  const currentPlatform = platform();
+  const chatPanelShortcutLabel = currentPlatform === "macos" ? "⌘ J" : "Ctrl J";
 
   const { currentSessionId } = useSessionTab();
 
@@ -41,11 +44,13 @@ export function ChatView() {
         chat.mode !== "RightPanelOpen" && "bg-stone-50",
       ])}
     >
-      <div className="flex h-10 shrink-0 items-center border-b border-neutral-100 pr-2 pl-0">
+      <div className="flex h-10 shrink-0 items-center border-b border-neutral-100 pr-0 pl-0">
         <ChatToolbarControls
           currentChatGroupId={groupId}
           onNewChat={chat.startNewChat}
           onSelectChat={chat.selectChat}
+          onCloseChat={() => chat.sendEvent({ type: "CLOSE" })}
+          shortcutLabel={chatPanelShortcutLabel}
         />
       </div>
       {user_id && (

--- a/apps/desktop/src/chat/components/toolbar-controls.tsx
+++ b/apps/desktop/src/chat/components/toolbar-controls.tsx
@@ -19,36 +19,53 @@ import * as main from "~/store/tinybase/store/main";
 
 export function ChatToolbarControls({
   currentChatGroupId,
+  onCloseChat,
   onNewChat,
   onSelectChat,
+  shortcutLabel,
 }: {
   currentChatGroupId: string | undefined;
+  onCloseChat: () => void;
   onNewChat: () => void;
   onSelectChat: (chatGroupId: string) => void;
+  shortcutLabel?: string;
 }) {
   return (
-    <div className="flex h-full min-w-0 items-center gap-1">
-      <ChatGroups
-        currentChatGroupId={currentChatGroupId}
-        onSelectChat={onSelectChat}
-      />
+    <div className="relative flex h-full w-full min-w-0 items-center">
+      <div className="flex min-w-0 items-center gap-1 pr-8">
+        <ChatGroups
+          currentChatGroupId={currentChatGroupId}
+          onSelectChat={onSelectChat}
+        />
+        <ChatActionButton
+          icon={<Plus size={16} />}
+          onClick={onNewChat}
+          title="New chat"
+        />
+      </div>
       <ChatActionButton
-        icon={<Plus size={16} />}
-        onClick={onNewChat}
-        title="New chat"
+        icon={<MessageCircle size={16} />}
+        onClick={onCloseChat}
+        title="Close chat"
+        shortcutLabel={shortcutLabel}
+        className="absolute top-1/2 right-0 -translate-y-1/2 bg-neutral-100 text-neutral-900 hover:bg-neutral-100"
       />
     </div>
   );
 }
 
 function ChatActionButton({
+  className,
   icon,
   title,
   onClick,
+  shortcutLabel,
 }: {
+  className?: string;
   icon: React.ReactNode;
   title: string;
   onClick: () => void;
+  shortcutLabel?: string;
 }) {
   return (
     <Tooltip>
@@ -58,12 +75,19 @@ function ChatActionButton({
           title={title}
           size="icon"
           variant="ghost"
-          className="text-neutral-600"
+          className={cn(["text-neutral-600", className])}
         >
           {icon}
         </Button>
       </TooltipTrigger>
-      <TooltipContent side="bottom">{title}</TooltipContent>
+      <TooltipContent side="bottom" className="flex items-center gap-2">
+        <span>{title}</span>
+        {shortcutLabel && (
+          <span className="rounded border border-neutral-200 bg-neutral-50 px-1 py-0.5 text-[10px] text-neutral-500">
+            {shortcutLabel}
+          </span>
+        )}
+      </TooltipContent>
     </Tooltip>
   );
 }
@@ -98,12 +122,12 @@ function ChatGroups({
         <Button
           variant="ghost"
           className={cn([
-            "group flex h-8 max-w-64 min-w-0 justify-start gap-2 pr-2 pl-1",
+            "group flex h-8 max-w-64 min-w-0 justify-start gap-2 px-0 py-0",
             "text-neutral-700",
           ])}
         >
           <h3 className="min-w-0 flex-1 truncate text-xs font-medium text-neutral-700">
-            {currentChatTitle || "Ask Charlie anything"}
+            {currentChatTitle || "Ask Anarlog AI anything"}
           </h3>
           <ChevronDown
             className={cn([

--- a/apps/desktop/src/composer/index.tsx
+++ b/apps/desktop/src/composer/index.tsx
@@ -99,7 +99,7 @@ export function ComposerScreen() {
               }
               onStop={sessionProps.stop}
               onSendMessage={sendMessage}
-              title={currentTitle || "Ask Charlie anything"}
+              title={currentTitle || "Ask Anarlog AI anything"}
             />
           ) : (
             <ComposerSettingsCard />
@@ -300,7 +300,7 @@ function ComposerInput({
 
 const composerPlaceholder: PlaceholderFunction = ({ node, pos }) => {
   if (node.type.name === "paragraph" && pos === 0) {
-    return "Message Charlie";
+    return "Message Anarlog AI";
   }
 
   return "";

--- a/apps/desktop/src/main/tab-chrome.tsx
+++ b/apps/desktop/src/main/tab-chrome.tsx
@@ -3,6 +3,7 @@ import { platform } from "@tauri-apps/plugin-os";
 import {
   ArrowLeftIcon,
   ArrowRightIcon,
+  MessageCircleIcon,
   PanelLeftOpenIcon,
   PlusIcon,
 } from "lucide-react";
@@ -286,7 +287,6 @@ export function ClassicMainTabChrome({ tabs }: { tabs: Tab[] }) {
 function TabChatButton({ shortcutLabel }: { shortcutLabel?: string }) {
   const { chat } = useShell();
   const isChatOpen = chat.mode === "RightPanelOpen";
-  const isTabbarSelected = isChatOpen;
 
   const { data: isChatEnabled } = useQuery({
     refetchInterval: 10_000,
@@ -300,14 +300,13 @@ function TabChatButton({ shortcutLabel }: { shortcutLabel?: string }) {
     },
   });
 
-  if (!isChatEnabled) {
+  if (!isChatEnabled || isChatOpen) {
     return null;
   }
 
-  const buttonTitle = isTabbarSelected ? "Close chat" : "Chat with notes";
+  const buttonTitle = "Chat with notes";
 
-  const handleClick = () =>
-    chat.sendEvent(isTabbarSelected ? { type: "TOGGLE" } : { type: "OPEN" });
+  const handleClick = () => chat.sendEvent({ type: "OPEN" });
 
   return (
     <Tooltip>
@@ -316,22 +315,13 @@ function TabChatButton({ shortcutLabel }: { shortcutLabel?: string }) {
           onClick={handleClick}
           variant="ghost"
           size="icon"
-          className={cn([
-            "text-neutral-600",
-            isTabbarSelected &&
-              "bg-neutral-200 text-neutral-900 hover:bg-neutral-200",
-          ])}
+          className="text-neutral-600"
           aria-label={buttonTitle}
-          aria-pressed={isTabbarSelected}
           title={buttonTitle}
         >
-          <img
-            src="/assets/anarlog-icon.png"
-            alt="Anarlog"
-            className={cn([
-              "size-[16px] shrink-0 object-contain object-center opacity-80",
-              isTabbarSelected && "opacity-100",
-            ])}
+          <MessageCircleIcon
+            aria-hidden="true"
+            className="size-4 shrink-0 opacity-80"
           />
         </Button>
       </TooltipTrigger>

--- a/crates/template-app-legacy/assets/chat.system.jinja
+++ b/crates/template-app-legacy/assets/chat.system.jinja
@@ -1,9 +1,9 @@
 {% from "_language.partial" import enforce_language %}
 
-You are Charlie, a helpful AI meeting assistant in Hyprnote, an intelligent meeting platform that transcribes
+You are Anarlog AI, a helpful AI meeting assistant in Anarlog, an intelligent meeting platform that transcribes
 and analyzes meetings. Your purpose is to help users understand their meeting content better.
 
-If the user asks for your name or identity, say your name is Charlie.
+If the user asks for your name or identity, say your name is Anarlog AI.
 
 {{ enforce_language(language, "IMPORTANT: Respond in") }}
 

--- a/crates/template-app/assets/chat.system.md.jinja
+++ b/crates/template-app/assets/chat.system.md.jinja
@@ -4,8 +4,8 @@
 
 Current date: {{ ""|current_date }}
 
-- You are Charlie, a helpful AI meeting assistant in Hyprnote, an intelligent meeting platform that transcribes and analyzes meetings. Your purpose is to help users understand their meeting content better.
-- If the user asks for your name or identity, say your name is Charlie.
+- You are Anarlog AI, a helpful AI meeting assistant in Anarlog, an intelligent meeting platform that transcribes and analyzes meetings. Your purpose is to help users understand their meeting content better.
+- If the user asks for your name or identity, say your name is Anarlog AI.
 - Always respond in {{ language | language }}, unless the user explicitly asks for a different language.
 - Always keep your responses concise, professional, and directly relevant to the user's questions.
 - Your primary source of truth is the meeting transcript. Try to generate responses primarily from the transcript, and then the summary or other information (unless the user asks for something specific).

--- a/crates/template-app/src/chat.rs
+++ b/crates/template-app/src/chat.rs
@@ -47,8 +47,8 @@ mod tests {
 
     Current date: 2025-01-01
 
-    - You are Charlie, a helpful AI meeting assistant in Hyprnote, an intelligent meeting platform that transcribes and analyzes meetings. Your purpose is to help users understand their meeting content better.
-    - If the user asks for your name or identity, say your name is Charlie.
+    - You are Anarlog AI, a helpful AI meeting assistant in Anarlog, an intelligent meeting platform that transcribes and analyzes meetings. Your purpose is to help users understand their meeting content better.
+    - If the user asks for your name or identity, say your name is Anarlog AI.
     - Always respond in English, unless the user explicitly asks for a different language.
     - Always keep your responses concise, professional, and directly relevant to the user's questions.
     - Your primary source of truth is the meeting transcript. Try to generate responses primarily from the transcript, and then the summary or other information (unless the user asks for something specific).


### PR DESCRIPTION
Use chat icons in chat entry points and rename visible Charlie chat copy to Anarlog AI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/UX copy and icon updates plus a small wiring change to close the chat panel; low risk but could affect chat panel open/close behavior and shortcut labeling across platforms.
> 
> **Overview**
> Rebrands the desktop chat assistant from **Charlie** to **Anarlog AI** across the empty-state, chat group dropdown, and composer (titles and placeholders), and replaces the Anarlog image asset with `MessageCircle` icons at chat entry points.
> 
> Updates chat chrome behavior by hiding the tab bar chat button while the right chat panel is open, and adds a dedicated *Close chat* control in `ChatToolbarControls` with a platform-specific shortcut label (`⌘ J`/`Ctrl J`).
> 
> Updates chat system prompt templates/tests to identify the assistant as **Anarlog AI** (instead of Charlie/Hyprnote).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 867509be3818a73f0c5fb091c267d817bcdff97b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->