### PR TITLE
fix(desktop): hide transcript resize handle line

### DIFF
--- a/apps/desktop/src/shared/main/index.tsx
+++ b/apps/desktop/src/shared/main/index.tsx
@@ -82,7 +82,7 @@ export function StandardTabWrapper({
             <ResizableHandle
               disabled={!afterBorderExpanded}
               className={cn([
-                "z-10 bg-transparent",
+                "z-10 !bg-transparent",
                 !afterBorderExpanded && "pointer-events-none",
               ])}
             />


### PR DESCRIPTION
Make the expanded transcript split handle explicitly transparent so the accessory does not render a light separator.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Styling-only change to the desktop UI; low risk aside from potential minor visual regressions in the resizable handle appearance.
> 
> **Overview**
> Ensures the expanded transcript split `ResizableHandle` renders with an explicitly transparent background (`!bg-transparent`) so the handle no longer shows a faint separator line when the transcript panel is expanded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80d51ce19eb901fe20db25063d4187534a5bedb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->