### PR TITLE
fix(desktop): stop dev sidecar rebuild loop

### DIFF
--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -1,3 +1,10 @@
+#[cfg(target_os = "macos")]
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
 fn main() {
     #[cfg(target_os = "macos")]
     println!("cargo:rustc-link-arg=-fapple-link-rtlib");
@@ -12,18 +19,26 @@ fn main() {
 fn build_check_permissions() {
     let triple = std::env::var("TARGET").unwrap();
 
-    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let build_rs = manifest_dir.join("build.rs");
     let swift_src = manifest_dir.join("../../../plugins/permissions/swift/check-permissions.swift");
     let binaries_dir = manifest_dir.join("binaries");
     let dst = binaries_dir.join(format!("check-permissions-{triple}"));
+    let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").expect("OUT_DIR is set"));
+    let compiled = out_dir.join(format!("check-permissions-{triple}"));
 
+    println!("cargo:rerun-if-changed={}", build_rs.display());
     println!("cargo:rerun-if-changed={}", swift_src.display());
 
-    std::fs::create_dir_all(&binaries_dir).expect("create binaries/");
+    fs::create_dir_all(&binaries_dir).expect("create binaries/");
 
-    let status = std::process::Command::new("swiftc")
+    if is_fresh(&dst, &[&build_rs, &swift_src]) {
+        return;
+    }
+
+    let status = Command::new("swiftc")
         .args(["-O", "-o"])
-        .arg(&dst)
+        .arg(&compiled)
         .arg(&swift_src)
         // we should theoretically cross compile for the target
         // .args(["-target", &triple])
@@ -34,4 +49,29 @@ fn build_check_permissions() {
         status.success(),
         "swiftc failed to compile check-permissions"
     );
+
+    if !same_contents(&compiled, &dst) {
+        fs::copy(&compiled, &dst).expect("copy check-permissions binary");
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn is_fresh(output: &Path, inputs: &[&Path]) -> bool {
+    let Ok(output_modified) = fs::metadata(output).and_then(|metadata| metadata.modified()) else {
+        return false;
+    };
+
+    inputs.iter().all(|input| {
+        fs::metadata(input)
+            .and_then(|metadata| metadata.modified())
+            .is_ok_and(|modified| modified <= output_modified)
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn same_contents(a: &Path, b: &Path) -> bool {
+    match (fs::read(a), fs::read(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
 }


### PR DESCRIPTION
Avoid rewriting the generated check-permissions sidecar during Tauri dev builds unless its inputs changed, so the watcher no longer restarts on its own output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the macOS `build.rs` sidecar compilation path; incorrect freshness/content checks could leave a stale `check-permissions` binary or mask rebuilds, but scope is limited to build-time behavior.
> 
> **Overview**
> Stops the macOS `check-permissions` sidecar from being rewritten on every dev build by adding input/output freshness checks and only copying the newly compiled binary into `binaries/` when its contents differ.
> 
> The build script now compiles into `OUT_DIR` first, tracks `build.rs` and the Swift source via `cargo:rerun-if-changed`, and introduces helper functions (`is_fresh`, `same_contents`) to avoid triggering file watchers unnecessarily.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fd7c3bebc57c48e2c43ed9713c8af43a42dd594. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->