### PR TITLE
fix(desktop): reduce active meeting note lag

### DIFF
--- a/apps/desktop/src/store/tinybase/persister/session/changes.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/changes.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "vitest";
 
-import { getChangedSessionIds, parseSessionIdFromPath } from "./changes";
+import {
+  getChangedSessionIds,
+  getSessionSaveScope,
+  parseSessionIdFromPath,
+} from "./changes";
 
 import type {
   ChangedTables,
@@ -71,6 +75,82 @@ describe("parseSessionIdFromPath", () => {
   });
 });
 
+describe("getSessionSaveScope", () => {
+  test("saves every session artifact for a full save", () => {
+    expect(getSessionSaveScope()).toEqual({
+      session: true,
+      transcript: true,
+      note: true,
+    });
+  });
+
+  test("limits transcript-only changes to transcript output", () => {
+    expect(
+      getSessionSaveScope({
+        transcripts: { "transcript-1": {} },
+      }),
+    ).toEqual({
+      session: false,
+      transcript: true,
+      note: false,
+    });
+  });
+
+  test("limits raw note changes to note output", () => {
+    expect(
+      getSessionSaveScope({
+        sessions: {
+          "session-1": [{ raw_md: ["{}", "stamp"] }],
+        },
+      }),
+    ).toEqual({
+      session: false,
+      transcript: false,
+      note: true,
+    });
+  });
+
+  test("limits title changes to session metadata output", () => {
+    expect(
+      getSessionSaveScope({
+        sessions: {
+          "session-1": [{ title: ["Weekly sync", "stamp"] }],
+        },
+      }),
+    ).toEqual({
+      session: true,
+      transcript: false,
+      note: false,
+    });
+  });
+
+  test("saves all artifacts when the session folder changes", () => {
+    expect(
+      getSessionSaveScope({
+        sessions: {
+          "session-1": [{ folder_id: ["work", "stamp"] }],
+        },
+      }),
+    ).toEqual({
+      session: true,
+      transcript: true,
+      note: true,
+    });
+  });
+
+  test("treats unknown session row changes conservatively", () => {
+    expect(
+      getSessionSaveScope({
+        sessions: { "session-1": {} },
+      }),
+    ).toEqual({
+      session: true,
+      transcript: true,
+      note: true,
+    });
+  });
+});
+
 describe("getChangedSessionIds", () => {
   describe("direct session changes", () => {
     test("adds changed session ids directly", () => {
@@ -118,6 +198,40 @@ describe("getChangedSessionIds", () => {
 
       expect(result?.changedSessionIds).toEqual(new Set());
       expect(result?.hasUnresolvedDeletions).toBe(true);
+    });
+  });
+
+  describe("tag changes", () => {
+    test("resolves session id from tag mapping", () => {
+      const tables: TablesContent = {
+        mapping_tag_session: {
+          "mapping-1": { tag_id: "tag-1", session_id: "session-1" },
+        },
+      };
+      const changedTables: ChangedTables = {
+        tags: { "tag-1": {} },
+      };
+
+      const result = getChangedSessionIds(tables, changedTables);
+
+      expect(result?.changedSessionIds).toEqual(new Set(["session-1"]));
+      expect(result?.hasUnresolvedDeletions).toBe(false);
+    });
+
+    test("resolves session id from tag mapping changes", () => {
+      const tables: TablesContent = {
+        mapping_tag_session: {
+          "mapping-1": { tag_id: "tag-1", session_id: "session-1" },
+        },
+      };
+      const changedTables: ChangedTables = {
+        mapping_tag_session: { "mapping-1": {} },
+      };
+
+      const result = getChangedSessionIds(tables, changedTables);
+
+      expect(result?.changedSessionIds).toEqual(new Set(["session-1"]));
+      expect(result?.hasUnresolvedDeletions).toBe(false);
     });
   });
 

--- a/apps/desktop/src/store/tinybase/persister/session/changes.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/changes.ts
@@ -1,6 +1,7 @@
 import {
   type ChangedTables,
   getChangedIds,
+  iterateTableRows,
   SESSION_META_FILE,
   SESSION_NOTE_EXTENSION,
   SESSION_TRANSCRIPT_FILE,
@@ -32,6 +33,27 @@ export type SessionChangeResult = {
   hasUnresolvedDeletions: boolean;
 };
 
+export type SessionSaveScope = {
+  session: boolean;
+  transcript: boolean;
+  note: boolean;
+};
+
+const ALL_SESSION_SAVE_SCOPES: SessionSaveScope = {
+  session: true,
+  transcript: true,
+  note: true,
+};
+
+const SESSION_META_CELLS = new Set([
+  "user_id",
+  "created_at",
+  "title",
+  "event_json",
+  "folder_id",
+]);
+const SESSION_NOTE_CELLS = new Set(["raw_md", "folder_id"]);
+
 export function getChangedSessionIds(
   tables: TablesContent,
   changedTables: ChangedTables,
@@ -44,6 +66,10 @@ export function getChangedSessionIds(
         tables.mapping_session_participant?.[id]?.session_id,
     },
     {
+      table: "mapping_tag_session",
+      extractId: (id, tables) => tables.mapping_tag_session?.[id]?.session_id,
+    },
+    {
       table: "transcripts",
       extractId: (id, tables) => tables.transcripts?.[id]?.session_id,
     },
@@ -53,12 +79,111 @@ export function getChangedSessionIds(
     },
   ]);
 
-  if (!result) {
+  const changedSessionIds = new Set(result?.changedIds ?? []);
+  addTagChangeSessionIds(tables, changedTables, changedSessionIds);
+
+  if (changedSessionIds.size === 0 && !result?.hasUnresolvedDeletions) {
     return undefined;
   }
 
   return {
-    changedSessionIds: result.changedIds,
-    hasUnresolvedDeletions: result.hasUnresolvedDeletions,
+    changedSessionIds,
+    hasUnresolvedDeletions: result?.hasUnresolvedDeletions ?? false,
   };
+}
+
+function addTagChangeSessionIds(
+  tables: TablesContent,
+  changedTables: ChangedTables,
+  changedSessionIds: Set<string>,
+) {
+  if (!hasTableChange(changedTables, "tags")) {
+    return;
+  }
+
+  const changedTags = changedTables.tags;
+  const changedTagIds = changedTags ? new Set(Object.keys(changedTags)) : null;
+
+  for (const mapping of iterateTableRows(tables, "mapping_tag_session")) {
+    if (!mapping.session_id || !mapping.tag_id) {
+      continue;
+    }
+
+    if (!changedTagIds || changedTagIds.has(mapping.tag_id)) {
+      changedSessionIds.add(mapping.session_id);
+    }
+  }
+}
+
+export function getSessionSaveScope(
+  changedTables?: ChangedTables,
+): SessionSaveScope {
+  if (!changedTables) {
+    return ALL_SESSION_SAVE_SCOPES;
+  }
+
+  const sessionPathChanged = hasSessionCellChange(
+    changedTables,
+    new Set(["folder_id"]),
+  );
+
+  return {
+    session:
+      hasSessionCellChange(changedTables, SESSION_META_CELLS) ||
+      hasTableChange(changedTables, "mapping_session_participant") ||
+      hasTableChange(changedTables, "mapping_tag_session") ||
+      hasTableChange(changedTables, "tags"),
+    transcript:
+      sessionPathChanged || hasTableChange(changedTables, "transcripts"),
+    note:
+      hasSessionCellChange(changedTables, SESSION_NOTE_CELLS) ||
+      hasTableChange(changedTables, "enhanced_notes"),
+  };
+}
+
+function hasTableChange(
+  changedTables: ChangedTables,
+  table: keyof ChangedTables,
+): boolean {
+  return Object.prototype.hasOwnProperty.call(changedTables, table);
+}
+
+function hasSessionCellChange(
+  changedTables: ChangedTables,
+  cellIds: Set<string>,
+): boolean {
+  const changedSessions = changedTables.sessions;
+  if (!hasTableChange(changedTables, "sessions")) {
+    return false;
+  }
+  if (!changedSessions) {
+    return true;
+  }
+
+  return Object.values(changedSessions).some((rowChange) => {
+    const changedCellIds = getChangedCellIds(rowChange);
+    if (!changedCellIds) {
+      return true;
+    }
+
+    for (const cellId of cellIds) {
+      if (changedCellIds.has(cellId)) {
+        return true;
+      }
+    }
+
+    return false;
+  });
+}
+
+function getChangedCellIds(rowChange: unknown): Set<string> | null {
+  const row =
+    Array.isArray(rowChange) && rowChange.length > 0 ? rowChange[0] : rowChange;
+
+  if (!row || typeof row !== "object" || Array.isArray(row)) {
+    return null;
+  }
+
+  const cellIds = Object.keys(row);
+  return cellIds.length > 0 ? new Set(cellIds) : null;
 }

--- a/apps/desktop/src/store/tinybase/persister/session/persister.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/persister.ts
@@ -1,6 +1,10 @@
 import type { Schemas } from "@hypr/store";
 
-import { getChangedSessionIds, parseSessionIdFromPath } from "./changes";
+import {
+  getChangedSessionIds,
+  getSessionSaveScope,
+  parseSessionIdFromPath,
+} from "./changes";
 import {
   loadAllSessionData,
   type LoadedSessionData,
@@ -32,6 +36,7 @@ export function createSessionPersister(store: Store) {
     loadSingle: loadSingleSession,
     save: (store, tables, dataDir, changedTables) => {
       let changedSessionIds: Set<string> | undefined;
+      const saveScope = getSessionSaveScope(changedTables);
 
       if (changedTables) {
         const changeResult = getChangedSessionIds(tables, changedTables);
@@ -46,23 +51,15 @@ export function createSessionPersister(store: Store) {
         }
       }
 
-      const sessionOps = buildSessionSaveOps(
-        store,
-        tables,
-        dataDir,
-        changedSessionIds,
-      );
-      const transcriptOps = buildTranscriptSaveOps(
-        tables,
-        dataDir,
-        changedSessionIds,
-      );
-      const noteOps = buildNoteSaveOps(
-        store,
-        tables,
-        dataDir,
-        changedSessionIds,
-      );
+      const sessionOps = saveScope.session
+        ? buildSessionSaveOps(store, tables, dataDir, changedSessionIds)
+        : [];
+      const transcriptOps = saveScope.transcript
+        ? buildTranscriptSaveOps(tables, dataDir, changedSessionIds)
+        : [];
+      const noteOps = saveScope.note
+        ? buildNoteSaveOps(store, tables, dataDir, changedSessionIds)
+        : [];
 
       return {
         operations: [...sessionOps, ...transcriptOps, ...noteOps],

--- a/apps/desktop/src/store/tinybase/persister/session/save/transcript.test.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/save/transcript.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { buildTranscriptSaveOps } from "./transcript";
+
+import type { TablesContent } from "~/store/tinybase/persister/shared";
+
+vi.mock("@tauri-apps/api/path", () => ({
+  sep: () => "/",
+}));
+
+describe("buildTranscriptSaveOps", () => {
+  const dataDir = "/data";
+
+  test("only parses transcripts for changed sessions", () => {
+    const tables: TablesContent = {
+      sessions: {
+        "session-1": {
+          user_id: "user-1",
+          created_at: "2024-01-01T00:00:00Z",
+          title: "Changed Session",
+          folder_id: "",
+          event_json: "",
+          raw_md: "",
+        },
+        "session-2": {
+          user_id: "user-1",
+          created_at: "2024-01-02T00:00:00Z",
+          title: "Unchanged Session",
+          folder_id: "",
+          event_json: "",
+          raw_md: "",
+        },
+      },
+      transcripts: {
+        "transcript-1": {
+          session_id: "session-1",
+          user_id: "user-1",
+          created_at: "2024-01-01T00:00:00Z",
+          started_at: 100,
+          words: "[]",
+          speaker_hints: "[]",
+          memo_md: "",
+        },
+        "transcript-2": {
+          session_id: "session-2",
+          user_id: "user-1",
+          created_at: "2024-01-02T00:00:00Z",
+          started_at: 200,
+          words: "{invalid json",
+          speaker_hints: "[]",
+          memo_md: "",
+        },
+      },
+    };
+
+    const ops = buildTranscriptSaveOps(tables, dataDir, new Set(["session-1"]));
+
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toMatchObject({
+      type: "write-json",
+      path: "/data/sessions/session-1/transcript.json",
+    });
+  });
+});

--- a/apps/desktop/src/store/tinybase/persister/session/save/transcript.ts
+++ b/apps/desktop/src/store/tinybase/persister/session/save/transcript.ts
@@ -24,12 +24,8 @@ export function buildTranscriptSaveOps(
   const ctx: BuildContext = { tables, dataDir, changedSessionIds };
 
   const transcriptsBySession = groupTranscriptsBySession(ctx);
-  const sessionsToProcess = filterByChangedSessions(
-    transcriptsBySession,
-    changedSessionIds,
-  );
 
-  return buildOperations(ctx, sessionsToProcess);
+  return buildOperations(ctx, [...transcriptsBySession]);
 }
 
 function groupTranscriptsBySession(
@@ -40,6 +36,12 @@ function groupTranscriptsBySession(
 
   for (const transcript of iterateTableRows(tables, "transcripts")) {
     if (!transcript.session_id) continue;
+    if (
+      ctx.changedSessionIds &&
+      !ctx.changedSessionIds.has(transcript.session_id)
+    ) {
+      continue;
+    }
 
     const data: TranscriptWithData = {
       id: transcript.id,
@@ -61,15 +63,6 @@ function groupTranscriptsBySession(
   }
 
   return grouped;
-}
-
-function filterByChangedSessions(
-  transcriptsBySession: Map<string, TranscriptWithData[]>,
-  changedSessionIds?: Set<string>,
-): Array<[string, TranscriptWithData[]]> {
-  const entries = [...transcriptsBySession];
-  if (!changedSessionIds) return entries;
-  return entries.filter(([id]) => changedSessionIds.has(id));
 }
 
 function buildOperations(


### PR DESCRIPTION
Limit session persister writes to the artifacts changed by each TinyBase transaction and avoid parsing transcripts from unchanged sessions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the session persistence decision logic to skip writing some artifacts based on TinyBase change sets; mistakes here could cause sessions, transcripts, or notes to not be saved/updated in some edge cases (especially around tag/folder updates).
> 
> **Overview**
> Reduces session persister work by computing a per-transaction `SessionSaveScope` and only generating save operations for the artifacts actually affected (session metadata, `transcript.json`, and/or note output), instead of always writing all three.
> 
> Improves change detection by expanding `getChangedSessionIds` to account for tag-driven session impacts (via `mapping_tag_session` and direct `tags` changes), and updates transcript saving to only parse/group transcripts for `changedSessionIds` to avoid touching unchanged sessions; adds focused tests for the new scoping and transcript filtering behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d14142c5cb62cf8cd349733e5bb01eb685489c89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->