### PR TITLE
fix(desktop): persist OpenAI text-only transcripts

### DIFF
--- a/apps/desktop/src/store/zustand/listener/batch.ts
+++ b/apps/desktop/src/store/zustand/listener/batch.ts
@@ -11,6 +11,8 @@ import { transformWordEntries } from "./utils";
 
 import { type RuntimeSpeakerHint, type WordLike } from "~/stt/segment";
 
+const APPROX_TEXT_WORD_DURATION_MS = 400;
+
 export type BatchPhase = "importing" | "transcribing";
 export type BatchTerminalReason = "failed" | "timed_out" | "stopped";
 
@@ -279,7 +281,14 @@ function transformBatch(
 
   response.results.channels.forEach((channel, channelIndex) => {
     const alternative = channel.alternatives[0];
-    if (!alternative || !alternative.words || !alternative.words.length) {
+    if (!alternative) {
+      return;
+    }
+
+    if (!alternative.words || !alternative.words.length) {
+      allWords.push(
+        ...synthesizeWordsFromTranscript(alternative.transcript, channelIndex),
+      );
       return;
     }
 
@@ -300,6 +309,33 @@ function transformBatch(
   });
 
   return [allWords, allHints];
+}
+
+function synthesizeWordsFromTranscript(
+  transcript: string,
+  channel: number,
+): WordLike[] {
+  const words: WordLike[] = [];
+  let previousEnd = 0;
+
+  for (const match of transcript.matchAll(/\S+/g)) {
+    const token = match[0];
+    const tokenStart = match.index ?? previousEnd;
+    const prefix =
+      words.length === 0 ? " " : transcript.slice(previousEnd, tokenStart);
+    const startMs = words.length * APPROX_TEXT_WORD_DURATION_MS;
+
+    words.push({
+      text: `${prefix}${token}`,
+      start_ms: startMs,
+      end_ms: startMs + APPROX_TEXT_WORD_DURATION_MS,
+      channel,
+    });
+
+    previousEnd = tokenStart + token.length;
+  }
+
+  return words;
 }
 
 function mergeBatchPreview(

--- a/apps/desktop/src/store/zustand/listener/general.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general.test.ts
@@ -144,6 +144,49 @@ describe("General Listener Slice", () => {
       expect(store.getState().batchPreview[sessionId]).toBeUndefined();
     });
 
+    test("handleBatchResponse persists text-only batch transcripts", () => {
+      const sessionId = "session-text-only-batch";
+      const { handleBatchStarted, handleBatchResponse, setBatchPersist } =
+        store.getState();
+      let persistedWords: Array<{
+        text: string;
+        start_ms: number;
+        end_ms: number;
+        channel: number;
+      }> = [];
+
+      handleBatchStarted(sessionId);
+      setBatchPersist(sessionId, (words) => {
+        persistedWords = words;
+      });
+
+      handleBatchResponse(sessionId, {
+        metadata: {},
+        results: {
+          channels: [
+            {
+              alternatives: [
+                {
+                  transcript: "Hello world from OpenAI.",
+                  confidence: 1,
+                  words: [],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      expect(persistedWords).toEqual([
+        { text: " Hello", start_ms: 0, end_ms: 400, channel: 0 },
+        { text: " world", start_ms: 400, end_ms: 800, channel: 0 },
+        { text: " from", start_ms: 800, end_ms: 1200, channel: 0 },
+        { text: " OpenAI.", start_ms: 1200, end_ms: 1600, channel: 0 },
+      ]);
+      expect(store.getState().batch[sessionId]).toBeUndefined();
+      expect(store.getState().batchPreview[sessionId]).toBeUndefined();
+    });
+
     test("handleBatchFailed preserves batch error for UI surfaces", () => {
       const sessionId = "session-batch-error";
       const { handleBatchFailed, getSessionMode } = store.getState();


### PR DESCRIPTION
Synthesize approximate transcript words for batch responses without word timings so OpenAI GPT transcription results are saved and summaries can run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batch transcription persistence behavior by generating synthetic `WordLike` timing data when providers return transcript text without word-level timings, which could affect downstream alignment/speaker-hint indexing. Scope is localized to batch result handling and covered by a new unit test.
> 
> **Overview**
> Batch result handling now supports **text-only** alternatives: when a `BatchResponse` includes a `transcript` but no `words`, it synthesizes `WordLike` entries with approximate 400ms durations and persists them instead of dropping the result.
> 
> Adds a regression test ensuring `handleBatchResponse` persists these synthesized words and still clears `batch`/`batchPreview` state after persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1252b5bd3a079459c01eb4da87608b9396050d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->