### PR TITLE
fix(desktop): handle overloaded summaries

### DIFF
--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-workflow.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-workflow.ts
@@ -21,6 +21,10 @@ import { normalizeBulletPoints } from "~/store/zustand/ai-task/shared/transform_
 import { withEarlyValidationRetry } from "~/store/zustand/ai-task/shared/validate";
 import { assertCanonicalTemplateSections } from "~/templates/codec";
 
+const AI_GENERATION_MAX_RETRIES = 4;
+const TEMPLATE_MAX_OUTPUT_TOKENS = 2048;
+const SUMMARY_MAX_OUTPUT_TOKENS = 8192;
+
 export const enhanceWorkflow: Pick<
   TaskConfig<"enhance">,
   "executeWorkflow" | "transforms"
@@ -194,6 +198,8 @@ async function generateStructuredOutput<T extends z.ZodTypeAny>(params: {
       temperature: 0,
       output: Output.object({ schema }),
       abortSignal: signal,
+      maxRetries: AI_GENERATION_MAX_RETRIES,
+      maxOutputTokens: TEMPLATE_MAX_OUTPUT_TOKENS,
       prompt,
     });
 
@@ -208,6 +214,8 @@ async function generateStructuredOutput<T extends z.ZodTypeAny>(params: {
         model,
         temperature: 0,
         abortSignal: signal,
+        maxRetries: AI_GENERATION_MAX_RETRIES,
+        maxOutputTokens: TEMPLATE_MAX_OUTPUT_TOKENS,
         prompt,
       });
 
@@ -262,6 +270,8 @@ IMPORTANT: Previous attempt failed. ${previousFeedback}`;
           system,
           prompt: enhancedPrompt,
           abortSignal: combinedController.signal,
+          maxRetries: AI_GENERATION_MAX_RETRIES,
+          maxOutputTokens: SUMMARY_MAX_OUTPUT_TOKENS,
         });
         return result.fullStream;
       } finally {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/title-workflow.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/title-workflow.ts
@@ -6,6 +6,9 @@ import type { TaskArgsMapTransformed, TaskConfig } from ".";
 
 import type { Store } from "~/store/tinybase/store/main";
 
+const AI_GENERATION_MAX_RETRIES = 4;
+const TITLE_MAX_OUTPUT_TOKENS = 128;
+
 export const titleWorkflow: Pick<
   TaskConfig<"title">,
   "executeWorkflow" | "transforms"
@@ -35,6 +38,8 @@ async function* executeWorkflow(params: {
     system,
     prompt,
     abortSignal: signal,
+    maxRetries: AI_GENERATION_MAX_RETRIES,
+    maxOutputTokens: TITLE_MAX_OUTPUT_TOKENS,
   });
 
   for await (const chunk of result.textStream) {

--- a/apps/desktop/src/store/zustand/ai-task/tasks.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/tasks.test.ts
@@ -1,0 +1,48 @@
+import { APICallError } from "ai";
+import { describe, expect, it } from "vitest";
+
+import { extractUnderlyingError } from "./tasks";
+
+describe("extractUnderlyingError", () => {
+  it("normalizes exhausted provider overload retries", () => {
+    const retryError = new Error(
+      "Failed after 3 attempts. Last error: Overloaded",
+    );
+    retryError.name = "AI_RetryError";
+    (retryError as any).lastError = new Error("Overloaded");
+
+    expect(extractUnderlyingError(retryError).message).toBe(
+      "The AI model is overloaded right now. Wait a moment, then retry.",
+    );
+  });
+
+  it("normalizes retryable API call failures", () => {
+    const error = new APICallError({
+      message: "Service unavailable",
+      url: "https://example.com",
+      requestBodyValues: {},
+      statusCode: 503,
+    });
+
+    expect(extractUnderlyingError(error).message).toBe(
+      "The AI model is overloaded right now. Wait a moment, then retry.",
+    );
+  });
+
+  it("preserves API conflict errors", () => {
+    const error = new APICallError({
+      message: "Conflict",
+      url: "https://example.com",
+      requestBodyValues: {},
+      statusCode: 409,
+    });
+
+    expect(extractUnderlyingError(error)).toBe(error);
+  });
+
+  it("preserves non-transient errors", () => {
+    const error = new Error("Invalid API key");
+
+    expect(extractUnderlyingError(error)).toBe(error);
+  });
+});

--- a/apps/desktop/src/store/zustand/ai-task/tasks.ts
+++ b/apps/desktop/src/store/zustand/ai-task/tasks.ts
@@ -1,4 +1,4 @@
-import type { LanguageModel } from "ai";
+import { APICallError, type LanguageModel } from "ai";
 import { create as mutate } from "mutative";
 import type { StoreApi } from "zustand";
 
@@ -277,24 +277,29 @@ export const createTasksSlice = <T extends TasksState & TasksActions>(
   },
 });
 
-function extractUnderlyingError(err: unknown): Error {
+export function extractUnderlyingError(err: unknown): Error {
   if (!(err instanceof Error)) {
     return new Error(String(err));
   }
 
+  let error = err;
+
   if (err.name === "AI_RetryError") {
     if ("cause" in err && err.cause instanceof Error) {
-      return err.cause;
+      error = err.cause;
+      return normalizeTaskError(error);
     }
 
     if ("lastError" in err && err.lastError instanceof Error) {
-      return err.lastError;
+      error = err.lastError;
+      return normalizeTaskError(error);
     }
 
     if ("errors" in err && Array.isArray((err as any).errors)) {
       const errors = (err as any).errors;
       if (errors.length > 0 && errors[errors.length - 1] instanceof Error) {
-        return errors[errors.length - 1];
+        error = errors[errors.length - 1];
+        return normalizeTaskError(error);
       }
     }
 
@@ -303,9 +308,57 @@ function extractUnderlyingError(err: unknown): Error {
       const underlyingMessage = match[1];
       const underlyingError = new Error(underlyingMessage);
       underlyingError.name = "AI_ProviderError";
-      return underlyingError;
+      return normalizeTaskError(underlyingError);
     }
   }
 
-  return err;
+  return normalizeTaskError(error);
+}
+
+const TRANSIENT_AI_ERROR_MESSAGE =
+  "The AI model is overloaded right now. Wait a moment, then retry.";
+
+const TRANSIENT_AI_ERROR_PATTERNS = [
+  "overload",
+  "rate limit",
+  "rate_limit",
+  "too many requests",
+  "429",
+  "timeout",
+  "timed out",
+  "temporarily unavailable",
+  "service unavailable",
+  "502",
+  "503",
+  "504",
+];
+
+function normalizeTaskError(error: Error): Error {
+  if (!isTransientAIError(error)) {
+    return error;
+  }
+
+  const normalized = new Error(TRANSIENT_AI_ERROR_MESSAGE);
+  normalized.name = error.name;
+  return normalized;
+}
+
+function isTransientAIError(error: Error): boolean {
+  if (APICallError.isInstance(error)) {
+    if (error.statusCode === 409) {
+      return false;
+    }
+
+    return (
+      error.isRetryable ||
+      error.statusCode === 429 ||
+      error.statusCode === 408 ||
+      (typeof error.statusCode === "number" && error.statusCode >= 500)
+    );
+  }
+
+  const message = error.message.toLowerCase();
+  return TRANSIENT_AI_ERROR_PATTERNS.some((pattern) =>
+    message.includes(pattern),
+  );
 }


### PR DESCRIPTION
Cap AI output token budgets for generated notes and keep retryable provider overloads clear.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes AI generation parameters (token limits/retries) and alters error normalization for AI failures, which can affect output completeness and user-visible error messaging across tasks.
> 
> **Overview**
> Adds explicit AI generation limits across desktop AI tasks by setting `maxRetries` and `maxOutputTokens` for template generation, note summarization, and title generation.
> 
> Improves failure handling by exporting `extractUnderlyingError` and normalizing transient/retryable AI/provider overload errors (including `APICallError` cases) into a consistent user-facing message, with new tests covering overload, retryable 5xx/503, and non-transient cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 238331767e6f8587ce08f5458a64e02cef39f2cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->