### PR TITLE
fix(stt): normalize Soniox batch tokens

### DIFF
--- a/crates/owhisper-client/src/adapter/soniox/batch.rs
+++ b/crates/owhisper-client/src/adapter/soniox/batch.rs
@@ -6,7 +6,8 @@ use owhisper_interface::batch::{
     Results as BatchResults, Word as BatchWord,
 };
 
-use super::SonioxAdapter;
+use super::{SonioxAdapter, words};
+use crate::adapter::parsing::ms_to_secs_opt;
 use crate::adapter::{BatchFuture, BatchSttAdapter, ClientWithMiddleware, MIXED_CAPTURE_CHANNEL};
 use crate::error::Error;
 
@@ -103,17 +104,17 @@ impl SonioxAdapter {
     }
 
     fn to_batch_response(transcript: soniox::TranscriptResponse) -> BatchResponse {
-        let words: Vec<BatchWord> = transcript
-            .tokens
-            .iter()
-            .map(|token| BatchWord {
-                word: token.text.clone(),
-                start: token.start_ms.unwrap_or(0) as f64 / 1000.0,
-                end: token.end_ms.unwrap_or(0) as f64 / 1000.0,
-                confidence: token.confidence.unwrap_or(1.0),
+        let tokens = transcript.tokens.iter().collect::<Vec<_>>();
+        let words: Vec<BatchWord> = words::build_token_words(&tokens)
+            .into_iter()
+            .map(|word| BatchWord {
+                word: word.text.clone(),
+                start: ms_to_secs_opt(word.start_ms),
+                end: ms_to_secs_opt(word.end_ms),
+                confidence: word.confidence,
                 channel: MIXED_CAPTURE_CHANNEL,
-                speaker: token.speaker.as_ref().and_then(|s| s.as_usize()),
-                punctuated_word: Some(token.text.clone()),
+                speaker: word.speaker.and_then(|speaker| speaker.try_into().ok()),
+                punctuated_word: Some(word.text),
             })
             .collect();
 
@@ -186,7 +187,7 @@ mod tests {
                     language: Some("en".to_string()),
                 },
                 soniox::Token {
-                    text: "there".to_string(),
+                    text: " there".to_string(),
                     start_ms: Some(400),
                     end_ms: Some(900),
                     confidence: Some(0.8),
@@ -200,10 +201,112 @@ mod tests {
         let batch = SonioxAdapter::to_batch_response(transcript);
         let words = &batch.results.channels[0].alternatives[0].words;
 
+        assert_eq!(words.len(), 2);
+        assert_eq!(words[0].word, "hello");
         assert_eq!(words[0].channel, MIXED_CAPTURE_CHANNEL);
         assert_eq!(words[0].speaker, Some(0));
+        assert_eq!(words[1].word, "there");
         assert_eq!(words[1].channel, MIXED_CAPTURE_CHANNEL);
         assert_eq!(words[1].speaker, Some(1));
+    }
+
+    #[test]
+    fn subword_tokens_are_grouped_into_batch_words() {
+        let transcript = soniox::TranscriptResponse {
+            text: "What would it require?".to_string(),
+            tokens: vec![
+                soniox::Token {
+                    text: "Wh".to_string(),
+                    start_ms: Some(0),
+                    end_ms: Some(40),
+                    confidence: Some(0.9),
+                    is_final: Some(true),
+                    speaker: None,
+                    language: Some("en".to_string()),
+                },
+                soniox::Token {
+                    text: "at".to_string(),
+                    start_ms: Some(40),
+                    end_ms: Some(80),
+                    confidence: Some(0.8),
+                    is_final: Some(true),
+                    speaker: None,
+                    language: Some("en".to_string()),
+                },
+                soniox::Token {
+                    text: " would".to_string(),
+                    start_ms: Some(120),
+                    end_ms: Some(240),
+                    confidence: Some(0.95),
+                    is_final: Some(true),
+                    speaker: None,
+                    language: Some("en".to_string()),
+                },
+                soniox::Token {
+                    text: " it".to_string(),
+                    start_ms: Some(260),
+                    end_ms: Some(300),
+                    confidence: Some(0.95),
+                    is_final: Some(true),
+                    speaker: None,
+                    language: Some("en".to_string()),
+                },
+                soniox::Token {
+                    text: " re".to_string(),
+                    start_ms: Some(320),
+                    end_ms: Some(360),
+                    confidence: Some(0.9),
+                    is_final: Some(true),
+                    speaker: None,
+                    language: Some("en".to_string()),
+                },
+                soniox::Token {
+                    text: "qu".to_string(),
+                    start_ms: Some(360),
+                    end_ms: Some(400),
+                    confidence: Some(0.8),
+                    is_final: Some(true),
+                    speaker: None,
+                    language: Some("en".to_string()),
+                },
+                soniox::Token {
+                    text: "ire".to_string(),
+                    start_ms: Some(400),
+                    end_ms: Some(480),
+                    confidence: Some(0.7),
+                    is_final: Some(true),
+                    speaker: None,
+                    language: Some("en".to_string()),
+                },
+                soniox::Token {
+                    text: "?".to_string(),
+                    start_ms: Some(480),
+                    end_ms: Some(500),
+                    confidence: Some(1.0),
+                    is_final: Some(true),
+                    speaker: None,
+                    language: Some("en".to_string()),
+                },
+            ],
+        };
+
+        let batch = SonioxAdapter::to_batch_response(transcript);
+        let alternative = &batch.results.channels[0].alternatives[0];
+        let words = &alternative.words;
+
+        assert_eq!(alternative.transcript, "What would it require?");
+        assert_eq!(
+            words
+                .iter()
+                .map(|word| word.word.as_str())
+                .collect::<Vec<_>>(),
+            vec!["What", "would", "it", "require?"]
+        );
+        assert_eq!(words[0].start, 0.0);
+        assert_eq!(words[0].end, 0.08);
+        assert_eq!(words[3].start, 0.32);
+        assert_eq!(words[3].end, 0.5);
+        assert_eq!(words[3].punctuated_word.as_deref(), Some("require?"));
     }
 
     #[tokio::test]

--- a/crates/owhisper-client/src/adapter/soniox/live.rs
+++ b/crates/owhisper-client/src/adapter/soniox/live.rs
@@ -3,7 +3,7 @@ use owhisper_interface::ListenParams;
 use owhisper_interface::stream::{Alternatives, Channel, Metadata, StreamResponse};
 use serde::Serialize;
 
-use super::SonioxAdapter;
+use super::{SonioxAdapter, words};
 use crate::adapter::RealtimeSttAdapter;
 use crate::adapter::parsing::{WordBuilder, calculate_time_span, ms_to_secs_opt};
 
@@ -230,70 +230,16 @@ impl SonioxAdapter {
 }
 
 fn build_words(tokens: &[&soniox::Token]) -> Vec<owhisper_interface::stream::Word> {
-    #[derive(Default)]
-    struct PendingWord {
-        text: String,
-        start_ms: Option<u64>,
-        end_ms: Option<u64>,
-        speaker: Option<i32>,
-        language: Option<String>,
-        confidence_sum: f64,
-        confidence_count: u32,
-    }
-
-    impl PendingWord {
-        fn push_token(&mut self, token: &soniox::Token, text: &str) {
-            if self.start_ms.is_none() {
-                self.start_ms = token.start_ms;
-            }
-            self.end_ms = token.end_ms.or(self.end_ms);
-            self.text.push_str(text);
-
-            if self.speaker.is_none() {
-                self.speaker = token.speaker.as_ref().and_then(|speaker| speaker.as_i32());
-            }
-            if self.language.is_none() {
-                self.language = token.language.clone();
-            }
-
-            self.confidence_sum += token.confidence.unwrap_or(1.0);
-            self.confidence_count += 1;
-        }
-
-        fn build(self) -> Option<owhisper_interface::stream::Word> {
-            if self.text.is_empty() {
-                return None;
-            }
-
-            let confidence = if self.confidence_count == 0 {
-                1.0
-            } else {
-                self.confidence_sum / f64::from(self.confidence_count)
-            };
-
-            Some(
-                WordBuilder::new(self.text)
-                    .start(ms_to_secs_opt(self.start_ms))
-                    .end(ms_to_secs_opt(self.end_ms))
-                    .confidence(confidence)
-                    .speaker(self.speaker)
-                    .language(self.language)
-                    .build(),
-            )
-        }
-    }
-
-    token_groups_from_refs(tokens)
+    words::build_token_words(tokens)
         .into_iter()
-        .filter_map(|group| {
-            let mut pending = PendingWord::default();
-            for token in group {
-                let trimmed = token.text.trim();
-                if !trimmed.is_empty() {
-                    pending.push_token(token, trimmed);
-                }
-            }
-            pending.build()
+        .map(|word| {
+            WordBuilder::new(word.text)
+                .start(ms_to_secs_opt(word.start_ms))
+                .end(ms_to_secs_opt(word.end_ms))
+                .confidence(word.confidence)
+                .speaker(word.speaker)
+                .language(word.language)
+                .build()
         })
         .collect()
 }
@@ -301,73 +247,7 @@ fn build_words(tokens: &[&soniox::Token]) -> Vec<owhisper_interface::stream::Wor
 fn partition_tokens_by_word_finality(
     tokens: &[soniox::Token],
 ) -> (Vec<&soniox::Token>, Vec<&soniox::Token>) {
-    let mut final_tokens = Vec::new();
-    let mut non_final_tokens = Vec::new();
-    for group in token_groups_from_values(tokens) {
-        if group.iter().all(|token| token.is_final.unwrap_or(true)) {
-            final_tokens.extend(group);
-        } else {
-            non_final_tokens.extend(group);
-        }
-    }
-
-    (final_tokens, non_final_tokens)
-}
-
-fn token_groups_from_refs<'a>(tokens: &[&'a soniox::Token]) -> Vec<Vec<&'a soniox::Token>> {
-    let mut groups = Vec::new();
-    let mut current = Vec::new();
-    let mut current_has_content = false;
-
-    let flush = |groups: &mut Vec<Vec<&'a soniox::Token>>, current: &mut Vec<&'a soniox::Token>| {
-        if !current.is_empty() {
-            groups.push(std::mem::take(current));
-        }
-    };
-
-    for token in tokens {
-        let has_content = !token.text.trim().is_empty();
-        let starts_with_ws = token.text.chars().next().is_some_and(char::is_whitespace);
-
-        if starts_with_ws && current_has_content {
-            flush(&mut groups, &mut current);
-            current_has_content = false;
-        }
-
-        current.push(*token);
-        current_has_content |= has_content;
-    }
-
-    flush(&mut groups, &mut current);
-    groups
-}
-
-fn token_groups_from_values<'a>(tokens: &'a [soniox::Token]) -> Vec<Vec<&'a soniox::Token>> {
-    let mut groups = Vec::new();
-    let mut current = Vec::new();
-    let mut current_has_content = false;
-
-    let flush = |groups: &mut Vec<Vec<&'a soniox::Token>>, current: &mut Vec<&'a soniox::Token>| {
-        if !current.is_empty() {
-            groups.push(std::mem::take(current));
-        }
-    };
-
-    for token in tokens {
-        let has_content = !token.text.trim().is_empty();
-        let starts_with_ws = token.text.chars().next().is_some_and(char::is_whitespace);
-
-        if starts_with_ws && current_has_content {
-            flush(&mut groups, &mut current);
-            current_has_content = false;
-        }
-
-        current.push(token);
-        current_has_content |= has_content;
-    }
-
-    flush(&mut groups, &mut current);
-    groups
+    words::partition_tokens_by_word_finality(tokens)
 }
 
 #[cfg(test)]

--- a/crates/owhisper-client/src/adapter/soniox/mod.rs
+++ b/crates/owhisper-client/src/adapter/soniox/mod.rs
@@ -3,6 +3,7 @@ mod callback;
 pub mod error;
 mod language;
 mod live;
+mod words;
 
 use super::LanguageSupport;
 

--- a/crates/owhisper-client/src/adapter/soniox/words.rs
+++ b/crates/owhisper-client/src/adapter/soniox/words.rs
@@ -1,0 +1,149 @@
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct TokenWord {
+    pub text: String,
+    pub start_ms: Option<u64>,
+    pub end_ms: Option<u64>,
+    pub confidence: f64,
+    pub speaker: Option<i32>,
+    pub language: Option<String>,
+}
+
+#[derive(Default)]
+struct PendingWord {
+    text: String,
+    start_ms: Option<u64>,
+    end_ms: Option<u64>,
+    speaker: Option<i32>,
+    language: Option<String>,
+    confidence_sum: f64,
+    confidence_count: u32,
+}
+
+impl PendingWord {
+    fn push_token(&mut self, token: &soniox::Token, text: &str) {
+        if self.start_ms.is_none() {
+            self.start_ms = token.start_ms;
+        }
+        self.end_ms = token.end_ms.or(self.end_ms);
+        self.text.push_str(text);
+
+        if self.speaker.is_none() {
+            self.speaker = token.speaker.as_ref().and_then(|speaker| speaker.as_i32());
+        }
+        if self.language.is_none() {
+            self.language = token.language.clone();
+        }
+
+        self.confidence_sum += token.confidence.unwrap_or(1.0);
+        self.confidence_count += 1;
+    }
+
+    fn build(self) -> Option<TokenWord> {
+        if self.text.is_empty() {
+            return None;
+        }
+
+        let confidence = if self.confidence_count == 0 {
+            1.0
+        } else {
+            self.confidence_sum / f64::from(self.confidence_count)
+        };
+
+        Some(TokenWord {
+            text: self.text,
+            start_ms: self.start_ms,
+            end_ms: self.end_ms,
+            confidence,
+            speaker: self.speaker,
+            language: self.language,
+        })
+    }
+}
+
+pub(super) fn build_token_words(tokens: &[&soniox::Token]) -> Vec<TokenWord> {
+    token_groups_from_refs(tokens)
+        .into_iter()
+        .filter_map(|group| {
+            let mut pending = PendingWord::default();
+            for token in group {
+                let trimmed = token.text.trim();
+                if !trimmed.is_empty() {
+                    pending.push_token(token, trimmed);
+                }
+            }
+            pending.build()
+        })
+        .collect()
+}
+
+pub(super) fn partition_tokens_by_word_finality(
+    tokens: &[soniox::Token],
+) -> (Vec<&soniox::Token>, Vec<&soniox::Token>) {
+    let mut final_tokens = Vec::new();
+    let mut non_final_tokens = Vec::new();
+    for group in token_groups_from_values(tokens) {
+        if group.iter().all(|token| token.is_final.unwrap_or(true)) {
+            final_tokens.extend(group);
+        } else {
+            non_final_tokens.extend(group);
+        }
+    }
+
+    (final_tokens, non_final_tokens)
+}
+
+fn token_groups_from_refs<'a>(tokens: &[&'a soniox::Token]) -> Vec<Vec<&'a soniox::Token>> {
+    let mut groups = Vec::new();
+    let mut current = Vec::new();
+    let mut current_has_content = false;
+
+    let flush = |groups: &mut Vec<Vec<&'a soniox::Token>>, current: &mut Vec<&'a soniox::Token>| {
+        if !current.is_empty() {
+            groups.push(std::mem::take(current));
+        }
+    };
+
+    for token in tokens {
+        let has_content = !token.text.trim().is_empty();
+        let starts_with_ws = token.text.chars().next().is_some_and(char::is_whitespace);
+
+        if starts_with_ws && current_has_content {
+            flush(&mut groups, &mut current);
+            current_has_content = false;
+        }
+
+        current.push(*token);
+        current_has_content |= has_content;
+    }
+
+    flush(&mut groups, &mut current);
+    groups
+}
+
+fn token_groups_from_values<'a>(tokens: &'a [soniox::Token]) -> Vec<Vec<&'a soniox::Token>> {
+    let mut groups = Vec::new();
+    let mut current = Vec::new();
+    let mut current_has_content = false;
+
+    let flush = |groups: &mut Vec<Vec<&'a soniox::Token>>, current: &mut Vec<&'a soniox::Token>| {
+        if !current.is_empty() {
+            groups.push(std::mem::take(current));
+        }
+    };
+
+    for token in tokens {
+        let has_content = !token.text.trim().is_empty();
+        let starts_with_ws = token.text.chars().next().is_some_and(char::is_whitespace);
+
+        if starts_with_ws && current_has_content {
+            flush(&mut groups, &mut current);
+            current_has_content = false;
+        }
+
+        current.push(token);
+        current_has_content |= has_content;
+    }
+
+    flush(&mut groups, &mut current);
+    groups
+}


### PR DESCRIPTION
Group Soniox token-level async transcripts into word entries before batch persistence, and cover subword batches with tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Soniox token-level output is grouped into word entries for both batch and realtime responses, which can affect persisted word timings/speaker attribution and downstream consumers. Logic is covered by new unit tests but still impacts core transcription parsing.
> 
> **Overview**
> Normalizes Soniox token-level transcripts into word-level entries by introducing shared `soniox/words.rs` grouping logic and reusing it in both `batch.rs` and `live.rs`.
> 
> Batch transcription now groups subword/whitespace-prefixed tokens into coherent `Word`s (with aggregated timing, confidence, speaker/language) before building the batch response, and adds unit coverage for subword token batches and speaker-labeled tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7efe541c831fbb7517e48969d7c20550acc16810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->