### PR TITLE
Fix meeting auto-start and auto-stop behavior

### DIFF
--- a/apps/desktop/src/services/event-listeners.test.tsx
+++ b/apps/desktop/src/services/event-listeners.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { EventListeners } from "./event-listeners";
 
@@ -100,6 +100,10 @@ describe("EventListeners notification events", () => {
     getOrCreateSessionForEventIdMock.mockReturnValue("session-event");
     useMainStoreMock.mockReturnValue(null);
     useSettingsStoreMock.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   test("stores mic-detected footer actions as ignored platforms", async () => {
@@ -231,8 +235,17 @@ describe("EventListeners notification events", () => {
     expect(openNewMock).toHaveBeenCalledTimes(1);
   });
 
-  test("notification_confirm with calendar_event source does not set triggerAppIds", async () => {
-    useMainStoreMock.mockReturnValue({} as never);
+  test("notification_confirm with upcoming calendar_event opens notes without auto-start", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(
+      new Date("2026-05-15T12:00:00.000Z").getTime(),
+    );
+    useMainStoreMock.mockReturnValue({
+      getRow: vi.fn((table: string, rowId: string) =>
+        table === "events" && rowId === "evt-1"
+          ? { started_at: "2026-05-15T12:02:00.000Z" }
+          : undefined,
+      ),
+    } as never);
 
     render(<EventListeners />);
 
@@ -251,6 +264,45 @@ describe("EventListeners notification events", () => {
     });
 
     expect(setTriggerAppIdsMock).not.toHaveBeenCalled();
-    expect(openNewMock).toHaveBeenCalledTimes(1);
+    expect(openNewMock).toHaveBeenCalledWith({
+      type: "sessions",
+      id: "session-event",
+      state: { view: null, autoStart: null },
+    });
+  });
+
+  test("notification_confirm with started calendar_event starts listening", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(
+      new Date("2026-05-15T12:02:00.000Z").getTime(),
+    );
+    useMainStoreMock.mockReturnValue({
+      getRow: vi.fn((table: string, rowId: string) =>
+        table === "events" && rowId === "evt-1"
+          ? { started_at: "2026-05-15T12:00:00.000Z" }
+          : undefined,
+      ),
+    } as never);
+
+    render(<EventListeners />);
+
+    await vi.waitFor(() =>
+      expect(notificationListenMock).toHaveBeenCalledTimes(1),
+    );
+
+    const handler = notificationListenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    handler({
+      payload: {
+        type: "notification_confirm",
+        source: { type: "calendar_event", event_id: "evt-1" },
+      },
+    });
+
+    expect(openNewMock).toHaveBeenCalledWith({
+      type: "sessions",
+      id: "session-event",
+      state: { view: null, autoStart: true },
+    });
   });
 });

--- a/apps/desktop/src/services/event-listeners.tsx
+++ b/apps/desktop/src/services/event-listeners.tsx
@@ -17,6 +17,8 @@ import * as settings from "~/store/tinybase/store/settings";
 import { listenerStore } from "~/store/zustand/listener/instance";
 import { useTabs } from "~/store/zustand/tabs";
 
+type MainStore = NonNullable<ReturnType<typeof main.UI.useStore>>;
+
 function parseIgnoredPlatforms(value: unknown) {
   if (typeof value !== "string") {
     return [];
@@ -32,6 +34,28 @@ function parseIgnoredPlatforms(value: unknown) {
   } catch {
     return [];
   }
+}
+
+function shouldAutoStartNotificationSession(
+  store: MainStore,
+  eventId: string | null,
+  triggerAppIds: string[] | null,
+): boolean {
+  if (triggerAppIds && triggerAppIds.length > 0) {
+    return true;
+  }
+
+  if (!eventId) {
+    return true;
+  }
+
+  const startedAt = store.getRow("events", eventId)?.started_at;
+  if (!startedAt) {
+    return false;
+  }
+
+  const startTime = new Date(String(startedAt)).getTime();
+  return !Number.isNaN(startTime) && startTime <= Date.now();
 }
 
 function useUpdaterEvents() {
@@ -91,11 +115,16 @@ function useNotificationEvents() {
       if (triggerAppIds && triggerAppIds.length > 0) {
         listenerStore.getState().setTriggerAppIds(triggerAppIds);
       }
+      const autoStart = shouldAutoStartNotificationSession(
+        store,
+        eventId,
+        triggerAppIds,
+      );
 
       openNew({
         type: "sessions",
         id: sessionId,
-        state: { view: null, autoStart: true },
+        state: { view: null, autoStart: autoStart ? true : null },
       });
     }
   }, [store, openNew]);
@@ -134,11 +163,16 @@ function useNotificationEvents() {
           if (triggerAppIds && triggerAppIds.length > 0) {
             listenerStore.getState().setTriggerAppIds(triggerAppIds);
           }
+          const autoStart = shouldAutoStartNotificationSession(
+            currentStore,
+            eventId,
+            triggerAppIds,
+          );
 
           openNewRef.current({
             type: "sessions",
             id: sessionId,
-            state: { view: null, autoStart: true },
+            state: { view: null, autoStart: autoStart ? true : null },
           });
         } else if (payload.type === "notification_option_selected") {
           const currentStore = storeRef.current;

--- a/apps/desktop/src/services/event-notification/index.test.ts
+++ b/apps/desktop/src/services/event-notification/index.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { checkEventNotifications } from ".";
+
+import type * as main from "~/store/tinybase/store/main";
+import type * as settings from "~/store/tinybase/store/settings";
+
+const { showNotificationMock } = vi.hoisted(() => ({
+  showNotificationMock: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-notification", () => ({
+  commands: {
+    showNotification: showNotificationMock,
+  },
+}));
+
+describe("checkEventNotifications", () => {
+  beforeEach(() => {
+    showNotificationMock.mockReset();
+    vi.spyOn(Date, "now").mockReturnValue(
+      new Date("2026-05-15T12:00:00.000Z").getTime(),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("scheduled meeting notifications do not include expanded payloads", () => {
+    const store = {
+      getValue: vi.fn(() => undefined),
+      forEachRow: vi.fn((table: string, callback: (rowId: string) => void) => {
+        if (table === "events") {
+          callback("event-1");
+        }
+      }),
+      getRow: vi.fn((table: string, rowId: string) => {
+        if (table === "events" && rowId === "event-1") {
+          return {
+            started_at: "2026-05-15T12:02:00.000Z",
+            tracking_id_event: "tracking-1",
+            title: "Design Review",
+            meeting_link: "https://meet.example.com/design",
+          };
+        }
+        return undefined;
+      }),
+    } as unknown as main.Store;
+    const settingsStore = {
+      getValue: vi.fn((key: string) =>
+        key === "notification_event" ? true : undefined,
+      ),
+    } as unknown as settings.Store;
+
+    checkEventNotifications(store, settingsStore, new Map());
+
+    expect(showNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: { type: "calendar_event", event_id: "event-1" },
+        action_label: "Open notes",
+        participants: null,
+        event_details: null,
+        options: null,
+        footer: null,
+      }),
+    );
+  });
+});

--- a/apps/desktop/src/services/event-notification/index.ts
+++ b/apps/desktop/src/services/event-notification/index.ts
@@ -1,10 +1,5 @@
-import {
-  type EventDetails,
-  commands as notificationCommands,
-  type Participant,
-} from "@hypr/plugin-notification";
+import { commands as notificationCommands } from "@hypr/plugin-notification";
 
-import { findSessionByEventId } from "~/session/utils";
 import type * as main from "~/store/tinybase/store/main";
 import type * as settings from "~/store/tinybase/store/settings";
 
@@ -15,32 +10,6 @@ const NOTIFY_WINDOW_MS = 5 * 60 * 1000; // 5 minutes before
 const NOTIFIED_EVENTS_TTL_MS = 10 * 60 * 1000; // 10 minutes TTL for cleanup
 
 export type NotifiedEventsMap = Map<string, number>;
-
-function getParticipantsForSession(
-  store: main.Store,
-  sessionId: string,
-): Participant[] {
-  const participants: Participant[] = [];
-
-  store.forEachRow("mapping_session_participant", (mappingId, _forEachCell) => {
-    const mapping = store.getRow("mapping_session_participant", mappingId);
-    if (mapping?.session_id !== sessionId) return;
-
-    const humanId = mapping.human_id as string | undefined;
-    if (!humanId) return;
-
-    const human = store.getRow("humans", humanId);
-    if (!human) return;
-
-    participants.push({
-      name: (human.name as string) || null,
-      email: (human.email as string) || "",
-      status: "Accepted",
-    });
-  });
-
-  return participants;
-}
 
 export function checkEventNotifications(
   store: main.Store,
@@ -112,22 +81,6 @@ export function checkEventNotifications(
       const title = String(event.title || "Upcoming Event");
       const minutesUntil = Math.ceil(timeUntilStart / 60000);
 
-      const eventDetails: EventDetails = {
-        what: title,
-        timezone: null,
-        location:
-          (event.meeting_link as string) || (event.location as string) || null,
-      };
-
-      let participants: Participant[] | null = null;
-      const sessionId = findSessionByEventId(store, eventId);
-      if (sessionId) {
-        const sessionParticipants = getParticipantsForSession(store, sessionId);
-        if (sessionParticipants.length > 0) {
-          participants = sessionParticipants;
-        }
-      }
-
       void notificationCommands.showNotification({
         key: notificationKey,
         title: title,
@@ -135,9 +88,9 @@ export function checkEventNotifications(
         timeout: null,
         source: { type: "calendar_event", event_id: eventId },
         start_time: Math.floor(startTime.getTime() / 1000),
-        participants: participants,
-        event_details: eventDetails,
-        action_label: "Start listening",
+        participants: null,
+        event_details: null,
+        action_label: "Open notes",
         options: null,
         footer: null,
         icon: null,

--- a/apps/desktop/src/session/components/floating/listen.test.tsx
+++ b/apps/desktop/src/session/components/floating/listen.test.tsx
@@ -1,0 +1,91 @@
+import { render } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { ListenButton } from "./listen";
+
+import type { Tab } from "~/store/zustand/tabs";
+
+const {
+  countdownCallbacks,
+  updateSessionTabStateMock,
+  useConfigValueMock,
+  useListenerMock,
+} = vi.hoisted(() => ({
+  countdownCallbacks: [] as Array<() => void>,
+  updateSessionTabStateMock: vi.fn(),
+  useConfigValueMock: vi.fn(() => true),
+  useListenerMock: vi.fn((selector) =>
+    selector({
+      live: { loading: false, sessionId: null },
+      canStartLiveSession: () => true,
+    }),
+  ),
+}));
+
+vi.mock("@hypr/plugin-opener2", () => ({
+  commands: {
+    openUrl: vi.fn(),
+  },
+}));
+
+vi.mock("../listen-action", () => ({
+  ListenActionButton: ({ sessionId }: { sessionId: string }) => (
+    <button type="button">Listen {sessionId}</button>
+  ),
+}));
+
+vi.mock("~/session/components/shared", () => ({
+  useListenButtonState: () => ({
+    shouldRender: true,
+    isDisabled: false,
+    warningMessage: "",
+  }),
+}));
+
+vi.mock("~/session/hooks/useEventCountdown", () => ({
+  useEventCountdown: (
+    _sessionId: string,
+    options?: { onExpire?: () => void },
+  ) => {
+    if (options?.onExpire) {
+      countdownCallbacks.push(options.onExpire);
+    }
+    return { label: "meeting starts in 1s" };
+  },
+}));
+
+vi.mock("~/session/hooks/useRemoteMeeting", () => ({
+  useRemoteMeeting: () => null,
+}));
+
+vi.mock("~/shared/config", () => ({
+  useConfigValue: useConfigValueMock,
+}));
+
+vi.mock("~/store/zustand/tabs", () => ({
+  useTabs: (selector: any) =>
+    selector({ updateSessionTabState: updateSessionTabStateMock }),
+}));
+
+vi.mock("~/stt/contexts", () => ({
+  useListener: useListenerMock,
+}));
+
+describe("floating ListenButton", () => {
+  test("requests auto-start when the event countdown expires", () => {
+    const tab = {
+      type: "sessions",
+      id: "session-1",
+      state: { view: null, autoStart: null },
+    } as Extract<Tab, { type: "sessions" }>;
+
+    render(<ListenButton tab={tab} />);
+
+    countdownCallbacks[countdownCallbacks.length - 1]?.();
+
+    expect(updateSessionTabStateMock).toHaveBeenCalledWith(tab, {
+      view: null,
+      autoStart: true,
+    });
+  });
+});

--- a/apps/desktop/src/session/components/floating/listen.tsx
+++ b/apps/desktop/src/session/components/floating/listen.tsx
@@ -12,7 +12,9 @@ import {
   type RemoteMeeting,
   useRemoteMeeting,
 } from "~/session/hooks/useRemoteMeeting";
+import { useConfigValue } from "~/shared/config";
 import type { Tab } from "~/store/zustand/tabs";
+import { useTabs } from "~/store/zustand/tabs";
 import { useListener } from "~/stt/contexts";
 
 export function ListenButton({
@@ -24,8 +26,29 @@ export function ListenButton({
   const loading = useListener(
     (state) => state.live.loading && state.live.sessionId === tab.id,
   );
+  const canStartLiveSession = useListener((state) =>
+    state.canStartLiveSession(tab.id),
+  );
+  const autoStartScheduledMeetings = useConfigValue(
+    "auto_start_scheduled_meetings",
+  );
+  const updateSessionTabState = useTabs((state) => state.updateSessionTabState);
   const remote = useRemoteMeeting(tab.id);
-  const countdown = useEventCountdown(tab.id);
+  const handleCountdownExpire = useCallback(() => {
+    if (!autoStartScheduledMeetings || !canStartLiveSession) {
+      return;
+    }
+
+    updateSessionTabState(tab, { ...tab.state, autoStart: true });
+  }, [
+    autoStartScheduledMeetings,
+    canStartLiveSession,
+    tab,
+    updateSessionTabState,
+  ]);
+  const countdown = useEventCountdown(tab.id, {
+    onExpire: handleCountdownExpire,
+  });
 
   if (loading) {
     return <ListenActionButton sessionId={tab.id} />;

--- a/apps/desktop/src/session/hooks/useEventCountdown.test.tsx
+++ b/apps/desktop/src/session/hooks/useEventCountdown.test.tsx
@@ -1,0 +1,55 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { useEventCountdown } from "./useEventCountdown";
+
+const { useSessionEventMock } = vi.hoisted(() => ({
+  useSessionEventMock: vi.fn(),
+}));
+
+vi.mock("~/store/tinybase/hooks", () => ({
+  useSessionEvent: useSessionEventMock,
+}));
+
+describe("useEventCountdown", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-15T12:00:00.000Z"));
+    useSessionEventMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("fires onExpire when an active countdown reaches the start time", () => {
+    const onExpire = vi.fn();
+    useSessionEventMock.mockReturnValue({
+      started_at: new Date(Date.now() + 2000).toISOString(),
+    });
+
+    const { result } = renderHook(() =>
+      useEventCountdown("session-1", { onExpire }),
+    );
+
+    expect(result.current.label).toBe("meeting starts in 2s");
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.label).toBeNull();
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not fire onExpire for an event that is already in the past", () => {
+    const onExpire = vi.fn();
+    useSessionEventMock.mockReturnValue({
+      started_at: new Date(Date.now() - 1000).toISOString(),
+    });
+
+    renderHook(() => useEventCountdown("session-1", { onExpire }));
+
+    expect(onExpire).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/session/hooks/useEventCountdown.ts
+++ b/apps/desktop/src/session/hooks/useEventCountdown.ts
@@ -23,6 +23,7 @@ export function useEventCountdown(
 
     const eventStart = new Date(startedAt).getTime();
     let fired = false;
+    let armed = false;
 
     let interval: ReturnType<typeof setInterval>;
 
@@ -32,7 +33,7 @@ export function useEventCountdown(
       if (diff <= 0) {
         setLabel(null);
         clearInterval(interval);
-        if (!fired) {
+        if (armed && !fired) {
           fired = true;
           onExpireRef.current?.();
         }
@@ -44,6 +45,7 @@ export function useEventCountdown(
         return;
       }
 
+      armed = true;
       const totalSeconds = Math.floor(diff / 1000);
       const mins = Math.floor(totalSeconds / 60);
       const secs = totalSeconds % 60;

--- a/apps/desktop/src/settings/general/app-settings.tsx
+++ b/apps/desktop/src/settings/general/app-settings.tsx
@@ -9,11 +9,13 @@ interface SettingItem {
 
 interface AppSettingsViewProps {
   autostart: SettingItem;
+  autoStopMeetings: SettingItem;
   telemetryConsent: SettingItem;
 }
 
 export function AppSettingsView({
   autostart,
+  autoStopMeetings,
   telemetryConsent,
 }: AppSettingsViewProps) {
   return (
@@ -25,6 +27,12 @@ export function AppSettingsView({
           description={autostart.description}
           checked={autostart.value}
           onChange={autostart.onChange}
+        />
+        <SettingRow
+          title={autoStopMeetings.title}
+          description={autoStopMeetings.description}
+          checked={autoStopMeetings.value}
+          onChange={autoStopMeetings.onChange}
         />
         <SettingRow
           title={telemetryConsent.title}

--- a/apps/desktop/src/settings/general/app-settings.tsx
+++ b/apps/desktop/src/settings/general/app-settings.tsx
@@ -9,12 +9,14 @@ interface SettingItem {
 
 interface AppSettingsViewProps {
   autostart: SettingItem;
+  autoStartScheduledMeetings: SettingItem;
   autoStopMeetings: SettingItem;
   telemetryConsent: SettingItem;
 }
 
 export function AppSettingsView({
   autostart,
+  autoStartScheduledMeetings,
   autoStopMeetings,
   telemetryConsent,
 }: AppSettingsViewProps) {
@@ -27,6 +29,12 @@ export function AppSettingsView({
           description={autostart.description}
           checked={autostart.value}
           onChange={autostart.onChange}
+        />
+        <SettingRow
+          title={autoStartScheduledMeetings.title}
+          description={autoStartScheduledMeetings.description}
+          checked={autoStartScheduledMeetings.value}
+          onChange={autoStartScheduledMeetings.onChange}
         />
         <SettingRow
           title={autoStopMeetings.title}

--- a/apps/desktop/src/settings/general/index.tsx
+++ b/apps/desktop/src/settings/general/index.tsx
@@ -24,6 +24,7 @@ import * as settings from "~/store/tinybase/store/settings";
 function useSettingsForm() {
   const value = useConfigValues([
     "autostart",
+    "auto_stop_meetings",
     "notification_detect",
     "telemetry_consent",
     "ai_language",
@@ -58,6 +59,7 @@ function useSettingsForm() {
   const form = useForm({
     defaultValues: {
       autostart: value.autostart,
+      auto_stop_meetings: value.auto_stop_meetings,
       notification_detect: value.notification_detect,
       telemetry_consent: value.telemetry_consent,
       ai_language: value.ai_language,
@@ -86,6 +88,7 @@ function useSettingsForm() {
       void analyticsCommands.event({
         event: "settings_changed",
         autostart: value.autostart,
+        auto_stop_meetings: value.auto_stop_meetings,
         notification_detect: value.notification_detect,
         telemetry_consent: value.telemetry_consent,
       });
@@ -120,23 +123,36 @@ export function SettingsApp() {
     <div className="flex flex-col gap-8">
       <form.Field name="autostart">
         {(autostartField) => (
-          <form.Field name="telemetry_consent">
-            {(telemetryConsentField) => (
-              <AppSettingsView
-                autostart={{
-                  title: "Start Anarlog at login",
-                  description: "Always ready without manually launching.",
-                  value: autostartField.state.value,
-                  onChange: (val) => autostartField.handleChange(val),
-                }}
-                telemetryConsent={{
-                  title: "Share usage data",
-                  description:
-                    "Send anonymous usage analytics to help improve Anarlog.",
-                  value: telemetryConsentField.state.value,
-                  onChange: (val) => telemetryConsentField.handleChange(val),
-                }}
-              />
+          <form.Field name="auto_stop_meetings">
+            {(autoStopMeetingsField) => (
+              <form.Field name="telemetry_consent">
+                {(telemetryConsentField) => (
+                  <AppSettingsView
+                    autostart={{
+                      title: "Start Anarlog at login",
+                      description: "Always ready without manually launching.",
+                      value: autostartField.state.value,
+                      onChange: (val) => autostartField.handleChange(val),
+                    }}
+                    autoStopMeetings={{
+                      title: "Stop when meeting ends",
+                      description:
+                        "Automatically stop listening when the meeting app releases the microphone.",
+                      value: autoStopMeetingsField.state.value,
+                      onChange: (val) =>
+                        autoStopMeetingsField.handleChange(val),
+                    }}
+                    telemetryConsent={{
+                      title: "Share usage data",
+                      description:
+                        "Send anonymous usage analytics to help improve Anarlog.",
+                      value: telemetryConsentField.state.value,
+                      onChange: (val) =>
+                        telemetryConsentField.handleChange(val),
+                    }}
+                  />
+                )}
+              </form.Field>
             )}
           </form.Field>
         )}

--- a/apps/desktop/src/settings/general/index.tsx
+++ b/apps/desktop/src/settings/general/index.tsx
@@ -24,6 +24,7 @@ import * as settings from "~/store/tinybase/store/settings";
 function useSettingsForm() {
   const value = useConfigValues([
     "autostart",
+    "auto_start_scheduled_meetings",
     "auto_stop_meetings",
     "notification_detect",
     "telemetry_consent",
@@ -59,6 +60,7 @@ function useSettingsForm() {
   const form = useForm({
     defaultValues: {
       autostart: value.autostart,
+      auto_start_scheduled_meetings: value.auto_start_scheduled_meetings,
       auto_stop_meetings: value.auto_stop_meetings,
       notification_detect: value.notification_detect,
       telemetry_consent: value.telemetry_consent,
@@ -88,6 +90,7 @@ function useSettingsForm() {
       void analyticsCommands.event({
         event: "settings_changed",
         autostart: value.autostart,
+        auto_start_scheduled_meetings: value.auto_start_scheduled_meetings,
         auto_stop_meetings: value.auto_stop_meetings,
         notification_detect: value.notification_detect,
         telemetry_consent: value.telemetry_consent,
@@ -123,34 +126,47 @@ export function SettingsApp() {
     <div className="flex flex-col gap-8">
       <form.Field name="autostart">
         {(autostartField) => (
-          <form.Field name="auto_stop_meetings">
-            {(autoStopMeetingsField) => (
-              <form.Field name="telemetry_consent">
-                {(telemetryConsentField) => (
-                  <AppSettingsView
-                    autostart={{
-                      title: "Start Anarlog at login",
-                      description: "Always ready without manually launching.",
-                      value: autostartField.state.value,
-                      onChange: (val) => autostartField.handleChange(val),
-                    }}
-                    autoStopMeetings={{
-                      title: "Stop when meeting ends",
-                      description:
-                        "Automatically stop listening when the meeting app releases the microphone.",
-                      value: autoStopMeetingsField.state.value,
-                      onChange: (val) =>
-                        autoStopMeetingsField.handleChange(val),
-                    }}
-                    telemetryConsent={{
-                      title: "Share usage data",
-                      description:
-                        "Send anonymous usage analytics to help improve Anarlog.",
-                      value: telemetryConsentField.state.value,
-                      onChange: (val) =>
-                        telemetryConsentField.handleChange(val),
-                    }}
-                  />
+          <form.Field name="auto_start_scheduled_meetings">
+            {(autoStartScheduledMeetingsField) => (
+              <form.Field name="auto_stop_meetings">
+                {(autoStopMeetingsField) => (
+                  <form.Field name="telemetry_consent">
+                    {(telemetryConsentField) => (
+                      <AppSettingsView
+                        autostart={{
+                          title: "Start Anarlog at login",
+                          description:
+                            "Always ready without manually launching.",
+                          value: autostartField.state.value,
+                          onChange: (val) => autostartField.handleChange(val),
+                        }}
+                        autoStartScheduledMeetings={{
+                          title: "Start when meeting begins",
+                          description:
+                            "Automatically start listening when an event-backed note reaches its scheduled start time.",
+                          value: autoStartScheduledMeetingsField.state.value,
+                          onChange: (val) =>
+                            autoStartScheduledMeetingsField.handleChange(val),
+                        }}
+                        autoStopMeetings={{
+                          title: "Stop when meeting ends",
+                          description:
+                            "Automatically stop listening when the meeting app releases the microphone.",
+                          value: autoStopMeetingsField.state.value,
+                          onChange: (val) =>
+                            autoStopMeetingsField.handleChange(val),
+                        }}
+                        telemetryConsent={{
+                          title: "Share usage data",
+                          description:
+                            "Send anonymous usage analytics to help improve Anarlog.",
+                          value: telemetryConsentField.state.value,
+                          onChange: (val) =>
+                            telemetryConsentField.handleChange(val),
+                        }}
+                      />
+                    )}
+                  </form.Field>
                 )}
               </form.Field>
             )}

--- a/apps/desktop/src/store/tinybase/store/settings.ts
+++ b/apps/desktop/src/store/tinybase/store/settings.ts
@@ -31,6 +31,11 @@ export const SETTINGS_MAPPING = {
       path: ["general", "autostart"],
       default: false as boolean,
     },
+    auto_stop_meetings: {
+      type: "boolean",
+      path: ["general", "auto_stop_meetings"],
+      default: true as boolean,
+    },
     save_recordings: {
       type: "boolean",
       path: ["general", "save_recordings"],

--- a/apps/desktop/src/store/tinybase/store/settings.ts
+++ b/apps/desktop/src/store/tinybase/store/settings.ts
@@ -36,6 +36,11 @@ export const SETTINGS_MAPPING = {
       path: ["general", "auto_stop_meetings"],
       default: true as boolean,
     },
+    auto_start_scheduled_meetings: {
+      type: "boolean",
+      path: ["general", "auto_start_scheduled_meetings"],
+      default: true as boolean,
+    },
     save_recordings: {
       type: "boolean",
       path: ["general", "save_recordings"],

--- a/apps/desktop/src/store/zustand/listener/general-live.ts
+++ b/apps/desktop/src/store/zustand/listener/general-live.ts
@@ -67,6 +67,19 @@ const startSessionEffect = (params: CaptureParams) =>
 
 const stopSessionEffect = () => fromResult(listenerCommands.stopCapture());
 
+function getAutoStopTriggerAppIds(
+  appIds: string[] | null,
+  bundleId: string,
+): string[] {
+  return [
+    ...new Set(
+      (appIds ?? []).filter(
+        (id) => id && id !== bundleId && !id.startsWith("pid:"),
+      ),
+    ),
+  ];
+}
+
 const clearLiveInterval = (intervalId?: LiveIntervalId) => {
   if (intervalId) {
     clearInterval(intervalId);
@@ -262,6 +275,15 @@ export const startLiveSession = <T extends LiveStore>(
 
     const sessionPath = buildSessionPath(dataDirPath, targetSessionId);
     const app_meeting = micUsingApps?.[0] ?? null;
+    const triggerAppIds = getAutoStopTriggerAppIds(micUsingApps, bundleId);
+
+    if (triggerAppIds.length > 0) {
+      setLiveState(set, (live) => {
+        if (live.sessionId === targetSessionId) {
+          live.triggerAppIds = triggerAppIds;
+        }
+      });
+    }
 
     yield* Effect.tryPromise({
       try: () =>

--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -1,17 +1,28 @@
-import { render } from "@testing-library/react";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-import { ListenerProvider } from "./contexts";
+import { AUTO_STOP_CONFIRM_DELAY_MS, ListenerProvider } from "./contexts";
 
 import { createListenerStore } from "~/store/zustand/listener";
 
-const { listenMock, showNotificationMock, useStoreMock } = vi.hoisted(() => ({
+const {
+  listMicUsingApplicationsMock,
+  listenMock,
+  showNotificationMock,
+  useStoreMock,
+  useSettingsStoreMock,
+} = vi.hoisted(() => ({
+  listMicUsingApplicationsMock: vi.fn(),
   listenMock: vi.fn(),
   showNotificationMock: vi.fn(),
   useStoreMock: vi.fn(() => null),
+  useSettingsStoreMock: vi.fn(() => null),
 }));
 
 vi.mock("@hypr/plugin-detect", () => ({
+  commands: {
+    listMicUsingApplications: listMicUsingApplicationsMock,
+  },
   events: {
     detectEvent: {
       listen: listenMock,
@@ -32,13 +43,36 @@ vi.mock("~/store/tinybase/store/main", () => ({
   },
 }));
 
+vi.mock("~/store/tinybase/store/settings", () => ({
+  STORE_ID: "settings-store",
+  UI: {
+    useStore: useSettingsStoreMock,
+  },
+}));
+
+function setStoreActive(store: ReturnType<typeof createListenerStore>) {
+  store.setState((state) => ({
+    live: { ...state.live, status: "active" },
+  }));
+}
+
 describe("ListenerProvider detect events", () => {
   beforeEach(() => {
     listenMock.mockReset();
     showNotificationMock.mockReset();
     useStoreMock.mockReset();
+    useSettingsStoreMock.mockReset();
     useStoreMock.mockReturnValue(null);
+    useSettingsStoreMock.mockReturnValue(null);
     listenMock.mockResolvedValue(() => {});
+    listMicUsingApplicationsMock.mockResolvedValue({ status: "ok", data: [] });
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   test("does not stop listening on MicStopped when no trigger apps are set (manual session — regression: #5120)", async () => {
@@ -71,12 +105,93 @@ describe("ListenerProvider detect events", () => {
     expect(stopSpy).not.toHaveBeenCalled();
   });
 
-  test("stops listening on MicStopped when a trigger app stops (auto-session — preserves Zoom end UX)", async () => {
+  test("stops listening after confirming a trigger app remains stopped", async () => {
     const store = createListenerStore();
     const stopSpy = vi.fn();
 
     store.setState({ stop: stopSpy });
     store.getState().setTriggerAppIds(["us.zoom.xos"]);
+    setStoreActive(store);
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    vi.useFakeTimers();
+    listMicUsingApplicationsMock.mockClear();
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "us.zoom.xos", name: "Zoom" }],
+      },
+    });
+
+    expect(stopSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+
+    expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not stop when a trigger app resumes during the auto-stop grace period", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["us.zoom.xos"]);
+    setStoreActive(store);
+    listMicUsingApplicationsMock.mockResolvedValue({
+      status: "ok",
+      data: [{ id: "us.zoom.xos", name: "Zoom" }],
+    });
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+
+    const handler = listenMock.mock.calls[0]?.[0];
+    expect(handler).toBeTypeOf("function");
+
+    vi.useFakeTimers();
+    listMicUsingApplicationsMock.mockClear();
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "us.zoom.xos", name: "Zoom" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+
+    expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  test("does not stop on MicStopped when auto-stop is disabled", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["us.zoom.xos"]);
+    useSettingsStoreMock.mockReturnValue({
+      getValue: vi.fn((key: string) =>
+        key === "auto_stop_meetings" ? false : undefined,
+      ),
+    } as any);
 
     render(
       <ListenerProvider store={store}>
@@ -96,7 +211,7 @@ describe("ListenerProvider detect events", () => {
       },
     });
 
-    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(stopSpy).not.toHaveBeenCalled();
   });
 
   test("does not stop on MicStopped when only a non-trigger app stops (auto-session — regression: #4846)", async () => {

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -2,16 +2,21 @@ import React, { createContext, useContext, useEffect, useRef } from "react";
 import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 
-import { events as detectEvents } from "@hypr/plugin-detect";
+import {
+  commands as detectCommands,
+  events as detectEvents,
+} from "@hypr/plugin-detect";
 import { commands as notificationCommands } from "@hypr/plugin-notification";
 
 import * as main from "~/store/tinybase/store/main";
+import * as settings from "~/store/tinybase/store/settings";
 import {
   createListenerStore,
   type ListenerStore,
 } from "~/store/zustand/listener";
 
 const ListenerContext = createContext<ListenerStore | null>(null);
+export const AUTO_STOP_CONFIRM_DELAY_MS = 5_000;
 
 function getIgnorableAppIds(apps: { id: string }[]) {
   return [
@@ -88,15 +93,49 @@ const useHandleDetectEvents = (store: ListenerStore) => {
   const stop = useStore(store, (state) => state.stop);
   const setMuted = useStore(store, (state) => state.setMuted);
   const tinybaseStore = main.UI.useStore(main.STORE_ID);
+  const settingsStore = settings.UI.useStore(settings.STORE_ID);
 
   const tinybaseStoreRef = useRef(tinybaseStore);
+  const settingsStoreRef = useRef(settingsStore);
+  const pendingAutoStopRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     tinybaseStoreRef.current = tinybaseStore;
-  }, [tinybaseStore]);
+    settingsStoreRef.current = settingsStore;
+  }, [tinybaseStore, settingsStore]);
 
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     let cancelled = false;
+    const clearPendingAutoStop = () => {
+      if (pendingAutoStopRef.current) {
+        clearTimeout(pendingAutoStopRef.current);
+        pendingAutoStopRef.current = null;
+      }
+    };
+
+    const confirmAutoStop = async (stoppedTriggerAppIds: string[]) => {
+      if (store.getState().live.status !== "active") {
+        return;
+      }
+
+      const currentTrigger = store.getState().live.triggerAppIds;
+      if (
+        !currentTrigger ||
+        !stoppedTriggerAppIds.some((id) => currentTrigger.includes(id))
+      ) {
+        return;
+      }
+
+      const result = await detectCommands.listMicUsingApplications();
+      if (result.status === "ok") {
+        const activeAppIds = new Set(result.data.map((app) => app.id));
+        if (stoppedTriggerAppIds.some((id) => activeAppIds.has(id))) {
+          return;
+        }
+      }
+
+      stop();
+    };
 
     detectEvents.detectEvent
       .listen(({ payload }) => {
@@ -144,16 +183,27 @@ const useHandleDetectEvents = (store: ListenerStore) => {
             icon: null,
           });
         } else if (payload.type === "micStopped") {
+          const autoStopEnabled =
+            settingsStoreRef.current?.getValue("auto_stop_meetings") !== false;
+          if (!autoStopEnabled) {
+            return;
+          }
+
           const trigger = store.getState().live.triggerAppIds;
-          if (
-            trigger &&
-            trigger.length > 0 &&
-            payload.apps.some((app) => trigger.includes(app.id))
-          ) {
-            stop();
+          const stoppedTriggerAppIds =
+            trigger?.filter((id) =>
+              payload.apps.some((app) => app.id === id),
+            ) ?? [];
+          if (stoppedTriggerAppIds.length > 0) {
+            clearPendingAutoStop();
+            pendingAutoStopRef.current = setTimeout(() => {
+              pendingAutoStopRef.current = null;
+              void confirmAutoStop(stoppedTriggerAppIds);
+            }, AUTO_STOP_CONFIRM_DELAY_MS);
           }
         } else if (payload.type === "sleepStateChanged") {
           if (payload.value) {
+            clearPendingAutoStop();
             stop();
           }
         } else if (payload.type === "micMuted") {
@@ -173,7 +223,8 @@ const useHandleDetectEvents = (store: ListenerStore) => {
 
     return () => {
       cancelled = true;
+      clearPendingAutoStop();
       unlisten?.();
     };
-  }, [stop, setMuted]);
+  }, [stop, setMuted, store]);
 };

--- a/packages/store/src/tinybase.ts
+++ b/packages/store/src/tinybase.ts
@@ -155,6 +155,7 @@ export const tableSchemaForTinybase = {
 export const valueSchemaForTinybase = {
   user_id: { type: "string" },
   autostart: { type: "boolean" },
+  auto_stop_meetings: { type: "boolean" },
   save_recordings: { type: "boolean" },
   audio_retention: { type: "string" },
   notification_event: { type: "boolean" },

--- a/packages/store/src/tinybase.ts
+++ b/packages/store/src/tinybase.ts
@@ -156,6 +156,7 @@ export const valueSchemaForTinybase = {
   user_id: { type: "string" },
   autostart: { type: "boolean" },
   auto_stop_meetings: { type: "boolean" },
+  auto_start_scheduled_meetings: { type: "boolean" },
   save_recordings: { type: "boolean" },
   audio_retention: { type: "string" },
   notification_event: { type: "boolean" },

--- a/packages/store/src/zod.ts
+++ b/packages/store/src/zod.ts
@@ -262,6 +262,7 @@ export const providerSpeakerIndexSchema = z.object({
 export const generalSchema = z.object({
   user_id: z.string(),
   autostart: z.boolean().default(false),
+  auto_stop_meetings: z.boolean().default(true),
   telemetry_consent: z.boolean().default(true),
   save_recordings: z.boolean().default(true),
   audio_retention: z.string().default("oneMonth"),

--- a/packages/store/src/zod.ts
+++ b/packages/store/src/zod.ts
@@ -263,6 +263,7 @@ export const generalSchema = z.object({
   user_id: z.string(),
   autostart: z.boolean().default(false),
   auto_stop_meetings: z.boolean().default(true),
+  auto_start_scheduled_meetings: z.boolean().default(true),
   telemetry_consent: z.boolean().default(true),
   save_recordings: z.boolean().default(true),
   audio_retention: z.string().default("oneMonth"),

--- a/plugins/detect/src/handler.rs
+++ b/plugins/detect/src/handler.rs
@@ -5,7 +5,6 @@ use crate::{
     DetectEvent, ProcessorState,
     env::{Env, TauriEnv},
     mic_usage_tracker,
-    policy::{MicEventType, PolicyContext},
 };
 
 pub fn setup<R: Runtime>(app: &AppHandle<R>) -> Result<(), Box<dyn std::error::Error>> {
@@ -43,13 +42,6 @@ pub fn handle_detect_event<E: Env>(
             handle_mic_started(env, state, apps);
         }
         hypr_detect::DetectEvent::MicStopped(apps) => {
-            if !env.is_detect_enabled() {
-                let mut guard = state.lock().unwrap_or_else(|e| e.into_inner());
-                for app in &apps {
-                    guard.mic_usage_tracker.cancel_app(&app.id);
-                }
-                return;
-            }
             handle_mic_stopped(env, state, apps);
         }
         #[cfg(all(target_os = "macos", feature = "zoom"))]
@@ -103,31 +95,13 @@ fn handle_mic_stopped<E: Env>(
     state: &ProcessorState,
     apps: Vec<hypr_detect::InstalledApp>,
 ) {
-    let is_dnd = env.is_do_not_disturb();
-
-    let policy_result = {
+    {
         let mut guard = state.lock().unwrap_or_else(|e| e.into_inner());
 
         for app in &apps {
             guard.mic_usage_tracker.cancel_app(&app.id);
         }
-
-        let ctx = PolicyContext {
-            apps: &apps,
-            is_dnd,
-            event_type: MicEventType::Stopped,
-        };
-        guard.policy.evaluate(&ctx)
-    };
-
-    match policy_result {
-        Ok(result) => {
-            env.emit(DetectEvent::MicStopped {
-                apps: result.filtered_apps,
-            });
-        }
-        Err(reason) => {
-            tracing::info!(?reason, "skip_mic_stopped");
-        }
     }
+
+    env.emit(DetectEvent::MicStopped { apps });
 }

--- a/plugins/detect/tests/mic_detection.rs
+++ b/plugins/detect/tests/mic_detection.rs
@@ -166,10 +166,12 @@ async fn test_full_scenario_zoom_and_dictation() {
     );
 
     h.mic_stopped(aqua_voice());
-    assert!(
-        h.take_events().is_empty(),
-        "dictation app stop should be filtered"
-    );
+    let events = h.take_events();
+    assert_eq!(events.len(), 1, "dictation app stop should emit MicStopped");
+    assert!(matches!(
+        &events[0],
+        DetectEvent::MicStopped { apps } if apps[0].id == "com.electron.aqua-voice"
+    ));
 
     h.advance_secs(15).await;
     let events = h.take_events();
@@ -359,7 +361,7 @@ async fn test_detect_disabled_mid_flight_suppresses_mic_detected() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn test_mic_stopped_with_detect_disabled_cancels_timers() {
+async fn test_mic_stopped_with_detect_disabled_cancels_timers_and_emits() {
     let h = Harness::new();
 
     h.mic_started(zoom());
@@ -368,7 +370,16 @@ async fn test_mic_stopped_with_detect_disabled_cancels_timers() {
     h.advance_secs(3).await;
     h.env.set_detect_enabled(false);
     h.mic_stopped(zoom());
-    h.take_events();
+    let events = h.take_events();
+    assert_eq!(
+        events.len(),
+        1,
+        "MicStopped should emit even when notification detect is disabled"
+    );
+    assert!(matches!(
+        &events[0],
+        DetectEvent::MicStopped { apps } if apps[0].id == "us.zoom.xos"
+    ));
 
     h.env.set_detect_enabled(true);
 
@@ -417,7 +428,7 @@ async fn test_mic_started_with_detect_disabled_is_noop() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn test_dnd_suppresses_mic_stopped_notification() {
+async fn test_dnd_does_not_suppress_mic_stopped_event() {
     let h = Harness::new();
 
     h.mic_started(zoom());
@@ -431,10 +442,16 @@ async fn test_dnd_suppresses_mic_stopped_notification() {
     h.env.set_dnd(true);
 
     h.mic_stopped(zoom());
-    assert!(
-        h.take_events().is_empty(),
-        "MicStopped should be suppressed by DnD"
+    let events = h.take_events();
+    assert_eq!(
+        events.len(),
+        1,
+        "MicStopped should emit while DnD is enabled"
     );
+    assert!(matches!(
+        &events[0],
+        DetectEvent::MicStopped { apps } if apps[0].id == "us.zoom.xos"
+    ));
 }
 
 #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## Summary

- Restore meeting auto-stop behavior with a setting for disabling it.
- Auto-start event-backed notes when their meeting countdown reaches start time.
- Keep scheduled meeting notifications compact and use pre-meeting note-opening copy before the meeting starts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect meeting lifecycle (auto-start/auto-stop), notification flows, and the detect plugin’s MicStopped emission, which can alter when sessions start/stop and when events fire across the app.
> 
> **Overview**
> Improves meeting session lifecycle behavior across notifications, UI, and mic detection.
> 
> `EventListeners` now decides whether a notification-opened session should auto-start based on trigger apps or whether the linked calendar event has actually started, so *upcoming* event notifications open notes without starting capture.
> 
> Adds configurable toggles for `auto_start_scheduled_meetings` and `auto_stop_meetings` (schema + settings UI/analytics). Scheduled meeting notifications are simplified to omit expanded event/participant payloads and use **“Open notes”** copy.
> 
> Auto-stop is restored with safer behavior: live sessions capture trigger app IDs on start, and `ListenerProvider` waits a short confirm delay then rechecks active mic apps before stopping (and respects the new disable setting). The detect plugin now always emits `MicStopped` (even under DnD/disabled detect) while still cancelling timers, with updated tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5c32e5c079ba3198f32261fcdf84a59c661c239. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->