### PR TITLE
fix(audio): align AEC reference cancellation

### DIFF
--- a/crates/audio-actual/src/capture/stream.rs
+++ b/crates/audio-actual/src/capture/stream.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -22,6 +23,15 @@ pub(crate) type ChunkStream =
     Pin<Box<dyn Stream<Item = Result<Vec<f32>, hypr_resampler::Error>> + Send>>;
 
 const AUDIO_SYNC_PROBE_ENV: &str = "AUDIO_SYNC_PROBE";
+const AEC_MAX_REFERENCE_LAG_MS: u32 = 100;
+const AEC_MIN_REFERENCE_RMS: f32 = 1e-4;
+const AEC_MIN_MIC_RMS: f32 = 1e-4;
+const AEC_MIN_REFERENCE_CORRELATION: f32 = 0.12;
+const AEC_MAX_LINEAR_GAIN: f32 = 1.25;
+const AEC_LINEAR_GAIN_SMOOTHING: f32 = 0.12;
+const AEC_DOUBLE_TALK_RESIDUAL_RATIO: f32 = 0.08;
+const AEC_ROBUST_GAIN_SEGMENTS: usize = 8;
+const AEC_ROBUST_GAIN_MIN_SEGMENTS: usize = 3;
 
 struct CaptureStreamInner {
     inner: ReceiverStream<Result<CaptureFrame, Error>>,
@@ -132,7 +142,12 @@ async fn run_dual_loop(
 ) {
     let mut joiner = Joiner::new();
     let mut aec = if enable_aec { build_aec() } else { None };
-    let mut sync_probe = ObserveOnlySyncProbe::from_env(sample_rate);
+    let mut linear_echo_gain = None;
+    let mut aec_reference = if aec.is_some() {
+        Some(AecReferenceAligner::new(sample_rate))
+    } else {
+        None
+    };
 
     loop {
         let result = tokio::select! {
@@ -150,10 +165,16 @@ async fn run_dual_loop(
                 while let Some((raw_mic, raw_speaker)) = joiner.pop_pair() {
                     let raw_mic = Arc::<[f32]>::from(raw_mic);
                     let raw_speaker = Arc::<[f32]>::from(raw_speaker);
-                    if let Some(probe) = &mut sync_probe {
-                        probe.observe(&raw_mic, &raw_speaker);
-                    }
-                    let aec_mic = process_aec(&mut aec, &raw_mic, &raw_speaker);
+                    let aec_reference_speaker = aec_reference
+                        .as_mut()
+                        .map(|aligner| aligner.align(&raw_speaker, &raw_mic))
+                        .unwrap_or_else(|| Arc::clone(&raw_speaker));
+                    let aec_mic = process_aec(
+                        &mut aec,
+                        &mut linear_echo_gain,
+                        &raw_mic,
+                        &aec_reference_speaker,
+                    );
                     if tx
                         .send(Ok(CaptureFrame {
                             raw_mic,
@@ -176,39 +197,85 @@ async fn run_dual_loop(
     }
 }
 
-struct ObserveOnlySyncProbe {
+struct AecReferenceAligner {
     probe: SyncProbe,
+    delay_line: SampleDelayLine,
+    last_delay_samples: usize,
     last_logged_state: Option<SyncProbeState>,
     last_logged_stable_lag_samples: Option<isize>,
+    log_probe_events: bool,
 }
 
-impl ObserveOnlySyncProbe {
-    fn from_env(sample_rate: u32) -> Option<Self> {
-        if std::env::var(AUDIO_SYNC_PROBE_ENV).ok().as_deref() != Some("1") {
-            return None;
-        }
+impl AecReferenceAligner {
+    fn new(sample_rate: u32) -> Self {
+        let max_lag_samples = ((sample_rate as usize) * (AEC_MAX_REFERENCE_LAG_MS as usize)) / 1000;
+        let mut config = SyncProbeConfig::new(sample_rate);
+        config.max_lag_samples = max_lag_samples.max(config.max_lag_samples);
+        let max_delay_samples = config.max_lag_samples;
 
-        Some(Self {
-            probe: SyncProbe::new(SyncProbeConfig::new(sample_rate)),
+        Self {
+            probe: SyncProbe::new(config),
+            delay_line: SampleDelayLine::new(max_delay_samples),
+            last_delay_samples: 0,
             last_logged_state: None,
             last_logged_stable_lag_samples: None,
-        })
+            log_probe_events: std::env::var(AUDIO_SYNC_PROBE_ENV).ok().as_deref() == Some("1"),
+        }
     }
 
-    fn observe(&mut self, raw_mic: &[f32], raw_speaker: &[f32]) {
+    fn align(&mut self, raw_speaker: &[f32], raw_mic: &[f32]) -> Arc<[f32]> {
         let observed = catch_unwind(AssertUnwindSafe(|| {
             self.probe.observe(raw_speaker, raw_mic)
         }));
-        let Some(event) = (match observed {
+        let event = match observed {
             Ok(event) => event,
             Err(_) => {
                 tracing::error!("audio_sync_probe_panicked");
-                return;
+                None
             }
-        }) else {
-            return;
         };
 
+        if let Some(event) = event {
+            self.update_delay(&event);
+            if self.log_probe_events {
+                self.log_probe_event(event);
+            }
+        }
+
+        Arc::<[f32]>::from(
+            self.delay_line
+                .process(raw_speaker, self.last_delay_samples),
+        )
+    }
+
+    fn update_delay(&mut self, event: &SyncProbeEvent) {
+        let snapshot = event.snapshot();
+        let next_delay = if matches!(
+            snapshot.state,
+            SyncProbeState::Locked | SyncProbeState::Holdover
+        ) {
+            snapshot
+                .stable_lag_samples
+                .filter(|lag| *lag > 0)
+                .map(|lag| lag as usize)
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        if next_delay != self.last_delay_samples {
+            tracing::info!(
+                previous_delay_samples = self.last_delay_samples,
+                delay_samples = next_delay,
+                delay_ms = next_delay as f32 / self.probe.config().sample_rate as f32 * 1000.0,
+                state = ?snapshot.state,
+                "aec_reference_delay_changed"
+            );
+            self.last_delay_samples = next_delay;
+        }
+    }
+
+    fn log_probe_event(&mut self, event: SyncProbeEvent) {
         let snapshot = event.snapshot();
         let should_log = self.last_logged_state != Some(snapshot.state)
             || self.last_logged_stable_lag_samples != snapshot.stable_lag_samples;
@@ -261,6 +328,43 @@ impl ObserveOnlySyncProbe {
 
         self.last_logged_state = Some(snapshot.state);
         self.last_logged_stable_lag_samples = snapshot.stable_lag_samples;
+    }
+}
+
+struct SampleDelayLine {
+    history: VecDeque<f32>,
+    max_delay_samples: usize,
+}
+
+impl SampleDelayLine {
+    fn new(max_delay_samples: usize) -> Self {
+        Self {
+            history: VecDeque::with_capacity(max_delay_samples + 1),
+            max_delay_samples,
+        }
+    }
+
+    fn process(&mut self, input: &[f32], delay_samples: usize) -> Vec<f32> {
+        let delay_samples = delay_samples.min(self.max_delay_samples);
+        let mut output = Vec::with_capacity(input.len());
+
+        for &sample in input {
+            self.history.push_back(sample);
+            let delayed = self
+                .history
+                .len()
+                .checked_sub(delay_samples + 1)
+                .and_then(|idx| self.history.get(idx))
+                .copied()
+                .unwrap_or(0.0);
+            output.push(delayed);
+
+            while self.history.len() > self.max_delay_samples + 1 {
+                self.history.pop_front();
+            }
+        }
+
+        output
     }
 }
 
@@ -346,15 +450,139 @@ fn build_aec() -> Option<AEC> {
         .ok()
 }
 
-fn process_aec(aec: &mut Option<AEC>, mic: &[f32], speaker: &[f32]) -> Option<Arc<[f32]>> {
+fn process_aec(
+    aec: &mut Option<AEC>,
+    linear_echo_gain: &mut Option<f32>,
+    mic: &[f32],
+    speaker: &[f32],
+) -> Option<Arc<[f32]>> {
     let processor = aec.as_mut()?;
     match processor.process_streaming(mic, speaker) {
-        Ok(processed) => Some(Arc::<[f32]>::from(processed)),
+        Ok(processed) => Some(Arc::<[f32]>::from(cancel_linear_echo(
+            speaker,
+            processed,
+            linear_echo_gain,
+        ))),
         Err(error) => {
             tracing::warn!(error.message = ?error, "aec_failed");
             None
         }
     }
+}
+
+fn cancel_linear_echo(
+    speaker: &[f32],
+    processed: Vec<f32>,
+    linear_echo_gain: &mut Option<f32>,
+) -> Vec<f32> {
+    let len = speaker.len().min(processed.len());
+    if len == 0 {
+        return processed;
+    }
+
+    let mut processed_energy = 0.0;
+    let mut speaker_energy = 0.0;
+    let mut cross_energy = 0.0;
+    for idx in 0..len {
+        let processed_sample = processed[idx];
+        let speaker_sample = speaker[idx];
+        processed_energy += processed_sample * processed_sample;
+        speaker_energy += speaker_sample * speaker_sample;
+        cross_energy += processed_sample * speaker_sample;
+    }
+
+    let len_f32 = len as f32;
+    let processed_rms = (processed_energy / len_f32).sqrt();
+    let speaker_rms = (speaker_energy / len_f32).sqrt();
+    if processed_rms < AEC_MIN_MIC_RMS || speaker_rms < AEC_MIN_REFERENCE_RMS {
+        return processed;
+    }
+
+    let correlation = cross_energy.abs() / (processed_energy * speaker_energy).sqrt().max(1e-6);
+    if correlation < AEC_MIN_REFERENCE_CORRELATION {
+        return processed;
+    }
+
+    let instantaneous_gain =
+        (cross_energy / speaker_energy.max(1e-6)).clamp(-AEC_MAX_LINEAR_GAIN, AEC_MAX_LINEAR_GAIN);
+    let residual_energy =
+        (processed_energy - (cross_energy * cross_energy / speaker_energy.max(1e-6))).max(0.0);
+    let residual_ratio = (residual_energy / len_f32).sqrt() / processed_rms.max(1e-6);
+    let measured_gain = if residual_ratio > AEC_DOUBLE_TALK_RESIDUAL_RATIO {
+        segmented_trimmed_gain(&processed, speaker, len, instantaneous_gain)
+    } else {
+        instantaneous_gain
+    };
+    let smoothed_gain = linear_echo_gain
+        .map(|gain| gain + (measured_gain - gain) * AEC_LINEAR_GAIN_SMOOTHING)
+        .unwrap_or(measured_gain);
+    *linear_echo_gain = Some(smoothed_gain);
+
+    let gain = if residual_ratio > AEC_DOUBLE_TALK_RESIDUAL_RATIO {
+        smoothed_gain
+    } else {
+        measured_gain
+    };
+
+    let mut output = Vec::with_capacity(processed.len());
+    output.extend(processed.iter().zip(speaker).take(len).map(
+        |(processed_sample, speaker_sample)| {
+            (processed_sample - gain * speaker_sample).clamp(-1.0, 1.0)
+        },
+    ));
+    output.extend_from_slice(&processed[len..]);
+    output
+}
+
+fn segmented_trimmed_gain(
+    processed: &[f32],
+    speaker: &[f32],
+    len: usize,
+    initial_gain: f32,
+) -> f32 {
+    let segment_len = (len / AEC_ROBUST_GAIN_SEGMENTS).max(1);
+    let mut gains = Vec::with_capacity(AEC_ROBUST_GAIN_SEGMENTS);
+    let mut start = 0;
+    while start < len {
+        let end = (start + segment_len).min(len);
+        let mut processed_energy = 0.0;
+        let mut speaker_energy = 0.0;
+        let mut cross_energy = 0.0;
+        for idx in start..end {
+            let processed_sample = processed[idx];
+            let speaker_sample = speaker[idx];
+            processed_energy += processed_sample * processed_sample;
+            speaker_energy += speaker_sample * speaker_sample;
+            cross_energy += processed_sample * speaker_sample;
+        }
+
+        if processed_energy > 1e-8 && speaker_energy > 1e-8 {
+            let correlation =
+                cross_energy.abs() / (processed_energy * speaker_energy).sqrt().max(1e-6);
+            if correlation >= AEC_MIN_REFERENCE_CORRELATION {
+                let gain = (cross_energy / speaker_energy.max(1e-6))
+                    .clamp(-AEC_MAX_LINEAR_GAIN, AEC_MAX_LINEAR_GAIN);
+                gains.push((gain, speaker_energy));
+            }
+        }
+
+        start = end;
+    }
+
+    if gains.len() < AEC_ROBUST_GAIN_MIN_SEGMENTS {
+        return initial_gain;
+    }
+
+    gains.sort_by(|left, right| left.0.total_cmp(&right.0));
+    let trim = if gains.len() >= 6 { gains.len() / 6 } else { 0 };
+    let kept = &gains[trim..gains.len() - trim];
+    let weighted_gain = kept.iter().map(|(gain, energy)| gain * energy).sum::<f32>();
+    let kept_energy = kept.iter().map(|(_, energy)| energy).sum::<f32>();
+    if kept_energy <= 1e-8 {
+        return initial_gain;
+    }
+
+    (weighted_gain / kept_energy).clamp(-AEC_MAX_LINEAR_GAIN, AEC_MAX_LINEAR_GAIN)
 }
 
 #[cfg(test)]
@@ -370,10 +598,42 @@ mod tests {
     #[test]
     fn process_aec_returns_output_when_enabled() {
         let mut aec = build_aec();
+        let mut linear_echo_gain = None;
         let mic = Arc::<[f32]>::from(vec![0.1_f32; 160]);
         let speaker = Arc::<[f32]>::from(vec![0.2_f32; 160]);
 
-        let processed = process_aec(&mut aec, &mic, &speaker);
+        let processed = process_aec(&mut aec, &mut linear_echo_gain, &mic, &speaker);
         assert_eq!(processed.as_ref().map(|data| data.len()), Some(160));
+    }
+
+    #[test]
+    fn sample_delay_line_outputs_current_samples_with_zero_delay() {
+        let mut delay = SampleDelayLine::new(4);
+
+        let output = delay.process(&[1.0, 2.0, 3.0], 0);
+
+        assert_eq!(output, vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn sample_delay_line_outputs_delayed_samples() {
+        let mut delay = SampleDelayLine::new(4);
+
+        let first = delay.process(&[1.0, 2.0, 3.0], 2);
+        let second = delay.process(&[4.0, 5.0], 2);
+
+        assert_eq!(first, vec![0.0, 0.0, 1.0]);
+        assert_eq!(second, vec![2.0, 3.0]);
+    }
+
+    #[test]
+    fn sample_delay_line_clamps_to_max_delay() {
+        let mut delay = SampleDelayLine::new(2);
+
+        let first = delay.process(&[1.0, 2.0, 3.0], 10);
+        let second = delay.process(&[4.0], 10);
+
+        assert_eq!(first, vec![0.0, 0.0, 1.0]);
+        assert_eq!(second, vec![2.0]);
     }
 }


### PR DESCRIPTION
Summary:
- Delay the speaker reference with SyncProbe before sending it to AEC.
- Add bounded post-AEC linear echo cancellation with carried robust gain smoothing.
- Add delay-line tests for aligned reference behavior.

Verification:
- cargo fmt -p audio-actual
- cargo test -p audio-actual capture::stream
- cargo check -p audio-actual

Note:
- pnpm exec dprint fmt currently fails because dprint references missing packages/ui files before reaching this Rust file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the audio capture/AEC signal path by dynamically delaying the speaker reference and applying additional gain-based echo subtraction, which can affect audio quality and stability in edge cases (lag estimation, double-talk).
> 
> **Overview**
> Improves echo cancellation in `capture/stream.rs` by **aligning the speaker reference** before AEC using a new `AecReferenceAligner` (SyncProbe-driven lag estimation + bounded `SampleDelayLine`) instead of probe-only observation.
> 
> Adds a **post-AEC linear echo canceller** (`cancel_linear_echo`) with RMS/correlation gating, robust segmented gain estimation, and smoothed carried gain across frames; updates `process_aec`/`run_dual_loop` to thread this state.
> 
> Extends tests to cover `SampleDelayLine` behavior and adjusts the AEC test for the new `process_aec` signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 358584364f16f529f7bfd9617e08cd018fa21706. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->