### PR TITLE
fix(stt): respect Soniqo spoken language support

### DIFF
--- a/crates/listener-core/src/actors/listener/adapters.rs
+++ b/crates/listener-core/src/actors/listener/adapters.rs
@@ -51,6 +51,14 @@ pub(super) async fn spawn_rx_task(
             )));
         }
 
+        if !model.supports_languages(&args.languages) {
+            return Err(actor_error(format!(
+                "unsupported_language: {} does not support all requested spoken languages ({})",
+                model.as_str(),
+                format_languages(&args.languages)
+            )));
+        }
+
         let result = spawn_soniqo_rx_task(model, args, myself).await?;
         return Ok((result.0, result.1, result.2, "soniqo".to_string()));
     }
@@ -442,6 +450,18 @@ fn assemblyai_expected_speakers(args: &ListenerArgs) -> Option<u32> {
     (participants.len() > 1).then_some(participants.len() as u32)
 }
 
+fn format_languages(languages: &[hypr_language::Language]) -> String {
+    if languages.is_empty() {
+        return "none".to_string();
+    }
+
+    languages
+        .iter()
+        .map(hypr_language::Language::bcp47_code)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 fn build_extra(args: &ListenerArgs) -> (f64, Extra) {
     let session_offset_secs = args.session_started_at.elapsed().as_secs_f64();
     let started_unix_millis = args
@@ -690,5 +710,12 @@ mod tests {
         let args = listener_args("http://localhost:50060/v1", "cactus-whisper-small-int8");
 
         assert_eq!(soniqo_model_for_args(&args).unwrap(), None);
+    }
+
+    #[test]
+    fn format_languages_uses_bcp47_codes() {
+        let languages = vec!["en-US".parse().unwrap(), hypr_language::ISO639::Fr.into()];
+
+        assert_eq!(format_languages(&languages), "en-US, fr");
     }
 }

--- a/crates/listener-core/src/actors/session/types.rs
+++ b/crates/listener-core/src/actors/session/types.rs
@@ -39,7 +39,9 @@ impl SessionParams {
         if let Some(model) =
             hypr_transcribe_soniqo::local_model_from_request(&self.base_url, &self.model)
         {
-            return if model.supports_live_on_current_platform() {
+            return if model.supports_live_on_current_platform()
+                && model.supports_languages(&self.languages)
+            {
                 TranscriptionMode::Live
             } else {
                 TranscriptionMode::Batch
@@ -135,6 +137,21 @@ mod tests {
         };
 
         assert_eq!(params.effective_transcription_mode(), expected);
+    }
+
+    #[test]
+    fn effective_mode_rejects_soniqo_live_for_unsupported_language() {
+        let mut params = session_params(
+            hypr_transcribe_soniqo::LOCAL_BASE_URL,
+            "soniqo-parakeet-streaming",
+            TranscriptionMode::Live,
+        );
+        params.languages = vec![hypr_language::ISO639::Ko.into()];
+
+        assert_eq!(
+            params.effective_transcription_mode(),
+            TranscriptionMode::Batch
+        );
     }
 
     #[test]

--- a/plugins/transcription/src/api.rs
+++ b/plugins/transcription/src/api.rs
@@ -35,7 +35,9 @@ impl CaptureParams {
         if let Some(model) =
             hypr_transcribe_soniqo::local_model_from_request(&self.base_url, &self.model)
         {
-            return if model.supports_live_on_current_platform() {
+            return if model.supports_live_on_current_platform()
+                && model.supports_languages(&self.languages)
+            {
                 listener::TranscriptionMode::Live
             } else {
                 listener::TranscriptionMode::Batch
@@ -467,6 +469,20 @@ mod tests {
         };
 
         assert_eq!(params.default_transcription_mode(), expected);
+    }
+
+    #[test]
+    fn defaults_soniqo_streaming_with_unsupported_language_to_batch_mode() {
+        let params = capture_params_with_languages(
+            "soniqo://local",
+            "soniqo-parakeet-streaming",
+            vec![ISO639::Ko.into()],
+        );
+
+        assert_eq!(
+            params.default_transcription_mode(),
+            TranscriptionMode::Batch
+        );
     }
 
     #[test]


### PR DESCRIPTION
Route local Soniqo live mode through the selected spoken-language support check and reject unsupported live requests before starting Parakeet streaming.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live/batch mode selection and runtime validation for local Soniqo streaming based on requested languages, which can cause sessions to fall back to batch or error where they previously streamed live.
> 
> **Overview**
> Prevents starting local Soniqo/Parakeet live transcription when the requested spoken languages aren’t supported.
> 
> This adds a `supports_languages` gate in the live listener adapter (returning an `unsupported_language` error with a formatted BCP-47 language list), and updates both `SessionParams::effective_transcription_mode` and plugin `CaptureParams::default_transcription_mode` to fall back to *batch* when Soniqo live is unavailable for the selected languages. New tests cover the language formatting and the live-to-batch fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42249a87c05aef158fe4175c8319a8a4cace14c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->