### PR TITLE
chore(web): update homepage announcement

### DIFF
--- a/apps/web/src/queries.ts
+++ b/apps/web/src/queries.ts
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getGitHubStats, getStargazers } from "./functions/github";
 
 const ORG_REPO = "fastrepl/char";
-const LAST_SEEN_STARS = 8173;
+const LAST_SEEN_STARS = 8466;
 const LAST_SEEN_FORKS = 582;
 
 export function useGitHubStats() {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -109,7 +109,7 @@ export const Route = createFileRoute("/")({
   },
   component: Component,
   loader: async () => ({
-    githubStars: (await getGitHubStats()).stars ?? 0,
+    githubStars: (await getGitHubStats()).stars ?? 8466,
   }),
   head: () => ({
     links: [{ rel: "canonical", href: ANARLOG_SITE_URL }],
@@ -226,11 +226,11 @@ function AnnouncementBanner() {
     <Link
       to="/blog/$slug/"
       params={{ slug: "char-is-now-anarlog" }}
-      className="border-color-subtle bg-surface-subtle group hover:bg-page block border-b transition-colors"
+      className="border-color-subtle group block border-b bg-neutral-50"
       aria-label="Read about Char becoming Anarlog"
     >
       <span className="text-color mx-auto flex min-h-10 w-full max-w-[700px] items-center justify-center gap-2 px-5 py-2 text-center text-sm font-medium md:px-8">
-        <span>Char is now Anarlog</span>
+        <span>Announcement: Char is now Anarlog</span>
         <ArrowRight
           size={16}
           strokeWidth={2.2}


### PR DESCRIPTION
Use a neutral-50 announcement banner, add the Announcement prefix to the rename notice, and fall back to 8,466 GitHub stars.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts UI copy/styles and updates hardcoded fallback values for GitHub star counts; no auth, data writes, or core logic changes.
> 
> **Overview**
> Updates the homepage GitHub stars *fallback* to `8466` (both in `useGitHubStats` and the `/` route loader) so the star display remains stable if the GitHub API returns null.
> 
> Tweaks the top announcement banner styling to use `bg-neutral-50` and changes the copy to prefix the message with **“Announcement:”**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b1e34c5c8a493e59456fb52517d0e4dafe49a57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->