### PR TITLE
fix(stt): prefer supported live transcription language

### DIFF
--- a/apps/desktop/src/settings/general/index.tsx
+++ b/apps/desktop/src/settings/general/index.tsx
@@ -8,6 +8,7 @@ import type { General, GeneralStorage } from "@hypr/store";
 
 export { SettingsAccount } from "./account";
 import { AppSettingsView } from "./app-settings";
+import { getAdditionalSpokenLanguages } from "./language";
 import { MainLanguageView } from "./main-language";
 import { NotificationSettingsView } from "./notification";
 import { Permissions } from "./permissions";
@@ -65,7 +66,10 @@ function useSettingsForm() {
       notification_detect: value.notification_detect,
       telemetry_consent: value.telemetry_consent,
       ai_language: value.ai_language,
-      spoken_languages: value.spoken_languages,
+      spoken_languages: getAdditionalSpokenLanguages(
+        value.ai_language,
+        value.spoken_languages,
+      ),
     },
     listeners: {
       onChange: ({ formApi }) => {
@@ -79,9 +83,17 @@ function useSettingsForm() {
       },
     },
     onSubmit: ({ value }) => {
-      setPartialValues(value);
+      const normalizedValue = {
+        ...value,
+        spoken_languages: getAdditionalSpokenLanguages(
+          value.ai_language,
+          value.spoken_languages,
+        ),
+      };
 
-      if (value.autostart) {
+      setPartialValues(normalizedValue);
+
+      if (normalizedValue.autostart) {
         void enable();
       } else {
         void disable();
@@ -89,15 +101,16 @@ function useSettingsForm() {
 
       void analyticsCommands.event({
         event: "settings_changed",
-        autostart: value.autostart,
-        auto_start_scheduled_meetings: value.auto_start_scheduled_meetings,
-        auto_stop_meetings: value.auto_stop_meetings,
-        notification_detect: value.notification_detect,
-        telemetry_consent: value.telemetry_consent,
+        autostart: normalizedValue.autostart,
+        auto_start_scheduled_meetings:
+          normalizedValue.auto_start_scheduled_meetings,
+        auto_stop_meetings: normalizedValue.auto_stop_meetings,
+        notification_detect: normalizedValue.notification_detect,
+        telemetry_consent: normalizedValue.telemetry_consent,
       });
       void analyticsCommands.setProperties({
         set: {
-          telemetry_opt_out: value.telemetry_consent === false,
+          telemetry_opt_out: normalizedValue.telemetry_consent === false,
         },
       });
     },
@@ -183,7 +196,16 @@ export function SettingsApp() {
             {(field) => (
               <MainLanguageView
                 value={field.state.value}
-                onChange={(val) => field.handleChange(val)}
+                onChange={(val) => {
+                  field.handleChange(val);
+                  form.setFieldValue(
+                    "spoken_languages",
+                    getAdditionalSpokenLanguages(
+                      val,
+                      form.state.values.spoken_languages,
+                    ),
+                  );
+                }}
                 supportedLanguages={supportedLanguages}
               />
             )}
@@ -193,8 +215,16 @@ export function SettingsApp() {
           <form.Field name="spoken_languages">
             {(field) => (
               <SpokenLanguagesView
+                mainLanguage={form.state.values.ai_language}
                 value={field.state.value}
-                onChange={(val) => field.handleChange(val)}
+                onChange={(val) =>
+                  field.handleChange(
+                    getAdditionalSpokenLanguages(
+                      form.state.values.ai_language,
+                      val,
+                    ),
+                  )
+                }
                 supportedLanguages={supportedLanguages}
               />
             )}

--- a/apps/desktop/src/settings/general/language.test.ts
+++ b/apps/desktop/src/settings/general/language.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+
+import { getAdditionalSpokenLanguages } from "./language";
+
+describe("getAdditionalSpokenLanguages", () => {
+  test("removes the main language from stored spoken languages", () => {
+    expect(getAdditionalSpokenLanguages("en", ["en", "ko"])).toEqual(["ko"]);
+  });
+
+  test("matches regional variants by base language", () => {
+    expect(getAdditionalSpokenLanguages("en-US", ["en", "ko-KR"])).toEqual([
+      "ko",
+    ]);
+  });
+
+  test("deduplicates additional languages", () => {
+    expect(getAdditionalSpokenLanguages("en", ["ko", "ko-KR", "ja"])).toEqual([
+      "ko",
+      "ja",
+    ]);
+  });
+});

--- a/apps/desktop/src/settings/general/language.ts
+++ b/apps/desktop/src/settings/general/language.ts
@@ -9,6 +9,30 @@ export function getBaseLanguageCode(code: string): string {
   return parseLocale(code).language;
 }
 
+export function getAdditionalSpokenLanguages(
+  mainLanguage: string | null | undefined,
+  spokenLanguages: readonly string[] | null | undefined,
+) {
+  const mainLanguageCode = mainLanguage
+    ? getBaseLanguageCode(mainLanguage)
+    : null;
+  const seen = new Set<string>();
+  const languages: string[] = [];
+
+  for (const spokenLanguage of spokenLanguages ?? []) {
+    const code = getBaseLanguageCode(spokenLanguage);
+
+    if (!code || code === mainLanguageCode || seen.has(code)) {
+      continue;
+    }
+
+    seen.add(code);
+    languages.push(code);
+  }
+
+  return languages;
+}
+
 export function parseLocale(code: string): {
   language: string;
   region?: string;

--- a/apps/desktop/src/settings/general/spoken-languages.tsx
+++ b/apps/desktop/src/settings/general/spoken-languages.tsx
@@ -5,15 +5,21 @@ import { Badge } from "@hypr/ui/components/ui/badge";
 import { Button } from "@hypr/ui/components/ui/button";
 import { cn } from "@hypr/utils";
 
-import { getBaseLanguageCode, getBaseLanguageDisplayName } from "./language";
+import {
+  getAdditionalSpokenLanguages,
+  getBaseLanguageCode,
+  getBaseLanguageDisplayName,
+} from "./language";
 
 interface SpokenLanguagesViewProps {
+  mainLanguage: string;
   value: string[];
   onChange: (value: string[]) => void;
   supportedLanguages: readonly string[];
 }
 
 export function SpokenLanguagesView({
+  mainLanguage,
   value,
   onChange,
   supportedLanguages,
@@ -36,19 +42,11 @@ export function SpokenLanguagesView({
     return codes;
   }, [supportedLanguages]);
 
-  const selectedLanguageCodes = useMemo(() => {
-    const seen = new Set<string>();
-    const codes: string[] = [];
-
-    for (const langCode of value) {
-      const baseCode = getBaseLanguageCode(langCode);
-      if (seen.has(baseCode)) continue;
-      seen.add(baseCode);
-      codes.push(baseCode);
-    }
-
-    return codes;
-  }, [value]);
+  const mainLanguageCode = getBaseLanguageCode(mainLanguage);
+  const selectedLanguageCodes = useMemo(
+    () => getAdditionalSpokenLanguages(mainLanguage, value),
+    [mainLanguage, value],
+  );
 
   const filteredLanguages = useMemo(() => {
     if (!languageSearchQuery.trim()) {
@@ -56,11 +54,17 @@ export function SpokenLanguagesView({
     }
     const query = languageSearchQuery.toLowerCase();
     return supportedLanguageCodes.filter((langCode) => {
+      if (langCode === mainLanguageCode) return false;
       if (selectedLanguageCodes.includes(langCode)) return false;
       const langName = getBaseLanguageDisplayName(langCode);
       return langName.toLowerCase().includes(query);
     });
-  }, [languageSearchQuery, selectedLanguageCodes, supportedLanguageCodes]);
+  }, [
+    languageSearchQuery,
+    mainLanguageCode,
+    selectedLanguageCodes,
+    supportedLanguageCodes,
+  ]);
 
   const handleLanguageKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (
@@ -105,9 +109,9 @@ export function SpokenLanguagesView({
 
   return (
     <div>
-      <h3 className="mb-1 text-sm font-medium">Spoken languages</h3>
+      <h3 className="mb-1 text-sm font-medium">Additional spoken languages</h3>
       <p className="mb-3 text-xs text-neutral-600">
-        Add other languages you use other than the main language
+        The main language is always included for transcription
       </p>
       <div className="relative">
         <div

--- a/apps/desktop/src/stt/capabilities.test.ts
+++ b/apps/desktop/src/stt/capabilities.test.ts
@@ -1,6 +1,29 @@
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { getOnDeviceTranscriptionMode } from "./capabilities";
+const { isSupportedLanguagesLiveMock } = vi.hoisted(() => ({
+  isSupportedLanguagesLiveMock: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-transcription", () => ({
+  commands: {
+    isSupportedLanguagesLive: isSupportedLanguagesLiveMock,
+  },
+}));
+
+import {
+  getLiveTranscriptionConfig,
+  getOnDeviceTranscriptionConfig,
+  getOnDeviceTranscriptionMode,
+  getTranscriptionLanguages,
+} from "./capabilities";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isSupportedLanguagesLiveMock.mockResolvedValue({
+    status: "ok",
+    data: true,
+  });
+});
 
 describe("getOnDeviceTranscriptionMode", () => {
   test("uses live mode for realtime local models", () => {
@@ -13,5 +36,90 @@ describe("getOnDeviceTranscriptionMode", () => {
     expect(
       getOnDeviceTranscriptionMode("cactus-parakeet-tdt-0.6b-v3-int8"),
     ).toBe("batch");
+  });
+
+  test("falls back to batch when realtime local model has no supported language", () => {
+    expect(
+      getOnDeviceTranscriptionMode("soniqo-parakeet-streaming", ["ko"]),
+    ).toBe("batch");
+  });
+});
+
+describe("getOnDeviceTranscriptionConfig", () => {
+  test("uses the first supported language for realtime local models", () => {
+    expect(
+      getOnDeviceTranscriptionConfig("soniqo-parakeet-streaming", ["en", "ko"]),
+    ).toEqual({
+      languages: ["en"],
+      transcriptionMode: "live",
+    });
+  });
+});
+
+describe("getLiveTranscriptionConfig", () => {
+  test("keeps all languages when the selected provider supports them live", async () => {
+    const config = await getLiveTranscriptionConfig({
+      provider: "deepgram",
+      model: "nova-3-general",
+      languages: ["en", "es"],
+    });
+
+    expect(config).toEqual({
+      languages: ["en", "es"],
+      transcriptionMode: undefined,
+    });
+    expect(isSupportedLanguagesLiveMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("falls back to the main language when additional languages are unsupported live", async () => {
+    isSupportedLanguagesLiveMock.mockImplementation(
+      (_provider, _model, languages) =>
+        Promise.resolve({
+          status: "ok",
+          data: languages.length === 1 && languages[0] === "en",
+        }),
+    );
+
+    await expect(
+      getLiveTranscriptionConfig({
+        provider: "deepgram",
+        model: "nova-3-general",
+        languages: ["en", "ko"],
+      }),
+    ).resolves.toEqual({
+      languages: ["en"],
+      transcriptionMode: undefined,
+    });
+  });
+
+  test("checks custom providers as Deepgram-compatible for language fallback", async () => {
+    isSupportedLanguagesLiveMock.mockImplementation(
+      (_provider, _model, languages) =>
+        Promise.resolve({
+          status: "ok",
+          data: languages.length === 1 && languages[0] === "en",
+        }),
+    );
+
+    await getLiveTranscriptionConfig({
+      provider: "custom",
+      model: "nova-3-general",
+      languages: ["en", "ko"],
+    });
+
+    expect(isSupportedLanguagesLiveMock.mock.calls[0]?.[0]).toBe("deepgram");
+  });
+});
+
+describe("getTranscriptionLanguages", () => {
+  test("prefers the main language before additional spoken languages", () => {
+    expect(getTranscriptionLanguages("en", ["ko"])).toEqual(["en", "ko"]);
+  });
+
+  test("deduplicates regional variants by base language", () => {
+    expect(getTranscriptionLanguages("en-US", ["en", "ko"])).toEqual([
+      "en-US",
+      "ko",
+    ]);
   });
 });

--- a/apps/desktop/src/stt/capabilities.ts
+++ b/apps/desktop/src/stt/capabilities.ts
@@ -1,15 +1,167 @@
-import { commands as listenerCommands } from "@hypr/plugin-transcription";
+import {
+  commands as listenerCommands,
+  type TranscriptionMode,
+} from "@hypr/plugin-transcription";
+
+type LiveTranscriptionConfig = {
+  languages: string[];
+  transcriptionMode?: TranscriptionMode;
+};
+
+const SONIQO_PARAKEET_LANGUAGE_CODES = new Set([
+  "bg",
+  "cs",
+  "da",
+  "de",
+  "el",
+  "en",
+  "es",
+  "et",
+  "fi",
+  "fr",
+  "hr",
+  "hu",
+  "it",
+  "lt",
+  "lv",
+  "mt",
+  "nl",
+  "pl",
+  "pt",
+  "ro",
+  "ru",
+  "sk",
+  "sl",
+  "sv",
+  "uk",
+]);
 
 export function isRealtimeLocalModel(model?: string | null) {
   return model === "soniqo-parakeet-streaming";
 }
 
-export function getOnDeviceTranscriptionMode(model: string | null | undefined) {
-  if (!isRealtimeLocalModel(model)) {
-    return "batch" as const;
+function baseLanguageCode(language: string) {
+  return language.split(/[-_]/)[0]?.toLowerCase() ?? "";
+}
+
+function languageSupportProvider(provider: string) {
+  return provider === "custom" ? "deepgram" : provider;
+}
+
+async function isSupportedLanguagesLive(
+  provider: string,
+  model: string | null | undefined,
+  languages: readonly string[],
+) {
+  const result = await listenerCommands.isSupportedLanguagesLive(
+    languageSupportProvider(provider),
+    model ?? null,
+    [...languages],
+  );
+
+  return result.status === "ok" ? result.data : true;
+}
+
+export function getTranscriptionLanguages(
+  mainLanguage: string | null | undefined,
+  spokenLanguages: readonly string[] | null | undefined,
+) {
+  const seen = new Set<string>();
+  const languages: string[] = [];
+
+  for (const language of [mainLanguage, ...(spokenLanguages ?? [])]) {
+    if (!language) {
+      continue;
+    }
+
+    const baseCode = baseLanguageCode(language);
+    if (!baseCode || seen.has(baseCode)) {
+      continue;
+    }
+
+    seen.add(baseCode);
+    languages.push(language);
   }
 
-  return "live" as const;
+  return languages;
+}
+
+export function getOnDeviceTranscriptionConfig(
+  model: string | null | undefined,
+  languages: readonly string[],
+): LiveTranscriptionConfig {
+  if (!isRealtimeLocalModel(model)) {
+    return {
+      languages: [...languages],
+      transcriptionMode: "batch",
+    };
+  }
+
+  const supportedLiveLanguages = languages.filter((language) =>
+    SONIQO_PARAKEET_LANGUAGE_CODES.has(baseLanguageCode(language)),
+  );
+
+  if (languages.length > 0 && supportedLiveLanguages.length === 0) {
+    return {
+      languages: [...languages],
+      transcriptionMode: "batch",
+    };
+  }
+
+  return {
+    languages:
+      supportedLiveLanguages.length > 0
+        ? [supportedLiveLanguages[0]]
+        : [...languages],
+    transcriptionMode: "live",
+  };
+}
+
+export function getOnDeviceTranscriptionMode(
+  model: string | null | undefined,
+  languages: readonly string[] = [],
+) {
+  return getOnDeviceTranscriptionConfig(model, languages).transcriptionMode;
+}
+
+export async function getLiveTranscriptionConfig({
+  provider,
+  model,
+  languages,
+}: {
+  provider?: string | null;
+  model?: string | null;
+  languages: readonly string[];
+}): Promise<LiveTranscriptionConfig> {
+  if (provider === "hyprnote" && model !== "cloud") {
+    return getOnDeviceTranscriptionConfig(model, languages);
+  }
+
+  const config = {
+    languages: [...languages],
+    transcriptionMode: undefined as TranscriptionMode | undefined,
+  } satisfies LiveTranscriptionConfig;
+
+  if (!provider || languages.length <= 1) {
+    return config;
+  }
+
+  if (await isSupportedLanguagesLive(provider, model, languages)) {
+    return config;
+  }
+
+  const primaryLanguage = languages[0];
+  if (
+    primaryLanguage &&
+    (await isSupportedLanguagesLive(provider, model, [primaryLanguage]))
+  ) {
+    return {
+      ...config,
+      languages: [primaryLanguage],
+    };
+  }
+
+  return config;
 }
 
 export async function isLiveTranscriptionSupported(
@@ -20,11 +172,5 @@ export async function isLiveTranscriptionSupported(
     return false;
   }
 
-  const result = await listenerCommands.isSupportedLanguagesLive(
-    provider,
-    model,
-    [],
-  );
-
-  return result.status === "ok" ? result.data : true;
+  return isSupportedLanguagesLive(provider, model, []);
 }

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -11,6 +11,7 @@ import { useConfigValue } from "~/shared/config";
 import { id } from "~/shared/utils";
 import * as main from "~/store/tinybase/store/main";
 import type { BatchPersistCallback } from "~/store/zustand/listener/transcript";
+import { getTranscriptionLanguages } from "~/stt/capabilities";
 import type { SpeakerHintWithId, WordWithId } from "~/stt/types";
 import {
   parseTranscriptHints,
@@ -88,7 +89,8 @@ export const useRunBatch = (sessionId: string) => {
   const startTranscription = useListener((state) => state.startTranscription);
   const { conn } = useSTTConnection();
   const keywords = useKeywords(sessionId);
-  const languages = useConfigValue("spoken_languages");
+  const aiLanguage = useConfigValue("ai_language");
+  const spokenLanguages = useConfigValue("spoken_languages");
 
   return useCallback(
     async (filePath: string, options?: RunOptions) => {
@@ -227,7 +229,9 @@ export const useRunBatch = (sessionId: string) => {
         base_url: options?.baseUrl ?? conn.baseUrl,
         api_key: options?.apiKey ?? conn.apiKey,
         keywords: options?.keywords ?? keywords ?? [],
-        languages: options?.languages ?? languages ?? [],
+        languages:
+          options?.languages ??
+          getTranscriptionLanguages(aiLanguage, spokenLanguages),
         num_speakers: options?.numSpeakers,
         min_speakers: options?.minSpeakers,
         max_speakers: options?.maxSpeakers,
@@ -237,9 +241,10 @@ export const useRunBatch = (sessionId: string) => {
     },
     [
       conn,
+      aiLanguage,
       indexes,
       keywords,
-      languages,
+      spokenLanguages,
       startTranscription,
       sessionId,
       store,

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -14,6 +14,7 @@ const {
   useIndexesMock,
   useConfigValueMock,
   useSTTConnectionMock,
+  isSupportedLanguagesLiveMock,
 } = vi.hoisted(() => ({
   queueAutoEnhanceIfSummaryEmptyMock: vi.fn(),
   startMock: vi.fn(),
@@ -24,6 +25,13 @@ const {
   useIndexesMock: vi.fn(),
   useConfigValueMock: vi.fn(),
   useSTTConnectionMock: vi.fn(),
+  isSupportedLanguagesLiveMock: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-transcription", () => ({
+  commands: {
+    isSupportedLanguagesLive: isSupportedLanguagesLiveMock,
+  },
 }));
 
 vi.mock("./contexts", () => ({
@@ -140,7 +148,9 @@ describe("useStartListening", () => {
     );
     useValuesMock.mockReturnValue({ user_id: "user-1" });
     useIndexesMock.mockReturnValue(null);
-    useConfigValueMock.mockReturnValue([]);
+    useConfigValueMock.mockImplementation((key) =>
+      key === "ai_language" ? "en" : [],
+    );
     useSTTConnectionMock.mockReturnValue({
       conn: {
         provider: "hyprnote",
@@ -158,6 +168,10 @@ describe("useStartListening", () => {
     });
     startMock.mockResolvedValue(true);
     runBatchMock.mockResolvedValue(undefined);
+    isSupportedLanguagesLiveMock.mockResolvedValue({
+      status: "ok",
+      data: true,
+    });
   });
 
   test("runs batch transcription after record-only capture stops", async () => {
@@ -224,6 +238,63 @@ describe("useStartListening", () => {
 
     expect(startMock.mock.calls[0]?.[0]).toMatchObject({
       transcription_mode: "live",
+    });
+  });
+
+  test("keeps realtime local transcription live by filtering unsupported extra spoken languages", async () => {
+    useConfigValueMock.mockImplementation((key) =>
+      key === "ai_language" ? "en" : ["ko"],
+    );
+    useSTTConnectionMock.mockReturnValue({
+      conn: {
+        provider: "hyprnote",
+        model: "soniqo-parakeet-streaming",
+        baseUrl: "http://localhost:8080",
+        apiKey: "",
+      },
+    });
+
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(startMock.mock.calls[0]?.[0]).toMatchObject({
+      languages: ["en"],
+      transcription_mode: "live",
+    });
+  });
+
+  test("uses the main language for Deepgram live capture when extras are unsupported", async () => {
+    useConfigValueMock.mockImplementation((key) =>
+      key === "ai_language" ? "en" : ["ko"],
+    );
+    useSTTConnectionMock.mockReturnValue({
+      conn: {
+        provider: "deepgram",
+        model: "nova-3-general",
+        baseUrl: "https://api.deepgram.com/v1/listen",
+        apiKey: "test-key",
+      },
+    });
+    isSupportedLanguagesLiveMock.mockImplementation(
+      (_provider, _model, languages) =>
+        Promise.resolve({
+          status: "ok",
+          data: languages.length === 1 && languages[0] === "en",
+        }),
+    );
+
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(startMock.mock.calls[0]?.[0]).toMatchObject({
+      languages: ["en"],
+      transcription_mode: undefined,
     });
   });
 });

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -21,7 +21,10 @@ import type {
   LiveTranscriptPersistCallback,
   OnStoppedCallback,
 } from "~/store/zustand/listener/transcript";
-import { getOnDeviceTranscriptionMode } from "~/stt/capabilities";
+import {
+  getLiveTranscriptionConfig,
+  getTranscriptionLanguages,
+} from "~/stt/capabilities";
 import { applyLiveTranscriptDelta } from "~/stt/utils";
 
 export function getPostCaptureAction(
@@ -47,7 +50,8 @@ export function useStartListening(sessionId: string) {
   const store = main.UI.useStore(main.STORE_ID);
   const indexes = main.UI.useIndexes(main.STORE_ID);
 
-  const languages = useConfigValue("spoken_languages");
+  const aiLanguage = useConfigValue("ai_language");
+  const spokenLanguages = useConfigValue("spoken_languages");
 
   const start = useListener((state) => state.start);
   const { conn } = useSTTConnection();
@@ -143,19 +147,23 @@ export function useStartListening(sessionId: string) {
       },
     );
 
+    const languages = getTranscriptionLanguages(aiLanguage, spokenLanguages);
+    const liveTranscriptionConfig = await getLiveTranscriptionConfig({
+      provider: conn?.provider,
+      model: conn?.model,
+      languages,
+    });
+
     const started = await start(
       {
         session_id: sessionId,
-        languages,
+        languages: liveTranscriptionConfig.languages,
         onboarding: false,
         model: conn?.model ?? "",
         base_url: conn?.baseUrl ?? "",
         api_key: conn?.apiKey ?? "",
         keywords,
-        transcription_mode:
-          conn?.provider === "hyprnote" && conn.model !== "cloud"
-            ? getOnDeviceTranscriptionMode(conn.model)
-            : undefined,
+        transcription_mode: liveTranscriptionConfig.transcriptionMode,
         participant_human_ids: participantHumanIds,
         self_human_id: typeof user_id === "string" ? user_id : null,
       },
@@ -182,7 +190,17 @@ export function useStartListening(sessionId: string) {
           }
         : {}),
     });
-  }, [conn, store, indexes, sessionId, start, keywords, user_id, languages]);
+  }, [
+    aiLanguage,
+    conn,
+    store,
+    indexes,
+    sessionId,
+    start,
+    keywords,
+    user_id,
+    spokenLanguages,
+  ]);
 
   return startListening;
 }

--- a/crates/owhisper-client/src/adapter/soniox/live.rs
+++ b/crates/owhisper-client/src/adapter/soniox/live.rs
@@ -79,7 +79,7 @@ impl RealtimeSttAdapter for SonioxAdapter {
             audio_format: "pcm_s16le",
             num_channels: channels,
             sample_rate: params.sample_rate,
-            language_hints_strict: !language_hints.is_empty(),
+            language_hints_strict: language_hints.len() == 1,
             language_hints,
             enable_endpoint_detection: true,
             enable_speaker_diarization: true,
@@ -324,7 +324,11 @@ mod tests {
         assert_eq!(hints.len(), 2);
         assert_eq!(hints[0].as_str().unwrap(), "en");
         assert_eq!(hints[1].as_str().unwrap(), "ko");
-        assert_eq!(json["language_hints_strict"].as_bool().unwrap(), true);
+        assert!(
+            json.get("language_hints_strict").is_none()
+                || !json["language_hints_strict"].as_bool().unwrap_or(false),
+            "Multiple language hints should not enable strict restriction"
+        );
     }
 
     #[test]
@@ -368,7 +372,11 @@ mod tests {
         assert_eq!(hints[0].as_str().unwrap(), "en");
         assert_eq!(hints[1].as_str().unwrap(), "es");
         assert_eq!(hints[2].as_str().unwrap(), "fr");
-        assert_eq!(json["language_hints_strict"].as_bool().unwrap(), true);
+        assert!(
+            json.get("language_hints_strict").is_none()
+                || !json["language_hints_strict"].as_bool().unwrap_or(false),
+            "Multiple language hints should not enable strict restriction"
+        );
     }
 
     macro_rules! single_test {


### PR DESCRIPTION
Use the app language as the primary transcription hint for capture and batch fallback, filter Soniqo Parakeet realtime sessions to one supported language, and avoid strict Soniox hints for multilingual sessions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how language hints are normalized, persisted, and sent to live/batch transcription providers, including async capability checks and on-device mode selection that could affect capture behavior.
> 
> **Overview**
> **Improves language hint handling for transcription** by treating `ai_language` as the primary language and storing `spoken_languages` as *additional* (base-code deduped, excluding the main language). The settings UI now normalizes and keeps additional spoken languages in sync when the main language changes, and updates copy accordingly.
> 
> **Updates STT capability selection** to build a prioritized, deduplicated language list (`getTranscriptionLanguages`), choose on-device live vs batch configs based on supported language codes for the realtime local model, and for cloud providers fall back to the primary language when multi-language live isn’t supported (including mapping `custom` providers to Deepgram for this check). `useStartListening` and `useRunBatch` now use these helpers so both live capture and batch fallback send the preferred/supported language set.
> 
> **Adjusts Soniox live adapter behavior** to only enable `language_hints_strict` when exactly one language hint is provided, avoiding strict restriction for multilingual sessions. Adds/expands unit tests covering the new normalization and fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec85e53fa7977af4c48b004bf939aa22a2fe590a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->