### PR TITLE
fix(stt): preserve resumed live transcript preview

### DIFF
--- a/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.test.tsx
@@ -121,6 +121,30 @@ describe("DuringSessionAccessory", () => {
     expect(getLiveTranscriptScrollViewport().scrollTop).toBe(800);
   });
 
+  it("keeps rendered transcript history visible while resumed live segments stream", () => {
+    useQueryMock.mockReturnValue({
+      data: [segment("Earlier saved transcript.", 0)],
+    });
+    liveSegments = [segment("New live words.", 500)];
+
+    render(<DuringSessionAccessory sessionId="session-1" isExpanded />);
+
+    expect(screen.getByText("Earlier saved transcript.")).toBeTruthy();
+    expect(screen.getByText("New live words.")).toBeTruthy();
+  });
+
+  it("does not duplicate rendered segments already represented by live segments", () => {
+    const sharedSegment = segment("Shared live words.", 0);
+    useQueryMock.mockReturnValue({
+      data: [sharedSegment],
+    });
+    liveSegments = [sharedSegment];
+
+    render(<DuringSessionAccessory sessionId="session-1" isExpanded />);
+
+    expect(screen.getAllByText("Shared live words.")).toHaveLength(1);
+  });
+
   it("truncates long speaker labels inside the chip", () => {
     const label = "Alexandria Catherine Montgomery";
 

--- a/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
+++ b/apps/desktop/src/session/components/bottom-accessory/during-session.tsx
@@ -7,7 +7,11 @@ import { getSegmentColor } from "~/session/components/note-input/transcript/rend
 import * as main from "~/store/tinybase/store/main";
 import { getLiveCaptureUiMode } from "~/store/zustand/listener/general-shared";
 import { useListener } from "~/stt/contexts";
-import { SegmentKeyUtils, type Segment } from "~/stt/live-segment";
+import {
+  mergeRenderedAndLiveSegments,
+  SegmentKeyUtils,
+  type Segment,
+} from "~/stt/live-segment";
 import {
   buildRenderTranscriptRequestFromStore,
   renderTranscriptSegments,
@@ -292,7 +296,7 @@ function useLiveTranscriptSegments(sessionId: string): Segment[] {
   });
 
   return useMemo(() => {
-    return liveSegments.length > 0 ? liveSegments : renderedSegments;
+    return mergeRenderedAndLiveSegments(renderedSegments, liveSegments);
   }, [liveSegments, renderedSegments]);
 }
 

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
@@ -14,7 +14,11 @@ import {
 } from "./segment-hooks";
 
 import * as main from "~/store/tinybase/store/main";
-import type { Segment, SegmentWord } from "~/stt/live-segment";
+import {
+  mergeRenderedAndLiveSegments,
+  type Segment,
+  type SegmentWord,
+} from "~/stt/live-segment";
 import {
   defaultRenderLabelContext,
   SpeakerLabelManager,
@@ -42,9 +46,11 @@ export function RenderTranscript({
   audioExists: boolean;
 }) {
   const storedSegments = useRenderedTranscriptSegments(transcriptId);
-  const segments = useStableSegments(
-    liveSegments.length > 0 ? liveSegments : storedSegments,
+  const mergedSegments = useMemo(
+    () => mergeRenderedAndLiveSegments(storedSegments, liveSegments),
+    [liveSegments, storedSegments],
   );
+  const segments = useStableSegments(mergedSegments);
   const offsetMs = useTranscriptOffset(transcriptId);
 
   if (segments.length === 0) {

--- a/apps/desktop/src/stt/live-segment.ts
+++ b/apps/desktop/src/stt/live-segment.ts
@@ -134,3 +134,38 @@ export const SegmentKeyUtils = {
       : `Speaker ${channelLabel}`;
   },
 };
+
+export function mergeRenderedAndLiveSegments(
+  renderedSegments: Segment[],
+  liveSegments: Segment[],
+): Segment[] {
+  if (liveSegments.length === 0) {
+    return renderedSegments;
+  }
+
+  if (renderedSegments.length === 0) {
+    return liveSegments;
+  }
+
+  const liveSegmentIds = new Set(
+    liveSegments
+      .map((segment) => segment.id)
+      .filter((id): id is string => typeof id === "string" && id.length > 0),
+  );
+  const liveWordIds = new Set(
+    liveSegments.flatMap((segment) =>
+      segment.words
+        .map((word) => word.id)
+        .filter((id): id is string => typeof id === "string" && id.length > 0),
+    ),
+  );
+  const renderedOnlySegments = renderedSegments.filter((segment) => {
+    if (segment.id && liveSegmentIds.has(segment.id)) {
+      return false;
+    }
+
+    return !segment.words.some((word) => word.id && liveWordIds.has(word.id));
+  });
+
+  return [...renderedOnlySegments, ...liveSegments];
+}


### PR DESCRIPTION
Merge stored rendered transcript segments with active live segments so resumed capture keeps existing transcript history visible while new words stream.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how live and stored transcript segments are combined and deduplicated; errors could cause missing/duplicated transcript text or ordering issues in the UI during active capture.
> 
> **Overview**
> Ensures resumed live transcription **keeps previously rendered transcript history visible** instead of replacing it when new live segments arrive.
> 
> Introduces `mergeRenderedAndLiveSegments()` to combine stored rendered segments with current live segments while *deduplicating* overlaps by segment/word `id`, and switches both the during-session footer (`DuringSessionAccessory`) and main transcript renderer (`RenderTranscript`) to use this merge.
> 
> Adds tests covering the resumed-history merge behavior and preventing duplicate segments when rendered and live streams overlap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13cbd390e7820d680bd9dbb4ec8036fecaec0367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->