### PR TITLE
fix(notification): keep ignore action in background

### DIFF
--- a/plugins/notification/src/handler.rs
+++ b/plugins/notification/src/handler.rs
@@ -85,8 +85,6 @@ pub fn init(app: tauri::AppHandle<tauri::Wry>) {
     {
         let app = app.clone();
         hypr_notification::setup_footer_action_handler(move |ctx| {
-            if let Err(_e) = app.windows().show(tauri_plugin_windows::AppWindow::Main) {}
-
             let _ = NotificationEvent::FooterAction {
                 key: ctx.key,
                 source: ctx.source,


### PR DESCRIPTION
Stop showing the main window when mic-detected notification footer actions are clicked so the app is ignored without opening Char.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a single window-show side effect from the notification footer-action handler; other notification handlers and emitted events/analytics are unchanged.
> 
> **Overview**
> Prevents notification *footer actions* from automatically showing the main app window by removing the `app.windows().show(AppWindow::Main)` call from `setup_footer_action_handler`.
> 
> Footer-action events (`NotificationEvent::FooterAction`) and their analytics (`"footer_action"`) continue to be emitted as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86be7d38e13c3d03062228103178e751bc7638ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->