### PR TITLE
chore(web): link Char v2 from announcement

### DIFF
--- a/apps/web/content/articles/char-is-now-anarlog.mdx
+++ b/apps/web/content/articles/char-is-now-anarlog.mdx
@@ -50,9 +50,9 @@ Type a checkbox in your daily note. An agent picks it up — researches a compan
 
 The category Char competes in isn't "meeting notetaker". It's the todo list — Things, Todoist, Notion — and the new wave of delegation agents (Yutori, AirJelly, Manus). Notetakers stop where the meeting ends. Char starts there: every action item becomes a checkbox that finishes itself.
 
-It's a different product. Private alpha right now, paid SaaS when it ships. Same company. Same conviction that humans deserve to stay in command of their own work. Different shape.
+It's a different product. We're working on Char right now at [v2.char.com](https://v2.char.com). Private alpha right now, paid SaaS when it ships. Same company. Same conviction that humans deserve to stay in command of their own work. Different shape.
 
-If that sounds interesting, char.com is the place. If it doesn't — totally fine. Stay on Anarlog, take your meeting notes, own your files. We built it for you.
+If that sounds interesting, [v2.char.com](https://v2.char.com) is the place. If it doesn't — totally fine. Stay on Anarlog, take your meeting notes, own your files. We built it for you.
 
 ### the journey
 


### PR DESCRIPTION
State that Char is actively in progress and link the announcement to v2.char.com.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content-only change: updates a blog/announcement MDX to point readers to `v2.char.com`, with no runtime code or data-handling impact.
> 
> **Overview**
> Updates the `char-is-now-anarlog.mdx` announcement to explicitly state Char is actively being developed and directs readers to **`v2.char.com`** (replacing the previous generic `char.com` mention) in the “so what is char now” section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 500190110be8e55db3d3088f9924d19c131e10d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->