### PR TITLE
chore(readme): point Char links to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-> **Note:** We're now working primarily on **[char](https://char.com)** — a new productivity-focused product that's where most of our active development goes. **anarlog** stays open-source, MIT-licensed, and maintained. The cross-link to char lives here so you know where the team's attention is. Same team, different bets.
+> **Note:** We're now working primarily on **[char](https://v2.char.com)** — a new productivity-focused product that's where most of our active development goes. **anarlog** stays open-source, MIT-licensed, and maintained. The cross-link to char lives here so you know where the team's attention is. Same team, different bets.
 
 ![anarlog](https://repository-images.githubusercontent.com/900550981/a4267a9f-414b-4c36-965c-419313ce2417)
 
 <p align="center">
   <p align="center">
-   <a href="https://deepwiki.com/fastrepl/char"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
-   <a href="https://char.com/discord" target="_blank"><img src="https://img.shields.io/static/v1?label=Join%20our&message=Discord&color=blue&logo=Discord" alt="Discord"></a>
-   <a href="https://x.com/getcharnotes" target="_blank"><img src="https://img.shields.io/static/v1?label=Follow%20us%20on&message=X&color=black&logo=x" alt="X"></a>
+   <a href="https://deepwiki.com/fastrepl/anarlog"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
   </p>
 </p>
 
@@ -40,7 +38,7 @@ We started this as **Hyprnote**. It became **char**. Now it's **anarlog**.
 
 Each name change came from a different reason — a legal one, a strategic one, a brand one. The product underneath kept getting clearer: a notetaker that respects your time, your data, and your right to walk away with both.
 
-We're now building [**char**](https://char.com) — a new product, productivity-focused, where most of our active development happens. **anarlog** isn't a sunset. It's the open-source companion we promised to keep alive, and we will. This repository keeps its full history, its stars, and its trajectory. Same team. Same standards. Just a clearer split between what's open and what's experimental.
+We're now building [**char**](https://v2.char.com) — a new product, productivity-focused, where most of our active development happens. **anarlog** isn't a sunset. It's the open-source companion we promised to keep alive, and we will. This repository keeps its full history, its stars, and its trajectory. Same team. Same standards. Just a clearer split between what's open and what's experimental.
 
 If you came here from Granola, welcome. If you came here from Hyprnote, welcome back.
 


### PR DESCRIPTION
Update README product and Discord links to v2.char.com.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it only updates outbound links and removes social/community badges with no runtime impact.
> 
> **Overview**
> Updates `README.md` to point **char** references at `https://v2.char.com` instead of `https://char.com`.
> 
> Also refreshes the header badges by switching the DeepWiki badge to `fastrepl/anarlog` and removing the Discord and X badges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 517b6293a06ab05d238e338081092abec6530759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->