### PR TITLE
fix: disable local STT on Intel

### DIFF
--- a/crates/local-model/src/lib.rs
+++ b/crates/local-model/src/lib.rs
@@ -253,20 +253,13 @@ impl LocalModel {
     }
 
     pub fn is_available_on_current_platform(&self) -> bool {
-        let is_macos = cfg!(target_os = "macos");
         let is_apple_silicon = cfg!(target_arch = "aarch64") && cfg!(target_os = "macos");
 
         match self {
             LocalModel::Soniqo(model) => model.is_available_on_current_platform(),
-            LocalModel::Whisper(_) => is_macos,
+            LocalModel::Whisper(_) => is_apple_silicon,
             LocalModel::Am(_) => is_apple_silicon,
-            LocalModel::Cactus(model) => {
-                if model.is_apple() {
-                    is_apple_silicon
-                } else {
-                    !is_apple_silicon
-                }
-            }
+            LocalModel::Cactus(model) => model.is_apple() && is_apple_silicon,
             LocalModel::GgufLlm(_) => cfg!(target_arch = "aarch64"),
             LocalModel::CactusLlm(model) => {
                 if model.is_apple() {

--- a/crates/transcribe-soniqo/Cargo.toml
+++ b/crates/transcribe-soniqo/Cargo.toml
@@ -17,5 +17,5 @@ tracing = { workspace = true }
 [target.'cfg(target_os = "macos")'.build-dependencies]
 swift-rs = { workspace = true, features = ["build"] }
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
 swift-rs = { workspace = true }

--- a/crates/transcribe-soniqo/build.rs
+++ b/crates/transcribe-soniqo/build.rs
@@ -1,6 +1,7 @@
 #[cfg(target_os = "macos")]
 use std::{
     collections::BTreeSet,
+    env,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -41,9 +42,22 @@ fn swift_bin_path() -> Option<PathBuf> {
     (!path.is_empty()).then(|| PathBuf::from(path))
 }
 
+#[cfg(target_os = "macos")]
+fn target_is_macos_apple_silicon() -> bool {
+    env::var("CARGO_CFG_TARGET_OS").is_ok_and(|value| value == "macos")
+        && env::var("CARGO_CFG_TARGET_ARCH").is_ok_and(|value| value == "aarch64")
+}
+
 fn main() {
     #[cfg(target_os = "macos")]
     {
+        if !target_is_macos_apple_silicon() {
+            println!(
+                "cargo:warning=Soniqo speech-swift linking is only available on macOS Apple Silicon"
+            );
+            return;
+        }
+
         swift_rs::SwiftLinker::new("15.0")
             .with_package("soniqo-swift", "./swift-lib/")
             .link();
@@ -59,6 +73,8 @@ fn main() {
 
     #[cfg(not(target_os = "macos"))]
     {
-        println!("cargo:warning=Soniqo speech-swift linking is only available on macOS");
+        println!(
+            "cargo:warning=Soniqo speech-swift linking is only available on macOS Apple Silicon"
+        );
     }
 }

--- a/crates/transcribe-soniqo/src/lib.rs
+++ b/crates/transcribe-soniqo/src/lib.rs
@@ -194,6 +194,7 @@ pub enum TranscriptSource {
 }
 
 impl TranscriptSource {
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
     const fn as_str(self) -> &'static str {
         match self {
             Self::Microphone => "microphone",
@@ -503,7 +504,7 @@ fn split_words(text: &str) -> Vec<&str> {
         .collect()
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 mod platform {
     use super::*;
     use swift_rs::{Bool, SRData, SRString, swift};
@@ -676,7 +677,7 @@ mod platform {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 mod platform {
     use super::*;
 

--- a/plugins/local-stt/src/error.rs
+++ b/plugins/local-stt/src/error.rs
@@ -26,6 +26,8 @@ pub enum Error {
     AmApiKeyNotSet,
     #[error("Internal server only supports Whisper models")]
     UnsupportedModelType,
+    #[error("On-device transcription is only available on Apple Silicon")]
+    UnsupportedPlatform,
     #[error("Model delete failed: {0}")]
     ModelDeleteFailed(String),
     #[error("Model unpack failed: {0}")]

--- a/plugins/local-stt/src/ext.rs
+++ b/plugins/local-stt/src/ext.rs
@@ -62,7 +62,13 @@ impl<'a, R: Runtime, M: Manager<R>> LocalStt<'a, R, M> {
             LocalModel::Soniqo(_)
             | LocalModel::Am(_)
             | LocalModel::Whisper(_)
-            | LocalModel::Cactus(_) => Ok(()),
+            | LocalModel::Cactus(_) => {
+                if model.is_available_on_current_platform() {
+                    Ok(())
+                } else {
+                    Err(crate::Error::UnsupportedPlatform)
+                }
+            }
             LocalModel::GgufLlm(_) | LocalModel::CactusLlm(_) => {
                 Err(crate::Error::UnsupportedModelType)
             }


### PR DESCRIPTION
Limit on-device transcription models and the Soniqo Swift bridge to Apple Silicon, with unsupported-platform guards for direct local STT commands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes platform gating for on-device STT, affecting which targets compile/link the Swift bridge and which models are considered runnable; risk is mainly unintended build/feature regressions on macOS Intel or non-macOS targets.
> 
> **Overview**
> Restricts on-device STT support to **macOS Apple Silicon** by tightening platform checks in `LocalModel::is_available_on_current_platform()` (e.g., Whisper and Cactus STT now require Apple Silicon).
> 
> Limits the `transcribe-soniqo` Swift bridge to `cfg(all(target_os = "macos", target_arch = "aarch64"))`, adds a build-time target check that skips linking with a warning on unsupported targets, and updates Rust-side `cfg` gates accordingly.
> 
> Adds an `UnsupportedPlatform` error in `local-stt` and rejects unsupported on-device models (notably Cactus STT) at command entry points instead of attempting to run them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf42844f0cce112e559768c5408257c7a646b253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->