### PR TITLE
fix(session): move note title into header

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -7,13 +7,16 @@ import type { EditorView } from "~/store/zustand/tabs/schema";
 export function OuterHeader({
   sessionId,
   currentView,
+  title,
 }: {
   sessionId: string;
   currentView: EditorView;
+  title?: React.ReactNode;
 }) {
   return (
     <div className="w-full pt-1">
-      <div className="flex items-center justify-end">
+      <div className="flex min-w-0 items-center justify-between gap-3">
+        {title ? <div className="min-w-0 flex-1">{title}</div> : null}
         <div className="flex shrink-0 items-center">
           <ListenButton sessionId={sessionId} />
           <MetadataButton sessionId={sessionId} />

--- a/apps/desktop/src/session/components/session-surface.tsx
+++ b/apps/desktop/src/session/components/session-surface.tsx
@@ -2,7 +2,6 @@ import { StandardTabWrapper } from "~/shared/main";
 
 export function SessionSurface({
   header,
-  title,
   children,
   afterBorder,
   afterBorderExpanded,
@@ -12,7 +11,6 @@ export function SessionSurface({
   mergeAfterBorder,
 }: {
   header?: React.ReactNode;
-  title?: React.ReactNode;
   children: React.ReactNode;
   afterBorder?: React.ReactNode;
   afterBorderExpanded?: boolean;
@@ -32,7 +30,6 @@ export function SessionSurface({
     >
       <div className="flex h-full flex-col">
         {header ? <div className="pr-1 pl-2">{header}</div> : null}
-        {title ? <div className="mt-2 shrink-0 px-3">{title}</div> : null}
         <div className="mt-2 min-h-0 flex-1 px-2">{children}</div>
       </div>
     </StandardTabWrapper>

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -84,8 +84,8 @@ export const TitleInput = forwardRef<
 
     if (isGenerating) {
       return (
-        <div className="flex h-[28px] w-full items-center">
-          <span className="text-muted-foreground animate-pulse text-xl font-semibold">
+        <div className="flex h-8 w-full items-center">
+          <span className="text-muted-foreground animate-pulse text-sm font-semibold">
             Generating title...
           </span>
         </div>
@@ -94,8 +94,8 @@ export const TitleInput = forwardRef<
 
     if (showRevealAnimation && generatedTitle) {
       return (
-        <div className="flex h-[28px] w-full items-center overflow-hidden">
-          <span className="animate-reveal-left text-xl font-semibold whitespace-nowrap">
+        <div className="flex h-8 w-full items-center overflow-hidden">
+          <span className="animate-reveal-left text-sm font-semibold whitespace-nowrap">
             {generatedTitle}
           </span>
         </div>
@@ -350,10 +350,10 @@ const TitleInputInner = memo(
             className={cn([
               "min-w-0 flex-1 transition-opacity duration-200",
               "border-none bg-transparent focus:outline-hidden",
-              "placeholder:text-muted-foreground text-xl font-semibold",
+              "placeholder:text-muted-foreground text-sm font-semibold",
             ])}
           />
-          {onGenerateTitle && (
+          {onGenerateTitle && !localTitle.trim() && (
             <GenerateButton onGenerateTitle={onGenerateTitle} />
           )}
         </div>

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -243,15 +243,20 @@ function TabContentNoteInner({
 
   return (
     <SessionSurface
-      header={<OuterHeader sessionId={tab.id} currentView={currentView} />}
-      title={
-        <TitleInput
-          ref={titleInputRef}
-          tab={tab}
-          onTransferContentToEditor={handleTransferContentToEditor}
-          onFocusEditorAtStart={handleFocusEditorAtStart}
-          onFocusEditorAtPixelWidth={handleFocusEditorAtPixelWidth}
-          onGenerateTitle={hasTranscript ? generateTitle : undefined}
+      header={
+        <OuterHeader
+          sessionId={tab.id}
+          currentView={currentView}
+          title={
+            <TitleInput
+              ref={titleInputRef}
+              tab={tab}
+              onTransferContentToEditor={handleTransferContentToEditor}
+              onFocusEditorAtStart={handleFocusEditorAtStart}
+              onFocusEditorAtPixelWidth={handleFocusEditorAtPixelWidth}
+              onGenerateTitle={hasTranscript ? generateTitle : undefined}
+            />
+          }
         />
       }
       afterBorder={bottomAccessory}


### PR DESCRIPTION
Place the editable session title in the outer header and use breadcrumb-sized, heavier title text.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5235 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5233 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout refactor that changes where the title input is rendered and tweaks title-generation button visibility; minimal impact outside the session header rendering path.
> 
> **Overview**
> Moves the editable session `TitleInput` into `OuterHeader` (new `title` prop) and removes the separate `title` slot from `SessionSurface`, so the title now sits inline with the header actions.
> 
> Adjusts title presentation to a smaller, heavier “breadcrumb” style (including generating/reveal states), and only shows the regenerate button when the title is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53c822a855e8174c41242405d1e2d14ce8a89a73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->