### PR TITLE
chore(changelog): update 1.0.27 release notes

### DIFF
--- a/packages/changelog/content/1.0.27.md
+++ b/packages/changelog/content/1.0.27.md
@@ -12,6 +12,7 @@ date: "2026-05-16"
 ## Transcription
 
 - Soniqo on-device transcription is more stable across realtime and batch modes, with safer model and language handling
+- On-device transcription options now stay hidden on Intel Macs where local models are unsupported
 - Live transcription now falls back to a supported language when a provider cannot handle every selected spoken language
 - Resumed live sessions keep earlier transcript history visible while new words stream in
 - GPT and Soniox batch transcripts now save complete text and word timing more consistently
@@ -27,6 +28,9 @@ date: "2026-05-16"
 
 - Pro trial start and end dialogs now explain plan changes more clearly
 - Settings navigation is cleaner, with Data moved into its own tab and language selection simplified
+- Session titles now sit in the top header with recording and metadata controls, leaving more room for notes
 - Chat controls now live inside the chat panel, and the assistant is labeled Anarlog AI
+- Folder controls have been removed so sessions remain the primary organization model
 - App icon and installer artwork updated for the Anarlog brand
+- In-app web links now point to Anarlog pages instead of older Char docs
 - Notification footer actions such as Ignore no longer open the main window


### PR DESCRIPTION
Add newer transcription, UI polish, folder removal, and Anarlog link cleanup notes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change updating release notes with no runtime or behavioral impact.
> 
> **Overview**
> Updates the `1.0.27` changelog to include additional release notes covering **on-device transcription visibility on Intel Macs**, **UI layout tweaks** (session title/header placement), **removal of folder controls**, and **updated in-app links** to Anarlog pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 656e7a528b9b8908768abd4142b7bd486cd89676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->