### PR TITLE
fix(editor): guard ProseMirror transaction crashes

### DIFF
--- a/packages/editor/src/chat/index.tsx
+++ b/packages/editor/src/chat/index.tsx
@@ -29,8 +29,10 @@ import { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
 import "@hypr/tiptap/styles.css";
 import { cn } from "@hypr/utils";
 
+import { EditorErrorBoundary } from "../editor-error-boundary";
 import { AttachmentChipView, MentionNodeView } from "../node-views";
 import { type PlaceholderFunction, placeholderPlugin } from "../plugins";
+import { dispatchEditorTransaction } from "../transaction-guard";
 import {
   type MentionConfig,
   MentionSuggestion,
@@ -256,29 +258,33 @@ export const ChatEditor = forwardRef<ChatEditorHandle, ChatEditorProps>(
     }, []);
 
     return (
-      <ProseMirror
-        defaultState={defaultState}
-        nodeViewComponents={nodeViews}
-        dispatchTransaction={function (this: EditorView, tr) {
-          const newState = this.state.apply(tr);
-          this.updateState(newState);
-          if (tr.docChanged) {
-            onUpdateRef.current?.(newState.doc.toJSON() as JSONContent);
-          }
-        }}
-        attributes={{
-          spellcheck: "false",
-          autocomplete: "off",
-          autocorrect: "off",
-          autocapitalize: "off",
-          role: "textbox",
-          class: cn(className, "tiptap"),
-        }}
-      >
-        <ProseMirrorDoc />
-        <ViewCapture viewRef={viewRef} />
-        {mentionConfig && <MentionSuggestion config={mentionConfig} />}
-      </ProseMirror>
+      <EditorErrorBoundary>
+        <ProseMirror
+          defaultState={defaultState}
+          nodeViewComponents={nodeViews}
+          dispatchTransaction={function (this: EditorView, tr) {
+            dispatchEditorTransaction({
+              view: this,
+              transaction: tr,
+              onDocChanged: (view) => {
+                onUpdateRef.current?.(view.state.doc.toJSON() as JSONContent);
+              },
+            });
+          }}
+          attributes={{
+            spellcheck: "false",
+            autocomplete: "off",
+            autocorrect: "off",
+            autocapitalize: "off",
+            role: "textbox",
+            class: cn(className, "tiptap"),
+          }}
+        >
+          <ProseMirrorDoc />
+          <ViewCapture viewRef={viewRef} />
+          {mentionConfig && <MentionSuggestion config={mentionConfig} />}
+        </ProseMirror>
+      </EditorErrorBoundary>
     );
   },
 );

--- a/packages/editor/src/editor-error-boundary.tsx
+++ b/packages/editor/src/editor-error-boundary.tsx
@@ -1,0 +1,42 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+type EditorErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type EditorErrorBoundaryState = {
+  hasError: boolean;
+};
+
+export class EditorErrorBoundary extends Component<
+  EditorErrorBoundaryProps,
+  EditorErrorBoundaryState
+> {
+  constructor(props: EditorErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): EditorErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("Editor render failed", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          role="alert"
+          className="rounded-md border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-600"
+        >
+          The editor hit an error. Your recording is still running.
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -32,6 +32,7 @@ import { useDebounceCallback } from "usehooks-ts";
 
 import "@hypr/tiptap/styles.css";
 
+import { EditorErrorBoundary } from "../editor-error-boundary";
 import {
   FileAttachmentView,
   MentionNodeView,
@@ -64,6 +65,7 @@ import {
   normalizeTaskContent,
   type TaskSource,
 } from "../tasks";
+import { dispatchEditorTransaction } from "../transaction-guard";
 import {
   FormatToolbar,
   type MentionConfig,
@@ -471,33 +473,37 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
     return (
       <TaskSourceProvider source={taskSource ?? null}>
         <LinkedItemOpenBehaviorContext.Provider value={linkedItemOpenBehavior}>
-          <ProseMirror
-            defaultState={defaultState}
-            nodeViewComponents={nodeViews}
-            dispatchTransaction={function (this: EditorView, tr: Transaction) {
-              const { state: newState, transactions } =
-                this.state.applyTransaction(tr);
-              this.updateState(newState);
-              if (transactions.some((transaction) => transaction.docChanged)) {
-                onUpdate(this);
-              }
-            }}
-            attributes={{
-              spellcheck: "false",
-              autocomplete: "off",
-              autocorrect: "off",
-              autocapitalize: "off",
-              role: "textbox",
-              class: "tiptap",
-            }}
-          >
-            <ProseMirrorDoc />
-            <ViewCapture viewRef={viewRef} onViewReady={onViewReady} />
-            <EditorCommandsBridge commandsRef={commandsRef} />
-            <FormatToolbar />
-            <SlashCommandMenu />
-            {mentionConfig && <MentionSuggestion config={mentionConfig} />}
-          </ProseMirror>
+          <EditorErrorBoundary>
+            <ProseMirror
+              defaultState={defaultState}
+              nodeViewComponents={nodeViews}
+              dispatchTransaction={function (
+                this: EditorView,
+                tr: Transaction,
+              ) {
+                dispatchEditorTransaction({
+                  view: this,
+                  transaction: tr,
+                  onDocChanged: () => onUpdate(this),
+                });
+              }}
+              attributes={{
+                spellcheck: "false",
+                autocomplete: "off",
+                autocorrect: "off",
+                autocapitalize: "off",
+                role: "textbox",
+                class: "tiptap",
+              }}
+            >
+              <ProseMirrorDoc />
+              <ViewCapture viewRef={viewRef} onViewReady={onViewReady} />
+              <EditorCommandsBridge commandsRef={commandsRef} />
+              <FormatToolbar />
+              <SlashCommandMenu />
+              {mentionConfig && <MentionSuggestion config={mentionConfig} />}
+            </ProseMirror>
+          </EditorErrorBoundary>
         </LinkedItemOpenBehaviorContext.Provider>
       </TaskSourceProvider>
     );

--- a/packages/editor/src/transaction-guard.test.ts
+++ b/packages/editor/src/transaction-guard.test.ts
@@ -1,0 +1,103 @@
+import { EditorState, type Transaction } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+
+import { schema } from "./note/schema";
+import { dispatchEditorTransaction } from "./transaction-guard";
+
+const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+afterEach(() => {
+  consoleError.mockClear();
+});
+
+afterAll(() => {
+  consoleError.mockRestore();
+});
+
+describe("dispatchEditorTransaction", () => {
+  it("applies document changes and reports updates", () => {
+    let state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [schema.node("paragraph")]),
+    });
+    const view = {
+      get state() {
+        return state;
+      },
+      updateState(nextState: EditorState) {
+        state = nextState;
+      },
+    } as Pick<EditorView, "state" | "updateState"> as EditorView;
+    const onDocChanged = vi.fn();
+
+    dispatchEditorTransaction({
+      view,
+      transaction: state.tr.insertText("hello", 1),
+      onDocChanged,
+    });
+
+    expect(state.doc.textContent).toBe("hello");
+    expect(onDocChanged).toHaveBeenCalledOnce();
+  });
+
+  it("catches stale transactions without throwing", () => {
+    const initialState = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [schema.node("paragraph")]),
+    });
+    const staleTransaction = initialState.tr.insertText("stale", 1);
+    let state = initialState.apply(initialState.tr.insertText("current", 1));
+    const view = {
+      get state() {
+        return state;
+      },
+      updateState(nextState: EditorState) {
+        state = nextState;
+      },
+    } as Pick<EditorView, "state" | "updateState"> as EditorView;
+    const onError = vi.fn();
+
+    expect(() =>
+      dispatchEditorTransaction({
+        view,
+        transaction: staleTransaction,
+        onError,
+      }),
+    ).not.toThrow();
+
+    expect(state.doc.textContent).toBe("current");
+    expect(onError).toHaveBeenCalledWith(
+      expect.any(RangeError),
+      view,
+      staleTransaction,
+    );
+  });
+
+  it("does not report non-document transactions as content changes", () => {
+    let state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [schema.text("hello")]),
+      ]),
+    });
+    const view = {
+      get state() {
+        return state;
+      },
+      updateState(nextState: EditorState) {
+        state = nextState;
+      },
+    } as Pick<EditorView, "state" | "updateState"> as EditorView;
+    const onDocChanged = vi.fn();
+
+    dispatchEditorTransaction({
+      view,
+      transaction: state.tr.setMeta("source", "test") as Transaction,
+      onDocChanged,
+    });
+
+    expect(state.doc.textContent).toBe("hello");
+    expect(onDocChanged).not.toHaveBeenCalled();
+  });
+});

--- a/packages/editor/src/transaction-guard.ts
+++ b/packages/editor/src/transaction-guard.ts
@@ -1,0 +1,38 @@
+import type { Transaction } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+
+export type EditorTransactionErrorHandler = (
+  error: unknown,
+  view: EditorView,
+  transaction: Transaction,
+) => void;
+
+export function dispatchEditorTransaction({
+  view,
+  transaction,
+  onDocChanged,
+  onError = logEditorTransactionError,
+}: {
+  view: EditorView;
+  transaction: Transaction;
+  onDocChanged?: (
+    view: EditorView,
+    transactions: readonly Transaction[],
+  ) => void;
+  onError?: EditorTransactionErrorHandler;
+}) {
+  try {
+    const { state, transactions } = view.state.applyTransaction(transaction);
+    view.updateState(state);
+
+    if (transactions.some((tr) => tr.docChanged)) {
+      onDocChanged?.(view, transactions);
+    }
+  } catch (error) {
+    onError(error, view, transaction);
+  }
+}
+
+export function logEditorTransactionError(error: unknown) {
+  console.error("Editor transaction failed", error);
+}


### PR DESCRIPTION
Catch failed editor transactions and render failures so typing-time editor errors do not bring down the desktop app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core editor rendering/transaction dispatch in both `ChatEditor` and `NoteEditor`; failures are now swallowed and logged, which reduces crash risk but could mask real state-sync issues if errors become frequent.
> 
> **Overview**
> Prevents typing-time editor crashes by adding a shared `dispatchEditorTransaction` helper that wraps ProseMirror `applyTransaction` in a `try/catch`, only firing update callbacks when *doc-changing* transactions occur.
> 
> Wraps both `ChatEditor` and `NoteEditor` in a new `EditorErrorBoundary` that logs render errors and shows a fallback message instead of taking down the app, and adds Vitest coverage for stale-transaction and non-doc-change behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 137fd061eb69c1a055473a1a08806fe08d52e33f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->